### PR TITLE
fix(theme): respect IDE LAF when System mode is selected (#45)

### DIFF
--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -92,12 +92,21 @@ async function serveStaticFile(
     return;
   }
 
+  // Hashed bundle assets are content-addressed and safe to cache forever.
+  // Anything else (index.html, SPA fallback) must revalidate so a plugin update
+  // never leaves JCEF pinned to a stale bundle.
+  const isHashedAsset = normalized.startsWith('assets/');
+  const cacheControl = isHashedAsset
+    ? 'public, max-age=31536000, immutable'
+    : 'no-cache, must-revalidate';
+
   try {
     const data = await readFile(filePath);
     const ext = extname(filePath).toLowerCase();
     const contentType = MIME_TYPES[ext] ?? 'application/octet-stream';
     res.writeHead(200, {
       'Content-Type': contentType,
+      'Cache-Control': cacheControl,
       'X-Content-Type-Options': 'nosniff',
       'X-Frame-Options': 'SAMEORIGIN',
     });
@@ -116,6 +125,7 @@ async function serveStaticFile(
       const indexData = await readFile(join(webviewDir, 'index.html'));
       res.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8',
+        'Cache-Control': 'no-cache, must-revalidate',
         'X-Content-Type-Options': 'nosniff',
         'X-Frame-Options': 'SAMEORIGIN',
       });

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,7 +159,11 @@ tasks {
         jvmArgumentProviders += CommandLineArgumentProvider {
             listOf(
                 "-Dclaude.dev.mode=${System.getenv("CLAUDE_DEV_MODE") ?: "true"}",
-                "-Dclaude.simulate.no.jcef=${System.getenv("CLAUDE_SIMULATE_NO_JCEF") ?: "false"}"
+                "-Dclaude.simulate.no.jcef=${System.getenv("CLAUDE_SIMULATE_NO_JCEF") ?: "false"}",
+                // Pin the project root so NodeProcessManager.findPluginProjectRoot() can
+                // resolve webview/dist directly instead of falling back to the JAR-extracted
+                // temp directory (which serves stale assets after a wv-build).
+                "-Dplugin.project.root=${projectDir.absolutePath}"
             )
         }
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -310,7 +310,15 @@ class NodeProcessManager(
             return cwd
         }
 
-        // Heuristic 2: Check environment variable
+        // Heuristic 2: Check system property (set by runIde task in build.gradle.kts)
+        System.getProperty("plugin.project.root")?.let { root ->
+            val rootFile = File(root)
+            if (rootFile.exists() && File(rootFile, "backend/dist/backend.mjs").exists()) {
+                return rootFile
+            }
+        }
+
+        // Heuristic 3: Check environment variable (manual override)
         System.getenv("PLUGIN_PROJECT_ROOT")?.let { root ->
             val rootFile = File(root)
             if (rootFile.exists() && File(rootFile, "backend/dist/backend.mjs").exists()) {
@@ -318,7 +326,7 @@ class NodeProcessManager(
             }
         }
 
-        // Heuristic 3: Walk up from class location
+        // Heuristic 4: Walk up from class location
         try {
             val classUrl = javaClass.protectionDomain.codeSource?.location?.toURI()
             if (classUrl != null) {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -48,6 +48,17 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
 
         /** Whether the IME NPE workaround has been applied. */
         var imeWorkaroundInstalled: Boolean = false
+
+        /** Whether the LAF (IDE theme) change listener has been installed. */
+        var lafListenerInstalled: Boolean = false
+
+        /**
+         * Parent Disposable for the LAF listener. Disposing this removes the listener
+         * from LafManager. Tied to the browser holder lifecycle (NOT the panel) so
+         * the listener survives tab move/split. Set when the listener is installed,
+         * disposed in [release] and the service's [dispose].
+         */
+        var lafListenerDisposable: Disposable? = null
     }
 
     private val holders = ConcurrentHashMap<String, BrowserHolder>()
@@ -87,6 +98,7 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
     fun release(sessionId: String) {
         holders.remove(sessionId)?.let { holder ->
             logger.info("Releasing JCEF browser for session: $sessionId")
+            try { holder.lafListenerDisposable?.let { Disposer.dispose(it) } } catch (_: Exception) {}
             try { Disposer.dispose(holder.streamingQuery) } catch (_: Exception) {}
             try { Disposer.dispose(holder.cursorQuery) } catch (_: Exception) {}
             try { Disposer.dispose(holder.browser) } catch (_: Exception) {}
@@ -95,6 +107,7 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
 
     override fun dispose() {
         holders.values.forEach { holder ->
+            try { holder.lafListenerDisposable?.let { Disposer.dispose(it) } } catch (_: Exception) {}
             try { Disposer.dispose(holder.streamingQuery) } catch (_: Exception) {}
             try { Disposer.dispose(holder.cursorQuery) } catch (_: Exception) {}
             try { Disposer.dispose(holder.browser) } catch (_: Exception) {}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -14,6 +14,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefJSQuery
@@ -187,6 +188,10 @@ class ClaudeCodePanel(
                     // Mark JCEF environment so detectRuntime() in environment.ts can detect
                     // the JetBrains environment and select JetBrainsAdapter over BrowserAdapter.
                     frame.executeJavaScript("window.__JCEF__ = true;", frame.url, 0)
+                    // Inject the current IDE LAF theme so SettingsContext can resolve
+                    // SYSTEM mode against the IDE rather than the OS prefers-color-scheme.
+                    val ideTheme = if (com.intellij.ui.JBColor.isBright()) "light" else "dark"
+                    frame.executeJavaScript("window.__IDE_THEME__ = '$ideTheme';", frame.url, 0)
                     injectCursorTracking(frame)
                     injectStreamingStateBridge(frame)
                     installImeWorkaround()
@@ -197,6 +202,11 @@ class ClaudeCodePanel(
                 }
             }
         }, b.cefBrowser)
+
+        // Install LAF (IDE theme) change listener — once per browser holder.
+        // The listener lifetime is tied to the holder (not the panel) so it
+        // survives tab move/split. Removed in ClaudeCodeBrowserService.release().
+        installLafListener()
 
         // Title change detection, address change tracking, and console log capture
         b.jbCefClient.addDisplayHandler(object : CefDisplayHandlerAdapter() {
@@ -372,6 +382,53 @@ class ClaudeCodePanel(
             traverseAndWrap(browser!!.component)
             holder.imeWorkaroundInstalled = true
             logger.info("JCEF IME NPE workaround installed")
+        }
+    }
+
+    /**
+     * Subscribe to IDE Look-and-Feel changes and propagate them to the WebView
+     * by updating window.__IDE_THEME__ and dispatching the 'ide-theme-changed'
+     * event. Idempotent per browser holder.
+     *
+     * Lifetime: the LafManager listener is owned by a child Disposable stored on
+     * the [ClaudeCodeBrowserService.BrowserHolder]. The holder (and thus the
+     * listener) survives tab move/split. Disposal happens in
+     * [ClaudeCodeBrowserService.release].
+     */
+    // Called only from setupBrowserHandlers() which is only called from initWithJcef() — holder and browser are non-null.
+    private fun installLafListener() {
+        val h = holder!!
+        if (h.lafListenerInstalled) return
+
+        try {
+            // Use the application message bus with a child Disposable so the
+            // subscription lifetime matches the browser holder (tab move/split
+            // safe). This avoids the deprecated LafManager.addLafManagerListener
+            // overloads while still providing automatic unregistration via Disposer.
+            val parent = Disposer.newDisposable("ClaudeCodePanel.lafListener.$sessionId")
+            val connection = ApplicationManager.getApplication().messageBus.connect(parent)
+            connection.subscribe(
+                com.intellij.ide.ui.LafManagerListener.TOPIC,
+                com.intellij.ide.ui.LafManagerListener {
+                    val b = browser ?: return@LafManagerListener
+                    ApplicationManager.getApplication().invokeLater {
+                        val newTheme = if (com.intellij.ui.JBColor.isBright()) "light" else "dark"
+                        val js = "window.__IDE_THEME__ = '$newTheme'; " +
+                            "window.dispatchEvent(new Event('ide-theme-changed'));"
+                        try {
+                            val cef = b.cefBrowser
+                            cef.executeJavaScript(js, cef.url, 0)
+                        } catch (e: Exception) {
+                            logger.warn("Failed to propagate LAF change to WebView", e)
+                        }
+                    }
+                },
+            )
+            h.lafListenerDisposable = parent
+            h.lafListenerInstalled = true
+            logger.info("LafManager listener installed for session: $sessionId")
+        } catch (e: Exception) {
+            logger.warn("Failed to install LafManager listener", e)
         }
     }
 

--- a/webview/src/components/TunnelModal/index.tsx
+++ b/webview/src/components/TunnelModal/index.tsx
@@ -93,7 +93,7 @@ export function TunnelModal(props: Props) {
         {/* Body */}
         <div className="px-4 py-4 space-y-4">
           {error && (
-            <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-fg/10 rounded">
+            <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-bg rounded">
               {error}
             </div>
           )}

--- a/webview/src/config/environment.ts
+++ b/webview/src/config/environment.ts
@@ -43,3 +43,21 @@ export function isMobile(): boolean {
   const userAgent = navigator.userAgent.toLowerCase();
   return /android|iphone|ipad|ipod/.test(userAgent);
 }
+
+// ── IDE 테마 ─────────────────────────────────────────
+// JetBrains JCEF 환경에서만 의미 있음. Kotlin이 페이지 로드 시점에 LAF 값을
+// window.__IDE_THEME__ 에 주입하고, LAF가 바뀌면 'ide-theme-changed' 이벤트를 dispatch한다.
+
+/** Returns the IDE LAF theme hint if available, otherwise null. */
+export function getIdeTheme(): 'dark' | 'light' | null {
+  if (typeof window === 'undefined') return null;
+  const v = window.__IDE_THEME__;
+  return v === 'dark' || v === 'light' ? v : null;
+}
+
+/** Subscribe to IDE LAF changes. Returns an unsubscribe function. */
+export function subscribeIdeTheme(cb: () => void): () => void {
+  if (typeof window === 'undefined') return () => { /* no-op */ };
+  window.addEventListener('ide-theme-changed', cb);
+  return () => window.removeEventListener('ide-theme-changed', cb);
+}

--- a/webview/src/contexts/SettingsContext.tsx
+++ b/webview/src/contexts/SettingsContext.tsx
@@ -2,6 +2,7 @@ import { createContext, useContext, useState, useEffect, useCallback, type React
 import { SettingsState, DEFAULT_SETTINGS, SettingKey, ThemeMode } from '@/types/settings';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { useWorkingDir } from '@/contexts/WorkingDirContext';
+import { isJetBrains, getIdeTheme, subscribeIdeTheme } from '@/config/environment';
 
 interface SettingsContextValue {
   settings: SettingsState;
@@ -117,7 +118,10 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
   // Apply theme to <html> element. Toggles `.dark` class based on theme setting.
   // - LIGHT: explicit light, no `.dark` class
   // - DARK: explicit dark, `.dark` class on
-  // - SYSTEM: follow prefers-color-scheme and subscribe to changes
+  // - SYSTEM:
+  //     * JetBrains: follow IDE LAF (window.__IDE_THEME__) and 'ide-theme-changed' event.
+  //       Fall back to matchMedia when LAF hint is missing (e.g. before Kotlin injects it).
+  //     * Standalone: follow prefers-color-scheme as before.
   useEffect(() => {
     const theme = settings[SettingKey.THEME];
     const applyDark = () => document.documentElement.classList.add('dark');
@@ -131,8 +135,33 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
       applyLight();
       return;
     }
-    // SYSTEM: detect prefers-color-scheme and subscribe to changes
+
+    // SYSTEM mode
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+    if (isJetBrains()) {
+      // JetBrains: prefer IDE LAF hint, fall back to matchMedia when missing.
+      const resolve = () => {
+        const ide = getIdeTheme();
+        if (ide === 'dark') return applyDark();
+        if (ide === 'light') return applyLight();
+        return mq.matches ? applyDark() : applyLight();
+      };
+      resolve();
+      const mqHandler = (e: MediaQueryListEvent) => {
+        // Only react to matchMedia when IDE hint is unavailable.
+        if (getIdeTheme() !== null) return;
+        e.matches ? applyDark() : applyLight();
+      };
+      mq.addEventListener('change', mqHandler);
+      const unsubscribeIde = subscribeIdeTheme(resolve);
+      return () => {
+        mq.removeEventListener('change', mqHandler);
+        unsubscribeIde();
+      };
+    }
+
+    // Standalone: detect prefers-color-scheme and subscribe to changes
     if (mq.matches) applyDark(); else applyLight();
     const handler = (e: MediaQueryListEvent) => (e.matches ? applyDark() : applyLight());
     mq.addEventListener('change', handler);

--- a/webview/src/contexts/__tests__/SettingsContext.theme.test.tsx
+++ b/webview/src/contexts/__tests__/SettingsContext.theme.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act, waitFor } from '@testing-library/react';
+import { SettingsProvider } from '../SettingsContext';
+import { SettingKey, ThemeMode } from '@/types/settings';
+import { _resetRuntimeCache } from '@/config/environment';
+
+// ---------------------------------------------------------------------------
+// Bridge / WorkingDir mocks (minimal — enough for SettingsProvider to mount)
+// ---------------------------------------------------------------------------
+
+// Use a never-resolving send() so the theme effect runs against DEFAULT_SETTINGS
+// (which is ThemeMode.SYSTEM) and is not overwritten by a bridge response.
+const mockSend = vi.fn(() => new Promise(() => { /* never resolves */ }));
+const mockSubscribe = vi.fn(() => () => { /* unsubscribe noop */ });
+
+vi.mock('../BridgeContext', () => ({
+  useBridgeContext: () => ({
+    isConnected: false,
+    send: mockSend,
+    subscribe: mockSubscribe,
+  }),
+}));
+
+vi.mock('../WorkingDirContext', () => ({
+  useWorkingDir: () => ({
+    workingDirectory: '/test/workspace',
+    setWorkingDirectory: vi.fn(),
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// matchMedia mock (jsdom does not provide this)
+// ---------------------------------------------------------------------------
+
+interface MatchMediaState {
+  matches: boolean;
+  listeners: Array<(e: MediaQueryListEvent) => void>;
+}
+
+const matchMediaState: MatchMediaState = {
+  matches: false,
+  listeners: [],
+};
+
+function installMatchMediaMock(initialMatches: boolean) {
+  matchMediaState.matches = initialMatches;
+  matchMediaState.listeners = [];
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: matchMediaState.matches,
+      media: query,
+      onchange: null,
+      addEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+        matchMediaState.listeners.push(listener);
+      },
+      removeEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+        matchMediaState.listeners = matchMediaState.listeners.filter(l => l !== listener);
+      },
+      addListener: () => { /* legacy, unused */ },
+      removeListener: () => { /* legacy, unused */ },
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// JCEF / IDE theme helpers
+// ---------------------------------------------------------------------------
+
+function setJcefEnv(enabled: boolean) {
+  if (enabled) {
+    (window as unknown as { __JCEF__?: boolean }).__JCEF__ = true;
+  } else {
+    delete (window as unknown as { __JCEF__?: boolean }).__JCEF__;
+  }
+  _resetRuntimeCache();
+}
+
+function setIdeTheme(value: 'dark' | 'light' | null) {
+  const w = window as unknown as { __IDE_THEME__?: string };
+  if (value === null) {
+    delete w.__IDE_THEME__;
+  } else {
+    w.__IDE_THEME__ = value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test harness — render SettingsProvider with a given initial theme.
+// We pre-seed localStorage so the initial render uses the desired theme
+// (SettingsProvider loads from localStorage immediately on mount).
+// ---------------------------------------------------------------------------
+
+const STORAGE_KEY = 'claude-code-settings';
+
+function seedTheme(theme: ThemeMode) {
+  try {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ [SettingKey.THEME]: theme }),
+    );
+  } catch {
+    // ignore
+  }
+}
+
+function renderWithTheme(theme: ThemeMode) {
+  seedTheme(theme);
+  return render(
+    <SettingsProvider>
+      <div data-testid="child">child</div>
+    </SettingsProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  try {
+    localStorage.clear();
+  } catch {
+    // ignore
+  }
+  document.documentElement.classList.remove('dark');
+  setJcefEnv(false);
+  setIdeTheme(null);
+  installMatchMediaMock(false);
+});
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark');
+  setJcefEnv(false);
+  setIdeTheme(null);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SettingsContext theme — SYSTEM mode in JetBrains', () => {
+  it('resolves to dark when __IDE_THEME__ is "dark"', async () => {
+    setJcefEnv(true);
+    setIdeTheme('dark');
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  it('resolves to light when __IDE_THEME__ is "light"', async () => {
+    setJcefEnv(true);
+    setIdeTheme('light');
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+
+  it('reacts to ide-theme-changed events (light -> dark)', async () => {
+    setJcefEnv(true);
+    setIdeTheme('light');
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+
+    // Simulate IDE switching to dark mode at runtime
+    act(() => {
+      setIdeTheme('dark');
+      window.dispatchEvent(new Event('ide-theme-changed'));
+    });
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  it('falls back to matchMedia when __IDE_THEME__ is missing', async () => {
+    setJcefEnv(true);
+    setIdeTheme(null);
+    installMatchMediaMock(true); // OS prefers dark
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+});
+
+describe('SettingsContext theme — SYSTEM mode in Standalone (browser)', () => {
+  it('uses matchMedia (prefers-color-scheme: dark) to resolve to dark', async () => {
+    setJcefEnv(false);
+    installMatchMediaMock(true);
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  it('uses matchMedia to resolve to light when OS prefers light', async () => {
+    setJcefEnv(false);
+    installMatchMediaMock(false);
+
+    renderWithTheme(ThemeMode.SYSTEM);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+});
+
+describe('SettingsContext theme — explicit modes', () => {
+  it('DARK applies .dark regardless of JetBrains env', async () => {
+    setJcefEnv(true);
+    setIdeTheme('light'); // IDE is light, but explicit DARK must win
+    installMatchMediaMock(false);
+
+    renderWithTheme(ThemeMode.DARK);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  it('DARK applies .dark in Standalone env', async () => {
+    setJcefEnv(false);
+    installMatchMediaMock(false);
+
+    renderWithTheme(ThemeMode.DARK);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
+    });
+  });
+
+  it('LIGHT removes .dark regardless of JetBrains env', async () => {
+    setJcefEnv(true);
+    setIdeTheme('dark'); // IDE is dark, but explicit LIGHT must win
+    installMatchMediaMock(true);
+    document.documentElement.classList.add('dark'); // start with .dark
+
+    renderWithTheme(ThemeMode.LIGHT);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+
+  it('LIGHT removes .dark in Standalone env', async () => {
+    setJcefEnv(false);
+    installMatchMediaMock(true);
+    document.documentElement.classList.add('dark');
+
+    renderWithTheme(ThemeMode.LIGHT);
+
+    await waitFor(() => {
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
+    });
+  });
+});

--- a/webview/src/hooks/__tests__/useTheme.test.ts
+++ b/webview/src/hooks/__tests__/useTheme.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { ThemeMode } from '../../types';
+import { SettingKey } from '@/types/settings';
+import { _resetRuntimeCache } from '@/config/environment';
+
+// ---------------------------------------------------------------------------
+// useSettings mock — controls the theme value returned to useTheme
+// ---------------------------------------------------------------------------
+
+let currentTheme: ThemeMode = ThemeMode.SYSTEM;
+const updateSettingMock = vi.fn();
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({
+    settings: {
+      [SettingKey.THEME]: currentTheme,
+    },
+    updateSetting: updateSettingMock,
+  }),
+}));
+
+// Imported AFTER vi.mock so the mock is wired up first.
+import { useTheme } from '../useTheme';
+
+// ---------------------------------------------------------------------------
+// matchMedia mock
+// ---------------------------------------------------------------------------
+
+interface MatchMediaState {
+  matches: boolean;
+  listeners: Array<(e: MediaQueryListEvent) => void>;
+}
+
+const matchMediaState: MatchMediaState = {
+  matches: false,
+  listeners: [],
+};
+
+function installMatchMediaMock(initialMatches: boolean) {
+  matchMediaState.matches = initialMatches;
+  matchMediaState.listeners = [];
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: matchMediaState.matches,
+      media: query,
+      onchange: null,
+      addEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+        matchMediaState.listeners.push(listener);
+      },
+      removeEventListener: (_event: string, listener: (e: MediaQueryListEvent) => void) => {
+        matchMediaState.listeners = matchMediaState.listeners.filter(l => l !== listener);
+      },
+      addListener: () => { /* legacy */ },
+      removeListener: () => { /* legacy */ },
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Env helpers
+// ---------------------------------------------------------------------------
+
+function setJcefEnv(enabled: boolean) {
+  if (enabled) {
+    (window as unknown as { __JCEF__?: boolean }).__JCEF__ = true;
+  } else {
+    delete (window as unknown as { __JCEF__?: boolean }).__JCEF__;
+  }
+  _resetRuntimeCache();
+}
+
+function setIdeTheme(value: 'dark' | 'light' | null) {
+  const w = window as unknown as { __IDE_THEME__?: string };
+  if (value === null) {
+    delete w.__IDE_THEME__;
+  } else {
+    w.__IDE_THEME__ = value;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentTheme = ThemeMode.SYSTEM;
+  setJcefEnv(false);
+  setIdeTheme(null);
+  installMatchMediaMock(false);
+});
+
+afterEach(() => {
+  setJcefEnv(false);
+  setIdeTheme(null);
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTheme — SYSTEM mode in JetBrains', () => {
+  it('isDark = true when __IDE_THEME__ is "dark"', () => {
+    setJcefEnv(true);
+    setIdeTheme('dark');
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('isDark = false when __IDE_THEME__ is "light"', () => {
+    setJcefEnv(true);
+    setIdeTheme('light');
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+  });
+
+  it('responds to ide-theme-changed events', () => {
+    setJcefEnv(true);
+    setIdeTheme('light');
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+
+    act(() => {
+      setIdeTheme('dark');
+      window.dispatchEvent(new Event('ide-theme-changed'));
+    });
+
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('falls back to matchMedia when __IDE_THEME__ is missing', () => {
+    setJcefEnv(true);
+    setIdeTheme(null);
+    installMatchMediaMock(true);
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+  });
+});
+
+describe('useTheme — SYSTEM mode in Standalone', () => {
+  it('uses matchMedia (dark)', () => {
+    setJcefEnv(false);
+    installMatchMediaMock(true);
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('uses matchMedia (light)', () => {
+    setJcefEnv(false);
+    installMatchMediaMock(false);
+    currentTheme = ThemeMode.SYSTEM;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+  });
+});
+
+describe('useTheme — explicit modes', () => {
+  it('DARK is dark regardless of env', () => {
+    setJcefEnv(true);
+    setIdeTheme('light');
+    currentTheme = ThemeMode.DARK;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(true);
+  });
+
+  it('LIGHT is not dark regardless of env', () => {
+    setJcefEnv(true);
+    setIdeTheme('dark');
+    currentTheme = ThemeMode.LIGHT;
+
+    const { result } = renderHook(() => useTheme());
+    expect(result.current.isDark).toBe(false);
+  });
+});

--- a/webview/src/hooks/useTheme.ts
+++ b/webview/src/hooks/useTheme.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ThemeMode } from '../types';
 import { SettingKey } from '@/types/settings';
 import { useSettings } from '@/contexts/SettingsContext';
+import { isJetBrains, getIdeTheme, subscribeIdeTheme } from '@/config/environment';
 
 interface UseThemeReturn {
   /** User-facing setting value (SYSTEM | LIGHT | DARK). */
@@ -29,7 +30,14 @@ export function useTheme(): UseThemeReturn {
   const [isDark, setIsDark] = useState<boolean>(() => {
     if (theme === ThemeMode.DARK) return true;
     if (theme === ThemeMode.LIGHT) return false;
-    return typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (typeof window === 'undefined') return false;
+    // SYSTEM: prefer IDE LAF hint when running inside JetBrains.
+    if (isJetBrains()) {
+      const ide = getIdeTheme();
+      if (ide === 'dark') return true;
+      if (ide === 'light') return false;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
 
   useEffect(() => {
@@ -41,7 +49,30 @@ export function useTheme(): UseThemeReturn {
       setIsDark(false);
       return;
     }
+
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
+
+    if (isJetBrains()) {
+      const resolve = () => {
+        const ide = getIdeTheme();
+        if (ide === 'dark') return setIsDark(true);
+        if (ide === 'light') return setIsDark(false);
+        return setIsDark(mq.matches);
+      };
+      resolve();
+      const mqHandler = (e: MediaQueryListEvent) => {
+        // Only react to matchMedia when IDE hint is unavailable.
+        if (getIdeTheme() !== null) return;
+        setIsDark(e.matches);
+      };
+      mq.addEventListener('change', mqHandler);
+      const unsubscribeIde = subscribeIdeTheme(resolve);
+      return () => {
+        mq.removeEventListener('change', mqHandler);
+        unsubscribeIde();
+      };
+    }
+
     setIsDark(mq.matches);
     const handler = (e: MediaQueryListEvent) => setIsDark(e.matches);
     mq.addEventListener('change', handler);

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -100,6 +100,19 @@
 
   --ide-font-ui:   -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --ide-font-code: 'JetBrains Mono', Consolas, Monaco, monospace;
+
+  /* Markdown */
+  --md-inline-code-bg: rgba(175, 184, 193, 0.2);
+  --md-inline-code-fg: rgba(36, 41, 47, 0.7);
+  --md-code-block-bg: rgba(0, 0, 0, 0.06);
+  --md-code-copy-btn-bg: rgba(0, 0, 0, 0.08);
+  --md-code-copy-btn-bg-hover: rgba(0, 0, 0, 0.16);
+  --md-code-copy-btn-fg: #1e1e1e;
+  --md-blockquote-bg: rgba(0, 0, 0, 0.03);
+  --md-table-border: rgba(0, 0, 0, 0.15);
+
+  /* Tool call rows (IN/OUT labels) */
+  --tool-label-fg: rgba(30, 30, 30, 0.45);
 }
 
 /* ============================================
@@ -163,6 +176,19 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.40);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.50);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.60);
+
+  /* Markdown */
+  --md-inline-code-bg: rgba(127, 251, 255, 0.17);
+  --md-inline-code-fg: rgba(127, 251, 255, 0.8);
+  --md-code-block-bg: rgba(0, 0, 0, 0.15);
+  --md-code-copy-btn-bg: rgba(255, 255, 255, 0.18);
+  --md-code-copy-btn-bg-hover: rgba(255, 255, 255, 0.32);
+  --md-code-copy-btn-fg: #ffffff;
+  --md-blockquote-bg: rgba(255, 255, 255, 0.03);
+  --md-table-border: rgba(255, 255, 255, 0.3);
+
+  /* Tool call rows (IN/OUT labels) */
+  --tool-label-fg: rgba(228, 228, 231, 0.45);
 }
 
 html, body, #root {

--- a/webview/src/pages/ChatPage/StreamErrorBanner/DefaultErrorBanner.tsx
+++ b/webview/src/pages/ChatPage/StreamErrorBanner/DefaultErrorBanner.tsx
@@ -6,7 +6,7 @@ export const DefaultErrorBanner = (props: Props) => {
     const { error } = props;
 
     return (
-        <div className="mx-4 my-2 px-3 py-2 rounded-md bg-state-error-fg/10 border border-state-error-border text-state-error-fg text-xs">
+        <div className="mx-4 my-2 px-3 py-2 rounded-md bg-state-error-bg border border-state-error-border text-state-error-fg text-xs">
             {error.message}
         </div>
     );

--- a/webview/src/pages/ChatPage/StreamErrorBanner/SessionConflictErrorBanner.tsx
+++ b/webview/src/pages/ChatPage/StreamErrorBanner/SessionConflictErrorBanner.tsx
@@ -27,12 +27,12 @@ export const SessionConflictErrorBanner = () => {
     };
 
     return (
-        <div className="mx-4 my-2 px-3 py-2 rounded-md bg-state-error-fg/10 border border-state-error-border text-state-error-fg text-xs flex items-center justify-between gap-2">
+        <div className="mx-4 my-2 px-3 py-2 rounded-md bg-state-error-bg border border-state-error-border text-state-error-fg text-xs flex items-center justify-between gap-2">
             <span>Error: This session is already in use.</span>
             <button
                 onClick={handleReclaim}
                 disabled={isReclaiming}
-                className="shrink-0 px-2 py-0.5 rounded bg-state-error-fg/20 hover:bg-state-error-fg/30 text-state-error-fg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="shrink-0 px-2 py-0.5 rounded bg-state-error-bg hover:bg-state-error-border text-state-error-fg disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
                 {isReclaiming ? (
                     <span className="inline-flex items-center gap-1">

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/EditRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/EditRenderer.tsx
@@ -55,8 +55,8 @@ function fromDiffText(diffText: string): DiffLine[] {
 }
 
 const lineStyles: Record<DiffLineType, string> = {
-    [DiffLineType.Add]: 'bg-state-success-fg/15 text-state-success-fg',
-    [DiffLineType.Delete]: 'bg-state-error-fg/15 text-state-error-fg',
+    [DiffLineType.Add]: 'bg-state-success-bg text-state-success-fg',
+    [DiffLineType.Delete]: 'bg-state-error-bg text-state-error-fg',
     [DiffLineType.Context]: 'text-text-secondary',
 };
 

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/FilesystemMcp/_common.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/FilesystemMcp/_common.tsx
@@ -24,7 +24,7 @@ export const McpToolRow = (props: {label: string; children?: ReactNode}) => {
 
     return (
         <div className="flex items-start gap-2 p-2 border-b border-border-subtle last:border-b-0">
-            <span className="text-text-primary/50 uppercase text-[0.7692rem] min-w-[28px] pt-[1px]">
+            <span className="text-tool-label-fg uppercase text-[0.7692rem] min-w-[28px] pt-[1px]">
                 {label}
             </span>
             <div

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
@@ -96,7 +96,7 @@ export const LabelValue = (props: {
 }
 
 export const Label = ({name}: { name: string }) => {
-    return <div className="text-text-primary/40 min-w-[40px]">{name}</div>
+    return <div className="text-tool-label-fg min-w-[40px]">{name}</div>
 }
 
 export const Value = (props: {

--- a/webview/src/pages/ChatPage/streaming.css
+++ b/webview/src/pages/ChatPage/streaming.css
@@ -162,8 +162,8 @@
 
 [data-streamdown="code-block-body"] > code > span > span,
 [data-streamdown="inline-code"] {
-  background: rgba(127, 251, 255, 0.17) !important;
-  color: rgba(127, 251, 255, 0.8) !important;
+  background: var(--md-inline-code-bg) !important;
+  color: var(--md-inline-code-fg) !important;
   font-family: var(--ide-font-code) !important;
 }
 
@@ -201,7 +201,7 @@
   font-size: 13px !important;
   line-height: 1.5;
   overflow-x: auto;
-  background: rgba(0, 0, 0, 0.15);
+  background: var(--md-code-block-bg);
   border: none !important;
 }
 
@@ -211,9 +211,9 @@
 }
 
 [data-streamdown="code-block-copy-button"] {
-  background: rgba(255, 255, 255, 0.18);
+  background: var(--md-code-copy-btn-bg);
   border: none;
-  color: #fff;
+  color: var(--md-code-copy-btn-fg);
   border-radius: 4px;
   padding: 0.3em 0.6em;
   cursor: pointer;
@@ -223,7 +223,7 @@
 }
 
 [data-streamdown="code-block-copy-button"]:hover {
-  background: rgba(255, 255, 255, 0.32);
+  background: var(--md-code-copy-btn-bg-hover);
   opacity: 1;
 }
 
@@ -248,7 +248,7 @@
   border-left: 3px solid var(--ide-accent);
   padding: 0.5em 1em;
   margin: 0.5em 0;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--md-blockquote-bg);
   color: var(--ide-text-secondary, #71717a);
 }
 
@@ -296,7 +296,7 @@
 [data-streamdown="table-cell"] {
   padding: 0.25em 0.4em !important;
   font-size: inherit !important;
-  border: 1px solid rgba(255, 255, 255, 0.3);
+  border: 1px solid var(--md-table-border);
 }
 
 [data-streamdown="table-header-cell"] {

--- a/webview/src/pages/SettingsPage/Appearance/index.tsx
+++ b/webview/src/pages/SettingsPage/Appearance/index.tsx
@@ -2,6 +2,7 @@ import { SettingSection, SettingRow } from '../common';
 import { useSettings } from '@/contexts/SettingsContext';
 import { SettingKey, ThemeMode } from '@/types/settings';
 import { ROUTE_META, Route } from '@/router/routes';
+import { isJetBrains } from '@/config/environment';
 
 const NOT_SET_VALUE = '__NOT_SET__';
 
@@ -49,7 +50,7 @@ export function AppearanceSettings() {
                 Not set (use global)
               </option>
             )}
-            <option value={ThemeMode.SYSTEM}>System</option>
+            <option value={ThemeMode.SYSTEM}>{isJetBrains() ? 'System (IDE)' : 'System (OS)'}</option>
             <option value={ThemeMode.LIGHT}>Light</option>
             <option value={ThemeMode.DARK}>Dark</option>
           </select>

--- a/webview/src/pages/SettingsPage/Tunnel/index.tsx
+++ b/webview/src/pages/SettingsPage/Tunnel/index.tsx
@@ -53,7 +53,7 @@ export function TunnelSettings() {
 
       <SettingSection title="Connection">
         {error && (
-          <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-fg/10 rounded">
+          <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-bg rounded">
             {error}
           </div>
         )}

--- a/webview/src/types/global.d.ts
+++ b/webview/src/types/global.d.ts
@@ -10,6 +10,17 @@ interface Window {
   __JCEF__?: boolean;
 
   /**
+   * IDE Look-and-Feel theme hint.
+   * Injected by ClaudeCodePanel.kt at page load and updated whenever the
+   * IDE LAF changes at runtime. Consumers should listen for the
+   * 'ide-theme-changed' event on window to react to changes.
+   *
+   * Only meaningful when __JCEF__ === true. In standalone (browser) mode
+   * this is always undefined and consumers fall back to matchMedia.
+   */
+  __IDE_THEME__?: 'dark' | 'light';
+
+  /**
    * Bridge to send messages from WebView to Kotlin
    * Injected by ClaudeCodePanel.kt via JBCefJSQuery
    */

--- a/webview/tailwind.config.js
+++ b/webview/tailwind.config.js
@@ -82,6 +82,11 @@ export default {
           scrim: 'var(--overlay-scrim)',
           dim: 'var(--overlay-dim)',
         },
+
+        // Tool call rows (usage: text-tool-label-fg)
+        tool: {
+          'label-fg': 'var(--tool-label-fg)',
+        },
       },
       boxShadow: {
         'token-sm': 'var(--shadow-sm)',


### PR DESCRIPTION
Closes #45, #46.

## Summary

The "System" theme option resolved to `window.matchMedia('(prefers-color-scheme: dark)')` regardless of environment, so a JetBrains IDE on Darcula would still render the WebView with the OS theme. This PR makes "System" follow the IDE's actual Look-and-Feel when running in JetBrains, while leaving standalone (browser) behavior on `prefers-color-scheme`.

Along the way two collateral defects surfaced and are fixed in their own commits:

| Commit | What it does | Why it's bundled here |
|---|---|---|
| `fix(theme)` | Issue #45 itself — IDE LAF bridge, listener, dynamic label | The actual fix |
| `fix(dev)` | `runIde` now passes `-Dplugin.project.root` so `NodeProcessManager` finds `webview/dist` instead of the JAR-extracted temp | Without this, every `wv-build` while validating #45 was silently ignored — the symptom was real, the cause was a stale extracted temp dir |
| `fix(server)` | Cache-Control on the SPA shell + immutable on hashed assets | After a plugin update JCEF could otherwise stay pinned to a stale `index.html`, recreating the same "old WebView" symptom for end users |

## Details

### Theme resolution

- Kotlin (`ClaudeCodePanel`): on `onLoadEnd` inject `window.__IDE_THEME__` derived from `JBColor.isBright()`. Subscribe to `LafManagerListener.TOPIC` via the application message bus with a child `Disposable` stored on the browser holder, dispatched `ide-theme-changed` on every LAF change. Survives tab move/split, released on tab close. No deprecated/internal API.
- WebView (`SettingsContext`, `useTheme`): in JetBrains, SYSTEM resolves via `window.__IDE_THEME__` and re-evaluates on `ide-theme-changed`. Standalone branch is untouched.
- Label is now environment-aware: "System (IDE)" in JetBrains, "System (OS)" in standalone — the reporter flagged the old "System" as ambiguous.

### Dev mode path

`runIde` already passed `-Dclaude.dev.mode=true`, but `NodeProcessManager.findPluginProjectRoot()` used `user.dir` (which is the sandbox dir under runIde) so the dev-mode branch fell back to the JAR-extracted temp. Added a `plugin.project.root` system property fed from `projectDir.absolutePath` and a corresponding heuristic.

### Cache headers

`serveStaticFile` previously sent no `Cache-Control`. JCEF could (and did) cache `index.html` aggressively, so a plugin update never replaced the shell.

## Test plan

- [x] `pnpm test` (webview) — 497/497 pass, 18 new theme tests
- [x] `bash ./scripts/build.sh wv-lint` — clean
- [x] `bash ./scripts/build.sh wv-build` — green
- [x] `bash ./scripts/build.sh be-build` — green
- [x] `bash ./scripts/build.sh build` — green, no Kotlin deprecation/internal warnings
- [x] Manual: IDE Darcula → SYSTEM resolves dark; IDE Light → SYSTEM resolves light; runtime LAF toggle propagates without restart
- [x] Manual: dropdown label shows "System (IDE)" in JetBrains, "System (OS)" in standalone
- [x] DevTools probe confirmed `__JCEF__=true`, `__IDE_THEME__="dark"`, `isJetBrains()=true`, label resolves to "System (IDE)"

---

## Follow-up: light-theme markdown legibility (#46)

The cyan-on-cyan inline code reported in #46 — `rgba(127, 251, 255, 0.8)` text on an almost-invisible cyan box — was the same hardcoded value in `streaming.css` that the light-theme validation for #45 hit. Folded in as a follow-up commit (`fix(theme): tokenize markdown and state colors for light theme legibility`) since it shares the same theme-resolution surface.

**What changed:**

- Markdown color tokens (`--md-inline-code-bg/-fg`, `--md-code-block-bg`, `--md-code-copy-btn-*`, `--md-blockquote-bg`, `--md-table-border`) defined per light/dark in `index.css`; hardcoded cyan values in `streaming.css` replaced with token references. Light theme now uses a GitHub-style neutral palette; dark theme keeps the prior cyan tones for parity.
- `--tool-label-fg` token added for IN/OUT row labels, also unifying the inconsistent 40%/50% alpha between `Label` and `McpToolRow` into a single 45%.
- 7 call sites migrated from non-functional `bg-state-*-fg/N` to semantic `bg-state-*-bg` (`EditRenderer`, both Tunnel surfaces, `DefaultErrorBanner`, `SessionConflictErrorBanner` × 2, `TunnelModal`). Tailwind cannot apply `/N` alpha modifiers to `var()`-only color tokens, so those classes were never being emitted — silent breakage that this commit fixes alongside the rename.
