### PR TITLE
fix: submit empty value for default model option in CLI settings

### DIFF
--- a/webview/src/pages/SettingsPage/Cli/index.tsx
+++ b/webview/src/pages/SettingsPage/Cli/index.tsx
@@ -7,7 +7,7 @@ import { SettingKey } from '@/types/settings';
 import { ROUTE_META, Route } from '@/router/routes';
 import { isJetBrains } from '@/config/environment';
 import { useCliConfig } from '@/contexts/CliConfigContext';
-import { toModelAlias } from '@/types/models';
+import { DEFAULT_MODEL_ALIAS, toModelAlias } from '@/types/models';
 
 interface TerminalInfo {
   id: string;
@@ -133,7 +133,10 @@ export function CliSettings() {
             {availableModels.length === 0 ? (
               <option value="">Default (recommended)</option>
             ) : availableModels.map((m) => (
-              <option key={m.value} value={m.value}>
+              <option
+                key={m.value}
+                value={m.value === DEFAULT_MODEL_ALIAS ? '' : m.value}
+              >
                 {m.displayName}
               </option>
             ))}


### PR DESCRIPTION
This is the only bug I found in #25 after it was merged.
In `CliSettings`, the select's current `value` is `''` when no model override is set (`claudeSettings.model` is `null`), but the `default` option's `value` was the alias string `"default"`. Two symptoms:
- On first render with no saved model, the select's controlled value didn't match any option, so the displayed selection was inconsistent with the underlying setting.
- Picking the `default` entry stored the literal string `"default"` in `claudeSettings.model` via `updateClaudeSetting('model', e.target.value || null)`, instead of `null` like every other "no override" path in the UI (terminal app, CLI path).
Fix: render the `default` option with `value=""` so it round-trips through the existing `e.target.value || null` mapping and persists as `null`, matching the rest of the settings page.