### PR TITLE
feat: attach current editor file path to chat input via shortcut (#44)

### DIFF
--- a/backend/src/core/features/auth-diagnosis.ts
+++ b/backend/src/core/features/auth-diagnosis.ts
@@ -1,5 +1,5 @@
 import { getEnvApiKeys } from './claude-settings';
-import type { ConnectionManager } from '../ws/connection-manager';
+import type { ConnectionManager } from '../../ws/connection-manager';
 
 const AUTH_ERROR_PATTERNS = [
   /invalid.?api.?key/i,

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -154,4 +154,92 @@ describe('ConnectionManager', () => {
       expect(cm.getBuffer('nonexistent')).toBe('');
     });
   });
+
+  describe('getConnectionCount', () => {
+    it('should return 0 when there are no connections', () => {
+      expect(cm.getConnectionCount()).toBe(0);
+    });
+
+    it('should reflect the number of active connections', () => {
+      cm.addConnection(createMockWs());
+      cm.addConnection(createMockWs());
+      expect(cm.getConnectionCount()).toBe(2);
+    });
+
+    it('should decrease when a connection is removed', () => {
+      const connId = cm.addConnection(createMockWs());
+      cm.addConnection(createMockWs());
+      cm.removeConnection(connId);
+      expect(cm.getConnectionCount()).toBe(1);
+    });
+  });
+
+  describe('pending editor context buffer', () => {
+    it('should return the stashed payload on consume', () => {
+      const payload = { absolutePath: '/abs/src/file.ts', relativePath: 'src/file.ts' };
+      cm.setPendingEditorContext(payload);
+      expect(cm.consumePendingEditorContext()).toEqual(payload);
+    });
+
+    it('should clear the buffer after a single consume', () => {
+      cm.setPendingEditorContext({ absolutePath: '/abs/a.ts', relativePath: 'a.ts' });
+      cm.consumePendingEditorContext();
+      expect(cm.consumePendingEditorContext()).toBeNull();
+    });
+
+    it('should return null when nothing was stashed', () => {
+      expect(cm.consumePendingEditorContext()).toBeNull();
+    });
+
+    it('should return null and clear after the 10s expiry window', () => {
+      cm.setPendingEditorContext({ absolutePath: '/abs/a.ts', relativePath: 'a.ts' });
+      vi.advanceTimersByTime(10_000 + 1);
+      expect(cm.consumePendingEditorContext()).toBeNull();
+    });
+
+    it('should still return the payload just before expiry', () => {
+      const payload = { absolutePath: '/abs/a.ts', relativePath: 'a.ts' };
+      cm.setPendingEditorContext(payload);
+      vi.advanceTimersByTime(9_999);
+      expect(cm.consumePendingEditorContext()).toEqual(payload);
+    });
+
+    it('should overwrite an earlier pending payload with the latest one', () => {
+      cm.setPendingEditorContext({ absolutePath: '/abs/old.ts', relativePath: 'old.ts' });
+      const latest = { absolutePath: '/abs/new.ts', relativePath: 'new.ts' };
+      cm.setPendingEditorContext(latest);
+      expect(cm.consumePendingEditorContext()).toEqual(latest);
+    });
+
+    it('should replay a stashed payload to a newly added connection as EDITOR_CONTEXT', () => {
+      const payload = { absolutePath: '/abs/src/file.ts', relativePath: 'src/file.ts', startLine: 10, endLine: 25 };
+      cm.setPendingEditorContext(payload);
+
+      const ws = createMockWs();
+      cm.addConnection(ws);
+
+      expect(ws.send).toHaveBeenCalledTimes(1);
+      const sent = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+      expect(sent.type).toBe('EDITOR_CONTEXT');
+      expect(sent.payload).toEqual(payload);
+    });
+
+    it('should consume the buffer on replay so the next connection gets nothing', () => {
+      cm.setPendingEditorContext({ absolutePath: '/abs/a.ts', relativePath: 'a.ts' });
+      cm.addConnection(createMockWs());
+
+      const ws2 = createMockWs();
+      cm.addConnection(ws2);
+      expect(ws2.send).not.toHaveBeenCalled();
+    });
+
+    it('should not replay an expired buffer to a newly added connection', () => {
+      cm.setPendingEditorContext({ absolutePath: '/abs/a.ts', relativePath: 'a.ts' });
+      vi.advanceTimersByTime(10_000 + 1);
+
+      const ws = createMockWs();
+      cm.addConnection(ws);
+      expect(ws.send).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/backend/src/ws/__tests__/editor-context-route.test.ts
+++ b/backend/src/ws/__tests__/editor-context-route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleEditorContextRequest } from '../editor-context-route';
+import { ConnectionManager } from '../connection-manager';
+
+function createMockWs(readyState = 1) {
+  return {
+    readyState,
+    send: vi.fn(),
+    close: vi.fn(),
+  } as unknown as import('ws').WebSocket;
+}
+
+describe('handleEditorContextRequest', () => {
+  it('returns 400 when the body is not valid JSON', () => {
+    const cm = new ConnectionManager();
+    const result = handleEditorContextRequest(cm, 'not json{');
+    expect(result.status).toBe(400);
+    expect(result.body).toHaveProperty('error');
+  });
+
+  it('returns 400 when absolutePath is missing', () => {
+    const cm = new ConnectionManager();
+    const result = handleEditorContextRequest(
+      cm,
+      JSON.stringify({ relativePath: 'src/file.ts' }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 when relativePath is missing', () => {
+    const cm = new ConnectionManager();
+    const result = handleEditorContextRequest(
+      cm,
+      JSON.stringify({ absolutePath: '/abs/src/file.ts' }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it('returns 400 when absolutePath is not a string', () => {
+    const cm = new ConnectionManager();
+    const result = handleEditorContextRequest(
+      cm,
+      JSON.stringify({ absolutePath: 42, relativePath: 'src/file.ts' }),
+    );
+    expect(result.status).toBe(400);
+  });
+
+  it('broadcasts EDITOR_CONTEXT when there is at least one connection', () => {
+    const cm = new ConnectionManager();
+    const ws = createMockWs();
+    cm.addConnection(ws);
+
+    const body = JSON.stringify({
+      absolutePath: '/abs/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: 10,
+      endLine: 25,
+      workingDir: '/abs',
+    });
+    const result = handleEditorContextRequest(cm, body);
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: true });
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(sent.type).toBe('EDITOR_CONTEXT');
+    expect(sent.payload).toEqual({
+      absolutePath: '/abs/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: 10,
+      endLine: 25,
+      workingDir: '/abs',
+    });
+  });
+
+  it('stashes the payload as pending when there are no connections', () => {
+    const cm = new ConnectionManager();
+    const setPending = vi.spyOn(cm, 'setPendingEditorContext');
+
+    const body = JSON.stringify({
+      absolutePath: '/abs/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: null,
+      endLine: null,
+      workingDir: '/abs',
+    });
+    const result = handleEditorContextRequest(cm, body);
+
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ success: true });
+    expect(setPending).toHaveBeenCalledTimes(1);
+    expect(setPending).toHaveBeenCalledWith({
+      absolutePath: '/abs/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: null,
+      endLine: null,
+      workingDir: '/abs',
+    });
+  });
+
+  it('preserves null startLine/endLine when no selection is present', () => {
+    const cm = new ConnectionManager();
+    const ws = createMockWs();
+    cm.addConnection(ws);
+
+    const body = JSON.stringify({
+      absolutePath: '/abs/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: null,
+      endLine: null,
+      workingDir: '/abs',
+    });
+    handleEditorContextRequest(cm, body);
+
+    const sent = JSON.parse((ws.send as ReturnType<typeof vi.fn>).mock.calls[0][0]);
+    expect(sent.payload.startLine).toBeNull();
+    expect(sent.payload.endLine).toBeNull();
+  });
+});

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -5,6 +5,22 @@ import { ClientEnv } from '../shared';
 
 const SESSION_CLEANUP_GRACE_MS = 30_000;
 const IDLE_SHUTDOWN_GRACE_MS = 60_000;
+/**
+ * How long an editor-context payload stays valid while waiting for a webview to
+ * connect. The "Add to Claude" action can fire before the JCEF panel has opened
+ * its /ws socket (cold start); we stash the payload and replay it to the first
+ * connection that arrives, but only within this window so a stale selection from
+ * minutes ago is never injected.
+ */
+const PENDING_EDITOR_CONTEXT_TTL_MS = 10_000;
+
+/** Push message type carrying the IDE editor selection to the webview. */
+export const EDITOR_CONTEXT_MESSAGE = 'EDITOR_CONTEXT';
+
+interface PendingEditorContext {
+  payload: Record<string, unknown>;
+  expiresAt: number;
+}
 
 interface SessionRecord {
   sessionId: string;
@@ -44,6 +60,9 @@ export class ConnectionManager {
   // is 1:1 (one JCEF browser per IDE panel, one /ws socket per browser), so this
   // map is always in sync with the panelId stored on each ClientRecord.
   private panelIdIndex = new Map<string, string>();
+  // Editor context awaiting a webview connection. Replayed to the first
+  // connection that arrives within PENDING_EDITOR_CONTEXT_TTL_MS, then cleared.
+  private pendingEditorContext: PendingEditorContext | null = null;
   private nextId = 0;
 
   // ─── Connection lifecycle ───────────────────────────────────────────────────
@@ -58,7 +77,40 @@ export class ConnectionManager {
       '[node-backend]',
       `Connection added: ${connectionId} (env: ${env}, panelId: ${panelId ?? 'none'})`,
     );
+
+    // Replay any editor context that arrived before this webview connected
+    // (e.g. "Add to Claude" fired during JCEF cold start).
+    const pendingEditorContext = this.consumePendingEditorContext();
+    if (pendingEditorContext) {
+      this.sendTo(connectionId, EDITOR_CONTEXT_MESSAGE, pendingEditorContext);
+    }
+
     return connectionId;
+  }
+
+  // ─── Editor context buffer ──────────────────────────────────────────────────
+
+  /**
+   * Stash an editor-context payload to replay to the next webview connection.
+   * Overwrites any earlier pending payload — only the latest selection matters.
+   */
+  setPendingEditorContext(payload: Record<string, unknown>): void {
+    this.pendingEditorContext = {
+      payload,
+      expiresAt: Date.now() + PENDING_EDITOR_CONTEXT_TTL_MS,
+    };
+  }
+
+  /**
+   * Return the stashed editor-context payload and clear the buffer. Returns null
+   * if nothing is stashed or the stash has expired (also clears in that case).
+   */
+  consumePendingEditorContext(): Record<string, unknown> | null {
+    const pending = this.pendingEditorContext;
+    this.pendingEditorContext = null;
+    if (!pending) return null;
+    if (Date.now() > pending.expiresAt) return null;
+    return pending.payload;
   }
 
   setNativeDropStash(panelId: string, entries: NativeDropEntry[]): boolean {
@@ -241,6 +293,10 @@ export class ConnectionManager {
   }
 
   // ─── Accessors ──────────────────────────────────────────────────────────────
+
+  getConnectionCount(): number {
+    return this.connectionMap.size;
+  }
 
   getClient(connectionId: string): ClientRecord | undefined {
     return this.clientMap.get(connectionId);

--- a/backend/src/ws/editor-context-route.ts
+++ b/backend/src/ws/editor-context-route.ts
@@ -1,0 +1,81 @@
+import { ConnectionManager, EDITOR_CONTEXT_MESSAGE } from './connection-manager';
+
+/**
+ * Result of handling a POST /internal/editor-context request. The caller writes
+ * `status` and JSON-serialized `body` back to the HTTP response.
+ */
+export interface EditorContextRouteResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+/**
+ * Validated editor-context payload pushed to the webview as EDITOR_CONTEXT.
+ * Kotlin sends this when the user invokes "Add to Claude" on an editor selection.
+ * `startLine`/`endLine` are null when the action fires without a selection.
+ */
+interface EditorContextPayload extends Record<string, unknown> {
+  absolutePath: string;
+  relativePath: string;
+  startLine: number | null;
+  endLine: number | null;
+  workingDir: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeLine(value: unknown): number | null {
+  return typeof value === 'number' ? value : null;
+}
+
+/**
+ * Parse + validate an editor-context request body and route it to the webview.
+ *
+ * If a webview is connected, the payload is broadcast immediately as
+ * EDITOR_CONTEXT. Otherwise it is stashed (the action may fire during JCEF cold
+ * start) and replayed to the first connection that arrives within the TTL.
+ *
+ * Extracted from the HTTP layer so the validation/routing logic is unit-testable
+ * without spinning up a server.
+ */
+export function handleEditorContextRequest(
+  connections: ConnectionManager,
+  rawBody: string,
+): EditorContextRouteResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { error: 'Invalid JSON body' } };
+  }
+
+  if (!isRecord(parsed)) {
+    return { status: 400, body: { error: 'Body must be a JSON object' } };
+  }
+
+  const { absolutePath, relativePath } = parsed;
+  if (typeof absolutePath !== 'string' || typeof relativePath !== 'string') {
+    return {
+      status: 400,
+      body: { error: 'absolutePath and relativePath are required strings' },
+    };
+  }
+
+  const payload: EditorContextPayload = {
+    absolutePath,
+    relativePath,
+    startLine: normalizeLine(parsed.startLine),
+    endLine: normalizeLine(parsed.endLine),
+    workingDir: typeof parsed.workingDir === 'string' ? parsed.workingDir : '',
+  };
+
+  if (connections.getConnectionCount() > 0) {
+    connections.broadcastToAll(EDITOR_CONTEXT_MESSAGE, payload);
+  } else {
+    connections.setPendingEditorContext(payload);
+  }
+
+  return { status: 200, body: { success: true } };
+}

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -3,6 +3,7 @@ import { readFile } from 'fs/promises';
 import { join, extname, resolve, sep } from 'path';
 import { WebSocketServer, type WebSocket } from 'ws';
 import { ConnectionManager } from './connection-manager';
+import { handleEditorContextRequest } from './editor-context-route';
 import type { Bridge } from '../bridge/bridge-interface';
 import type { IPCMessage } from '../core/types';
 import { ClientEnv } from '../shared';
@@ -73,6 +74,27 @@ const MIME_TYPES: Record<string, string> = {
   '.woff2': 'font/woff2',
   '.json': 'application/json; charset=utf-8',
 };
+
+/** Collect a request body into a string, capped to guard against unbounded input. */
+const MAX_REQUEST_BODY_BYTES = 64 * 1024;
+
+function readRequestBody(req: IncomingMessage): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > MAX_REQUEST_BODY_BYTES) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
 
 async function serveStaticFile(
   webviewDir: string,
@@ -192,6 +214,24 @@ export function startWebSocketServer(
         if (urlPath === '/version') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ version: getPluginVersion() }));
+          return;
+        }
+
+        // IDE → backend editor selection push. Kotlin POSTs the active editor
+        // selection here (loopback only); we route it to the webview as
+        // EDITOR_CONTEXT, buffering it if no webview is connected yet.
+        if (req.method === 'POST' && urlPath === '/internal/editor-context') {
+          let rawBody: string;
+          try {
+            rawBody = await readRequestBody(req);
+          } catch {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Failed to read request body' }));
+            return;
+          }
+          const result = handleEditorContextRequest(connections, rawBody);
+          res.writeHead(result.status, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result.body));
           return;
         }
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -1,0 +1,207 @@
+package com.github.yhk1038.claudecodegui.actions
+
+import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.intellij.openapi.actionSystem.ActionUpdateThread
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import java.net.HttpURLConnection
+import java.net.URI
+import java.util.UUID
+
+/**
+ * Pure, platform-independent logic for building the editor-context payload.
+ *
+ * Extracted from [SendSelectionToClaudeAction] so it can be unit-tested without
+ * the IntelliJ platform, EDT, coroutines, or HTTP. Only string handling and
+ * kotlinx.serialization are used here.
+ */
+object EditorContextPayload {
+
+    /**
+     * Compute the path of [absolutePath] relative to [workingDir].
+     *
+     * Returns [absolutePath] unchanged when:
+     * - [workingDir] is null or blank, or
+     * - [absolutePath] is not located under [workingDir].
+     *
+     * A trailing slash on [workingDir] is normalized. Sibling directories that
+     * merely share a name prefix (e.g. "/abs/path" vs "/abs/pathology") are not
+     * treated as a parent.
+     */
+    fun computeRelativePath(absolutePath: String, workingDir: String?): String {
+        if (workingDir.isNullOrBlank()) return absolutePath
+        val normalizedDir = workingDir.trimEnd('/')
+        val prefix = "$normalizedDir/"
+        return if (absolutePath.startsWith(prefix)) {
+            absolutePath.substring(prefix.length)
+        } else {
+            absolutePath
+        }
+    }
+
+    /**
+     * Build the JSON payload sent to the backend's /internal/editor-context endpoint.
+     *
+     * When there is no selection, [startLine] and [endLine] are null and serialized
+     * as JSON null. [workingDir] is serialized as JSON null when null. Note that
+     * selectedText and language are intentionally omitted — the chat input only
+     * needs the file path and optional line range.
+     */
+    fun buildPayload(
+        absolutePath: String,
+        relativePath: String,
+        startLine: Int?,
+        endLine: Int?,
+        workingDir: String?
+    ): JsonObject = buildJsonObject {
+        put("absolutePath", JsonPrimitive(absolutePath))
+        put("relativePath", JsonPrimitive(relativePath))
+        put("startLine", startLine?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("endLine", endLine?.let { JsonPrimitive(it) } ?: JsonNull)
+        put("workingDir", workingDir?.let { JsonPrimitive(it) } ?: JsonNull)
+    }
+}
+
+/**
+ * Editor action that sends the current file path (and selected line range, if any)
+ * to the Claude Code chat input.
+ *
+ * Triggered via Alt+K or the editor context menu. The action:
+ * 1. Extracts file path + optional selection range from the editor.
+ * 2. Ensures the Node.js backend is running and focuses/opens a Claude Code tab.
+ * 3. POSTs the editor context to the backend's /internal/editor-context endpoint
+ *    on a background coroutine (fire-and-forget).
+ *
+ * The backend forwards the context to the webview, which inserts it as text into
+ * the chat input (implemented in later stages).
+ */
+class SendSelectionToClaudeAction : AnAction() {
+
+    private val logger = Logger.getInstance(SendSelectionToClaudeAction::class.java)
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val vFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+
+        val selectionModel = editor.selectionModel
+        val hasSelection = selectionModel.hasSelection() && selectionModel.selectedText != null
+        val startLine: Int?
+        val endLine: Int?
+        if (hasSelection) {
+            // Editor positions are 0-based; the payload uses 1-based line numbers.
+            startLine = selectionModel.selectionStartPosition?.line?.plus(1)
+            endLine = selectionModel.selectionEndPosition?.line?.plus(1)
+        } else {
+            startLine = null
+            endLine = null
+        }
+
+        val absolutePath = vFile.path
+        val workingDir = project.basePath
+        val relativePath = EditorContextPayload.computeRelativePath(absolutePath, workingDir)
+        val payload = EditorContextPayload.buildPayload(
+            absolutePath = absolutePath,
+            relativePath = relativePath,
+            startLine = startLine,
+            endLine = endLine,
+            workingDir = workingDir
+        )
+
+        // Ensure the backend is running. A transient panel id keeps a no-op handler
+        // registered only for the lifetime of this request, then is released in finally.
+        val backend = NodeBackendService.getInstance()
+        val transientPanelId = "action-transient-" + System.currentTimeMillis()
+        backend.ensureStarted(workingDir ?: "", transientPanelId, NoopRpcHandler)
+
+        // Reuse the most recent Claude Code tab, or open a new one. FileEditorManager
+        // focuses the tab when it is already open. Must run on the EDT.
+        focusOrOpenClaudeTab(project)
+
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val port = backend.awaitPort()
+                postEditorContext(port, payload)
+            } catch (ex: Exception) {
+                logger.warn("Failed to send editor context to backend", ex)
+            } finally {
+                backend.releasePanel(workingDir ?: "", transientPanelId)
+            }
+        }
+    }
+
+    private fun focusOrOpenClaudeTab(project: Project) {
+        val openSessionIds = EditorTabStateService.getInstance(project).getOpenSessionIds()
+        val targetSessionId = if (openSessionIds.isNotEmpty()) {
+            EditorTabStateService.getInstance(project).getActiveSessionId()
+                ?: openSessionIds.last()
+        } else {
+            UUID.randomUUID().toString()
+        }
+        ApplicationManager.getApplication().invokeLater {
+            OpenClaudeCodeAction.openSession(project, targetSessionId)
+        }
+    }
+
+    private fun postEditorContext(port: Int, payload: JsonObject) {
+        val url = URI("http://127.0.0.1:$port/internal/editor-context").toURL()
+        val conn = url.openConnection() as HttpURLConnection
+        try {
+            conn.connectTimeout = 2000
+            conn.readTimeout = 2000
+            conn.requestMethod = "POST"
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.outputStream.use { it.write(payload.toString().toByteArray(Charsets.UTF_8)) }
+            // Fire-and-forget: read the response code only to flush the request.
+            val code = conn.responseCode
+            logger.info("Editor context POST returned HTTP $code")
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    override fun update(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val vFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        // Disable inside the Claude Code JCEF panel itself.
+        e.presentation.isEnabledAndVisible =
+            editor != null && vFile != null && vFile !is ClaudeCodeVirtualFile
+    }
+
+    override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
+    /**
+     * No-op RPC handler registered transiently while this action ensures the backend
+     * is running. The action never needs IDE-native callbacks, so every method is a
+     * minimal default. Released in [actionPerformed]'s finally block.
+     */
+    private object NoopRpcHandler : NodeProcessManager.RpcHandler {
+        override suspend fun openFile(path: String) {}
+        override suspend fun openDiff(filePath: String, oldContent: String, newContent: String, toolUseId: String?) {}
+        override suspend fun applyDiff(filePath: String, newContent: String, toolUseId: String?): Boolean = false
+        override suspend fun rejectDiff(toolUseId: String?) {}
+        override suspend fun createSession(workingDir: String) {}
+        override suspend fun openNewTab(workingDir: String) {}
+        override suspend fun openSettings(workingDir: String) {}
+        override suspend fun openTerminal(workingDir: String) {}
+        override suspend fun openUrl(url: String) {}
+        override suspend fun pickFiles(mode: String, multiple: Boolean): List<String> = emptyList()
+        override suspend fun updatePlugin() {}
+        override suspend fun requiresRestart(): Boolean = false
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -2,13 +2,13 @@ package com.github.yhk1038.claudecodegui.actions
 
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
 import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
-import com.github.yhk1038.claudecodegui.services.EditorTabStateService
 import com.github.yhk1038.claudecodegui.services.NodeBackendService
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import kotlinx.coroutines.CoroutineScope
@@ -145,15 +145,18 @@ class SendSelectionToClaudeAction : AnAction() {
     }
 
     private fun focusOrOpenClaudeTab(project: Project) {
-        val openSessionIds = EditorTabStateService.getInstance(project).getOpenSessionIds()
-        val targetSessionId = if (openSessionIds.isNotEmpty()) {
-            EditorTabStateService.getInstance(project).getActiveSessionId()
-                ?: openSessionIds.last()
-        } else {
-            UUID.randomUUID().toString()
-        }
         ApplicationManager.getApplication().invokeLater {
-            OpenClaudeCodeAction.openSession(project, targetSessionId)
+            val fileEditorManager = FileEditorManager.getInstance(project)
+            // Find a Claude Code tab that is actually open, regardless of whether its
+            // session has been created yet. EditorTabStateService tracks session ids,
+            // which an uninitialized tab (no first message sent) does not have — relying
+            // on it would spuriously open a brand-new tab instead of focusing the open one.
+            val existingTab = fileEditorManager.openFiles.firstOrNull { it is ClaudeCodeVirtualFile }
+            if (existingTab != null) {
+                fileEditorManager.openFile(existingTab, true)
+            } else {
+                OpenClaudeCodeAction.openSession(project, UUID.randomUUID().toString())
+            }
         }
     }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -108,5 +108,15 @@
             class="com.github.yhk1038.claudecodegui.actions.OpenClaudeCodeSettingsAction"
             text="Open Claude Code Settings"
             description="Open Claude Code settings in a new editor tab"/>
+
+        <!-- Send current file path (and selected line range) to the Claude Code chat input -->
+        <action
+            id="ClaudeCode.SendSelection"
+            class="com.github.yhk1038.claudecodegui.actions.SendSelectionToClaudeAction"
+            text="Send to Claude Code"
+            description="Send the current file path (and selected line range) to the Claude Code chat input">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <keyboard-shortcut keymap="$default" first-keystroke="alt K"/>
+        </action>
     </actions>
 </idea-plugin>

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeActionTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeActionTest.kt
@@ -1,0 +1,136 @@
+package com.github.yhk1038.claudecodegui.actions
+
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class SendSelectionToClaudeActionTest {
+
+    @Nested
+    inner class ComputeRelativePath {
+        @Test
+        fun `should return relative path for file under workingDir`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/path/src/file.ts",
+                workingDir = "/abs/path"
+            )
+            assertEquals("src/file.ts", result)
+        }
+
+        @Test
+        fun `should handle workingDir with trailing slash`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/path/src/file.ts",
+                workingDir = "/abs/path/"
+            )
+            assertEquals("src/file.ts", result)
+        }
+
+        @Test
+        fun `should handle workingDir without trailing slash`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/path/nested/dir/file.kt",
+                workingDir = "/abs/path"
+            )
+            assertEquals("nested/dir/file.kt", result)
+        }
+
+        @Test
+        fun `should return absolutePath when file is outside workingDir`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/other/place/file.ts",
+                workingDir = "/abs/path"
+            )
+            assertEquals("/other/place/file.ts", result)
+        }
+
+        @Test
+        fun `should return absolutePath when workingDir is null`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/path/src/file.ts",
+                workingDir = null
+            )
+            assertEquals("/abs/path/src/file.ts", result)
+        }
+
+        @Test
+        fun `should return absolutePath when workingDir is blank`() {
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/path/src/file.ts",
+                workingDir = "   "
+            )
+            assertEquals("/abs/path/src/file.ts", result)
+        }
+
+        @Test
+        fun `should not treat sibling prefix as parent dir`() {
+            // workingDir "/abs/path" must not match "/abs/pathology/file.ts"
+            val result = EditorContextPayload.computeRelativePath(
+                absolutePath = "/abs/pathology/file.ts",
+                workingDir = "/abs/path"
+            )
+            assertEquals("/abs/pathology/file.ts", result)
+        }
+    }
+
+    @Nested
+    inner class BuildPayload {
+        @Test
+        fun `should build payload with selection line range`() {
+            val payload = EditorContextPayload.buildPayload(
+                absolutePath = "/abs/path/src/file.ts",
+                relativePath = "src/file.ts",
+                startLine = 10,
+                endLine = 25,
+                workingDir = "/abs/path"
+            )
+            assertEquals(JsonPrimitive("/abs/path/src/file.ts"), payload["absolutePath"])
+            assertEquals(JsonPrimitive("src/file.ts"), payload["relativePath"])
+            assertEquals(JsonPrimitive(10), payload["startLine"])
+            assertEquals(JsonPrimitive(25), payload["endLine"])
+            assertEquals(JsonPrimitive("/abs/path"), payload["workingDir"])
+        }
+
+        @Test
+        fun `should build payload with null lines when no selection`() {
+            val payload = EditorContextPayload.buildPayload(
+                absolutePath = "/abs/path/src/file.ts",
+                relativePath = "src/file.ts",
+                startLine = null,
+                endLine = null,
+                workingDir = "/abs/path"
+            )
+            assertEquals(JsonNull, payload["startLine"])
+            assertEquals(JsonNull, payload["endLine"])
+        }
+
+        @Test
+        fun `should build payload with null workingDir`() {
+            val payload = EditorContextPayload.buildPayload(
+                absolutePath = "/abs/path/src/file.ts",
+                relativePath = "/abs/path/src/file.ts",
+                startLine = null,
+                endLine = null,
+                workingDir = null
+            )
+            assertEquals(JsonNull, payload["workingDir"])
+            assertEquals(JsonPrimitive("/abs/path/src/file.ts"), payload["absolutePath"])
+            assertEquals(JsonPrimitive("/abs/path/src/file.ts"), payload["relativePath"])
+        }
+
+        @Test
+        fun `should not include selectedText or language fields`() {
+            val payload = EditorContextPayload.buildPayload(
+                absolutePath = "/abs/path/src/file.ts",
+                relativePath = "src/file.ts",
+                startLine = 1,
+                endLine = 2,
+                workingDir = "/abs/path"
+            )
+            assertFalse(payload.containsKey("selectedText"))
+            assertFalse(payload.containsKey("language"))
+        }
+    }
+}

