### PR TITLE
feat: derive model list from CLI control response, fix: slash commands

### DIFF
--- a/backend/src/core/features/__tests__/loadCliConfig.test.ts
+++ b/backend/src/core/features/__tests__/loadCliConfig.test.ts
@@ -1,7 +1,96 @@
-import { describe, it, expect } from 'vitest';
-import { parseCliConfigResponse } from '../loadCliConfig';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { Readable, Writable } from 'stream';
+import type { ChildProcess } from 'child_process';
+
+vi.mock('../../claude', () => ({
+  Claude: {
+    spawn: vi.fn(),
+  },
+}));
+
+import { Claude } from '../../claude';
+import { loadCliConfig, parseCliConfigResponse, _resetCliConfigCache } from '../loadCliConfig';
+
+function makeFakeProc(stdoutPayload: string): ChildProcess {
+  const proc = new EventEmitter() as unknown as ChildProcess;
+  const stdout = new Readable({ read() {} });
+  const stderr = new Readable({ read() {} });
+  const stdin = new Writable({ write(_c, _e, cb) { cb(); } });
+  (proc as unknown as { stdout: Readable }).stdout = stdout;
+  (proc as unknown as { stderr: Readable }).stderr = stderr;
+  (proc as unknown as { stdin: Writable }).stdin = stdin;
+  (proc as unknown as { pid: number }).pid = 1234;
+  (proc as unknown as { kill: () => void }).kill = () => {};
+  setImmediate(() => {
+    proc.emit('spawn');
+    stdout.push(stdoutPayload);
+  });
+  return proc;
+}
+
+function controlResponse(commandName: string): string {
+  return JSON.stringify({
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'config_init',
+      response: {
+        commands: [{ name: commandName, description: '', argumentHint: '' }],
+        agents: [],
+        output_style: 'default',
+        available_output_styles: [],
+        models: [],
+        account: { email: '', subscriptionType: '' },
+        pid: 1,
+      },
+    },
+  }) + '\n';
+}
 
 describe('loadCliConfig', () => {
+  beforeEach(() => {
+    _resetCliConfigCache();
+    vi.mocked(Claude.spawn).mockReset();
+  });
+
+  describe('cache', () => {
+    it('caches per workingDir — different projects get different configs', async () => {
+      vi.mocked(Claude.spawn).mockImplementation((_args, options) => {
+        const cwd = options?.cwd as string;
+        const cmdName = cwd === '/project/a' ? 'skill-a' : 'skill-b';
+        return makeFakeProc(controlResponse(cmdName));
+      });
+
+      const configA = await loadCliConfig('/project/a');
+      const configB = await loadCliConfig('/project/b');
+
+      expect(configA?.response.response.commands[0].name).toBe('skill-a');
+      expect(configB?.response.response.commands[0].name).toBe('skill-b');
+    });
+
+    it('returns the cached config for the same workingDir without respawning', async () => {
+      vi.mocked(Claude.spawn).mockImplementation(() => makeFakeProc(controlResponse('skill-a')));
+
+      await loadCliConfig('/project/a');
+      await loadCliConfig('/project/a');
+
+      expect(vi.mocked(Claude.spawn)).toHaveBeenCalledTimes(1);
+    });
+
+    it('refresh:true bypasses the cache and re-spawns', async () => {
+      vi.mocked(Claude.spawn).mockImplementationOnce(() => makeFakeProc(controlResponse('first')));
+      const first = await loadCliConfig('/project/a');
+
+      vi.mocked(Claude.spawn).mockImplementationOnce(() => makeFakeProc(controlResponse('second')));
+      const second = await loadCliConfig('/project/a', { refresh: true });
+
+      expect(first?.response.response.commands[0].name).toBe('first');
+      expect(second?.response.response.commands[0].name).toBe('second');
+      expect(vi.mocked(Claude.spawn)).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('parseCliConfigResponse', () => {
     it('should return control_response as-is', () => {
       const controlResponse = {

--- a/backend/src/core/features/loadCliConfig.ts
+++ b/backend/src/core/features/loadCliConfig.ts
@@ -78,32 +78,56 @@ export function parseCliConfigResponse(stdout: string): CliConfigControlResponse
   return cliConfigResponse;
 }
 
-// Singleton: cache result + dedup concurrent requests
-let cachedConfig: CliConfigControlResponse | null = null;
-let pendingPromise: Promise<CliConfigControlResponse | null> | null = null;
+// Cache + dedup per workingDir. The Node backend is shared across all IDE
+// projects (NodeBackendService is @Service(Service.Level.APP)), so a single
+// global cache would leak commands/skills from the first project to every
+// other project.
+const cacheByWorkingDir = new Map<string, CliConfigControlResponse>();
+const pendingByWorkingDir = new Map<string, Promise<CliConfigControlResponse | null>>();
+
+export interface LoadCliConfigOptions {
+  /** Skip the cache and respawn the CLI (used by UI-triggered refresh). */
+  refresh?: boolean;
+}
 
 /**
- * Spawn a config-only CLI process to load CLI config.
+ * Spawn a config-only CLI process to load CLI config for a given workingDir.
  * Sends an `initialize` control_request to get control_response.
- * Results are cached — subsequent calls return the cached result immediately.
+ * Results are cached per workingDir; pass `{ refresh: true }` to bypass.
  */
-export async function loadCliConfig(workingDir: string): Promise<CliConfigControlResponse | null> {
-  if (cachedConfig) {
-    console.error('[loadCliConfig] returning cached config');
-    return cachedConfig;
+export async function loadCliConfig(
+  workingDir: string,
+  options: LoadCliConfigOptions = {},
+): Promise<CliConfigControlResponse | null> {
+  if (options.refresh) {
+    cacheByWorkingDir.delete(workingDir);
+    pendingByWorkingDir.delete(workingDir);
   }
-  if (pendingPromise) {
-    console.error('[loadCliConfig] dedup — waiting for pending request');
-    return pendingPromise;
+  const cached = cacheByWorkingDir.get(workingDir);
+  if (cached) {
+    console.error('[loadCliConfig] returning cached config for', workingDir);
+    return cached;
   }
-  pendingPromise = loadCliConfigInternal(workingDir);
+  const pending = pendingByWorkingDir.get(workingDir);
+  if (pending) {
+    console.error('[loadCliConfig] dedup — waiting for pending request for', workingDir);
+    return pending;
+  }
+  const promise = loadCliConfigInternal(workingDir);
+  pendingByWorkingDir.set(workingDir, promise);
   try {
-    const config = await pendingPromise;
-    if (config) cachedConfig = config;
+    const config = await promise;
+    if (config) cacheByWorkingDir.set(workingDir, config);
     return config;
   } finally {
-    pendingPromise = null;
+    pendingByWorkingDir.delete(workingDir);
   }
+}
+
+/** Test-only: clear the workingDir cache between test cases. */
+export function _resetCliConfigCache(): void {
+  cacheByWorkingDir.clear();
+  pendingByWorkingDir.clear();
 }
 
 function killProcess(proc: ChildProcess): void {

--- a/backend/src/core/handlers/getCliConfig.ts
+++ b/backend/src/core/handlers/getCliConfig.ts
@@ -10,11 +10,13 @@ export async function getCliConfigHandler(
   _bridge: Bridge,
 ): Promise<void> {
   try {
-    const workingDir = (message.payload as Record<string, unknown>)?.workingDir as string | undefined;
+    const payload = (message.payload as Record<string, unknown>) ?? {};
+    const workingDir = payload.workingDir as string | undefined;
+    const refresh = payload.refresh === true;
     const cwd = workingDir || process.cwd();
 
-    console.error('[node-backend]', `Loading CLI config for cwd: ${cwd}`);
-    const controlResponse = await loadCliConfig(cwd);
+    console.error('[node-backend]', `Loading CLI config for cwd: ${cwd}${refresh ? ' (refresh)' : ''}`);
+    const controlResponse = await loadCliConfig(cwd, { refresh });
 
     if (controlResponse) {
       console.error('[node-backend]', 'CLI config loaded');

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -67,6 +67,7 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
       currentSessionId: session.currentSessionId,
       sessionState: session.sessionState,
       workingDirectory: session.workingDirectory,
+      inputMode: session.inputMode,
 
       setSessionState: session.setSessionState,
       resetToNewSession: session.resetToNewSession,
@@ -96,6 +97,7 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
       currentSessionId: session.currentSessionId,
       sessionState: session.sessionState,
       workingDirectory: session.workingDirectory,
+      inputMode: session.inputMode,
 
       setSessionState: session.setSessionState,
       resetToNewSession: session.resetToNewSession,

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -170,10 +170,12 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
   }, [showSlashCommands, filteredSections, selectedSectionIndex, selectedItemIndex, executeAndClear, closePanel, moveSelection, onChange]);
 
   const detectSlashCommand = useCallback((newValue: string) => {
-    if (newValue.startsWith('/')) {
-      const query = newValue.substring(1).split(' ')[0];
+    // Show panel only while typing the command name itself. As soon as
+    // whitespace appears the user is typing arguments — keep the panel
+    // hidden so a stray match doesn't override what they typed.
+    if (newValue.startsWith('/') && !/\s/.test(newValue)) {
       setShowSlashCommands(true);
-      setFilterQuery(query);
+      setFilterQuery(newValue.substring(1));
       setSelectedSectionIndex(0);
       setSelectedItemIndex(0);
     } else {

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -123,7 +123,7 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
 
   const handleSlashKeyDown = useCallback((
     e: KeyboardEvent<HTMLTextAreaElement>,
-    _currentValue: string,
+    currentValue: string,
   ): boolean => {
     if (!showSlashCommands) return false;
 
@@ -137,6 +137,18 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
       // No matching command — close panel, let normal submit handle it
       closePanel();
       return false;
+    }
+    if (e.key === 'Tab' && !e.shiftKey) {
+      e.preventDefault();
+      const section = filteredSections[selectedSectionIndex];
+      const item = section?.items[selectedItemIndex];
+      if (item && item.type === PanelItemType.Command) {
+        const firstSpaceIdx = currentValue.indexOf(' ');
+        const rest = firstSpaceIdx === -1 ? ' ' : currentValue.slice(firstSpaceIdx);
+        onChange(`${(item as CommandItem).name}${rest}`);
+        closePanel();
+      }
+      return true;
     }
     if (e.key === 'ArrowUp') {
       e.preventDefault();
@@ -155,7 +167,7 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
     }
 
     return false;
-  }, [showSlashCommands, filteredSections, executeAndClear, closePanel, moveSelection]);
+  }, [showSlashCommands, filteredSections, selectedSectionIndex, selectedItemIndex, executeAndClear, closePanel, moveSelection, onChange]);
 
   const detectSlashCommand = useCallback((newValue: string) => {
     if (newValue.startsWith('/')) {

--- a/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
+++ b/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
@@ -1,11 +1,14 @@
 import { StaticItem } from '../../types';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
-import { getModelDef } from '@/types/models';
+import { useCliConfig } from '@/contexts/CliConfigContext';
 
 const SwitchModelValue = () => {
   const { sessionModel } = useChatStreamContext();
-  const text = sessionModel ? getModelDef(sessionModel).label : 'Default';
+  const { controlResponse } = useCliConfig();
+  const models = controlResponse?.response?.response?.models ?? [];
+  const info = sessionModel ? models.find((m) => m.value === sessionModel) : null;
+  const text = info?.displayName ?? (sessionModel ?? 'Default');
   return (
     <span className="text-[11px] text-zinc-400 whitespace-nowrap">
       {text}

--- a/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
+++ b/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
@@ -2,24 +2,25 @@ import { useEffect } from 'react';
 import { StaticItem } from '../../types';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
-import { ClaudeModel } from '@/types/models';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+import { toModelAlias } from '@/types/models';
+import type { ModelInfo } from '@/types/slashCommand';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 
 export const FAST_MODE_TOGGLE_EVENT = 'fast-mode-toggle';
 
-function isOpusModel(sessionModel: ClaudeModel | null, settingsModel: string | null): boolean {
-  if (sessionModel === ClaudeModel.OPUS) return true;
-  if (sessionModel === ClaudeModel.DEFAULT || sessionModel === null) {
-    // settingsModel이 null/undefined이면 CLI 기본 모델(Opus)을 사용 중
-    if (!settingsModel) return true;
-    return settingsModel.includes('opus');
-  }
-  return false;
+function resolveActiveModel(
+  models: ModelInfo[],
+  sessionModel: string | null,
+  settingsModel: string | null,
+): ModelInfo | null {
+  const alias = sessionModel ?? (settingsModel ? toModelAlias(settingsModel) : 'default');
+  return models.find((m) => m.value === alias) ?? null;
 }
 
 // disabled를 런타임에 동적으로 변경할 수 있도록 backing field + getter/setter 설정
 let _disabled = false;
-const _toggleFastModeItem = new StaticItem('toggle-fast-mode', 'Toggle fast mode (Opus 4.6 only)', {
+const _toggleFastModeItem = new StaticItem('toggle-fast-mode', 'Toggle fast mode', {
   disabled: false,
   keepOpen: true,
   valueComponent: () => <FastModeToggle />,
@@ -38,27 +39,30 @@ export const toggleFastModeItem = _toggleFastModeItem;
 const FastModeToggle = () => {
   const { settings, updateSetting } = useClaudeSettings();
   const { sessionModel } = useChatStreamContext();
-  const isOpus = isOpusModel(sessionModel, settings.model);
+  const { controlResponse } = useCliConfig();
+  const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
+  const activeModel = resolveActiveModel(models, sessionModel, settings.model);
+  const supportsFastMode = activeModel?.supportsFastMode ?? false;
   const enabled = settings.preferFastMode ?? false;
 
-  // 행(row) disabled 상태를 isOpus에 따라 동적으로 갱신
-  (toggleFastModeItem as unknown as { disabled: boolean }).disabled = !isOpus;
+  // 행(row) disabled 상태를 supportsFastMode에 따라 동적으로 갱신
+  (toggleFastModeItem as unknown as { disabled: boolean }).disabled = !supportsFastMode;
 
-  // 행(row) 클릭 시 발생하는 이벤트 처리 (isOpus일 때만 토글)
+  // 행(row) 클릭 시 발생하는 이벤트 처리 (지원되는 모델일 때만 토글)
   useEffect(() => {
     const handler = () => {
-      if (!isOpus) return;
+      if (!supportsFastMode) return;
       void updateSetting('preferFastMode', !enabled);
     };
     window.addEventListener(FAST_MODE_TOGGLE_EVENT, handler);
     return () => window.removeEventListener(FAST_MODE_TOGGLE_EVENT, handler);
-  }, [isOpus, enabled, updateSetting]);
+  }, [supportsFastMode, enabled, updateSetting]);
 
   return (
     <ToggleSwitch
       checked={enabled}
       onChange={(value) => void updateSetting('preferFastMode', value)}
-      disabled={!isOpus}
+      disabled={!supportsFastMode}
       size="small"
     />
   );

--- a/webview/src/commandPalette/sections/slashCommands/CliPassthroughCommand.ts
+++ b/webview/src/commandPalette/sections/slashCommands/CliPassthroughCommand.ts
@@ -1,5 +1,4 @@
 import { SlashCommand } from '../../types';
-import { InputModeValues } from '@/types/chatInput';
 import type { SlashCommandInfo } from '@/types/slashCommand';
 
 export class CliPassthroughCommand extends SlashCommand {
@@ -22,11 +21,11 @@ export class CliPassthroughCommand extends SlashCommand {
   }
 
   async execute(): Promise<void> {
-    const { chatStream } = this.getServices();
+    const { chatStream, session } = this.getServices();
     const currentInput = chatStream.input.trim();
     // Send full input (with args) when the user typed this command directly,
     // otherwise send just the command name (e.g. clicked from palette).
     const message = currentInput.startsWith(this.label) ? currentInput : this.label;
-    chatStream.sendMessage(message, InputModeValues.AUTO_EDIT);
+    chatStream.sendMessage(message, session.inputMode);
   }
 }

--- a/webview/src/commandPalette/sections/slashCommands/__tests__/CliPassthroughCommand.test.ts
+++ b/webview/src/commandPalette/sections/slashCommands/__tests__/CliPassthroughCommand.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { CliPassthroughCommand } from '../CliPassthroughCommand';
+import { InputModeValues, type InputMode } from '@/types/chatInput';
+import { SessionState } from '@/types';
+import type { CommandPaletteServices } from '../../../types';
+import type { SlashCommandInfo } from '@/types/slashCommand';
+
+function makeServices(overrides: {
+  inputMode: InputMode;
+  input?: string;
+}): { services: CommandPaletteServices; sendMessage: ReturnType<typeof vi.fn> } {
+  const sendMessage = vi.fn();
+  const services: CommandPaletteServices = {
+    chatStream: {
+      messages: [],
+      isStreaming: false,
+      input: overrides.input ?? '',
+      setInput: vi.fn(),
+      sendMessage,
+      stop: vi.fn(),
+      continue: vi.fn(),
+      clearMessages: vi.fn(),
+      resetStreamState: vi.fn(),
+      resetForSessionSwitch: vi.fn(),
+    },
+    session: {
+      currentSessionId: null,
+      sessionState: SessionState.Idle,
+      workingDirectory: '/tmp',
+      inputMode: overrides.inputMode,
+      setSessionState: vi.fn(),
+      resetToNewSession: vi.fn(),
+    },
+    adapter: {
+      openNewTab: vi.fn().mockResolvedValue(undefined),
+      openSettings: vi.fn().mockResolvedValue(undefined),
+      openTerminal: vi.fn().mockResolvedValue(undefined),
+    },
+  };
+  return { services, sendMessage };
+}
+
+function makeCommand(services: CommandPaletteServices, info: Partial<SlashCommandInfo> = {}): CliPassthroughCommand {
+  const cmd = new CliPassthroughCommand({
+    name: info.name ?? 'dummy',
+    description: info.description ?? 'dummy command',
+    argumentHint: info.argumentHint ?? '',
+  });
+  cmd._bind(() => services);
+  return cmd;
+}
+
+describe('CliPassthroughCommand.execute', () => {
+  // Regression test for bug where palette-launched slash commands hardcoded
+  // AUTO_EDIT (acceptEdits), ignoring the user's selected InputModeTag.
+  // See bb87c3a (textarea Enter path) — palette Enter path was missed.
+  it('sends with the current session inputMode (BYPASS)', async () => {
+    const { services, sendMessage } = makeServices({ inputMode: InputModeValues.BYPASS });
+    const cmd = makeCommand(services);
+
+    await cmd.execute();
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith('/dummy', InputModeValues.BYPASS);
+  });
+
+  it('sends with PLAN mode when session is in plan mode', async () => {
+    const { services, sendMessage } = makeServices({ inputMode: InputModeValues.PLAN });
+    const cmd = makeCommand(services);
+
+    await cmd.execute();
+
+    expect(sendMessage).toHaveBeenCalledWith('/dummy', InputModeValues.PLAN);
+  });
+
+  it('does not hardcode AUTO_EDIT when user mode is ASK_BEFORE_EDIT', async () => {
+    const { services, sendMessage } = makeServices({ inputMode: InputModeValues.ASK_BEFORE_EDIT });
+    const cmd = makeCommand(services);
+
+    await cmd.execute();
+
+    expect(sendMessage).toHaveBeenCalledWith('/dummy', InputModeValues.ASK_BEFORE_EDIT);
+    expect(sendMessage).not.toHaveBeenCalledWith(expect.anything(), InputModeValues.AUTO_EDIT);
+  });
+
+  it('sends only the command label when invoked from palette click (input does not start with label)', async () => {
+    const { services, sendMessage } = makeServices({
+      inputMode: InputModeValues.BYPASS,
+      input: '',
+    });
+    const cmd = makeCommand(services);
+
+    await cmd.execute();
+
+    expect(sendMessage).toHaveBeenCalledWith('/dummy', InputModeValues.BYPASS);
+  });
+
+  it('sends full input with args when user typed the command directly', async () => {
+    const { services, sendMessage } = makeServices({
+      inputMode: InputModeValues.BYPASS,
+      input: '/dummy some args',
+    });
+    const cmd = makeCommand(services);
+
+    await cmd.execute();
+
+    expect(sendMessage).toHaveBeenCalledWith('/dummy some args', InputModeValues.BYPASS);
+  });
+});

--- a/webview/src/commandPalette/types.ts
+++ b/webview/src/commandPalette/types.ts
@@ -27,6 +27,7 @@ export interface CommandPaletteServices {
     currentSessionId: string | null;
     sessionState: SessionState;
     workingDirectory: string | null;
+    inputMode: InputMode;
     setSessionState: (state: SessionState) => void;
     resetToNewSession: () => void;
   };

--- a/webview/src/commandPalette/ui/CommandPalettePanel.tsx
+++ b/webview/src/commandPalette/ui/CommandPalettePanel.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import { PanelSection, PanelItem } from '@/types/commandPalette';
 import { useVersionInfo } from '@/hooks/useVersionInfo';
+import { useCliConfig } from '@/contexts/CliConfigContext';
 import { PanelSectionComponent } from './PanelSectionComponent';
 
 interface CommandPalettePanelProps {
@@ -23,6 +24,20 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
   const panelRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
   const { pluginVersion, cliVersion } = useVersionInfo();
+  const { refresh } = useCliConfig();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (refreshing) return;
+    setRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   // Auto-scroll selected item into view
   useEffect(() => {
@@ -80,9 +95,19 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
       ))}
 
       <div className="text-[11px] flex items-center justify-between px-3 pt-2 pb-3 -mt-2.5">
-        <a className="text-zinc-500 underline hover:text-zinc-300" href="https://github.com/anthropics/claude-code/issues" target="_blank">
-          Report a problem
-        </a>
+        <div className="flex items-center gap-3">
+          <a className="text-zinc-500 underline hover:text-zinc-300" href="https://github.com/anthropics/claude-code/issues" target="_blank">
+            Report a problem
+          </a>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="text-zinc-500 underline hover:text-zinc-300 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {refreshing ? 'Reloading…' : 'Reload commands'}
+          </button>
+        </div>
         <div className="text-zinc-400/80">
           {cliVersion ? `v${pluginVersion} · Claude Code ${cliVersion}` : `v${pluginVersion}`}
         </div>

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -4,7 +4,8 @@ import { useDiffs } from '../hooks/useDiffs';
 import { useTools } from '../hooks/useTools';
 import { useBridgeContext } from './BridgeContext';
 import { useSessionContext } from './SessionContext';
-import { LoadedMessageDto, Context, Attachment, SessionState, ClaudeModel, parseClaudeModel } from '../types';
+import { LoadedMessageDto, Context, Attachment, SessionState } from '../types';
+import { toModelAlias } from '@/types/models';
 import { InputMode, InputModeValues } from '../types/chatInput';
 
 /** 스트리밍 중 큐잉된 메시지의 bridge payload */
@@ -55,8 +56,8 @@ interface ChatStreamContextType {
 
   // Session lifecycle
   systemInit: Record<string, unknown> | null;
-  sessionModel: ClaudeModel | null;
-  setSessionModel: (model: ClaudeModel | null) => void;
+  sessionModel: string | null;
+  setSessionModel: (model: string | null) => void;
   resetForSessionSwitch: () => void;
 
   // Context window usage
@@ -86,7 +87,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
   const [input, setInput] = useState('');
   const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
   const toggleThinkingExpanded = useCallback(() => setIsThinkingExpanded(prev => !prev), []);
-  const [sessionModel, setSessionModel] = useState<ClaudeModel | null>(null);
+  const [sessionModel, setSessionModel] = useState<string | null>(null);
 
   // Save input draft to localStorage for tab move/split restoration.
   // Skip the first mount to prevent the initial empty input from clearing
@@ -152,7 +153,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
   useEffect(() => {
     if (chatStream.systemInit) {
       const rawModel = (chatStream.systemInit as Record<string, unknown>).model as string | null ?? null;
-      setSessionModel(parseClaudeModel(rawModel));
+      setSessionModel(rawModel ? toModelAlias(rawModel) : null);
     }
   }, [chatStream.systemInit]);
 

--- a/webview/src/contexts/CliConfigContext.tsx
+++ b/webview/src/contexts/CliConfigContext.tsx
@@ -6,6 +6,7 @@ import type { CliConfigControlResponse } from '@/types/slashCommand';
 interface CliConfigContextValue {
   controlResponse: CliConfigControlResponse | null;
   isLoading: boolean;
+  refresh: () => Promise<void>;
 }
 
 const CliConfigContext = createContext<CliConfigContextValue | null>(null);
@@ -21,11 +22,14 @@ export function CliConfigProvider(props: Props) {
   const [controlResponse, setControlResponse] = useState<CliConfigControlResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  const fetchCliConfig = useCallback(async () => {
+  const fetchCliConfig = useCallback(async (refresh = false) => {
     if (!isConnected) return;
 
     try {
-      const response = await send('GET_CLI_CONFIG', { workingDir: workingDirectory ?? undefined });
+      const response = await send('GET_CLI_CONFIG', {
+        workingDir: workingDirectory ?? undefined,
+        refresh,
+      });
       const cr = (response as Record<string, unknown>)?.controlResponse as CliConfigControlResponse | undefined;
       if (cr) {
         setControlResponse(cr);
@@ -43,8 +47,10 @@ export function CliConfigProvider(props: Props) {
     fetchCliConfig();
   }, [fetchCliConfig]);
 
+  const refresh = useCallback(() => fetchCliConfig(true), [fetchCliConfig]);
+
   return (
-    <CliConfigContext.Provider value={{ controlResponse, isLoading }}>
+    <CliConfigContext.Provider value={{ controlResponse, isLoading, refresh }}>
       {children}
     </CliConfigContext.Provider>
   );

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -8,6 +8,41 @@ import { parsePartialJson } from '../utils/parsePartialJson';
 /** Re-export for backwards compatibility */
 export type { LoadedMessageDto as LoadedMessage } from '../types';
 
+interface ModelUsageEntry {
+  contextWindow?: number;
+  maxOutputTokens?: number;
+}
+
+/**
+ * Resolve modelUsage entry for the currently running model.
+ * The CLI's modelUsage dict may be keyed by a form that differs slightly
+ * from the `model` string in the same result event (e.g. `claude-opus-4-7`
+ * vs `claude-opus-4-7[1m]`), so we try direct match, variant-suffix strip,
+ * alias contains, and a single-key fallback before giving up.
+ */
+function pickModelUsage(
+  modelUsage: Record<string, ModelUsageEntry> | null | undefined,
+  model: string | null | undefined,
+): ModelUsageEntry | null {
+  if (!modelUsage) return null;
+  if (model && modelUsage[model]) return modelUsage[model];
+  if (model) {
+    const stripped = model.replace(/\[.*\]$/, '');
+    if (stripped !== model && modelUsage[stripped]) return modelUsage[stripped];
+    const lowered = model.toLowerCase();
+    for (const alias of ['opus', 'sonnet', 'haiku']) {
+      if (lowered.includes(alias) && modelUsage[alias]) return modelUsage[alias];
+    }
+    // Last chance: any key of modelUsage that shares a common stem with model
+    for (const key of Object.keys(modelUsage)) {
+      if (key && (model.startsWith(key) || key.startsWith(stripped))) return modelUsage[key];
+    }
+  }
+  const keys = Object.keys(modelUsage);
+  if (keys.length === 1) return modelUsage[keys[0]];
+  return null;
+}
+
 export interface UseChatStreamOptions {
   /** BridgeContext에서 가져온 bridge. subscribe/send/isConnected 포함. */
   bridge: {
@@ -770,18 +805,20 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
           onErrorRef.current?.(err);
         }
 
-        // result 이벤트에서 modelUsage를 통해 contextWindow/maxOutputTokens 업데이트
+        // result 이벤트에서 modelUsage를 통해 contextWindow/maxOutputTokens 업데이트.
+        // CLI 의 modelUsage 키와 model 문자열이 정확히 같지 않을 수 있어
+        // (예: `claude-opus-4-7[1m]` vs `claude-opus-4-7`) 퍼지 매칭을 시도한다.
         const modelUsage = cliEvent.modelUsage as Record<string, { contextWindow?: number; maxOutputTokens?: number }> | null;
         const currentModel = cliEvent.model as string | null;
-        if (modelUsage && currentModel) {
-          const modelData = modelUsage[currentModel];
-          if (modelData) {
-            setContextWindowUsage(prev => ({
-              totalTokens: prev?.totalTokens ?? 0,
-              contextWindow: modelData.contextWindow ?? prev?.contextWindow ?? 200_000,
-              maxOutputTokens: modelData.maxOutputTokens ?? prev?.maxOutputTokens ?? 0,
-            }));
-          }
+        const modelData = pickModelUsage(modelUsage, currentModel);
+        if (modelData) {
+          setContextWindowUsage(prev => ({
+            totalTokens: prev?.totalTokens ?? 0,
+            contextWindow: modelData.contextWindow ?? prev?.contextWindow ?? 200_000,
+            maxOutputTokens: modelData.maxOutputTokens ?? prev?.maxOutputTokens ?? 0,
+          }));
+        } else if (modelUsage && currentModel) {
+          console.warn('[useChatStream] modelUsage key miss for', currentModel, 'keys:', Object.keys(modelUsage));
         }
 
         // 스트리밍 종료

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -317,7 +317,7 @@ export function ChatInput() {
       e.preventDefault();
       onChange(historyValue);
     }
-  }, [disabled, value, attachments.length, onSubmit, inputHistory, onChange, palette, mention, cycleMode, clearAttachments]);
+  }, [disabled, value, attachments.length, onSubmit, inputHistory, onChange, palette, mention, cycleMode, clearAttachments, mode]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -3,29 +3,12 @@ import { CheckIcon } from '@heroicons/react/24/outline';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useBridge } from '@/hooks/useBridge';
 import { useSessionContext } from '@/contexts/SessionContext';
-import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
-import { ClaudeModel, LoadedMessageType } from '@/types';
-import { CLAUDE_MODELS, getModelDef, parseClaudeModel } from '@/types/models';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+import { LoadedMessageType } from '@/types';
+import { DEFAULT_MODEL_ALIAS } from '@/types/models';
+import type { ModelInfo } from '@/types/slashCommand';
 
 export const SWITCH_MODEL_EVENT = 'switch-model';
-
-interface ModelOption {
-  value: ClaudeModel;
-  label: string;
-  sublabel: string;
-}
-
-function buildDefaultSublabel(modelValue: string | null | undefined): string {
-  if (!modelValue) {
-    return 'Claude Code default · Most capable for complex work';
-  }
-  const parsed = parseClaudeModel(modelValue);
-  if (parsed && parsed !== ClaudeModel.DEFAULT) {
-    const def = getModelDef(parsed);
-    return def.id ? `${def.label} (${def.id})` : def.label;
-  }
-  return modelValue;
-}
 
 interface ModelSwitchOverlayProps {
   onClose: () => void;
@@ -35,17 +18,11 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
   const { sessionModel, setSessionModel, appendMessage } = useChatStreamContext();
   const { send } = useBridge();
   const { currentSessionId } = useSessionContext();
-  const { settings } = useClaudeSettings();
+  const { controlResponse } = useCliConfig();
   const panelRef = useRef<HTMLDivElement>(null);
 
-  const currentModel = sessionModel ?? ClaudeModel.DEFAULT;
-  const defaultSublabel = buildDefaultSublabel(settings.model);
-
-  const modelOptions: ModelOption[] = CLAUDE_MODELS.map((m) => ({
-    value: m.key,
-    label: m.label,
-    sublabel: m.key === ClaudeModel.DEFAULT ? defaultSublabel : m.description,
-  }));
+  const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
+  const currentModel = sessionModel ?? DEFAULT_MODEL_ALIAS;
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -67,13 +44,13 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
     };
   }, [onClose]);
 
-  const handleSelect = async (value: ClaudeModel) => {
+  const handleSelect = async (value: string) => {
     setSessionModel(value);
 
-    const def = getModelDef(value);
-    const notificationText = def.id
-      ? `Set model to ${def.label.toLowerCase()} (${def.id})`
-      : `Set model to ${def.label}`;
+    const info = models.find((m) => m.value === value);
+    const notificationText = info
+      ? `Set model to ${info.displayName}`
+      : `Set model to ${value}`;
 
     appendMessage({
       type: LoadedMessageType.Notification,
@@ -87,10 +64,6 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
     }
 
     onClose();
-  };
-
-  const isSelected = (option: ModelOption): boolean => {
-    return currentModel === option.value;
   };
 
   return (
@@ -116,22 +89,24 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
 
       {/* Model list */}
       <div className="pb-1.5 px-1">
-        {modelOptions.map((opt) => {
-          const selected = isSelected(opt);
+        {models.length === 0 ? (
+          <div className="px-2 py-1 text-[12px] text-zinc-500">Loading models…</div>
+        ) : models.map((m) => {
+          const selected = currentModel === m.value;
           return (
             <button
-              key={opt.value}
-              onClick={() => void handleSelect(opt.value)}
+              key={m.value}
+              onClick={() => void handleSelect(m.value)}
               className={`w-full relative flex items-center justify-between px-2 py-1 rounded-md text-left transition-colors ${
                 selected ? 'bg-white/10' : 'hover:bg-white/5'
               }`}
             >
               <span className="flex flex-col min-w-0">
                 <span className={`leading-tight text-[13px] truncate ${selected ? 'text-zinc-100' : 'text-zinc-200'}`}>
-                  {opt.label}
+                  {m.displayName}
                 </span>
                 <span className="leading-normal text-[11px] truncate text-zinc-400/80">
-                  {opt.sublabel}
+                  {m.description}
                 </span>
               </span>
               {selected && (

--- a/webview/src/pages/SettingsPage/Cli/index.tsx
+++ b/webview/src/pages/SettingsPage/Cli/index.tsx
@@ -6,7 +6,8 @@ import { useBridge } from '@/hooks/useBridge';
 import { SettingKey } from '@/types/settings';
 import { ROUTE_META, Route } from '@/router/routes';
 import { isJetBrains } from '@/config/environment';
-import { CLAUDE_MODELS } from '@/types/models';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+import { toModelAlias } from '@/types/models';
 
 interface TerminalInfo {
   id: string;
@@ -28,6 +29,8 @@ export function CliSettings() {
   const { send } = useBridge();
   const isJetBrainsEnv = isJetBrains();
   const { settings: claudeSettings, updateSetting: updateClaudeSetting } = useClaudeSettings();
+  const { controlResponse } = useCliConfig();
+  const availableModels = controlResponse?.response?.response?.models ?? [];
 
   const [terminals, setTerminals] = useState<TerminalInfo[]>([]);
   const [loading, setLoading] = useState(true);
@@ -123,13 +126,15 @@ export function CliSettings() {
           description="Default model for new sessions"
         >
           <select
-            value={claudeSettings.model ?? ''}
+            value={claudeSettings.model ? toModelAlias(claudeSettings.model) : ''}
             onChange={(e) => void updateClaudeSetting('model', e.target.value || null)}
             className="bg-zinc-800 border border-zinc-700 rounded-lg px-3 py-1.5 text-sm text-zinc-100"
           >
-            {CLAUDE_MODELS.map((m) => (
-              <option key={m.key} value={m.id ?? ''}>
-                {m.label}
+            {availableModels.length === 0 ? (
+              <option value="">Default (recommended)</option>
+            ) : availableModels.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.displayName}
               </option>
             ))}
           </select>

--- a/webview/src/types/effort.ts
+++ b/webview/src/types/effort.ts
@@ -10,7 +10,7 @@
  * `auto` is a plugin-side sentinel meaning "use the CLI default" — it is
  * persisted to `~/.claude/settings.json` as `effortLevel: null`.
  */
-import { parseClaudeModel, ClaudeModel } from './models';
+import { toModelAlias, DEFAULT_MODEL_ALIAS } from './models';
 import type { CliConfigControlResponse, ModelInfo } from './slashCommand';
 
 export const EFFORT_AUTO = 'auto';
@@ -86,8 +86,8 @@ export function getModelEffortConfig(
   settingsModel: string | null | undefined,
 ): ModelEffortConfig {
   const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
-  const modelKey = parseClaudeModel(settingsModel) ?? ClaudeModel.DEFAULT;
-  const info = models.find((m) => m.value === modelKey);
+  const alias = settingsModel ? toModelAlias(settingsModel) : DEFAULT_MODEL_ALIAS;
+  const info = models.find((m) => m.value === alias);
   if (!info?.supportsEffort) return { supportsEffort: false, levels: [] };
   return { supportsEffort: true, levels: info.supportedEffortLevels ?? [] };
 }

--- a/webview/src/types/models.ts
+++ b/webview/src/types/models.ts
@@ -1,40 +1,18 @@
-export enum ClaudeModel {
-  DEFAULT = 'default',
-  OPUS = 'opus',
-  HAIKU = 'haiku',
-  SONNET = 'sonnet',
-}
-
-export interface ClaudeModelDef {
-  key: ClaudeModel;
-  id: string | null;    // CLI에 넘기는 실제 모델 ID (null = default)
-  label: string;        // UI 표시 이름
-  description: string;  // 간략한 설명
-}
-
-export const CLAUDE_MODELS: ClaudeModelDef[] = [
-  { key: ClaudeModel.DEFAULT, id: null,                         label: 'Default (recommended)', description: 'Uses CLI default for your plan' },
-  { key: ClaudeModel.SONNET,  id: 'claude-sonnet-4-6',          label: 'Sonnet 4.6',            description: 'Best for everyday tasks' },
-  { key: ClaudeModel.HAIKU,   id: 'claude-haiku-4-5-20251001',  label: 'Haiku 4.5',             description: 'Fastest for quick answers' },
-  { key: ClaudeModel.OPUS,    id: 'claude-opus-4-6',            label: 'Opus 4.6',              description: 'Most capable for complex work' },
-];
-
-export function getModelDef(key: ClaudeModel): ClaudeModelDef {
-  return CLAUDE_MODELS.find((m) => m.key === key) ?? CLAUDE_MODELS[0];
-}
-
 /**
- * Claude CLI가 반환하는 모델 문자열(예: 'claude-opus-4-6')을 ClaudeModel enum으로 변환.
- * 알 수 없는 값이면 null 반환.
+ * CLI model alias ("default", "opus", "sonnet", "haiku") used by the
+ * Claude Code CLI as the short form of `ModelInfo.value` in the
+ * initialize control_response. Full model IDs such as
+ * `claude-opus-4-7[1m]` are mapped to one of these aliases via
+ * `toModelAlias`.
  */
-export function parseClaudeModel(model: string | null | undefined): ClaudeModel | null {
-  if (!model) return null;
-  if (model === 'default') return ClaudeModel.DEFAULT;
-  const exact = CLAUDE_MODELS.find((m) => m.id === model);
-  if (exact) return exact.key;
-  // fallback: partial match
-  if (model.includes('opus')) return ClaudeModel.OPUS;
-  if (model.includes('haiku')) return ClaudeModel.HAIKU;
-  if (model.includes('sonnet')) return ClaudeModel.SONNET;
-  return null;
+export const DEFAULT_MODEL_ALIAS = 'default';
+
+export function toModelAlias(value: string | null | undefined): string {
+  if (!value) return DEFAULT_MODEL_ALIAS;
+  if (value === DEFAULT_MODEL_ALIAS) return DEFAULT_MODEL_ALIAS;
+  if (value === 'opus' || value === 'sonnet' || value === 'haiku') return value;
+  if (value.includes('opus')) return 'opus';
+  if (value.includes('sonnet')) return 'sonnet';
+  if (value.includes('haiku')) return 'haiku';
+  return DEFAULT_MODEL_ALIAS;
 }


### PR DESCRIPTION
As per request from https://github.com/yhk1038/claude-code-gui-jetbrains/pull/24#issuecomment-4339457762 I am sending this. I am currently testing this to ensure it works properly so there could be some kinks to iron out.
### feat: derive model list from CLI control response
The CLI reports its supported models via the initialize `control_response` (`ModelInfo.value` / `displayName` / `supportsEffort` / `supportedEffortLevels`). Drop the hardcoded `ClaudeModel` enum and `CLAUDE_MODELS` table and source the list from that response so newly added models or aliases are picked up automatically. The UI now talks in terms of the CLI's short alias (`default`/`opus`/`sonnet`/`haiku`); full IDs such as `claude-opus-4-7[1m]` are mapped to one of those aliases via `toModelAlias`. `getCliConfig` also gains an optional `refresh` flag so the list can be re-fetched without restarting the backend.
### fix: hide slash command palette once arguments are typed
`detectSlashCommand` now hides the slash-command palette as soon as whitespace is typed after the command name. Previously the panel stayed open and could grab Enter once the user had moved on to typing arguments, producing a stray match instead of submitting the message.
### fix: propagate latest input mode on Enter submit
`handleKeyDown`'s `useCallback` was missing `mode` from its deps, so the Enter-key submit path captured a stale `mode` from the first render. Cycling the mode tag updated the UI and `SessionContext` but not the captured closure, so submissions sent the original `inputMode` in the `SEND_MESSAGE` payload — spawning the CLI with the wrong `--permission-mode` while the UI showed the new one. The send-button path was unaffected because it's an inline arrow recreated each render.