--- a/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
+++ b/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
@@ -38,7 +38,7 @@ function setupMockRegistry(sections: PanelSection[] = mockSections) {
 
 describe('useCommandPalette', () => {
   let onChange: ReturnType<typeof vi.fn>;
-  let textareaRef: { current: HTMLTextAreaElement | null };
+  let textareaRef: { current: HTMLDivElement | null };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -246,7 +246,7 @@ describe('useCommandPalette', () => {
         shiftKey: false,
         nativeEvent: { isComposing: false },
         preventDefault: vi.fn(),
-      } as unknown as import('react').KeyboardEvent<HTMLTextAreaElement>;
+      } as unknown as import('react').KeyboardEvent<HTMLElement>;
 
       act(() => {
         result.current.handleSlashKeyDown(enterEvent, '/');

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -4,7 +4,7 @@ import { useCommandPaletteRegistry } from '../CommandPaletteProvider';
 
 interface UseCommandPaletteOptions {
   onChange: (value: string) => void;
-  textareaRef: RefObject<HTMLTextAreaElement | null>;
+  textareaRef: RefObject<HTMLDivElement | null>;
 }
 
 export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOptions) {
@@ -121,7 +121,7 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
   }, [resetSelection]);
 
   const handleSlashKeyDown = useCallback((
-    e: KeyboardEvent<HTMLTextAreaElement>,
+    e: KeyboardEvent<HTMLElement>,
     currentValue: string,
   ): boolean => {
     if (!showSlashCommands) return false;

--- a/webview/src/contexts/ChatInputFocusContext.tsx
+++ b/webview/src/contexts/ChatInputFocusContext.tsx
@@ -1,8 +1,8 @@
 import { createContext, useContext, useRef, useCallback, ReactNode, RefObject } from 'react';
 
 interface ChatInputFocusContextType {
-  textareaRef: RefObject<HTMLTextAreaElement>;
-  /** Focus the ChatInput textarea from anywhere */
+  textareaRef: RefObject<HTMLDivElement>;
+  /** Focus the ChatInput composer from anywhere */
   focus: () => void;
 }
 
@@ -12,7 +12,7 @@ const ChatInputFocusContext = createContext<ChatInputFocusContextType>({
 });
 
 export function ChatInputFocusProvider({ children }: { children: ReactNode }) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const textareaRef = useRef<HTMLDivElement>(null);
 
   const focus = useCallback(() => {
     textareaRef.current?.focus();

--- a/webview/src/hooks/__tests__/useEditorContext.test.ts
+++ b/webview/src/hooks/__tests__/useEditorContext.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useRef } from 'react';
+import { setCaretOffset } from '@/utils/domSelection';
 
 // ---------------------------------------------------------------------------
 // BridgeContext mock — captures the EDITOR_CONTEXT handler so tests can
@@ -129,16 +130,25 @@ interface HarnessParams {
   cursor?: number;
 }
 
+/**
+ * Build a real contentEditable composer div mirroring RichInput: text content
+ * set to `value`, the caret placed at `cursor` (defaults to end). Mounted in the
+ * document so window.getSelection() / getCaretOffset reflect a real caret.
+ */
+function makeComposer(value: string, cursor: number): HTMLDivElement {
+  const el = document.createElement('div');
+  el.contentEditable = 'plaintext-only';
+  el.textContent = value;
+  document.body.appendChild(el);
+  el.focus();
+  setCaretOffset(el, cursor);
+  return el;
+}
+
 function renderEditorContext(params: HarnessParams, onChange: (next: string) => void) {
-  return renderHook(() => {
-    const textareaRef = useRef<HTMLTextAreaElement>(
-      {
-        value: params.value,
-        selectionStart: params.cursor ?? params.value.length,
-        focus: vi.fn(),
-        setSelectionRange: vi.fn(),
-      } as unknown as HTMLTextAreaElement,
-    );
+  const composer = makeComposer(params.value, params.cursor ?? params.value.length);
+  const result = renderHook(() => {
+    const textareaRef = useRef<HTMLDivElement>(composer);
     useEditorContext({
       value: params.value,
       onChange,
@@ -148,7 +158,12 @@ function renderEditorContext(params: HarnessParams, onChange: (next: string) => 
     });
     return { textareaRef };
   });
+  return result;
 }
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
 
 describe('useEditorContext — handler', () => {
   it('registers and cleans up the EDITOR_CONTEXT subscription', () => {

--- a/webview/src/hooks/__tests__/useEditorContext.test.ts
+++ b/webview/src/hooks/__tests__/useEditorContext.test.ts
@@ -128,6 +128,7 @@ interface HarnessParams {
   value: string;
   currentWorkingDir: string;
   cursor?: number;
+  onInsertToken?: (token: string) => void;
 }
 
 /**
@@ -155,6 +156,7 @@ function renderEditorContext(params: HarnessParams, onChange: (next: string) => 
       textareaRef,
       currentWorkingDir: params.currentWorkingDir,
       shouldFocus: false,
+      onInsertToken: params.onInsertToken,
     });
     return { textareaRef };
   });
@@ -214,6 +216,70 @@ describe('useEditorContext — handler', () => {
     });
 
     expect(onChange).toHaveBeenCalledWith('src/file.ts ');
+  });
+
+  it('fires onInsertToken with the bare token (no trailing space) on a selection', () => {
+    const onChange = vi.fn();
+    const onInsertToken = vi.fn();
+    renderEditorContext(
+      { value: '', currentWorkingDir: '/work', onInsertToken },
+      onChange,
+    );
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 10,
+        endLine: 25,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onInsertToken).toHaveBeenCalledTimes(1);
+    expect(onInsertToken).toHaveBeenCalledWith('src/file.ts#L10-L25');
+  });
+
+  it('fires onInsertToken with the relativePath when there is no selection', () => {
+    const onChange = vi.fn();
+    const onInsertToken = vi.fn();
+    renderEditorContext(
+      { value: '', currentWorkingDir: '/work', onInsertToken },
+      onChange,
+    );
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: null,
+        endLine: null,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onInsertToken).toHaveBeenCalledWith('src/file.ts');
+  });
+
+  it('does not fire onInsertToken when the payload is ignored (wrong workingDir)', () => {
+    const onChange = vi.fn();
+    const onInsertToken = vi.fn();
+    renderEditorContext(
+      { value: '', currentWorkingDir: '/work', onInsertToken },
+      onChange,
+    );
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/other/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 1,
+        endLine: 2,
+        workingDir: '/other',
+      });
+    });
+
+    expect(onInsertToken).not.toHaveBeenCalled();
   });
 
   it('ignores payloads whose workingDir does not match currentWorkingDir', () => {

--- a/webview/src/hooks/__tests__/useEditorContext.test.ts
+++ b/webview/src/hooks/__tests__/useEditorContext.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useRef } from 'react';
+
+// ---------------------------------------------------------------------------
+// BridgeContext mock — captures the EDITOR_CONTEXT handler so tests can
+// drive it directly, mirroring how the backend would push a message.
+// ---------------------------------------------------------------------------
+
+type Handler = (message: IPCMessage) => void;
+
+const handlers = new Map<string, Handler>();
+const unsubscribeMock = vi.fn();
+
+const subscribeMock = vi.fn((type: string, handler: Handler) => {
+  handlers.set(type, handler);
+  return unsubscribeMock;
+});
+
+function emitEditorContext(payload: Record<string, unknown>) {
+  const handler = handlers.get('EDITOR_CONTEXT');
+  if (!handler) throw new Error('EDITOR_CONTEXT handler not registered');
+  handler({ type: 'EDITOR_CONTEXT', payload, timestamp: Date.now() });
+}
+
+vi.mock('@/contexts/BridgeContext', () => ({
+  useBridgeContext: () => ({
+    isConnected: true,
+    send: vi.fn(),
+    subscribe: subscribeMock,
+    lastError: null,
+  }),
+}));
+
+// Imported AFTER vi.mock so the mock is wired up first.
+import {
+  useEditorContext,
+  buildEditorContextText,
+  insertAtCursor,
+} from '../useEditorContext';
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  handlers.clear();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Pure helper: buildEditorContextText
+// ---------------------------------------------------------------------------
+
+describe('buildEditorContextText', () => {
+  it('appends #L range when both start and end lines are numbers', () => {
+    expect(
+      buildEditorContextText({
+        absolutePath: '/abs/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 10,
+        endLine: 25,
+        workingDir: '/abs',
+      }),
+    ).toBe('src/file.ts#L10-L25');
+  });
+
+  it('returns relativePath only when there is no selection (endLine null)', () => {
+    expect(
+      buildEditorContextText({
+        absolutePath: '/abs/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 10,
+        endLine: null,
+        workingDir: '/abs',
+      }),
+    ).toBe('src/file.ts');
+  });
+
+  it('returns relativePath only when startLine is null', () => {
+    expect(
+      buildEditorContextText({
+        absolutePath: '/abs/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: null,
+        endLine: 25,
+        workingDir: '/abs',
+      }),
+    ).toBe('src/file.ts');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pure helper: insertAtCursor
+// ---------------------------------------------------------------------------
+
+describe('insertAtCursor', () => {
+  it('inserts text at a mid-string cursor, preserving before/after text', () => {
+    const { nextValue, nextCaret } = insertAtCursor('hello world', 'X', 5);
+    expect(nextValue).toBe('helloX world');
+    expect(nextCaret).toBe(6);
+  });
+
+  it('inserts at the end when cursor equals value length', () => {
+    const { nextValue, nextCaret } = insertAtCursor('abc', 'src/file.ts ', 3);
+    expect(nextValue).toBe('abcsrc/file.ts ');
+    expect(nextCaret).toBe(15);
+  });
+
+  it('inserts at the start when cursor is 0', () => {
+    const { nextValue, nextCaret } = insertAtCursor('abc', 'X ', 0);
+    expect(nextValue).toBe('X abc');
+    expect(nextCaret).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Hook integration
+// ---------------------------------------------------------------------------
+
+interface HarnessParams {
+  value: string;
+  currentWorkingDir: string;
+  cursor?: number;
+}
+
+function renderEditorContext(params: HarnessParams, onChange: (next: string) => void) {
+  return renderHook(() => {
+    const textareaRef = useRef<HTMLTextAreaElement>(
+      {
+        value: params.value,
+        selectionStart: params.cursor ?? params.value.length,
+        focus: vi.fn(),
+        setSelectionRange: vi.fn(),
+      } as unknown as HTMLTextAreaElement,
+    );
+    useEditorContext({
+      value: params.value,
+      onChange,
+      textareaRef,
+      currentWorkingDir: params.currentWorkingDir,
+      shouldFocus: false,
+    });
+    return { textareaRef };
+  });
+}
+
+describe('useEditorContext — handler', () => {
+  it('registers and cleans up the EDITOR_CONTEXT subscription', () => {
+    const onChange = vi.fn();
+    const { unmount } = renderEditorContext(
+      { value: '', currentWorkingDir: '/work' },
+      onChange,
+    );
+    expect(subscribeMock).toHaveBeenCalledWith('EDITOR_CONTEXT', expect.any(Function));
+    unmount();
+    expect(unsubscribeMock).toHaveBeenCalled();
+  });
+
+  it('inserts "relativePath#L.. " with trailing space at cursor on selection', () => {
+    const onChange = vi.fn();
+    // Cursor sits between "ab" and "cd"; inserted text keeps both sides intact.
+    renderEditorContext(
+      { value: 'abcd', currentWorkingDir: '/work', cursor: 2 },
+      onChange,
+    );
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 10,
+        endLine: 25,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('absrc/file.ts#L10-L25 cd');
+  });
+
+  it('inserts relativePath only when there is no selection', () => {
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: null,
+        endLine: null,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledWith('src/file.ts ');
+  });
+
+  it('ignores payloads whose workingDir does not match currentWorkingDir', () => {
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/other/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: 1,
+        endLine: 2,
+        workingDir: '/other',
+      });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('matches workingDir regardless of trailing slash differences', () => {
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work/' }, onChange);
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        relativePath: 'src/file.ts',
+        startLine: null,
+        endLine: null,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onChange).toHaveBeenCalledWith('src/file.ts ');
+  });
+
+  it('ignores payloads missing relativePath', () => {
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
+
+    act(() => {
+      emitEditorContext({
+        absolutePath: '/work/src/file.ts',
+        startLine: 1,
+        endLine: 2,
+        workingDir: '/work',
+      });
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('dedups identical payloads fired within 500ms (only one onChange)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
+
+    const payload = {
+      absolutePath: '/work/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: 10,
+      endLine: 25,
+      workingDir: '/work',
+    };
+
+    act(() => {
+      emitEditorContext(payload);
+      vi.setSystemTime(200);
+      emitEditorContext(payload);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows the same payload again after 500ms', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const onChange = vi.fn();
+    renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
+
+    const payload = {
+      absolutePath: '/work/src/file.ts',
+      relativePath: 'src/file.ts',
+      startLine: 10,
+      endLine: 25,
+      workingDir: '/work',
+    };
+
+    act(() => {
+      emitEditorContext(payload);
+      vi.setSystemTime(600);
+      emitEditorContext(payload);
+    });
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/webview/src/hooks/__tests__/useEditorContext.test.ts
+++ b/webview/src/hooks/__tests__/useEditorContext.test.ts
@@ -59,7 +59,7 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe('buildEditorContextText', () => {
-  it('appends #L range when both start and end lines are numbers', () => {
+  it('prefixes @ and appends #L range when both start and end lines are numbers', () => {
     expect(
       buildEditorContextText({
         absolutePath: '/abs/src/file.ts',
@@ -68,10 +68,10 @@ describe('buildEditorContextText', () => {
         endLine: 25,
         workingDir: '/abs',
       }),
-    ).toBe('src/file.ts#L10-L25');
+    ).toBe('@src/file.ts#L10-L25');
   });
 
-  it('returns relativePath only when there is no selection (endLine null)', () => {
+  it('returns @relativePath only when there is no selection (endLine null)', () => {
     expect(
       buildEditorContextText({
         absolutePath: '/abs/src/file.ts',
@@ -80,10 +80,10 @@ describe('buildEditorContextText', () => {
         endLine: null,
         workingDir: '/abs',
       }),
-    ).toBe('src/file.ts');
+    ).toBe('@src/file.ts');
   });
 
-  it('returns relativePath only when startLine is null', () => {
+  it('returns @relativePath only when startLine is null', () => {
     expect(
       buildEditorContextText({
         absolutePath: '/abs/src/file.ts',
@@ -92,7 +92,7 @@ describe('buildEditorContextText', () => {
         endLine: 25,
         workingDir: '/abs',
       }),
-    ).toBe('src/file.ts');
+    ).toBe('@src/file.ts');
   });
 });
 
@@ -179,7 +179,7 @@ describe('useEditorContext — handler', () => {
     expect(unsubscribeMock).toHaveBeenCalled();
   });
 
-  it('inserts "relativePath#L.. " with trailing space at cursor on selection', () => {
+  it('inserts "@relativePath#L.. " with trailing space at cursor on selection', () => {
     const onChange = vi.fn();
     // Cursor sits between "ab" and "cd"; inserted text keeps both sides intact.
     renderEditorContext(
@@ -198,10 +198,10 @@ describe('useEditorContext — handler', () => {
     });
 
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenCalledWith('absrc/file.ts#L10-L25 cd');
+    expect(onChange).toHaveBeenCalledWith('ab@src/file.ts#L10-L25 cd');
   });
 
-  it('inserts relativePath only when there is no selection', () => {
+  it('inserts @relativePath only when there is no selection', () => {
     const onChange = vi.fn();
     renderEditorContext({ value: '', currentWorkingDir: '/work' }, onChange);
 
@@ -215,10 +215,10 @@ describe('useEditorContext — handler', () => {
       });
     });
 
-    expect(onChange).toHaveBeenCalledWith('src/file.ts ');
+    expect(onChange).toHaveBeenCalledWith('@src/file.ts ');
   });
 
-  it('fires onInsertToken with the bare token (no trailing space) on a selection', () => {
+  it('fires onInsertToken with the @ token (no trailing space) on a selection', () => {
     const onChange = vi.fn();
     const onInsertToken = vi.fn();
     renderEditorContext(
@@ -237,10 +237,10 @@ describe('useEditorContext — handler', () => {
     });
 
     expect(onInsertToken).toHaveBeenCalledTimes(1);
-    expect(onInsertToken).toHaveBeenCalledWith('src/file.ts#L10-L25');
+    expect(onInsertToken).toHaveBeenCalledWith('@src/file.ts#L10-L25');
   });
 
-  it('fires onInsertToken with the relativePath when there is no selection', () => {
+  it('fires onInsertToken with @relativePath when there is no selection', () => {
     const onChange = vi.fn();
     const onInsertToken = vi.fn();
     renderEditorContext(
@@ -258,7 +258,7 @@ describe('useEditorContext — handler', () => {
       });
     });
 
-    expect(onInsertToken).toHaveBeenCalledWith('src/file.ts');
+    expect(onInsertToken).toHaveBeenCalledWith('@src/file.ts');
   });
 
   it('does not fire onInsertToken when the payload is ignored (wrong workingDir)', () => {
@@ -313,7 +313,7 @@ describe('useEditorContext — handler', () => {
       });
     });
 
-    expect(onChange).toHaveBeenCalledWith('src/file.ts ');
+    expect(onChange).toHaveBeenCalledWith('@src/file.ts ');
   });
 
   it('ignores payloads missing relativePath', () => {

--- a/webview/src/hooks/index.ts
+++ b/webview/src/hooks/index.ts
@@ -10,3 +10,4 @@ export { useAwaitingNotifications } from './useAwaitingNotifications';
 export type { LoadedMessage } from './useChatStream';
 export type { AttachedContext } from './useContext';
 export { useTunnelStatus } from './useTunnelStatus';
+export * from './useEditorContext';

--- a/webview/src/hooks/useEditorContext.ts
+++ b/webview/src/hooks/useEditorContext.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useBridgeContext } from '@/contexts/BridgeContext';
+import { getCaretOffset, setCaretOffset } from '@/utils/domSelection';
 
 /**
  * Payload pushed by the backend over the `EDITOR_CONTEXT` IPC message.
@@ -17,7 +18,7 @@ export interface EditorContextPayload {
 export interface UseEditorContextParams {
   value: string;
   onChange: (next: string) => void;
-  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  textareaRef: React.RefObject<HTMLDivElement>;
   currentWorkingDir: string;
   /** Move focus + caret after insertion. Defaults to true. */
   shouldFocus?: boolean;
@@ -128,19 +129,19 @@ export function useEditorContext(params: UseEditorContextParams): void {
       lastTimeRef.current = now;
 
       const insertText = buildEditorContextText(payload) + ' ';
-      const textarea = textareaRef.current;
+      const el = textareaRef.current;
       const currentValue = valueRef.current;
-      const cursorPos = textarea?.selectionStart ?? currentValue.length;
+      const cursorPos = el ? getCaretOffset(el) : currentValue.length;
 
       const { nextValue, nextCaret } = insertAtCursor(currentValue, insertText, cursorPos);
       onChangeRef.current(nextValue);
 
       if (shouldFocusRef.current) {
         requestAnimationFrame(() => {
-          const el = textareaRef.current;
-          if (!el) return;
-          el.focus();
-          el.setSelectionRange(nextCaret, nextCaret);
+          const target = textareaRef.current;
+          if (!target) return;
+          target.focus();
+          setCaretOffset(target, nextCaret);
         });
       }
     });

--- a/webview/src/hooks/useEditorContext.ts
+++ b/webview/src/hooks/useEditorContext.ts
@@ -22,6 +22,12 @@ export interface UseEditorContextParams {
   currentWorkingDir: string;
   /** Move focus + caret after insertion. Defaults to true. */
   shouldFocus?: boolean;
+  /**
+   * Called with the inserted path token (no trailing space), e.g.
+   * `src/file.ts#L10-L25` or `src/file.ts`, so the composer can highlight it
+   * as a chip. Fired once per successful insertion.
+   */
+  onInsertToken?: (token: string) => void;
 }
 
 /** Window during which an identical payload is treated as a duplicate. */
@@ -91,7 +97,7 @@ function parseEditorContextPayload(
  * - Tracks `value` via a ref to avoid stale-closure re-subscriptions.
  */
 export function useEditorContext(params: UseEditorContextParams): void {
-  const { value, onChange, textareaRef, currentWorkingDir, shouldFocus = true } = params;
+  const { value, onChange, textareaRef, currentWorkingDir, shouldFocus = true, onInsertToken } = params;
   const { subscribe } = useBridgeContext();
 
   // Latest values tracked via refs so the effect can subscribe once and still
@@ -104,6 +110,8 @@ export function useEditorContext(params: UseEditorContextParams): void {
   currentWorkingDirRef.current = currentWorkingDir;
   const shouldFocusRef = useRef(shouldFocus);
   shouldFocusRef.current = shouldFocus;
+  const onInsertTokenRef = useRef(onInsertToken);
+  onInsertTokenRef.current = onInsertToken;
 
   // Dedup bookkeeping.
   const lastKeyRef = useRef<string | null>(null);
@@ -128,13 +136,15 @@ export function useEditorContext(params: UseEditorContextParams): void {
       lastKeyRef.current = key;
       lastTimeRef.current = now;
 
-      const insertText = buildEditorContextText(payload) + ' ';
+      const token = buildEditorContextText(payload);
+      const insertText = token + ' ';
       const el = textareaRef.current;
       const currentValue = valueRef.current;
       const cursorPos = el ? getCaretOffset(el) : currentValue.length;
 
       const { nextValue, nextCaret } = insertAtCursor(currentValue, insertText, cursorPos);
       onChangeRef.current(nextValue);
+      onInsertTokenRef.current?.(token);
 
       if (shouldFocusRef.current) {
         requestAnimationFrame(() => {

--- a/webview/src/hooks/useEditorContext.ts
+++ b/webview/src/hooks/useEditorContext.ts
@@ -40,16 +40,18 @@ function normalizeDir(dir: string): string {
 
 /**
  * Build the text inserted into the composer for an editor-context payload.
- * With a selection (both lines numeric): `relativePath#L{start}-L{end}`.
- * Without a selection (either line null): `relativePath`.
+ * The token is prefixed with `@` so Claude Code CLI can recognise it as a
+ * file reference.
+ * With a selection (both lines numeric): `@relativePath#L{start}-L{end}`.
+ * Without a selection (either line null): `@relativePath`.
  * The trailing space is added by the caller at insertion time.
  */
 export function buildEditorContextText(payload: EditorContextPayload): string {
   const { relativePath, startLine, endLine } = payload;
   if (typeof startLine === 'number' && typeof endLine === 'number') {
-    return `${relativePath}#L${startLine}-L${endLine}`;
+    return `@${relativePath}#L${startLine}-L${endLine}`;
   }
-  return relativePath;
+  return `@${relativePath}`;
 }
 
 export interface InsertAtCursorResult {

--- a/webview/src/hooks/useEditorContext.ts
+++ b/webview/src/hooks/useEditorContext.ts
@@ -1,0 +1,148 @@
+import { useEffect, useRef } from 'react';
+import { useBridgeContext } from '@/contexts/BridgeContext';
+
+/**
+ * Payload pushed by the backend over the `EDITOR_CONTEXT` IPC message.
+ * The IDE reports the file the user is looking at, plus the active
+ * selection range (null lines when nothing is selected).
+ */
+export interface EditorContextPayload {
+  absolutePath: string;
+  relativePath: string;
+  startLine: number | null;
+  endLine: number | null;
+  workingDir: string;
+}
+
+export interface UseEditorContextParams {
+  value: string;
+  onChange: (next: string) => void;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
+  currentWorkingDir: string;
+  /** Move focus + caret after insertion. Defaults to true. */
+  shouldFocus?: boolean;
+}
+
+/** Window during which an identical payload is treated as a duplicate. */
+const DEDUP_WINDOW_MS = 500;
+
+/** Strip a single trailing slash so two working-dir spellings compare equal. */
+function normalizeDir(dir: string): string {
+  return dir.replace(/\/+$/, '');
+}
+
+/**
+ * Build the text inserted into the composer for an editor-context payload.
+ * With a selection (both lines numeric): `relativePath#L{start}-L{end}`.
+ * Without a selection (either line null): `relativePath`.
+ * The trailing space is added by the caller at insertion time.
+ */
+export function buildEditorContextText(payload: EditorContextPayload): string {
+  const { relativePath, startLine, endLine } = payload;
+  if (typeof startLine === 'number' && typeof endLine === 'number') {
+    return `${relativePath}#L${startLine}-L${endLine}`;
+  }
+  return relativePath;
+}
+
+export interface InsertAtCursorResult {
+  nextValue: string;
+  nextCaret: number;
+}
+
+/**
+ * Insert `insertText` into `value` at `cursorPos`, preserving surrounding text.
+ * Returns the new value and the caret position immediately after the insertion.
+ */
+export function insertAtCursor(
+  value: string,
+  insertText: string,
+  cursorPos: number,
+): InsertAtCursorResult {
+  const pos = Math.max(0, Math.min(cursorPos, value.length));
+  const nextValue = value.slice(0, pos) + insertText + value.slice(pos);
+  return { nextValue, nextCaret: pos + insertText.length };
+}
+
+/** Validate an unknown IPC payload as an EditorContextPayload. */
+function parseEditorContextPayload(
+  raw: Record<string, unknown> | undefined,
+): EditorContextPayload | null {
+  if (!raw) return null;
+  const { absolutePath, relativePath, startLine, endLine, workingDir } = raw;
+  if (typeof relativePath !== 'string' || relativePath.length === 0) return null;
+  if (typeof workingDir !== 'string') return null;
+  return {
+    absolutePath: typeof absolutePath === 'string' ? absolutePath : '',
+    relativePath,
+    startLine: typeof startLine === 'number' ? startLine : null,
+    endLine: typeof endLine === 'number' ? endLine : null,
+    workingDir,
+  };
+}
+
+/**
+ * Subscribe to backend `EDITOR_CONTEXT` pushes and insert the reported file
+ * path (with optional line range) into the composer at the current caret.
+ *
+ * - Filters out payloads from a different working directory.
+ * - Dedups identical payloads fired within {@link DEDUP_WINDOW_MS}.
+ * - Tracks `value` via a ref to avoid stale-closure re-subscriptions.
+ */
+export function useEditorContext(params: UseEditorContextParams): void {
+  const { value, onChange, textareaRef, currentWorkingDir, shouldFocus = true } = params;
+  const { subscribe } = useBridgeContext();
+
+  // Latest values tracked via refs so the effect can subscribe once and still
+  // read fresh state inside the handler (mirrors the useMention pattern).
+  const valueRef = useRef(value);
+  valueRef.current = value;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+  const currentWorkingDirRef = useRef(currentWorkingDir);
+  currentWorkingDirRef.current = currentWorkingDir;
+  const shouldFocusRef = useRef(shouldFocus);
+  shouldFocusRef.current = shouldFocus;
+
+  // Dedup bookkeeping.
+  const lastKeyRef = useRef<string | null>(null);
+  const lastTimeRef = useRef<number>(0);
+
+  useEffect(() => {
+    return subscribe('EDITOR_CONTEXT', (message) => {
+      const payload = parseEditorContextPayload(message.payload);
+      if (!payload) return;
+
+      // Working-dir filter (trailing-slash tolerant).
+      if (normalizeDir(payload.workingDir) !== normalizeDir(currentWorkingDirRef.current)) {
+        return;
+      }
+
+      // Dedup identical payloads within the time window.
+      const key = `${payload.relativePath}:${payload.startLine}:${payload.endLine}`;
+      const now = Date.now();
+      if (lastKeyRef.current === key && now - lastTimeRef.current < DEDUP_WINDOW_MS) {
+        return;
+      }
+      lastKeyRef.current = key;
+      lastTimeRef.current = now;
+
+      const insertText = buildEditorContextText(payload) + ' ';
+      const textarea = textareaRef.current;
+      const currentValue = valueRef.current;
+      const cursorPos = textarea?.selectionStart ?? currentValue.length;
+
+      const { nextValue, nextCaret } = insertAtCursor(currentValue, insertText, cursorPos);
+      onChangeRef.current(nextValue);
+
+      if (shouldFocusRef.current) {
+        requestAnimationFrame(() => {
+          const el = textareaRef.current;
+          if (!el) return;
+          el.focus();
+          el.setSelectionRange(nextCaret, nextCaret);
+        });
+      }
+    });
+  }, [subscribe, textareaRef]);
+}

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -56,7 +56,16 @@
   background-color: var(--accent-primary-subtle);
   color: var(--text-link);
   border-radius: 4px;
-  padding: 0 2px;
+  /*
+   * Extend the chip background sideways with box-shadow, NOT padding. Padding
+   * would widen the glyph run in the mirror layer, pushing following text out
+   * of sync with the transparent editable layer (whose glyphs have no padding)
+   * and misaligning the caret. box-shadow paints outside the box without
+   * affecting layout, so the editable and mirror layers stay glyph-aligned.
+   */
+  box-shadow:
+    -2px 0 0 var(--accent-primary-subtle),
+    2px 0 0 var(--accent-primary-subtle);
   /* Keep the chip background intact when the token wraps across lines. */
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -27,6 +27,42 @@
 }
 
 /* ============================================
+   RichInput mirror overlay (path-token chips)
+   The editable layer renders its glyphs transparent while keeping the caret
+   visible; the mirror layer behind it paints the real text and wraps known
+   path tokens in chips. Both layers share identical font/padding/wrapping
+   (Tailwind LAYOUT_CLASSES) so the mirror glyphs sit exactly under the caret.
+   ============================================ */
+.richInputEditable {
+  /* Hide the editable glyphs — the mirror paints them — but keep the caret. */
+  color: transparent;
+  caret-color: var(--text-primary);
+}
+
+/* The placeholder :before owns its own color, so it stays visible despite the
+   transparent text color above. (Specificity-safe restatement.) */
+.richInputEditable[data-placeholder]:empty:before {
+  color: var(--text-disabled);
+}
+
+.richInputMirror {
+  /* Paint the mirrored text with the normal composer color. */
+  color: var(--text-primary);
+  /* Glyph-for-glyph alignment with the editable layer requires identical line
+     metrics; the shared Tailwind classes cover font-size/family and wrapping. */
+}
+
+.richInputChip {
+  background-color: var(--accent-primary-subtle);
+  color: var(--text-link);
+  border-radius: 4px;
+  padding: 0 2px;
+  /* Keep the chip background intact when the token wraps across lines. */
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
+/* ============================================
    Semantic Color Tokens — Light (default :root)
    ============================================ */
 :root {

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -71,6 +71,14 @@
   box-decoration-break: clone;
 }
 
+/* Clickable path chips in submitted message bubbles brighten on hover/focus to
+   signal they open the file. Plain (folder) chips keep the static appearance. */
+.richInputChip[role='button']:hover,
+.richInputChip[role='button']:focus-visible {
+  filter: brightness(1.15);
+  outline: none;
+}
+
 /* ============================================
    Semantic Color Tokens — Light (default :root)
    ============================================ */

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -15,6 +15,18 @@
 }
 
 /* ============================================
+   contentEditable placeholder (RichInput)
+   Shown only while the editable element is empty. Mirrors the textarea's
+   placeholder using the disabled-text token. pointer-events:none keeps the
+   caret/click behaviour identical to a real placeholder.
+   ============================================ */
+[contenteditable][data-placeholder]:empty:before {
+  content: attr(data-placeholder);
+  color: var(--text-disabled);
+  pointer-events: none;
+}
+
+/* ============================================
    Semantic Color Tokens — Light (default :root)
    ============================================ */
 :root {

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
@@ -175,6 +175,57 @@ describe('RichInput — event delegation', () => {
   });
 });
 
+describe('RichInput — mirror overlay / chips', () => {
+  it('renders an aria-hidden mirror overlay alongside the editable div', () => {
+    const { container } = render(<RichInput value="hello" onChange={() => {}} />);
+    const mirror = container.querySelector('.richInputMirror');
+    expect(mirror).not.toBeNull();
+    expect(mirror?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders no chips when highlightTokens is empty', () => {
+    const { container } = render(
+      <RichInput value="src/file.ts hello" onChange={() => {}} />,
+    );
+    expect(container.querySelectorAll('.richInputChip').length).toBe(0);
+  });
+
+  it('wraps a known token in a chip span inside the mirror', () => {
+    const { container } = render(
+      <RichInput
+        value="see src/file.ts#L10-L25 now"
+        onChange={() => {}}
+        highlightTokens={['src/file.ts#L10-L25']}
+      />,
+    );
+    const chips = container.querySelectorAll('.richInputChip');
+    expect(chips.length).toBe(1);
+    expect(chips[0].textContent).toBe('src/file.ts#L10-L25');
+  });
+
+  it('does not chip arbitrary text that is not a known token', () => {
+    const { container } = render(
+      <RichInput value="this is src/other.ts" onChange={() => {}} highlightTokens={['src/file.ts']} />,
+    );
+    expect(container.querySelectorAll('.richInputChip').length).toBe(0);
+  });
+
+  it('renders a chip for every occurrence of a repeated token', () => {
+    const { container } = render(
+      <RichInput value="a.ts and a.ts" onChange={() => {}} highlightTokens={['a.ts']} />,
+    );
+    expect(container.querySelectorAll('.richInputChip').length).toBe(2);
+  });
+
+  it('keeps the editable textbox reachable (mirror is aria-hidden)', () => {
+    const { getByRole } = render(
+      <RichInput value="src/file.ts" onChange={() => {}} highlightTokens={['src/file.ts']} />,
+    );
+    // getByRole ignores aria-hidden mirror — the textbox is the editable div.
+    expect(getByRole('textbox').textContent).toBe('src/file.ts');
+  });
+});
+
 describe('RichInput — IME composition guard', () => {
   it('does not overwrite DOM textContent while composition is active', () => {
     const { getByRole, rerender } = render(

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
@@ -255,4 +255,131 @@ describe('RichInput — IME composition guard', () => {
 
     expect(onChange).toHaveBeenLastCalledWith('한글');
   });
+
+  it('does not call onChange mid-composition (only on compositionend)', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<RichInput value="" onChange={onChange} />);
+    const el = getByRole('textbox');
+
+    fireEvent.compositionStart(el);
+    // In-progress glyph: input fires but onChange must stay silent.
+    el.textContent = 'ㅎ';
+    fireEvent.input(el);
+    fireEvent.compositionUpdate(el);
+    expect(onChange).not.toHaveBeenCalled();
+
+    el.textContent = '한';
+    fireEvent.compositionEnd(el);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('한');
+  });
+});
+
+describe('RichInput — mirror real-time display (IME)', () => {
+  it('paints the mirror with in-progress composition text immediately', () => {
+    const { getByRole, container } = render(
+      <RichInput value="" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    const mirror = container.querySelector('.richInputMirror');
+
+    fireEvent.compositionStart(el);
+    // Composition update carries the in-progress glyph; the mirror must paint
+    // it at once even though the controlled `value` is still "".
+    el.textContent = '한';
+    fireEvent.compositionUpdate(el);
+
+    expect(mirror?.textContent).toBe('한');
+  });
+
+  it('paints the mirror via input event during composition', () => {
+    const { getByRole, container } = render(
+      <RichInput value="" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    const mirror = container.querySelector('.richInputMirror');
+
+    fireEvent.compositionStart(el);
+    el.textContent = '가';
+    fireEvent.input(el);
+
+    expect(mirror?.textContent).toBe('가');
+  });
+
+  it('mirror reflects the final text after compositionend', () => {
+    const { getByRole, container } = render(
+      <RichInput value="" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    const mirror = container.querySelector('.richInputMirror');
+
+    fireEvent.compositionStart(el);
+    el.textContent = '한글';
+    fireEvent.compositionUpdate(el);
+    fireEvent.compositionEnd(el);
+
+    expect(mirror?.textContent).toBe('한글');
+  });
+});
+
+describe('RichInput — mirror tracks display text', () => {
+  it('paints the mirror with controlled user input', () => {
+    // A normal controlled parent echoes the typed value straight back.
+    const onChange = vi.fn();
+    const { getByRole, container, rerender } = render(
+      <RichInput value="" onChange={onChange} />,
+    );
+    const el = getByRole('textbox');
+    const mirror = container.querySelector('.richInputMirror');
+
+    el.textContent = 'abc';
+    fireEvent.input(el);
+    expect(onChange).toHaveBeenCalledWith('abc');
+
+    rerender(<RichInput value="abc" onChange={onChange} />);
+    expect(mirror?.textContent).toBe('abc');
+  });
+
+  it('repaints the mirror when value changes externally', () => {
+    const { container, rerender } = render(
+      <RichInput value="one" onChange={() => {}} />,
+    );
+    const mirror = container.querySelector('.richInputMirror');
+    expect(mirror?.textContent).toBe('one');
+
+    rerender(<RichInput value="two" onChange={() => {}} />);
+    expect(mirror?.textContent).toBe('two');
+  });
+
+  it('clears the mirror when value is reset to empty (submit/clear)', () => {
+    const { container, rerender } = render(
+      <RichInput value="typed" onChange={() => {}} />,
+    );
+    const mirror = container.querySelector('.richInputMirror');
+    expect(mirror?.textContent).toBe('typed');
+
+    rerender(<RichInput value="" onChange={() => {}} />);
+    expect(mirror?.textContent).toBe('');
+  });
+});
+
+describe('RichInput — placeholder', () => {
+  it('keeps data-placeholder on the editable div for empty value', () => {
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} placeholder="Ask anything" />,
+    );
+    const el = getByRole('textbox');
+    expect(el.getAttribute('data-placeholder')).toBe('Ask anything');
+  });
+
+  it('leaves the editable div truly empty for an empty value', () => {
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} placeholder="Ask anything" />,
+    );
+    const el = getByRole('textbox');
+    // A real `:empty` node (no stray text/<br>) is required for the CSS
+    // placeholder `:empty:before` to render.
+    expect(el.textContent).toBe('');
+    expect(el.childNodes.length).toBe(0);
+  });
 });

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * Tests for RichInput — a contentEditable="plaintext-only" drop-in replacement
+ * for the composer <textarea>.
+ *
+ * jsdom has no real Selection/Range layout engine, so caret-position assertions
+ * are limited. These tests focus on the contract that does work under jsdom:
+ *   - value → textContent rendering
+ *   - user input (input event) → onChange(textContent)
+ *   - external value change → DOM textContent sync (only when differing)
+ *   - placeholder / disabled / aria-label attributes
+ *   - event delegation (keydown / paste / focus / blur)
+ *   - IME guard: composition-in-progress value change must not overwrite DOM
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createRef } from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { RichInput } from '../index';
+
+afterEach(() => cleanup());
+
+/**
+ * Simulate a user typing: jsdom doesn't update textContent from key events for
+ * contentEditable, so the test writes textContent directly then fires `input`,
+ * mirroring how a browser would surface a content mutation.
+ */
+function typeInto(el: HTMLElement, text: string) {
+  el.textContent = text;
+  fireEvent.input(el);
+}
+
+describe('RichInput — rendering', () => {
+  it('renders value as textContent', () => {
+    const { getByRole } = render(<RichInput value="hello" onChange={() => {}} />);
+    const el = getByRole('textbox');
+    expect(el.textContent).toBe('hello');
+  });
+
+  it('uses contentEditable=plaintext-only when enabled', () => {
+    const { getByRole } = render(<RichInput value="" onChange={() => {}} />);
+    const el = getByRole('textbox');
+    expect(el.getAttribute('contenteditable')).toBe('plaintext-only');
+  });
+
+  it('exposes placeholder via data-placeholder', () => {
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} placeholder="Type here" />,
+    );
+    const el = getByRole('textbox');
+    expect(el.getAttribute('data-placeholder')).toBe('Type here');
+  });
+
+  it('renders aria-label', () => {
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} ariaLabel="Message input" />,
+    );
+    expect(getByRole('textbox').getAttribute('aria-label')).toBe('Message input');
+  });
+
+  it('sets spellcheck=false', () => {
+    const { getByRole } = render(<RichInput value="" onChange={() => {}} />);
+    expect(getByRole('textbox').getAttribute('spellcheck')).toBe('false');
+  });
+
+  it('disables editing when disabled', () => {
+    const { getByRole } = render(
+      <RichInput value="x" onChange={() => {}} disabled />,
+    );
+    const el = getByRole('textbox');
+    expect(el.getAttribute('contenteditable')).toBe('false');
+  });
+
+  it('applies className', () => {
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} className="custom-class" />,
+    );
+    expect(getByRole('textbox').className).toContain('custom-class');
+  });
+
+  it('forwards a ref to the editable div', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(<RichInput ref={ref} value="" onChange={() => {}} />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+    expect(ref.current?.getAttribute('role')).toBe('textbox');
+  });
+});
+
+describe('RichInput — onChange', () => {
+  it('calls onChange with textContent on input', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<RichInput value="" onChange={onChange} />);
+    const el = getByRole('textbox');
+    typeInto(el, 'abc');
+    expect(onChange).toHaveBeenCalledWith('abc');
+  });
+
+  it('reports empty string when content is cleared', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<RichInput value="x" onChange={onChange} />);
+    const el = getByRole('textbox');
+    typeInto(el, '');
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+});
+
+describe('RichInput — external value sync', () => {
+  it('updates DOM textContent when value prop changes externally', () => {
+    const { getByRole, rerender } = render(
+      <RichInput value="one" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    expect(el.textContent).toBe('one');
+
+    rerender(<RichInput value="two" onChange={() => {}} />);
+    expect(el.textContent).toBe('two');
+  });
+
+  it('does not touch DOM when value already matches textContent', () => {
+    const { getByRole, rerender } = render(
+      <RichInput value="same" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    // Simulate user already having this exact text in the node.
+    const setterSpy = vi.spyOn(el, 'textContent', 'set');
+    rerender(<RichInput value="same" onChange={() => {}} />);
+    expect(setterSpy).not.toHaveBeenCalled();
+    setterSpy.mockRestore();
+  });
+
+  it('clears textContent when value becomes empty', () => {
+    const { getByRole, rerender } = render(
+      <RichInput value="text" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+    rerender(<RichInput value="" onChange={() => {}} />);
+    expect(el.textContent).toBe('');
+  });
+});
+
+describe('RichInput — event delegation', () => {
+  it('delegates onKeyDown', () => {
+    const onKeyDown = vi.fn();
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} onKeyDown={onKeyDown} />,
+    );
+    fireEvent.keyDown(getByRole('textbox'), { key: 'Enter' });
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+
+  it('delegates onPaste', () => {
+    const onPaste = vi.fn();
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} onPaste={onPaste} />,
+    );
+    fireEvent.paste(getByRole('textbox'));
+    expect(onPaste).toHaveBeenCalled();
+  });
+
+  it('delegates onFocus', () => {
+    const onFocus = vi.fn();
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} onFocus={onFocus} />,
+    );
+    fireEvent.focus(getByRole('textbox'));
+    expect(onFocus).toHaveBeenCalled();
+  });
+
+  it('delegates onBlur', () => {
+    const onBlur = vi.fn();
+    const { getByRole } = render(
+      <RichInput value="" onChange={() => {}} onBlur={onBlur} />,
+    );
+    fireEvent.blur(getByRole('textbox'));
+    expect(onBlur).toHaveBeenCalled();
+  });
+});
+
+describe('RichInput — IME composition guard', () => {
+  it('does not overwrite DOM textContent while composition is active', () => {
+    const { getByRole, rerender } = render(
+      <RichInput value="" onChange={() => {}} />,
+    );
+    const el = getByRole('textbox');
+
+    // User begins IME composition; the live DOM holds the in-progress text.
+    fireEvent.compositionStart(el);
+    el.textContent = '한';
+
+    // A value prop update arrives mid-composition (e.g. stale parent state).
+    rerender(<RichInput value="" onChange={() => {}} />);
+
+    // The composing text must survive — sync is skipped during composition.
+    expect(el.textContent).toBe('한');
+  });
+
+  it('calls onChange with final text on compositionend', () => {
+    const onChange = vi.fn();
+    const { getByRole } = render(<RichInput value="" onChange={onChange} />);
+    const el = getByRole('textbox');
+
+    fireEvent.compositionStart(el);
+    el.textContent = '한글';
+    fireEvent.compositionEnd(el);
+
+    expect(onChange).toHaveBeenLastCalledWith('한글');
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/segments.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/segments.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for splitIntoSegments — the pure tokenizer that powers the RichInput
+ * mirror overlay. It splits a value into token / plain segments so the mirror
+ * can wrap known path tokens (e.g. `src/file.ts#L10-L25`) in highlight chips.
+ *
+ * Contract:
+ *   - left-to-right scan, longest matching token wins at each position
+ *   - non-token runs are emitted as plain segments (adjacent plain merged)
+ *   - the same token may appear multiple times; every occurrence is a token
+ *   - empty token list ⇒ entire value is one plain segment
+ */
+
+import { describe, it, expect } from 'vitest';
+import { splitIntoSegments } from '../segments';
+
+describe('splitIntoSegments', () => {
+  it('returns a single plain segment when there are no tokens', () => {
+    expect(splitIntoSegments('hello world', [])).toEqual([
+      { text: 'hello world', isToken: false },
+    ]);
+  });
+
+  it('returns an empty array for an empty value', () => {
+    expect(splitIntoSegments('', ['src/file.ts'])).toEqual([]);
+  });
+
+  it('marks the whole value as a token when value equals the token', () => {
+    expect(splitIntoSegments('src/file.ts', ['src/file.ts'])).toEqual([
+      { text: 'src/file.ts', isToken: true },
+    ]);
+  });
+
+  it('preserves plain text on both sides of a mid-string token', () => {
+    expect(
+      splitIntoSegments('see src/file.ts now', ['src/file.ts']),
+    ).toEqual([
+      { text: 'see ', isToken: false },
+      { text: 'src/file.ts', isToken: true },
+      { text: ' now', isToken: false },
+    ]);
+  });
+
+  it('handles a token at the start of the value', () => {
+    expect(splitIntoSegments('src/file.ts here', ['src/file.ts'])).toEqual([
+      { text: 'src/file.ts', isToken: true },
+      { text: ' here', isToken: false },
+    ]);
+  });
+
+  it('handles a token at the end of the value', () => {
+    expect(splitIntoSegments('here src/file.ts', ['src/file.ts'])).toEqual([
+      { text: 'here ', isToken: false },
+      { text: 'src/file.ts', isToken: true },
+    ]);
+  });
+
+  it('matches every occurrence when a token repeats', () => {
+    expect(
+      splitIntoSegments('a.ts and a.ts again', ['a.ts']),
+    ).toEqual([
+      { text: 'a.ts', isToken: true },
+      { text: ' and ', isToken: false },
+      { text: 'a.ts', isToken: true },
+      { text: ' again', isToken: false },
+    ]);
+  });
+
+  it('matches multiple distinct tokens in one value', () => {
+    expect(
+      splitIntoSegments('a.ts then b.ts', ['a.ts', 'b.ts']),
+    ).toEqual([
+      { text: 'a.ts', isToken: true },
+      { text: ' then ', isToken: false },
+      { text: 'b.ts', isToken: true },
+    ]);
+  });
+
+  it('prefers the longest token when one is a prefix of another', () => {
+    // At position 0 both 'src/file.ts' and 'src/file.ts#L10-L25' start; the
+    // longer one must win so the range is not split into chip + plain.
+    expect(
+      splitIntoSegments('src/file.ts#L10-L25', [
+        'src/file.ts',
+        'src/file.ts#L10-L25',
+      ]),
+    ).toEqual([{ text: 'src/file.ts#L10-L25', isToken: true }]);
+  });
+
+  it('does not let a shorter token consume part of a longer match', () => {
+    expect(
+      splitIntoSegments('x src/file.ts#L10-L25 y', [
+        'src/file.ts',
+        'src/file.ts#L10-L25',
+      ]),
+    ).toEqual([
+      { text: 'x ', isToken: false },
+      { text: 'src/file.ts#L10-L25', isToken: true },
+      { text: ' y', isToken: false },
+    ]);
+  });
+
+  it('merges adjacent plain runs around non-matching token candidates', () => {
+    // 'file' is not a known token, so the whole string stays plain (one segment).
+    expect(splitIntoSegments('this file is fine', ['a.ts'])).toEqual([
+      { text: 'this file is fine', isToken: false },
+    ]);
+  });
+
+  it('ignores empty-string tokens to avoid zero-width loops', () => {
+    expect(splitIntoSegments('abc', ['', 'b'])).toEqual([
+      { text: 'a', isToken: false },
+      { text: 'b', isToken: true },
+      { text: 'c', isToken: false },
+    ]);
+  });
+
+  it('keeps two adjacent tokens as separate token segments', () => {
+    expect(splitIntoSegments('a.tsb.ts', ['a.ts', 'b.ts'])).toEqual([
+      { text: 'a.ts', isToken: true },
+      { text: 'b.ts', isToken: true },
+    ]);
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
@@ -8,8 +8,10 @@ import {
   type CompositionEvent as ReactCompositionEvent,
   type FormEvent,
   type KeyboardEvent as ReactKeyboardEvent,
+  type UIEvent as ReactUIEvent,
 } from 'react';
 import { setCaretOffset } from '@/utils/domSelection';
+import { splitIntoSegments } from './segments';
 
 interface Props {
   value: string;
@@ -22,21 +24,47 @@ interface Props {
   disabled?: boolean;
   className?: string;
   ariaLabel?: string;
+  /**
+   * Path tokens (e.g. `src/file.ts#L10-L25`) to highlight as chips in the
+   * mirror overlay. Only exact, known tokens are highlighted — arbitrary text
+   * is never chipped. Defaults to an empty list (plain text, no chips).
+   */
+  highlightTokens?: readonly string[];
 }
 
 /**
+ * Layout classes shared by the editable div and the mirror overlay. The two
+ * layers MUST agree on font, padding, line-height and wrapping so the visible
+ * (mirror) glyphs land exactly under the (transparent) editable glyphs and the
+ * caret. Keep this list the single source of truth for both layers.
+ */
+const LAYOUT_CLASSES = [
+  'w-full px-3 text-base',
+  'whitespace-pre-wrap break-words',
+] as const;
+
+/**
  * RichInput — a `contentEditable="plaintext-only"` div that behaves like a
- * controlled <textarea> for plain text. Mirrors the Claude Code extension
- * composer: plaintext-only (Chromium/JCEF-safe, IME-friendly), CSS placeholder
- * via `data-placeholder` on `:empty`, and CSS-only auto-grow (no resize hook).
+ * controlled <textarea> for plain text, with a non-interactive mirror overlay
+ * that paints the same text and wraps known path tokens in highlight chips.
  *
- * This stage renders opaque plain text only — no syntax highlight / mirror.
+ * Two-layer composition (mirrors the Claude Code extension composer):
+ *   - The editable div holds the real text + caret but renders its glyphs
+ *     transparent (`richInputEditable`: color:transparent, caret-color visible),
+ *     sitting on top (z-10) so typing / selection / IME all behave normally.
+ *   - The mirror div (`richInputMirror`, aria-hidden, pointer-events:none) sits
+ *     behind it and paints the visible text: plain runs as text, known tokens
+ *     as chip spans. It shares {@link LAYOUT_CLASSES} so glyphs align exactly.
  *
- * value ↔ textContent sync rule: the DOM is only rewritten when it actually
- * diverges from `value`, so user typing never triggers a caret-jumping reset.
- * External (programmatic) value changes move the caret to the end. While an IME
- * composition is in flight, the sync is skipped so the in-progress glyphs are
- * never clobbered.
+ * Editing always happens in the plaintext editable div, so caret-offset math
+ * (mentions, slash, history, Cmd+Arrow) is unchanged — the mirror is display
+ * only. Scroll position is synced from the editable div to the mirror.
+ *
+ * value ↔ textContent sync rule: the editable DOM is only rewritten when it
+ * actually diverges from `value`, so user typing never triggers a caret-jumping
+ * reset. External (programmatic) value changes move the caret to the end. While
+ * an IME composition is in flight the sync is skipped so the in-progress glyphs
+ * are never clobbered.
  */
 export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
   const {
@@ -50,9 +78,11 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
     disabled = false,
     className,
     ariaLabel,
+    highlightTokens = [],
   } = props;
 
   const elRef = useRef<HTMLDivElement>(null);
+  const mirrorRef = useRef<HTMLDivElement>(null);
   const isComposingRef = useRef(false);
 
   // Expose the editable div to the parent (focus / domSelection utilities) while
@@ -100,34 +130,79 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
     [onChange],
   );
 
+  // Keep the mirror's scroll position locked to the editable div so long /
+  // multi-line input stays glyph-aligned while scrolling.
+  const handleScroll = useCallback((e: ReactUIEvent<HTMLDivElement>) => {
+    const mirror = mirrorRef.current;
+    if (!mirror) return;
+    mirror.scrollTop = e.currentTarget.scrollTop;
+    mirror.scrollLeft = e.currentTarget.scrollLeft;
+  }, []);
+
+  const segments = splitIntoSegments(value, highlightTokens);
+  // A trailing newline collapses on the last line of a wrapping box; append a
+  // zero-content newline so the mirror's height matches the editable div.
+  const trailingNewline = value.endsWith('\n');
+
   return (
-    <div
-      ref={elRef}
-      role="textbox"
-      aria-label={ariaLabel}
-      aria-multiline="true"
-      contentEditable={disabled ? false : 'plaintext-only'}
-      spellCheck={false}
-      suppressContentEditableWarning
-      data-placeholder={placeholder}
-      className={[
-        'w-full px-3 cursor-text bg-transparent text-base text-text-primary',
-        'min-h-[20px] max-h-[200px] overflow-y-auto',
-        'whitespace-pre-wrap break-words',
-        'focus:outline-none',
-        disabled ? 'opacity-50' : '',
-        className ?? '',
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      onInput={handleInput}
-      onKeyDown={onKeyDown}
-      onPaste={onPaste}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onCompositionStart={handleCompositionStart}
-      onCompositionEnd={handleCompositionEnd}
-    />
+    <div className="relative">
+      {/* Mirror overlay — paints visible text + chips behind the editable div. */}
+      <div
+        ref={mirrorRef}
+        aria-hidden="true"
+        className={[
+          'richInputMirror',
+          'absolute inset-0 pointer-events-none',
+          'min-h-[20px] max-h-[200px] overflow-hidden',
+          ...LAYOUT_CLASSES,
+          className ?? '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+      >
+        {segments.map((seg, i) =>
+          seg.isToken ? (
+            <span key={i} className="richInputChip">
+              {seg.text}
+            </span>
+          ) : (
+            <span key={i}>{seg.text}</span>
+          ),
+        )}
+        {trailingNewline && '\n'}
+      </div>
+
+      {/* Editable div — real text + caret, glyphs transparent (see CSS). */}
+      <div
+        ref={elRef}
+        role="textbox"
+        aria-label={ariaLabel}
+        aria-multiline="true"
+        contentEditable={disabled ? false : 'plaintext-only'}
+        spellCheck={false}
+        suppressContentEditableWarning
+        data-placeholder={placeholder}
+        className={[
+          'richInputEditable',
+          'relative z-10 cursor-text bg-transparent',
+          'min-h-[20px] max-h-[200px] overflow-y-auto',
+          'focus:outline-none',
+          ...LAYOUT_CLASSES,
+          disabled ? 'opacity-50' : '',
+          className ?? '',
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        onInput={handleInput}
+        onKeyDown={onKeyDown}
+        onPaste={onPaste}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onScroll={handleScroll}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
+      />
+    </div>
   );
 });
 

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   useLayoutEffect,
   useRef,
+  useState,
   type ClipboardEvent as ReactClipboardEvent,
   type CompositionEvent as ReactCompositionEvent,
   type FormEvent,
@@ -39,7 +40,7 @@ interface Props {
  * caret. Keep this list the single source of truth for both layers.
  */
 const LAYOUT_CLASSES = [
-  'w-full px-3 text-base',
+  'w-full px-3 text-base leading-normal',
   'whitespace-pre-wrap break-words',
 ] as const;
 
@@ -85,6 +86,14 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
   const mirrorRef = useRef<HTMLDivElement>(null);
   const isComposingRef = useRef(false);
 
+  // Live display text that drives the mirror. Unlike `value` (the controlled
+  // prop, which is NOT updated mid-IME-composition), this tracks the editable
+  // div's textContent on every keystroke AND every composition update, so the
+  // mirror paints in-progress glyphs in real time. Without this the transparent
+  // editable glyphs would vanish during composition and the visible text would
+  // appear to lag one character behind.
+  const [displayText, setDisplayText] = useState(value);
+
   // Expose the editable div to the parent (focus / domSelection utilities) while
   // keeping our own internal ref for sync work.
   useImperativeHandle(ref, () => elRef.current as HTMLDivElement, []);
@@ -94,26 +103,46 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
   useLayoutEffect(() => {
     const el = elRef.current;
     if (el === null) return;
+    // While composing, leave both the DOM and displayText untouched so the
+    // in-progress glyphs (driven by composition events) are never clobbered.
     if (isComposingRef.current) return;
 
     const current = el.textContent ?? '';
-    if (current === value) return;
+    if (current === value) {
+      // An empty value can still leave a stray <br>/empty node behind (e.g.
+      // after clearing an IME composition), which defeats `:empty` and hides
+      // the placeholder. Force a real empty node so the placeholder shows.
+      if (value === '' && el.childNodes.length > 0) {
+        el.textContent = '';
+      }
+      // DOM already matches; still reconcile displayText so an external value
+      // change that equals the live text (rare) doesn't leave a stale mirror.
+      if (displayText !== value) setDisplayText(value);
+      return;
+    }
 
     el.textContent = value;
+    // External value changes (submit/clear/Alt+K insert) must repaint the
+    // mirror to match the freshly written DOM.
+    setDisplayText(value);
 
     // Only reposition the caret when this element is focused, so background
     // (programmatic) updates don't steal the selection from elsewhere.
     if (document.activeElement === el) {
       setCaretOffset(el, value.length);
     }
-  }, [value]);
+  }, [value, displayText]);
 
   const handleInput = useCallback(
     (e: FormEvent<HTMLDivElement>) => {
+      const text = e.currentTarget.textContent ?? '';
+      // Always repaint the mirror in real time, including mid-composition.
+      setDisplayText(text);
       // During composition the intermediate text is not yet committed; defer
-      // reporting until compositionend to avoid emitting partial glyphs.
+      // reporting to the parent until compositionend to avoid emitting partial
+      // glyphs. The mirror still updates above so the user sees live feedback.
       if (isComposingRef.current) return;
-      onChange(e.currentTarget.textContent ?? '');
+      onChange(text);
     },
     [onChange],
   );
@@ -122,10 +151,21 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
     isComposingRef.current = true;
   }, []);
 
+  const handleCompositionUpdate = useCallback(
+    (e: ReactCompositionEvent<HTMLDivElement>) => {
+      // Repaint the mirror on every composition update so the in-progress
+      // glyphs track the caret without lagging a character behind.
+      setDisplayText(e.currentTarget.textContent ?? '');
+    },
+    [],
+  );
+
   const handleCompositionEnd = useCallback(
     (e: ReactCompositionEvent<HTMLDivElement>) => {
       isComposingRef.current = false;
-      onChange(e.currentTarget.textContent ?? '');
+      const text = e.currentTarget.textContent ?? '';
+      setDisplayText(text);
+      onChange(text);
     },
     [onChange],
   );
@@ -139,10 +179,12 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
     mirror.scrollLeft = e.currentTarget.scrollLeft;
   }, []);
 
-  const segments = splitIntoSegments(value, highlightTokens);
+  // The mirror paints `displayText` (live, includes in-progress IME glyphs),
+  // NOT `value` (which lags during composition).
+  const segments = splitIntoSegments(displayText, highlightTokens);
   // A trailing newline collapses on the last line of a wrapping box; append a
   // zero-content newline so the mirror's height matches the editable div.
-  const trailingNewline = value.endsWith('\n');
+  const trailingNewline = displayText.endsWith('\n');
 
   return (
     <div className="relative">
@@ -200,6 +242,7 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
         onBlur={onBlur}
         onScroll={handleScroll}
         onCompositionStart={handleCompositionStart}
+        onCompositionUpdate={handleCompositionUpdate}
         onCompositionEnd={handleCompositionEnd}
       />
     </div>

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
@@ -1,0 +1,134 @@
+import {
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useLayoutEffect,
+  useRef,
+  type ClipboardEvent as ReactClipboardEvent,
+  type CompositionEvent as ReactCompositionEvent,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react';
+import { setCaretOffset } from '@/utils/domSelection';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  onKeyDown?: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
+  onPaste?: (e: ReactClipboardEvent<HTMLDivElement>) => void;
+  onFocus?: () => void;
+  onBlur?: () => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  ariaLabel?: string;
+}
+
+/**
+ * RichInput — a `contentEditable="plaintext-only"` div that behaves like a
+ * controlled <textarea> for plain text. Mirrors the Claude Code extension
+ * composer: plaintext-only (Chromium/JCEF-safe, IME-friendly), CSS placeholder
+ * via `data-placeholder` on `:empty`, and CSS-only auto-grow (no resize hook).
+ *
+ * This stage renders opaque plain text only — no syntax highlight / mirror.
+ *
+ * value ↔ textContent sync rule: the DOM is only rewritten when it actually
+ * diverges from `value`, so user typing never triggers a caret-jumping reset.
+ * External (programmatic) value changes move the caret to the end. While an IME
+ * composition is in flight, the sync is skipped so the in-progress glyphs are
+ * never clobbered.
+ */
+export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
+  const {
+    value,
+    onChange,
+    onKeyDown,
+    onPaste,
+    onFocus,
+    onBlur,
+    placeholder,
+    disabled = false,
+    className,
+    ariaLabel,
+  } = props;
+
+  const elRef = useRef<HTMLDivElement>(null);
+  const isComposingRef = useRef(false);
+
+  // Expose the editable div to the parent (focus / domSelection utilities) while
+  // keeping our own internal ref for sync work.
+  useImperativeHandle(ref, () => elRef.current as HTMLDivElement, []);
+
+  // value → DOM sync. Only writes when the DOM diverges from `value` (prevents
+  // caret jumps on every keystroke) and never during IME composition.
+  useLayoutEffect(() => {
+    const el = elRef.current;
+    if (el === null) return;
+    if (isComposingRef.current) return;
+
+    const current = el.textContent ?? '';
+    if (current === value) return;
+
+    el.textContent = value;
+
+    // Only reposition the caret when this element is focused, so background
+    // (programmatic) updates don't steal the selection from elsewhere.
+    if (document.activeElement === el) {
+      setCaretOffset(el, value.length);
+    }
+  }, [value]);
+
+  const handleInput = useCallback(
+    (e: FormEvent<HTMLDivElement>) => {
+      // During composition the intermediate text is not yet committed; defer
+      // reporting until compositionend to avoid emitting partial glyphs.
+      if (isComposingRef.current) return;
+      onChange(e.currentTarget.textContent ?? '');
+    },
+    [onChange],
+  );
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback(
+    (e: ReactCompositionEvent<HTMLDivElement>) => {
+      isComposingRef.current = false;
+      onChange(e.currentTarget.textContent ?? '');
+    },
+    [onChange],
+  );
+
+  return (
+    <div
+      ref={elRef}
+      role="textbox"
+      aria-label={ariaLabel}
+      aria-multiline="true"
+      contentEditable={disabled ? false : 'plaintext-only'}
+      spellCheck={false}
+      suppressContentEditableWarning
+      data-placeholder={placeholder}
+      className={[
+        'w-full px-3 cursor-text bg-transparent text-base text-text-primary',
+        'min-h-[20px] max-h-[200px] overflow-y-auto',
+        'whitespace-pre-wrap break-words',
+        'focus:outline-none',
+        disabled ? 'opacity-50' : '',
+        className ?? '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onInput={handleInput}
+      onKeyDown={onKeyDown}
+      onPaste={onPaste}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+    />
+  );
+});
+
+RichInput.displayName = 'RichInput';

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/segments.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/segments.ts
@@ -1,0 +1,60 @@
+/**
+ * A contiguous run of the composer value, classified for the mirror overlay.
+ * `isToken` runs are wrapped in highlight chips; plain runs render as text.
+ */
+export interface Segment {
+  text: string;
+  isToken: boolean;
+}
+
+/**
+ * Split `value` into token / plain {@link Segment}s for the RichInput mirror.
+ *
+ * Scans left → right. At each position the longest token in `tokens` that the
+ * value starts with (from that index) is emitted as a token segment and the
+ * scan jumps past it; this prevents a shorter token (e.g. `src/file.ts`) from
+ * carving up a longer match (`src/file.ts#L10-L25`). Characters with no token
+ * match accumulate into a plain run, which is flushed as one segment when the
+ * next token begins or the value ends — so adjacent plain runs always merge.
+ *
+ * Empty-string tokens are ignored (they would never advance the cursor). An
+ * empty `tokens` list (or no matches) yields the whole value as one plain
+ * segment; an empty value yields an empty array.
+ */
+export function splitIntoSegments(
+  value: string,
+  tokens: readonly string[],
+): Segment[] {
+  const candidates = tokens.filter((t) => t.length > 0);
+  const segments: Segment[] = [];
+
+  let plainStart = 0;
+  let i = 0;
+
+  const flushPlain = (end: number) => {
+    if (end > plainStart) {
+      segments.push({ text: value.slice(plainStart, end), isToken: false });
+    }
+  };
+
+  while (i < value.length) {
+    let longest = '';
+    for (const token of candidates) {
+      if (token.length > longest.length && value.startsWith(token, i)) {
+        longest = token;
+      }
+    }
+
+    if (longest.length > 0) {
+      flushPlain(i);
+      segments.push({ text: longest, isToken: true });
+      i += longest.length;
+      plainStart = i;
+    } else {
+      i += 1;
+    }
+  }
+
+  flushPlain(value.length);
+  return segments;
+}

--- a/webview/src/pages/ChatPage/ChatInput/hooks/__tests__/useMention.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/hooks/__tests__/useMention.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// BridgeContext mock — LIST_PROJECT_FILES resolves with a fixed file/dir set so
+// selectResult has populated results to act on.
+// ---------------------------------------------------------------------------
+
+interface ProjectFile {
+  relativePath: string;
+  type: string;
+}
+
+let projectFiles: ProjectFile[] = [];
+
+const sendMock = vi.fn((type: string) => {
+  if (type === 'LIST_PROJECT_FILES') {
+    return Promise.resolve({ requestId: 'r', files: projectFiles });
+  }
+  return Promise.resolve({});
+});
+
+vi.mock('@/contexts/BridgeContext', () => ({
+  useBridgeContext: () => ({
+    isConnected: true,
+    send: sendMock,
+    subscribe: vi.fn(() => vi.fn()),
+    lastError: null,
+  }),
+}));
+
+// Imported AFTER vi.mock so the mock is wired first.
+import {
+  useMention,
+  buildMentionToken,
+  MentionResult,
+  MentionItemType,
+} from '../useMention';
+
+interface HarnessParams {
+  value: string;
+  onChange: (next: string) => void;
+  onInsertMention: (token: string, caretOffset: number) => void;
+}
+
+function renderMention(params: HarnessParams) {
+  return renderHook(
+    (props: HarnessParams) =>
+      useMention({
+        workingDirectory: '/work',
+        value: props.value,
+        onChange: props.onChange,
+        onInsertMention: props.onInsertMention,
+      }),
+    { initialProps: params },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+  projectFiles = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// Pure helper: buildMentionToken
+// ---------------------------------------------------------------------------
+
+describe('buildMentionToken', () => {
+  it('prefixes @ and returns the relativePath for a file', () => {
+    const result = new MentionResult({ relativePath: 'src/App.tsx', type: MentionItemType.File });
+    expect(buildMentionToken(result)).toBe('@src/App.tsx');
+  });
+
+  it('prefixes @ and adds a trailing slash for a directory', () => {
+    const result = new MentionResult({ relativePath: 'src/utils', type: MentionItemType.Directory });
+    expect(buildMentionToken(result)).toBe('@src/utils/');
+  });
+
+  it('does not double the trailing slash for a directory that already ends with /', () => {
+    const result = new MentionResult({ relativePath: 'src/utils/', type: MentionItemType.Directory });
+    expect(buildMentionToken(result)).toBe('@src/utils/');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectResult — inline insertion
+// ---------------------------------------------------------------------------
+
+describe('useMention — selectResult', () => {
+  it('replaces @query with "@relativePath " and fires onInsertMention for a file', async () => {
+    projectFiles = [{ relativePath: 'src/App.tsx', type: 'file' }];
+    const onChange = vi.fn();
+    const onInsertMention = vi.fn();
+
+    const { result } = renderMention({ value: '@App', onChange, onInsertMention });
+
+    act(() => {
+      result.current.detectMention('@App', 4);
+    });
+
+    await waitFor(() => expect(result.current.results.length).toBe(1));
+
+    act(() => {
+      result.current.selectResult(0);
+    });
+
+    expect(onChange).toHaveBeenCalledWith('@src/App.tsx ');
+    expect(onInsertMention).toHaveBeenCalledWith('@src/App.tsx', '@src/App.tsx '.length);
+  });
+
+  it('uses a trailing-slash token for a directory', async () => {
+    projectFiles = [{ relativePath: 'src/utils', type: 'directory' }];
+    const onChange = vi.fn();
+    const onInsertMention = vi.fn();
+
+    const { result } = renderMention({ value: '@utils', onChange, onInsertMention });
+
+    act(() => {
+      result.current.detectMention('@utils', 6);
+    });
+
+    await waitFor(() => expect(result.current.results.length).toBe(1));
+
+    act(() => {
+      result.current.selectResult(0);
+    });
+
+    expect(onChange).toHaveBeenCalledWith('@src/utils/ ');
+    expect(onInsertMention).toHaveBeenCalledWith('@src/utils/', '@src/utils/ '.length);
+  });
+
+  it('preserves surrounding text when the @mention is mid-string', async () => {
+    projectFiles = [{ relativePath: 'src/App.tsx', type: 'file' }];
+    const onChange = vi.fn();
+    const onInsertMention = vi.fn();
+
+    // "see @App now" — caret after "@App" (index 8).
+    const { result } = renderMention({ value: 'see @App now', onChange, onInsertMention });
+
+    act(() => {
+      result.current.detectMention('see @App now', 8);
+    });
+
+    await waitFor(() => expect(result.current.results.length).toBe(1));
+
+    act(() => {
+      result.current.selectResult(0);
+    });
+
+    expect(onChange).toHaveBeenCalledWith('see @src/App.tsx  now');
+    // caret sits just past "@src/App.tsx " — triggerIndex(4) + token(12) + space(1) = 17
+    expect(onInsertMention).toHaveBeenCalledWith('@src/App.tsx', 17);
+  });
+
+  it('closes the dropdown after selecting', async () => {
+    projectFiles = [{ relativePath: 'src/App.tsx', type: 'file' }];
+    const onChange = vi.fn();
+    const onInsertMention = vi.fn();
+
+    const { result } = renderMention({ value: '@App', onChange, onInsertMention });
+
+    act(() => {
+      result.current.detectMention('@App', 4);
+    });
+
+    await waitFor(() => expect(result.current.results.length).toBe(1));
+
+    act(() => {
+      result.current.selectResult(0);
+    });
+
+    expect(result.current.isActive).toBe(false);
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/hooks/useAttachments.ts
+++ b/webview/src/pages/ChatPage/ChatInput/hooks/useAttachments.ts
@@ -11,7 +11,7 @@ export interface UseAttachmentsReturn {
   error: string | null;
   isDragOver: boolean;
   setIsDragOver: (v: boolean) => void;
-  handlePaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  handlePaste: (e: React.ClipboardEvent<HTMLElement>) => void;
   handleDrop: (e: React.DragEvent) => void;
 }
 
@@ -91,7 +91,7 @@ export function useAttachments(): UseAttachmentsReturn {
     setError(null);
   }, []);
 
-  const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+  const handlePaste = useCallback(async (e: React.ClipboardEvent<HTMLElement>) => {
     const items = e.clipboardData?.items;
     if (!items) return;
 

--- a/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
+++ b/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
@@ -50,7 +50,7 @@ interface UseMentionReturn {
   selectedIndex: number;
   isLoading: boolean;
   detectMention: (value: string, cursorPosition: number) => void;
-  handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean;
+  handleKeyDown: (e: React.KeyboardEvent<HTMLElement>) => boolean;
   selectResult: (index: number) => void;
   close: () => void;
 }
@@ -206,7 +206,7 @@ export function useMention(params: UseMentionParams): UseMentionReturn {
   );
 
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLTextAreaElement>): boolean => {
+    (e: React.KeyboardEvent<HTMLElement>): boolean => {
       if (!state.isActive) return false;
 
       if (e.key === 'ArrowDown') {

--- a/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
+++ b/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
@@ -38,10 +38,29 @@ interface MentionState {
 
 interface UseMentionParams {
   workingDirectory: string | null | undefined;
-  addFileAttachment: (absolutePath: string, fileName: string, size?: number) => void;
-  addFolderAttachment: (absolutePath: string, folderName: string) => void;
+  /**
+   * Called with the inserted path token (no trailing space) and the caret
+   * offset immediately after the inserted `token + ' '`, so the composer can
+   * highlight the token as a chip and restore the caret. Fired once per
+   * successful {@link UseMentionReturn.selectResult}.
+   */
+  onInsertMention: (token: string, caretOffset: number) => void;
   value: string;
   onChange: (value: string) => void;
+}
+
+/**
+ * Build the inline path token for a selected mention result. The token is
+ * prefixed with `@` so Claude Code CLI can recognise it as a file reference.
+ * Directories get a single trailing slash (added only when not already present).
+ * Examples: `@src/App.tsx`, `@src/utils/`.
+ */
+export function buildMentionToken(result: MentionResult): string {
+  if (result.type === MentionItemType.Directory) {
+    const path = result.relativePath.endsWith('/') ? result.relativePath : `${result.relativePath}/`;
+    return `@${path}`;
+  }
+  return `@${result.relativePath}`;
 }
 
 interface UseMentionReturn {
@@ -58,7 +77,7 @@ interface UseMentionReturn {
 const DEBOUNCE_MS = 150;
 
 export function useMention(params: UseMentionParams): UseMentionReturn {
-  const { workingDirectory, addFileAttachment, addFolderAttachment, value, onChange } = params;
+  const { workingDirectory, onInsertMention, value, onChange } = params;
   const bridge = useBridgeContext();
 
   const [state, setState] = useState<MentionState>({
@@ -181,28 +200,27 @@ export function useMention(params: UseMentionParams): UseMentionReturn {
       const result = state.results[index];
       if (!result || !workingDirectory) return;
 
-      const absolutePath = workingDirectory.replace(/\/$/, '') + '/' + result.relativePath;
-
-      if (result.type === MentionItemType.Directory) {
-        const folderName = result.displayName;
-        addFolderAttachment(absolutePath, folderName);
-      } else {
-        const fileName = result.displayName;
-        addFileAttachment(absolutePath, fileName);
-      }
-
-      // textarea에서 @query 텍스트 제거
-      const currentValue = valueRef.current;
       const { triggerIndex } = state;
-
-      if (triggerIndex !== -1) {
-        const newValue = currentValue.slice(0, triggerIndex) + currentValue.slice(triggerIndex + 1 + state.query.length);
-        onChange(newValue);
+      if (triggerIndex === -1) {
+        close();
+        return;
       }
+
+      // Replace the `@query` span (from the `@` through the typed query) with the
+      // resolved path token plus a trailing space, keeping surrounding text intact.
+      const token = buildMentionToken(result);
+      const currentValue = valueRef.current;
+      const before = currentValue.slice(0, triggerIndex);
+      const after = currentValue.slice(triggerIndex + 1 + state.query.length);
+      const newValue = before + token + ' ' + after;
+      const caretOffset = triggerIndex + token.length + 1;
+
+      onChange(newValue);
+      onInsertMention(token, caretOffset);
 
       close();
     },
-    [state, workingDirectory, addFileAttachment, addFolderAttachment, onChange, close],
+    [state, workingDirectory, onInsertMention, onChange, close],
   );
 
   const handleKeyDown = useCallback(

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -189,12 +189,13 @@ export function ChatInput() {
 
   // Backend pushes EDITOR_CONTEXT (the file the user is viewing + selection)
   // → insert `relativePath[#L..]` at the composer caret.
-  // shouldFocus defaults to true; wiring it to a user setting is step 4.
+  // shouldFocus is controlled by the focusInputOnEditorContext user setting (default true).
   useEditorContext({
     value,
     onChange,
     textareaRef,
     currentWorkingDir: workingDirectory ?? '',
+    shouldFocus: claudeSettings.focusInputOnEditorContext ?? true,
   });
 
   const handleCompact = useCallback(() => {

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -51,6 +51,10 @@ export function ChatInput() {
   const bridge = useBridgeContext();
   const { subscribe } = bridge;
   const [isFocused, setIsFocused] = useState(false);
+  // Known path tokens (e.g. `src/file.ts#L10-L25`) inserted via Alt+K /
+  // EDITOR_CONTEXT, highlighted as chips in the composer. Reset on submit and
+  // session switch (where `value` returns to '').
+  const [pathTokens, setPathTokens] = useState<string[]>([]);
   const lastInitSessionRef = useRef<string | undefined>(undefined);
 
   const {
@@ -197,6 +201,8 @@ export function ChatInput() {
     textareaRef,
     currentWorkingDir: workingDirectory ?? '',
     shouldFocus: claudeSettings.focusInputOnEditorContext ?? true,
+    onInsertToken: (token) =>
+      setPathTokens(prev => (prev.includes(token) ? prev : [...prev, token])),
   });
 
   const handleCompact = useCallback(() => {
@@ -266,6 +272,7 @@ export function ChatInput() {
     prevChatInputSessionRef.current = currentSessionId;
     if (prev !== null && prev !== currentSessionId) {
       clearAttachments();
+      setPathTokens([]);
       inputHistory.initHistory([]);
       lastInitSessionRef.current = undefined;
     }
@@ -385,6 +392,7 @@ export function ChatInput() {
           inputHistory.pushToHistory(value);
           onSubmit(undefined, mode, attachments.length > 0 ? attachments : undefined);
           clearAttachments();
+          setPathTokens([]);
         }
       }
       // When willSubmit is false: do not prevent default — let the textarea handle it natively
@@ -511,6 +519,7 @@ export function ChatInput() {
             placeholder={isStreaming ? "Queue another message..." : "⌘ Esc to focus or unfocus Claude"}
             disabled={disabled}
             ariaLabel="Message Claude"
+            highlightTokens={pathTokens}
           />
         </div>
 
@@ -557,6 +566,7 @@ export function ChatInput() {
               onSubmit={() => {
                 onSubmit(undefined, mode, attachments.length > 0 ? attachments : undefined);
                 clearAttachments();
+                setPathTokens([]);
               }}
               onStop={onStop}
             />

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, KeyboardEvent, useState, type DragEvent as ReactDragEvent } from 'react';
+import { useCallback, useEffect, useRef, KeyboardEvent, useState, type ClipboardEvent as ReactClipboardEvent, type DragEvent as ReactDragEvent } from 'react';
 import { CommandPalettePanel } from '@/commandPalette/ui/CommandPalettePanel';
 import { useCommandPalette } from '@/commandPalette/hooks/useCommandPalette';
 import { PanelSectionId, PanelItemType, CommandItem } from '@/types/commandPalette';
@@ -7,7 +7,6 @@ import { InputModeTag } from './InputModeTag';
 import { ActionButtons } from './ActionButtons';
 import { useChatInputFocus } from '../../../contexts/ChatInputFocusContext';
 import { useInputHistory } from './hooks/useInputHistory';
-import { useTextareaAutoResize } from './hooks/useTextareaAutoResize';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useBridgeContext } from '@/contexts/BridgeContext';
@@ -29,6 +28,8 @@ import { MentionDropdown } from './MentionDropdown';
 import { isMobile } from '@/config/environment';
 import { shouldSubmitOnEnter } from './shouldSubmitOnEnter';
 import { basename } from './basename';
+import { RichInput } from './RichInput';
+import { getCaretOffset, setCaretOffset, getSelectionRange } from '@/utils/domSelection';
 
 interface NativeDropEntry {
   path: string;
@@ -211,24 +212,21 @@ export function ChatInput() {
     const handleMentionFromPalette = () => {
       // Defer to the next tick so that the palette closes before we insert @
       setTimeout(() => {
-        const textarea = textareaRef.current;
-        if (!textarea) return;
+        const el = textareaRef.current;
+        if (!el) return;
 
         onChange('@');
         mention.detectMention('@', 1);
 
         requestAnimationFrame(() => {
-          textarea.focus();
-          textarea.setSelectionRange(1, 1);
+          el.focus();
+          setCaretOffset(el, 1);
         });
       }, 0);
     };
     window.addEventListener('command-palette:mention-file', handleMentionFromPalette);
     return () => window.removeEventListener('command-palette:mention-file', handleMentionFromPalette);
   }, [onChange, mention, textareaRef]);
-
-  // Auto-resize textarea
-  useTextareaAutoResize({ textareaRef, value });
 
   // Focus on session change or when input becomes enabled
   useEffect(() => {
@@ -318,7 +316,7 @@ export function ChatInput() {
     inputHistory.initHistory(userTexts);
   }, [currentSessionId, messages, inputHistory]);
 
-  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key.startsWith('Arrow')) console.log('[KeyDebug:textarea-keydown]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
 
     // JCEF workaround: Cmd+Arrow 처리 후 발생하는 순수 Arrow 유령 이벤트 무시
@@ -339,24 +337,24 @@ export function ChatInput() {
     // JCEF workaround: Cmd+Arrow (macOS 줄 처음/끝 이동) 수동 처리
     // shiftKey가 있으면 선택 영역 확장이므로 기본 동작에 맡김
     if (e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey && isArrowKey) {
-      const textarea = e.currentTarget;
-      const pos = textarea.selectionStart;
-      const text = textarea.value;
+      const editor = e.currentTarget;
+      const pos = getCaretOffset(editor);
+      const text = editor.textContent ?? '';
 
       e.preventDefault();
       lastMetaArrowTime.current = Date.now();
 
       if (e.key === 'ArrowLeft') {
         const lineStart = text.lastIndexOf('\n', pos - 1) + 1;
-        textarea.setSelectionRange(lineStart, lineStart);
+        setCaretOffset(editor, lineStart);
       } else if (e.key === 'ArrowRight') {
         let lineEnd = text.indexOf('\n', pos);
         if (lineEnd === -1) lineEnd = text.length;
-        textarea.setSelectionRange(lineEnd, lineEnd);
+        setCaretOffset(editor, lineEnd);
       } else if (e.key === 'ArrowUp') {
-        textarea.setSelectionRange(0, 0);
+        setCaretOffset(editor, 0);
       } else if (e.key === 'ArrowDown') {
-        textarea.setSelectionRange(text.length, text.length);
+        setCaretOffset(editor, text.length);
       }
       return;
     }
@@ -393,7 +391,7 @@ export function ChatInput() {
     } else if (e.key === 'ArrowUp' && !palette.showSlashCommands) {
       console.log('[KeyDebug:history-up-triggered]');
       // 복수행: 커서가 첫 번째 줄에 있을 때만 히스토리 탐색
-      const pos = e.currentTarget.selectionStart;
+      const pos = getCaretOffset(e.currentTarget);
       if (value.lastIndexOf('\n', pos - 1) !== -1) return;
 
       const historyValue = inputHistory.navigateUp(value);
@@ -403,7 +401,7 @@ export function ChatInput() {
     } else if (e.key === 'ArrowDown' && !palette.showSlashCommands) {
       console.log('[KeyDebug:history-down-triggered]');
       // 복수행: 커서가 마지막 줄에 있을 때만 히스토리 탐색
-      const pos = e.currentTarget.selectionStart;
+      const pos = getCaretOffset(e.currentTarget);
       if (value.indexOf('\n', pos) !== -1) return;
 
       const historyValue = inputHistory.navigateDown();
@@ -413,12 +411,45 @@ export function ChatInput() {
     }
   }, [disabled, value, attachments.length, onSubmit, inputHistory, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
 
-  const handleChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const newValue = e.target.value;
+  const handleRichChange = useCallback((newValue: string) => {
     onChange(newValue);
     palette.detectSlashCommand(newValue);
-    mention.detectMention(newValue, e.target.selectionStart ?? newValue.length);
-  }, [onChange, palette, mention]);
+    const caret = textareaRef.current ? getCaretOffset(textareaRef.current) : newValue.length;
+    mention.detectMention(newValue, caret);
+  }, [onChange, palette, mention, textareaRef]);
+
+  // Wrap the attachment paste handler so that, when the clipboard carries no
+  // image, we insert the plain-text payload ourselves. contentEditable would
+  // otherwise paste rich HTML; plaintext-only strips formatting but we still
+  // route through onChange to keep `value` the single source of truth.
+  const handleRichPaste = useCallback((e: ReactClipboardEvent<HTMLDivElement>) => {
+    const items = e.clipboardData?.items;
+    const hasImage = items
+      ? Array.from(items).some(item => item.kind === 'file' && item.type.startsWith('image/'))
+      : false;
+
+    if (hasImage) {
+      // Delegate image handling (it calls preventDefault internally).
+      handlePaste(e);
+      return;
+    }
+
+    const text = e.clipboardData.getData('text/plain');
+    if (!text) return;
+
+    e.preventDefault();
+    const el = textareaRef.current;
+    const { start, end } = el ? getSelectionRange(el) : { start: value.length, end: value.length };
+    const newValue = value.slice(0, start) + text + value.slice(end);
+    onChange(newValue);
+    palette.detectSlashCommand(newValue);
+    const caret = start + text.length;
+    mention.detectMention(newValue, caret);
+    requestAnimationFrame(() => {
+      const target = textareaRef.current;
+      if (target) setCaretOffset(target, caret);
+    });
+  }, [handlePaste, value, onChange, palette, mention, textareaRef]);
 
   const hasValue = !!value.trim() || attachments.length > 0;
 
@@ -467,21 +498,19 @@ export function ChatInput() {
         {/* 드래그 오버 오버레이 */}
         <DragOverlay visible={isDragOver} />
 
-        {/* Textarea 영역 */}
+        {/* Composer 영역 */}
         <div className="pt-2.5 pb-1.5">
-          <textarea
+          <RichInput
             ref={textareaRef}
             value={value}
-            onChange={handleChange}
+            onChange={handleRichChange}
             onKeyDown={handleKeyDown}
             onFocus={() => setIsFocused(true)}
             onBlur={() => setIsFocused(false)}
-            onPaste={handlePaste}
+            onPaste={handleRichPaste}
             placeholder={isStreaming ? "Queue another message..." : "⌘ Esc to focus or unfocus Claude"}
             disabled={disabled}
-            rows={1}
-            className="w-full px-3 cursor-text resize-none bg-transparent text-base text-text-primary placeholder-text-disabled focus:outline-none disabled:opacity-50"
-            style={{ minHeight: '20px', maxHeight: '200px' }}
+            ariaLabel="Message Claude"
           />
         </div>
 

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -24,6 +24,7 @@ import { THINKING_TOGGLE_EVENT } from '@/commandPalette/sections/model/ThinkingI
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useEffort } from '@/hooks/useEffort';
 import { useMention } from './hooks/useMention';
+import { useEditorContext } from '@/hooks/useEditorContext';
 import { MentionDropdown } from './MentionDropdown';
 import { isMobile } from '@/config/environment';
 import { shouldSubmitOnEnter } from './shouldSubmitOnEnter';
@@ -184,6 +185,16 @@ export function ChatInput() {
     addFolderAttachment,
     value,
     onChange,
+  });
+
+  // Backend pushes EDITOR_CONTEXT (the file the user is viewing + selection)
+  // → insert `relativePath[#L..]` at the composer caret.
+  // shouldFocus defaults to true; wiring it to a user setting is step 4.
+  useEditorContext({
+    value,
+    onChange,
+    textareaRef,
+    currentWorkingDir: workingDirectory ?? '',
   });
 
   const handleCompact = useCallback(() => {

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -186,10 +186,17 @@ export function ChatInput() {
 
   const mention = useMention({
     workingDirectory,
-    addFileAttachment,
-    addFolderAttachment,
     value,
     onChange,
+    // @-mention selection inserts an inline path token (same chip set as Alt+K
+    // editor-context inserts), then restores the caret just past the token.
+    onInsertMention: (token, caretOffset) => {
+      setPathTokens(prev => (prev.includes(token) ? prev : [...prev, token]));
+      requestAnimationFrame(() => {
+        const el = textareaRef.current;
+        if (el) setCaretOffset(el, caretOffset);
+      });
+    },
   });
 
   // Backend pushes EDITOR_CONTEXT (the file the user is viewing + selection)

--- a/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
@@ -7,6 +7,8 @@ import { ContextPills } from './components/ContextPills';
 import { ImageAttachments } from './components/ImageAttachments';
 import { MessageActions } from './components/MessageActions';
 import { parseUserContent } from './utils/parseUserContent';
+import { tokenizeMessagePaths } from './utils/tokenizeMessagePaths';
+import { MessagePathChip } from './components/MessagePathChip';
 import { InterruptedMessageRenderer } from './InterruptedMessageRenderer';
 import { MessageBox } from './components/MessageBox';
 
@@ -79,7 +81,13 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
         <div className="min-w-0">
           <MessageBox>
             <div className="text-text-primary/80 text-[1rem] leading-[1.5] whitespace-pre-wrap break-words">
-              {parsedContent.text}
+              {tokenizeMessagePaths(parsedContent.text).map((seg, idx) =>
+                seg.isPath ? (
+                  <MessagePathChip key={idx} token={seg.text} />
+                ) : (
+                  <React.Fragment key={idx}>{seg.text}</React.Fragment>
+                ),
+              )}
             </div>
           </MessageBox>
         </div>

--- a/webview/src/pages/ChatPage/message-renderers/components/MessagePathChip.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/MessagePathChip.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { getAdapter } from '../../../../adapters';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
+import { pathFromToken, isFolderToken, resolveFilePath } from '../utils/tokenizeMessagePaths';
+
+interface Props {
+  token: string;
+}
+
+/**
+ * Renders an `@`-path mention from a submitted user message as a highlighted
+ * chip. File mentions are clickable and open the file in the IDE. The mention
+ * path is relative to the project, so it is resolved against the working
+ * directory into an absolute path before `openFile` (the IDE's file lookup
+ * needs an absolute path). Folder mentions (trailing `/`) render as a
+ * non-interactive chip because `openFile` only opens files.
+ */
+export const MessagePathChip = (props: Props) => {
+  const { token } = props;
+  const { workingDirectory } = useWorkingDir();
+  const isFolder = isFolderToken(token);
+
+  const open = (event: React.SyntheticEvent) => {
+    if (isFolder) return;
+    // Stop the parent MessageBox from toggling its expand/collapse state.
+    event.stopPropagation();
+    const filePath = resolveFilePath(pathFromToken(token), workingDirectory);
+    getAdapter()
+      .openFile(filePath)
+      .catch((err) => {
+        console.error('[MessagePathChip] Failed to open file:', err);
+      });
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (isFolder) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      open(event);
+    }
+  };
+
+  if (isFolder) {
+    return (
+      <span className="richInputChip" title={pathFromToken(token)}>
+        {token}
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="richInputChip cursor-pointer"
+      role="button"
+      tabIndex={0}
+      title={pathFromToken(token)}
+      onClick={open}
+      onKeyDown={handleKeyDown}
+    >
+      {token}
+    </span>
+  );
+};

--- a/webview/src/pages/ChatPage/message-renderers/components/__tests__/MessagePathChip.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/__tests__/MessagePathChip.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MessagePathChip } from '../MessagePathChip';
+
+const mockOpenFile = vi.fn(() => Promise.resolve());
+
+vi.mock('@/adapters', () => ({
+  getAdapter: () => ({
+    openFile: mockOpenFile,
+  }),
+}));
+
+vi.mock('@/contexts/WorkingDirContext', () => ({
+  useWorkingDir: () => ({ workingDirectory: '/abs/project', setWorkingDirectory: vi.fn() }),
+}));
+
+describe('MessagePathChip', () => {
+  beforeEach(() => {
+    mockOpenFile.mockClear();
+  });
+
+  it('파일 토큰을 칩으로 렌더하고 토큰 텍스트를 그대로 표시한다', () => {
+    render(<MessagePathChip token="@src/file.ts" />);
+    expect(screen.getByText('@src/file.ts')).toBeInTheDocument();
+  });
+
+  it('파일 토큰 클릭 시 워킹디렉토리와 결합한 절대경로로 openFile을 호출한다', () => {
+    render(<MessagePathChip token="@src/file.ts#L10-L25" />);
+    fireEvent.click(screen.getByText('@src/file.ts#L10-L25'));
+    expect(mockOpenFile).toHaveBeenCalledTimes(1);
+    expect(mockOpenFile).toHaveBeenCalledWith('/abs/project/src/file.ts');
+  });
+
+  it('파일 토큰은 role=button 으로 클릭 가능하다', () => {
+    render(<MessagePathChip token="@src/file.ts" />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('폴더 토큰은 클릭해도 openFile을 호출하지 않는다', () => {
+    render(<MessagePathChip token="@src/utils/" />);
+    const chip = screen.getByText('@src/utils/');
+    fireEvent.click(chip);
+    expect(mockOpenFile).not.toHaveBeenCalled();
+  });
+
+  it('폴더 토큰은 role=button 이 아니다', () => {
+    render(<MessagePathChip token="@src/utils/" />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/utils/__tests__/tokenizeMessagePaths.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/__tests__/tokenizeMessagePaths.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { tokenizeMessagePaths, pathFromToken, resolveFilePath } from '../tokenizeMessagePaths';
+
+describe('resolveFilePath', () => {
+  it('상대경로를 워킹디렉토리와 결합해 절대경로로 만든다', () => {
+    expect(resolveFilePath('src/file.ts', '/abs/project')).toBe('/abs/project/src/file.ts');
+  });
+  it('워킹디렉토리의 trailing slash를 중복 없이 처리한다', () => {
+    expect(resolveFilePath('src/file.ts', '/abs/project/')).toBe('/abs/project/src/file.ts');
+  });
+  it('이미 절대경로면 그대로 둔다', () => {
+    expect(resolveFilePath('/etc/hosts', '/abs/project')).toBe('/etc/hosts');
+  });
+  it('워킹디렉토리가 없으면 상대경로를 그대로 반환한다', () => {
+    expect(resolveFilePath('src/file.ts', null)).toBe('src/file.ts');
+    expect(resolveFilePath('src/file.ts', undefined)).toBe('src/file.ts');
+  });
+});
+
+describe('tokenizeMessagePaths', () => {
+  it('빈 문자열은 빈 배열을 반환한다', () => {
+    expect(tokenizeMessagePaths('')).toEqual([]);
+  });
+
+  it('경로가 없으면 전체를 평문 세그먼트 하나로 반환한다', () => {
+    expect(tokenizeMessagePaths('Hello, world!')).toEqual([
+      { text: 'Hello, world!', isPath: false },
+    ]);
+  });
+
+  it('문장 중간의 @경로 앞뒤 평문을 보존한다', () => {
+    const result = tokenizeMessagePaths('수정 대상은 @src/file.ts 입니다');
+    expect(result).toEqual([
+      { text: '수정 대상은 ', isPath: false },
+      { text: '@src/file.ts', isPath: true },
+      { text: ' 입니다', isPath: false },
+    ]);
+  });
+
+  it('라인 범위 토큰을 하나의 경로로 인식한다', () => {
+    const result = tokenizeMessagePaths('@src/file.ts#L10-L25 봐줘');
+    expect(result).toEqual([
+      { text: '@src/file.ts#L10-L25', isPath: true },
+      { text: ' 봐줘', isPath: false },
+    ]);
+  });
+
+  it('폴더 토큰(trailing slash)을 경로로 인식한다', () => {
+    const result = tokenizeMessagePaths('@src/utils/ 안의 파일');
+    expect(result).toEqual([
+      { text: '@src/utils/', isPath: true },
+      { text: ' 안의 파일', isPath: false },
+    ]);
+  });
+
+  it('토큰 끝의 문장부호는 토큰에서 제외하고 평문으로 둔다', () => {
+    const result = tokenizeMessagePaths('이 파일을 봐 @file.ts.');
+    expect(result).toEqual([
+      { text: '이 파일을 봐 ', isPath: false },
+      { text: '@file.ts', isPath: true },
+      { text: '.', isPath: false },
+    ]);
+  });
+
+  it('여러 종류의 끝 문장부호를 제외한다', () => {
+    const result = tokenizeMessagePaths('(@a.ts), [@b.ts]!');
+    expect(result).toEqual([
+      { text: '(', isPath: false },
+      { text: '@a.ts', isPath: true },
+      { text: '), [', isPath: false },
+      { text: '@b.ts', isPath: true },
+      { text: ']!', isPath: false },
+    ]);
+  });
+
+  it('여러 토큰을 순서대로 반환한다', () => {
+    const result = tokenizeMessagePaths('@a.ts and @b.ts');
+    expect(result).toEqual([
+      { text: '@a.ts', isPath: true },
+      { text: ' and ', isPath: false },
+      { text: '@b.ts', isPath: true },
+    ]);
+  });
+
+  it('한글 사이의 토큰을 인식한다', () => {
+    const result = tokenizeMessagePaths('여기@src/app.ts여기');
+    // '@'는 공백 경계가 아니어도 매칭되며, 비공백 문자가 한글까지 흡수될 수 있으나
+    // 한글은 경로 문자로 흔치 않으므로 토큰은 @ 이후 비공백을 흡수한다.
+    expect(result[0]).toEqual({ text: '여기', isPath: false });
+    expect(result[1].isPath).toBe(true);
+    expect(result[1].text.startsWith('@src/app.ts')).toBe(true);
+  });
+
+  it('@ 단독은 토큰이 아니다', () => {
+    const result = tokenizeMessagePaths('이메일 a@ 끝');
+    expect(result).toEqual([{ text: '이메일 a@ 끝', isPath: false }]);
+  });
+
+  it('줄바꿈을 보존한다', () => {
+    const result = tokenizeMessagePaths('첫줄 @a.ts\n둘째줄');
+    expect(result).toEqual([
+      { text: '첫줄 ', isPath: false },
+      { text: '@a.ts', isPath: true },
+      { text: '\n둘째줄', isPath: false },
+    ]);
+  });
+});
+
+describe('pathFromToken', () => {
+  it('@ 접두를 제거한다', () => {
+    expect(pathFromToken('@src/file.ts')).toBe('src/file.ts');
+  });
+
+  it('라인 범위(#L..-L..)를 제거한다', () => {
+    expect(pathFromToken('@src/file.ts#L10-L25')).toBe('src/file.ts');
+  });
+
+  it('단일 라인 범위(#L..)를 제거한다', () => {
+    expect(pathFromToken('@src/file.ts#L10')).toBe('src/file.ts');
+  });
+
+  it('폴더의 trailing slash를 보존한다', () => {
+    expect(pathFromToken('@src/utils/')).toBe('src/utils/');
+  });
+
+  it('@ 없는 토큰도 처리한다', () => {
+    expect(pathFromToken('src/file.ts')).toBe('src/file.ts');
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/utils/tokenizeMessagePaths.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/tokenizeMessagePaths.ts
@@ -1,0 +1,99 @@
+/**
+ * A contiguous run of a submitted user message, classified for chip rendering.
+ * `isPath` runs are `@`-prefixed file/folder mentions that render as clickable
+ * chips; plain runs render as text (preserving whitespace/newlines).
+ */
+export interface MessageSegment {
+  text: string;
+  isPath: boolean;
+}
+
+/**
+ * Matches an `@`-prefixed path mention inside a submitted message.
+ *
+ * - `@` opens the token.
+ * - `\S*` greedily absorbs the body (any non-space run, e.g. `src/file.ts`,
+ *   `src/file.ts#L10-L25`, `src/utils/`).
+ * - `[^\s.,;:!?)\]}]` forces the LAST captured character to be a non-trailing
+ *   punctuation char, so a sentence-ending mark is left as plain text
+ *   (`@file.ts.` → token `@file.ts` + plain `.`). A bare `@` cannot match
+ *   because at least one valid final char is required.
+ *
+ * Folder mentions end in `/`, which is intentionally NOT in the excluded set,
+ * so `@src/utils/` keeps its trailing slash.
+ */
+const PATH_TOKEN_PATTERN = /@\S*[^\s.,;:!?)\]}]/g;
+
+/**
+ * Tokenize a submitted user message into ordered {@link MessageSegment}s.
+ *
+ * Plain text between matches is preserved verbatim (including whitespace and
+ * newlines) so the caller can keep `whitespace-pre-wrap` layout. When the text
+ * has no `@`-path mention the whole string is returned as a single plain
+ * segment; an empty string yields an empty array.
+ */
+export function tokenizeMessagePaths(text: string): MessageSegment[] {
+  if (text.length === 0) return [];
+
+  const segments: MessageSegment[] = [];
+  const pattern = new RegExp(PATH_TOKEN_PATTERN.source, 'g');
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = pattern.exec(text)) !== null) {
+    if (match.index > lastIndex) {
+      segments.push({ text: text.slice(lastIndex, match.index), isPath: false });
+    }
+    segments.push({ text: match[0], isPath: true });
+    lastIndex = match.index + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({ text: text.slice(lastIndex), isPath: false });
+  }
+
+  if (segments.length === 0) {
+    return [{ text, isPath: false }];
+  }
+
+  return segments;
+}
+
+/**
+ * Normalize an `@`-path token into the path to open in the IDE.
+ *
+ * Strips the leading `@` and any trailing line range (`#L10` or `#L10-L25`).
+ * A folder token keeps its trailing `/` so the caller can detect folders and
+ * skip opening them.
+ *
+ * @example pathFromToken('@src/file.ts#L10-L25') // 'src/file.ts'
+ * @example pathFromToken('@src/utils/')          // 'src/utils/'
+ */
+export function pathFromToken(token: string): string {
+  return token
+    .replace(/^@/, '')
+    .replace(/#L\d+(?:-L\d+)?$/, '');
+}
+
+/**
+ * Whether a token refers to a folder (ends with `/`). Folder chips are not
+ * clickable because `openFile` opens files, not directories.
+ */
+export function isFolderToken(token: string): boolean {
+  return pathFromToken(token).endsWith('/');
+}
+
+/**
+ * Resolve a mention path (relative to the project) into an absolute path for
+ * `openFile`. The IDE's file lookup (Kotlin `findFileByPath`) needs an absolute
+ * path, and the backend forwards the path verbatim, so the webview must combine
+ * the relative mention with the working directory here.
+ *
+ * Already-absolute paths (leading `/`) pass through unchanged. When the working
+ * directory is unknown the relative path is returned as-is (best effort).
+ */
+export function resolveFilePath(relativePath: string, workingDir: string | null | undefined): string {
+  if (relativePath.startsWith('/')) return relativePath;
+  if (!workingDir) return relativePath;
+  return `${workingDir.replace(/\/+$/, '')}/${relativePath}`;
+}

--- a/webview/src/pages/SettingsPage/General/index.tsx
+++ b/webview/src/pages/SettingsPage/General/index.tsx
@@ -27,6 +27,7 @@ export function GeneralSettings() {
   const currentLanguage = isNotSet ? NOT_SET_VALUE : ((rawLanguage as string) ?? '');
 
   const useCtrlEnterToSend = (scopeSettings.useCtrlEnterToSend as boolean | undefined) ?? false;
+  const focusInputOnEditorContext = (scopeSettings.focusInputOnEditorContext as boolean | undefined) ?? true;
 
   return (
     <div>
@@ -72,6 +73,17 @@ export function GeneralSettings() {
             checked={useCtrlEnterToSend}
             onChange={(checked) => updateSetting('useCtrlEnterToSend', checked)}
             ariaLabel="Use Ctrl Enter To Send"
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="Focus chat input after attaching file path"
+          description="When you press Alt+K in the editor, move focus to the chat input after inserting the file path."
+        >
+          <ToggleSwitch
+            checked={focusInputOnEditorContext}
+            onChange={(checked) => updateSetting('focusInputOnEditorContext', checked)}
+            ariaLabel="Focus chat input after attaching file path"
           />
         </SettingRow>
       </SettingSection>

--- a/webview/src/types/claude-settings.ts
+++ b/webview/src/types/claude-settings.ts
@@ -25,6 +25,7 @@ export interface ClaudeSettingsState {
   alwaysThinkingEnabled: boolean; // extended thinking always on
   preferFastMode: boolean; // fast output mode (Opus 4.6 only)
   useCtrlEnterToSend: boolean; // when true, Ctrl/Cmd+Enter sends; plain Enter inserts a newline
+  focusInputOnEditorContext: boolean; // when true, move focus to chat input after inserting file path via Alt+K
   permissions?: PermissionsConfig;
   [key: string]: unknown; // extensible for future settings
 }
@@ -36,4 +37,5 @@ export const DEFAULT_CLAUDE_SETTINGS: ClaudeSettingsState = {
   alwaysThinkingEnabled: true,
   preferFastMode: false,
   useCtrlEnterToSend: false,
+  focusInputOnEditorContext: true,
 };

--- a/webview/src/utils/__tests__/domSelection.test.ts
+++ b/webview/src/utils/__tests__/domSelection.test.ts
@@ -1,0 +1,384 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  textOffsetToPoint,
+  pointToTextOffset,
+  getCaretOffset,
+  setCaretOffset,
+  getSelectionRange,
+  setSelectionRange,
+} from '../domSelection';
+
+// jsdom is available via vitest's jsdom environment.
+// Selection API in jsdom is limited (addRange / getSelection work for basic cases),
+// so layer B (getCaretOffset, setCaretOffset, getSelectionRange, setSelectionRange)
+// tests are kept shallow — they just verify the functions exist and don't throw.
+
+function makeDiv(...children: (string | HTMLElement)[]): HTMLDivElement {
+  const div = document.createElement('div');
+  for (const child of children) {
+    if (typeof child === 'string') {
+      div.appendChild(document.createTextNode(child));
+    } else {
+      div.appendChild(child);
+    }
+  }
+  return div;
+}
+
+// ---------------------------------------------------------------------------
+// Layer A — textOffsetToPoint
+// ---------------------------------------------------------------------------
+
+describe('textOffsetToPoint', () => {
+  describe('single textNode', () => {
+    let root: HTMLDivElement;
+    let textNode: Text;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      textNode = document.createTextNode('hello');
+      root.appendChild(textNode);
+    });
+
+    it('offset 0 → {node: textNode, offset: 0}', () => {
+      const result = textOffsetToPoint(root, 0);
+      expect(result.node).toBe(textNode);
+      expect(result.offset).toBe(0);
+    });
+
+    it('offset 2 → {node: textNode, offset: 2}', () => {
+      const result = textOffsetToPoint(root, 2);
+      expect(result.node).toBe(textNode);
+      expect(result.offset).toBe(2);
+    });
+
+    it('offset 5 (end) → {node: textNode, offset: 5}', () => {
+      const result = textOffsetToPoint(root, 5);
+      expect(result.node).toBe(textNode);
+      expect(result.offset).toBe(5);
+    });
+
+    it('offset exceeding length → clamp to last position', () => {
+      const result = textOffsetToPoint(root, 100);
+      expect(result.node).toBe(textNode);
+      expect(result.offset).toBe(5);
+    });
+  });
+
+  describe('empty div (no textNodes)', () => {
+    it('offset 0 → {node: root, offset: 0}', () => {
+      const root = document.createElement('div');
+      const result = textOffsetToPoint(root, 0);
+      expect(result.node).toBe(root);
+      expect(result.offset).toBe(0);
+    });
+
+    it('any positive offset on empty div → {node: root, offset: 0}', () => {
+      const root = document.createElement('div');
+      const result = textOffsetToPoint(root, 5);
+      expect(result.node).toBe(root);
+      expect(result.offset).toBe(0);
+    });
+  });
+
+  describe('multiple textNodes across child elements', () => {
+    // Structure: <div><span>ab</span>cd</div>
+    // textNodes: ["ab"(span child), "cd"(div direct child)]
+    // global offsets: 0-1 → "ab", 2-3 → "cd"
+    let root: HTMLDivElement;
+    let abNode: Text;
+    let cdNode: Text;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      const span = document.createElement('span');
+      abNode = document.createTextNode('ab');
+      span.appendChild(abNode);
+      cdNode = document.createTextNode('cd');
+      root.appendChild(span);
+      root.appendChild(cdNode);
+    });
+
+    it('offset 0 → first textNode "ab", offset 0', () => {
+      const result = textOffsetToPoint(root, 0);
+      expect(result.node).toBe(abNode);
+      expect(result.offset).toBe(0);
+    });
+
+    it('offset 1 → first textNode "ab", offset 1', () => {
+      const result = textOffsetToPoint(root, 1);
+      expect(result.node).toBe(abNode);
+      expect(result.offset).toBe(1);
+    });
+
+    it('offset 2 → second textNode "cd", offset 0', () => {
+      const result = textOffsetToPoint(root, 2);
+      expect(result.node).toBe(cdNode);
+      expect(result.offset).toBe(0);
+    });
+
+    it('offset 3 → second textNode "cd", offset 1', () => {
+      const result = textOffsetToPoint(root, 3);
+      expect(result.node).toBe(cdNode);
+      expect(result.offset).toBe(1);
+    });
+
+    it('offset 4 (total length) → clamp to last textNode end', () => {
+      const result = textOffsetToPoint(root, 4);
+      expect(result.node).toBe(cdNode);
+      expect(result.offset).toBe(2);
+    });
+
+    it('offset beyond total → clamp', () => {
+      const result = textOffsetToPoint(root, 999);
+      expect(result.node).toBe(cdNode);
+      expect(result.offset).toBe(2);
+    });
+  });
+
+  describe('deeply nested structure', () => {
+    // <div><p><span>foo</span></p><p>bar</p></div>
+    // textContent = "foobar", offsets 0-2→foo, 3-5→bar
+    let root: HTMLDivElement;
+    let fooNode: Text;
+    let barNode: Text;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      const p1 = document.createElement('p');
+      const span = document.createElement('span');
+      fooNode = document.createTextNode('foo');
+      span.appendChild(fooNode);
+      p1.appendChild(span);
+      const p2 = document.createElement('p');
+      barNode = document.createTextNode('bar');
+      p2.appendChild(barNode);
+      root.appendChild(p1);
+      root.appendChild(p2);
+    });
+
+    it('offset 0 → fooNode, 0', () => {
+      const result = textOffsetToPoint(root, 0);
+      expect(result.node).toBe(fooNode);
+      expect(result.offset).toBe(0);
+    });
+
+    it('offset 2 → fooNode, 2', () => {
+      const result = textOffsetToPoint(root, 2);
+      expect(result.node).toBe(fooNode);
+      expect(result.offset).toBe(2);
+    });
+
+    it('offset 3 → barNode, 0', () => {
+      const result = textOffsetToPoint(root, 3);
+      expect(result.node).toBe(barNode);
+      expect(result.offset).toBe(0);
+    });
+
+    it('offset 5 → barNode, 2', () => {
+      const result = textOffsetToPoint(root, 5);
+      expect(result.node).toBe(barNode);
+      expect(result.offset).toBe(2);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer A — pointToTextOffset
+// ---------------------------------------------------------------------------
+
+describe('pointToTextOffset', () => {
+  describe('single textNode', () => {
+    let root: HTMLDivElement;
+    let textNode: Text;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      textNode = document.createTextNode('hello');
+      root.appendChild(textNode);
+    });
+
+    it('(textNode, 0) → 0', () => {
+      expect(pointToTextOffset(root, textNode, 0)).toBe(0);
+    });
+
+    it('(textNode, 3) → 3', () => {
+      expect(pointToTextOffset(root, textNode, 3)).toBe(3);
+    });
+
+    it('(textNode, 5) → 5', () => {
+      expect(pointToTextOffset(root, textNode, 5)).toBe(5);
+    });
+  });
+
+  describe('empty div', () => {
+    it('(root, 0) on empty div → 0', () => {
+      const root = document.createElement('div');
+      expect(pointToTextOffset(root, root, 0)).toBe(0);
+    });
+  });
+
+  describe('multiple textNodes', () => {
+    // <div><span>ab</span>cd</div>
+    let root: HTMLDivElement;
+    let abNode: Text;
+    let cdNode: Text;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      const span = document.createElement('span');
+      abNode = document.createTextNode('ab');
+      span.appendChild(abNode);
+      cdNode = document.createTextNode('cd');
+      root.appendChild(span);
+      root.appendChild(cdNode);
+    });
+
+    it('(abNode, 0) → 0', () => {
+      expect(pointToTextOffset(root, abNode, 0)).toBe(0);
+    });
+
+    it('(abNode, 1) → 1', () => {
+      expect(pointToTextOffset(root, abNode, 1)).toBe(1);
+    });
+
+    it('(cdNode, 0) → 2', () => {
+      expect(pointToTextOffset(root, cdNode, 0)).toBe(2);
+    });
+
+    it('(cdNode, 1) → 3', () => {
+      expect(pointToTextOffset(root, cdNode, 1)).toBe(3);
+    });
+
+    it('(cdNode, 2) → 4', () => {
+      expect(pointToTextOffset(root, cdNode, 2)).toBe(4);
+    });
+
+    it('element node as anchor → offset equals preceding text length', () => {
+      // passing root itself as the "node" with childIndex 0 → before first child
+      // This simulates a Selection that lands on an element node rather than text
+      const span = root.firstElementChild!;
+      // pointToTextOffset with element node: text accumulated before span = 0
+      expect(pointToTextOffset(root, span, 0)).toBe(0);
+    });
+  });
+
+  describe('round-trip: textOffsetToPoint → pointToTextOffset', () => {
+    // <div><span>ab</span>cd</div>, total length 4
+    let root: HTMLDivElement;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      const span = document.createElement('span');
+      span.appendChild(document.createTextNode('ab'));
+      root.appendChild(span);
+      root.appendChild(document.createTextNode('cd'));
+    });
+
+    it.each([0, 1, 2, 3, 4])('round-trip for offset %i', (offset) => {
+      const point = textOffsetToPoint(root, offset);
+      const restored = pointToTextOffset(root, point.node, point.offset);
+      expect(restored).toBe(offset);
+    });
+  });
+
+  describe('round-trip: deeply nested', () => {
+    // <div><p><span>foo</span></p><p>bar</p></div>, total length 6
+    let root: HTMLDivElement;
+
+    beforeEach(() => {
+      root = document.createElement('div');
+      const p1 = document.createElement('p');
+      const span = document.createElement('span');
+      span.appendChild(document.createTextNode('foo'));
+      p1.appendChild(span);
+      const p2 = document.createElement('p');
+      p2.appendChild(document.createTextNode('bar'));
+      root.appendChild(p1);
+      root.appendChild(p2);
+    });
+
+    it.each([0, 1, 2, 3, 4, 5, 6])('round-trip for offset %i', (offset) => {
+      const point = textOffsetToPoint(root, offset);
+      const restored = pointToTextOffset(root, point.node, point.offset);
+      expect(restored).toBe(offset);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer B — Selection wrapper (shallow smoke tests, jsdom limitation aware)
+// ---------------------------------------------------------------------------
+
+describe('Layer B Selection wrappers (smoke tests)', () => {
+  it('exports getCaretOffset as a function', () => {
+    expect(typeof getCaretOffset).toBe('function');
+  });
+
+  it('exports setCaretOffset as a function', () => {
+    expect(typeof setCaretOffset).toBe('function');
+  });
+
+  it('exports getSelectionRange as a function', () => {
+    expect(typeof getSelectionRange).toBe('function');
+  });
+
+  it('exports setSelectionRange as a function', () => {
+    expect(typeof setSelectionRange).toBe('function');
+  });
+
+  it('getCaretOffset returns 0 when no selection exists', () => {
+    // jsdom: getSelection() returns a Selection object but with no ranges
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    // Clear any existing selection
+    window.getSelection()?.removeAllRanges();
+    const offset = getCaretOffset(root);
+    expect(offset).toBe(0);
+    document.body.removeChild(root);
+  });
+
+  it('setCaretOffset does not throw even on empty div', () => {
+    const root = makeDiv();
+    document.body.appendChild(root);
+    expect(() => setCaretOffset(root, 0)).not.toThrow();
+    document.body.removeChild(root);
+  });
+
+  it('getSelectionRange returns {start:0, end:0} when no selection', () => {
+    const root = makeDiv('hello');
+    document.body.appendChild(root);
+    window.getSelection()?.removeAllRanges();
+    const range = getSelectionRange(root);
+    expect(range.start).toBe(0);
+    expect(range.end).toBe(0);
+    document.body.removeChild(root);
+  });
+
+  it('setSelectionRange does not throw', () => {
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    expect(() => setSelectionRange(root, 0, 5)).not.toThrow();
+    document.body.removeChild(root);
+  });
+
+  it('setCaretOffset + getCaretOffset round-trip on a div with text', () => {
+    const root = makeDiv('hello');
+    document.body.appendChild(root);
+
+    setCaretOffset(root, 3);
+    const offset = getCaretOffset(root);
+    // jsdom selection support is limited; just verify no exception and offset is a number
+    expect(typeof offset).toBe('number');
+    expect(offset).toBeGreaterThanOrEqual(0);
+
+    document.body.removeChild(root);
+  });
+
+  it('setSelectionRange for out-of-root selection does not throw', () => {
+    const root = makeDiv('hello');
+    // Don't attach to body — simulates out-of-document element
+    // Should not throw
+    expect(() => setSelectionRange(root, 0, 3)).not.toThrow();
+  });
+});

--- a/webview/src/utils/domSelection.ts
+++ b/webview/src/utils/domSelection.ts
@@ -1,0 +1,244 @@
+/**
+ * DOM Selection utilities for contentEditable plain-text offset mapping.
+ *
+ * Splits into two layers:
+ *
+ * Layer A — Pure tree mapping (no window.getSelection):
+ *   Converts between a plain-text character offset (relative to root.textContent)
+ *   and a {node, offset} DOM point. Fully unit-testable in jsdom.
+ *
+ * Layer B — Selection wrappers (uses window.getSelection):
+ *   Uses Layer A internally. Assumes root is focused and in the document.
+ *   jsdom support is limited; safe fallbacks are provided for missing APIs.
+ */
+
+// ---------------------------------------------------------------------------
+// Shared types
+// ---------------------------------------------------------------------------
+
+/** A cursor position in the DOM tree: a (node, offset-within-node) pair. */
+export interface DomPoint {
+  node: Node;
+  offset: number;
+}
+
+/** A selection range expressed as plain-text offsets relative to a root element. */
+export interface TextRange {
+  start: number;
+  end: number;
+}
+
+// ---------------------------------------------------------------------------
+// Layer A — Pure tree mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all Text nodes under `root` in depth-first order.
+ */
+function collectTextNodes(root: HTMLElement): Text[] {
+  const nodes: Text[] = [];
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let current = walker.nextNode();
+  while (current !== null) {
+    nodes.push(current as Text);
+    current = walker.nextNode();
+  }
+  return nodes;
+}
+
+/**
+ * Convert a plain-text `offset` (0-based, relative to `root.textContent`) to a
+ * DOM {node, offset} point.
+ *
+ * - Traverses text nodes depth-first, accumulating lengths.
+ * - Clamps to the last valid position if `offset` exceeds total length.
+ * - Returns {node: root, offset: 0} when there are no text nodes (empty element).
+ */
+export function textOffsetToPoint(root: HTMLElement, offset: number): DomPoint {
+  const textNodes = collectTextNodes(root);
+
+  if (textNodes.length === 0) {
+    return { node: root, offset: 0 };
+  }
+
+  let accumulated = 0;
+  for (let i = 0; i < textNodes.length; i++) {
+    const node = textNodes[i];
+    const len = node.length;
+    const isLast = i === textNodes.length - 1;
+
+    // offset falls strictly within this text node
+    if (offset < accumulated + len) {
+      return { node, offset: offset - accumulated };
+    }
+
+    // offset equals the end of this text node: prefer placing it at the
+    // *start* of the next text node so that moving one character forward
+    // crosses the node boundary cleanly — but only if a next node exists.
+    if (offset === accumulated + len && !isLast) {
+      return { node: textNodes[i + 1], offset: 0 };
+    }
+
+    // Last node (or past all nodes): clamp to end
+    if (isLast) {
+      const nodeOffset = Math.max(0, Math.min(offset - accumulated, len));
+      return { node, offset: nodeOffset };
+    }
+
+    accumulated += len;
+  }
+
+  // Should not reach here, but satisfy the compiler
+  const last = textNodes[textNodes.length - 1];
+  return { node: last, offset: last.length };
+}
+
+/**
+ * Convert a DOM {node, nodeOffset} point back to a plain-text offset relative
+ * to `root.textContent`.
+ *
+ * - If `node` is a Text node: sum lengths of all preceding text nodes + nodeOffset.
+ * - If `node` is an Element: sum lengths of text nodes that come before `node`
+ *   in document order (nodeOffset is treated as a child-index boundary, but for
+ *   plain-text purposes we just count the text accumulated up to that element).
+ * - Returns 0 for the root itself with any offset.
+ */
+export function pointToTextOffset(
+  root: HTMLElement,
+  node: Node,
+  nodeOffset: number,
+): number {
+  // root element with offset 0 → start of content
+  if (node === root) {
+    return 0;
+  }
+
+  const textNodes = collectTextNodes(root);
+
+  if (node.nodeType === Node.TEXT_NODE) {
+    let accumulated = 0;
+    for (const tn of textNodes) {
+      if (tn === node) {
+        return accumulated + Math.min(nodeOffset, tn.length);
+      }
+      accumulated += tn.length;
+    }
+    // node not found inside root — return 0
+    return 0;
+  }
+
+  // Element node: find how many text-node characters precede this element
+  // by walking the tree and stopping when we reach `node` (or its subtree).
+  let accumulated = 0;
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_ALL);
+  let current: Node | null = walker.nextNode();
+  while (current !== null) {
+    if (current === node) {
+      break;
+    }
+    if (current.nodeType === Node.TEXT_NODE) {
+      accumulated += (current as Text).length;
+    }
+    current = walker.nextNode();
+  }
+  return accumulated;
+}
+
+// ---------------------------------------------------------------------------
+// Layer B — Selection wrappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the current caret (focus) position as a plain-text offset relative to
+ * `root.textContent`. Returns 0 if there is no selection or the selection is
+ * outside `root`.
+ */
+export function getCaretOffset(root: HTMLElement): number {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return 0;
+
+  const focusNode = selection.focusNode;
+  if (focusNode === null || !root.contains(focusNode)) return 0;
+
+  // Use focus point for caret position
+  try {
+    return pointToTextOffset(root, focusNode, selection.focusOffset);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Move the caret to `offset` (plain-text, relative to `root.textContent`).
+ * No-op if there is no Selection API or if `root` has no content at that offset.
+ */
+export function setCaretOffset(root: HTMLElement, offset: number): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  try {
+    const point = textOffsetToPoint(root, offset);
+    const range = document.createRange();
+    range.setStart(point.node, point.offset);
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  } catch {
+    // Silently ignore if DOM is in an unexpected state
+  }
+}
+
+/**
+ * Return the current selection as {start, end} plain-text offsets, with
+ * start <= end always. Falls back to {start: 0, end: 0} if there is no
+ * selection or the selection is outside `root`.
+ */
+export function getSelectionRange(root: HTMLElement): TextRange {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return { start: 0, end: 0 };
+
+  const anchorNode = selection.anchorNode;
+  const focusNode = selection.focusNode;
+
+  if (
+    anchorNode === null ||
+    focusNode === null ||
+    !root.contains(anchorNode) ||
+    !root.contains(focusNode)
+  ) {
+    return { start: 0, end: 0 };
+  }
+
+  try {
+    const anchor = pointToTextOffset(root, anchorNode, selection.anchorOffset);
+    const focus = pointToTextOffset(root, focusNode, selection.focusOffset);
+    return { start: Math.min(anchor, focus), end: Math.max(anchor, focus) };
+  } catch {
+    return { start: 0, end: 0 };
+  }
+}
+
+/**
+ * Set the selection to [start, end] (plain-text offsets, relative to
+ * `root.textContent`). Silently ignores errors (e.g., root not in document).
+ */
+export function setSelectionRange(
+  root: HTMLElement,
+  start: number,
+  end: number,
+): void {
+  const selection = window.getSelection();
+  if (!selection) return;
+
+  try {
+    const startPoint = textOffsetToPoint(root, start);
+    const endPoint = textOffsetToPoint(root, end);
+    const range = document.createRange();
+    range.setStart(startPoint.node, startPoint.offset);
+    range.setEnd(endPoint.node, endPoint.offset);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  } catch {
+    // Silently ignore if DOM is not attached or in an unexpected state
+  }
+}


### PR DESCRIPTION
Closes #44 · supersedes the Option+K part of #10 (011 Phase 2)

## Goal
A remappable `Alt+K` shortcut that inserts the current editor file's path into the chat input as an inline chip, plus a richer composer where file references (Alt+K and `@`mentions) render as highlighted `@`-path chips.

## Part A — Alt+K editor-context insertion
Backbone follows the agreed design for #10's Option+K (`.omc/plans/option-k-editor-selection.md`, Rev.4): HTTP POST → broadcast + pending buffer + workingDir scoping. The result is **text inserted into the composer**, not an attachment chip.

- **Kotlin** `SendSelectionToClaudeAction` — `alt K` + editor context menu; resolves the file's relative path (+ selection range), ensures the backend, POSTs editor context (b81cd65). Focuses the open Claude tab instead of opening a new one (958a55e).
- **Backend** `POST /internal/editor-context` — validate → broadcast `EDITOR_CONTEXT` or buffer (10s TTL) and replay on next connect (c1b89d9). Plus a pre-existing import-path fix to keep be-lint green (643577d).
- **WebView** `useEditorContext` — insert at caret, working-dir filter, 500ms dedup, focus/caret move (aaa7808). Focus toggle setting `focusInputOnEditorContext` (bc6eb12).

## Part B — Rich composer (contenteditable + inline chips)
Reverse-engineered the Claude Code VS Code extension: it uses a `contentEditable="plaintext-only"` div with a transparent-text + mirror-overlay highlight (no rich-text library). We mirror that.

- **Caret utils** `domSelection` — plain-text offset <-> Selection/Range, replacing textarea's selectionStart/setSelectionRange (7523186).
- **RichInput** — contentEditable composer behaving like a controlled textarea; value<->textContent sync with no caret jumps, IME-safe (1e014cc). Swapped into ChatInput, porting every selection/value dependency (f524800). Korean IME + caret verified in-IDE.
- **Highlight** — transparent editable glyphs + a mirror overlay that chips known path tokens; box-shadow (not padding) keeps glyphs aligned; real-time mirror for IME, placeholder restored (179f314, 6144fa5).
- **@mentions as inline chips** — selecting a mention inserts an `@`-path into the text (the "insert" intent) sharing Alt+K's token set; attach intents (picker/drag/paste) keep the attachment preview. `@` prefix so the CLI reads the file (fa5ea44). Verified: Claude reads the referenced file on submit.

## Verification
- Layer tests: Kotlin 11 · Backend 33 · WebView 616 — all pass
- `full-build` (be + wv + plugin) BUILD SUCCESSFUL
- In-IDE: Korean IME (no lag), caret alignment, placeholder, mention/Alt+K chips, Claude reading referenced files — all confirmed

## Part C — Path chips in message bubbles
Submitted user messages now highlight `@`-path mentions as chips too, matching the composer. File chips are clickable and open the file in the IDE (the relative mention is resolved against the working directory into an absolute path). Folder chips are static. (6425932)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

