### PR TITLE
fix: find Node.js by capturing the user's shell PATH (#59)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeExecutableResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeExecutableResolver.kt
@@ -1,0 +1,77 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+/**
+ * Pure logic for resolving which Node.js installation to use.
+ *
+ * Extracted from [NodeProcessManager] so it can be unit-tested without touching
+ * the real filesystem or environment. The filesystem-facing glue (listing
+ * `~/.nvm/versions/node/`, reading `~/.nvm/alias/default`, existence checks) lives
+ * in [NodeProcessManager]; the version-selection policy lives here.
+ */
+object NodeExecutableResolver {
+
+    /**
+     * Pick the best nvm-installed node version directory name.
+     *
+     * nvm stores each version under `~/.nvm/versions/node/<name>` (e.g. `v24.16.0`)
+     * and records the user's default in `~/.nvm/alias/default` — which may hold an
+     * exact version (`v24.16.0`), a partial version (`24`, `v24`), or an LTS codename
+     * (`lts/iron`). Crucially, nvm does NOT create a `current` symlink, so the old
+     * `~/.nvm/current/bin/node` fallback never matched for nvm users (#59).
+     *
+     * Resolution order:
+     * 1. Exact match against the default alias.
+     * 2. Major-version prefix match against the default alias (newest matching minor).
+     * 3. Fall back to the newest installed version by numeric semver.
+     *
+     * @param installedVersions directory names found under `~/.nvm/versions/node/`
+     * @param defaultAlias raw contents of `~/.nvm/alias/default`, or null if absent
+     * @return the chosen directory name, or null when nothing usable is installed
+     */
+    fun selectNvmVersion(installedVersions: List<String>, defaultAlias: String?): String? {
+        val versions = installedVersions
+            .filter { isVersionName(it) }
+            .sortedWith(compareByDescending(VERSION_COMPARATOR) { it })
+        if (versions.isEmpty()) return null
+
+        val alias = defaultAlias?.trim()?.takeIf { it.isNotEmpty() }
+        if (alias != null) {
+            val normalized = alias.removePrefix("v")
+
+            // 1. Exact version match (with or without leading "v").
+            versions.firstOrNull { it.removePrefix("v") == normalized }?.let { return it }
+
+            // 2. Major-version prefix match (e.g. "24" -> newest v24.x). Only when the
+            //    alias is purely numeric, so codenames like "lts/iron" don't match.
+            if (normalized.all { it.isDigit() }) {
+                versions.firstOrNull { parseVersion(it).firstOrNull() == normalized.toInt() }
+                    ?.let { return it }
+            }
+        }
+
+        // 3. Newest installed version.
+        return versions.first()
+    }
+
+    /** True when [name] looks like `v24.16.0` / `24.16.0`. */
+    private fun isVersionName(name: String): Boolean {
+        val core = name.removePrefix("v")
+        val parts = core.split('.')
+        return parts.isNotEmpty() && parts.all { it.isNotEmpty() && it.all(Char::isDigit) }
+    }
+
+    /** Parse `v24.16.0` into `[24, 16, 0]`; non-numeric segments stop at 0. */
+    private fun parseVersion(name: String): List<Int> =
+        name.removePrefix("v").split('.').map { it.toIntOrNull() ?: 0 }
+
+    /** Compares version names like `v24.16.0` segment-by-segment, numerically. */
+    private val VERSION_COMPARATOR = Comparator<String> { a, b ->
+        val pa = parseVersion(a)
+        val pb = parseVersion(b)
+        for (i in 0 until maxOf(pa.size, pb.size)) {
+            val cmp = (pa.getOrElse(i) { 0 }).compareTo(pb.getOrElse(i) { 0 })
+            if (cmp != 0) return@Comparator cmp
+        }
+        0
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -60,37 +60,42 @@ class NodeProcessManager(
      * Start the Node.js backend process.
      */
     fun start() {
-        val nodePath = findNodeExecutable()
-        if (nodePath == null) {
-            logger.error(
-                "Node.js executable not found. The plugin searched PATH and common install " +
-                    "locations (nvm, volta, fnm, Homebrew) but found nothing.\n" +
-                    "How to fix:\n" +
-                    "  1. Install Node.js, or make sure 'node' is on your PATH.\n" +
-                    "  2. If you use nvm, run 'nvm alias default <version>' so a default is set.\n" +
-                    "  3. Or set the NODE_PATH_OVERRIDE environment variable to your node binary " +
-                    "(e.g. ~/.nvm/versions/node/v24.16.0/bin/node)."
-            )
-            _portDeferred.completeExceptionally(
-                IllegalStateException("Node.js executable not found")
-            )
-            return
-        }
-
-        val backendFile = findBackendFile()
-        if (backendFile == null) {
-            logger.error("Backend entry file (backend.mjs) not found.")
-            _portDeferred.completeExceptionally(
-                IllegalStateException("Backend entry file not found")
-            )
-            return
-        }
-
-        val webviewDir = extractWebviewResources()
-
-        logger.info("Starting Node.js backend: node=$nodePath, backend=${backendFile.absolutePath}, webviewDir=${webviewDir?.absolutePath}")
-
+        // Everything here — node discovery, shell PATH capture, backend extraction —
+        // can block for seconds (the `$SHELL -lic` capture is bounded only by a 10s
+        // timeout). It must NOT run on the caller's thread (EDT): start() is reached
+        // synchronously from tool-window content creation, so a blocking call here
+        // would freeze the IDE UI. Run the whole thing on Dispatchers.IO.
         scope.launch(Dispatchers.IO) {
+            val nodePath = findNodeExecutable()
+            if (nodePath == null) {
+                logger.error(
+                    "Node.js executable not found. The plugin searched PATH and common install " +
+                        "locations (nvm, volta, fnm, Homebrew) but found nothing.\n" +
+                        "How to fix:\n" +
+                        "  1. Install Node.js, or make sure 'node' is on your PATH.\n" +
+                        "  2. If you use nvm, run 'nvm alias default <version>' so a default is set.\n" +
+                        "  3. Or set the NODE_PATH_OVERRIDE environment variable to your node binary " +
+                        "(e.g. ~/.nvm/versions/node/v24.16.0/bin/node)."
+                )
+                _portDeferred.completeExceptionally(
+                    IllegalStateException("Node.js executable not found")
+                )
+                return@launch
+            }
+
+            val backendFile = findBackendFile()
+            if (backendFile == null) {
+                logger.error("Backend entry file (backend.mjs) not found.")
+                _portDeferred.completeExceptionally(
+                    IllegalStateException("Backend entry file not found")
+                )
+                return@launch
+            }
+
+            val webviewDir = extractWebviewResources()
+
+            logger.info("Starting Node.js backend: node=$nodePath, backend=${backendFile.absolutePath}, webviewDir=${webviewDir?.absolutePath}")
+
             try {
                 val env = buildMap {
                     putAll(EnvironmentUtil.getEnvironmentMap())

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -62,7 +62,15 @@ class NodeProcessManager(
     fun start() {
         val nodePath = findNodeExecutable()
         if (nodePath == null) {
-            logger.error("Node.js executable not found. Ensure 'node' is on PATH or installed in a well-known location.")
+            logger.error(
+                "Node.js executable not found. The plugin searched PATH and common install " +
+                    "locations (nvm, volta, fnm, Homebrew) but found nothing.\n" +
+                    "How to fix:\n" +
+                    "  1. Install Node.js, or make sure 'node' is on your PATH.\n" +
+                    "  2. If you use nvm, run 'nvm alias default <version>' so a default is set.\n" +
+                    "  3. Or set the NODE_PATH_OVERRIDE environment variable to your node binary " +
+                    "(e.g. ~/.nvm/versions/node/v24.16.0/bin/node)."
+            )
             _portDeferred.completeExceptionally(
                 IllegalStateException("Node.js executable not found")
             )
@@ -252,15 +260,17 @@ class NodeProcessManager(
             )
         } else {
             val home = System.getenv("HOME") ?: return null
-            listOf(
-                "/usr/local/bin/node",
-                "/opt/homebrew/bin/node",
-                "$home/.nvm/current/bin/node",
-                "$home/.volta/bin/node",
-                "$home/.fnm/aliases/default/bin/node",
-                "$home/.local/bin/node",
-                "/usr/bin/node",
-            )
+            buildList {
+                add("/usr/local/bin/node")
+                add("/opt/homebrew/bin/node")
+                // nvm has NO `current` symlink — scan ~/.nvm/versions/node/ and honour
+                // the default alias instead, otherwise nvm users are never matched (#59).
+                findNvmNode(home)?.let { add(it) }
+                add("$home/.volta/bin/node")
+                add("$home/.fnm/aliases/default/bin/node")
+                add("$home/.local/bin/node")
+                add("/usr/bin/node")
+            }
         }
 
         wellKnownPaths.firstOrNull { File(it).exists() && File(it).canExecute() }?.let { found ->
@@ -270,6 +280,35 @@ class NodeProcessManager(
 
         logger.warn("Node.js executable not found")
         return null
+    }
+
+    /**
+     * Resolve the nvm-managed `node` binary by scanning `~/.nvm/versions/node/` and
+     * honouring `~/.nvm/alias/default`. nvm does not maintain a `current` symlink, so a
+     * static well-known path can never find it — the directory must be scanned (#59).
+     *
+     * Version-selection policy lives in [NodeExecutableResolver]; this method only does
+     * the filesystem glue.
+     */
+    private fun findNvmNode(home: String): String? {
+        val versionsDir = File(home, ".nvm/versions/node")
+        if (!versionsDir.isDirectory) return null
+
+        val installed = versionsDir.listFiles { f -> f.isDirectory }?.map { it.name } ?: return null
+        if (installed.isEmpty()) return null
+
+        val defaultAlias = File(home, ".nvm/alias/default")
+            .takeIf { it.isFile }
+            ?.readText()
+
+        val chosen = NodeExecutableResolver.selectNvmVersion(installed, defaultAlias) ?: return null
+        val nodePath = File(versionsDir, "$chosen/bin/node")
+        return if (nodePath.exists() && nodePath.canExecute()) {
+            logger.info("Found node via nvm scan: ${nodePath.absolutePath} (alias=${defaultAlias?.trim()})")
+            nodePath.absolutePath
+        } else {
+            null
+        }
     }
 
     /**

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -95,6 +95,9 @@ class NodeProcessManager(
                 val env = buildMap {
                     putAll(EnvironmentUtil.getEnvironmentMap())
                     put("JETBRAINS_MODE", "true")
+                    // Hand the backend the user's real shell PATH so anything it spawns
+                    // (claude, npx, git) is found even when the IDE started from GUI (#59).
+                    put("PATH", effectivePath())
                     if (webviewDir != null) {
                         put("WEBVIEW_DIR", webviewDir.absolutePath)
                     }
@@ -214,6 +217,19 @@ class NodeProcessManager(
     // ─── Node.js / Backend file discovery ───────────────────────────
 
     /**
+     * The PATH to use for `node` discovery and the backend process: the user's real
+     * shell PATH (captured via [ShellPathResolver], carries nvm/fnm/etc.) merged ahead
+     * of the IDE-inherited PATH. The merge keeps the inherited PATH as a fallback when
+     * shell capture fails (no $SHELL, Windows, timeout). Computed once per backend start.
+     */
+    private val effectivePathValue: String by lazy {
+        val basePath = EnvironmentUtil.getEnvironmentMap()["PATH"] ?: System.getenv("PATH") ?: ""
+        ShellPathResolver.mergePaths(ShellPathResolver.resolve(), basePath, File.pathSeparator)
+    }
+
+    private fun effectivePath(): String = effectivePathValue
+
+    /**
      * Find the `node` executable.
      * Tries:
      * 1. `which node` (PATH-based)
@@ -228,12 +244,13 @@ class NodeProcessManager(
             }
         }
 
-        // 2. PATH lookup via shell command (EnvironmentUtil provides full shell PATH)
+        // 2. PATH lookup via shell command (effectivePath captures the user's real
+        //    shell PATH so the lookup succeeds even when the IDE is launched from GUI)
         try {
             val command = if (SystemInfo.isWindows) arrayOf("cmd", "/c", "where", "node") else arrayOf("which", "node")
             val pb = ProcessBuilder(*command).redirectErrorStream(true)
             // Inject shell-aware PATH so lookup succeeds even when IDE is launched from GUI
-            pb.environment()["PATH"] = EnvironmentUtil.getEnvironmentMap()["PATH"] ?: System.getenv("PATH") ?: ""
+            pb.environment()["PATH"] = effectivePath()
             val proc = pb.start()
             val output = proc.inputStream.bufferedReader().readText().trim()
             val exitCode = proc.waitFor()

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
@@ -56,8 +56,13 @@ object ShellPathResolver {
     private fun runShell(shell: String): String? {
         val marker = UUID.randomUUID().toString().replace("-", "")
         return try {
+            // Capture stdout ONLY. An interactive shell can write warnings to stderr
+            // (e.g. zsh's `can't change option: zle` without a tty); merging them into
+            // stdout risks polluting the marker-sandwiched PATH. DISCARD routes stderr
+            // to the OS null sink, so it can neither corrupt the slice nor fill a pipe
+            // buffer and block the shell.
             val pb = ProcessBuilder(shell, "-lic", buildShellCommand(marker))
-                .redirectErrorStream(true)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
             val proc = pb.start()
             val output = proc.inputStream.bufferedReader().use { it.readText() }
             val finished = proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
@@ -1,0 +1,120 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.util.SystemInfo
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+
+/**
+ * Captures the user's real shell PATH by launching their login + interactive shell.
+ *
+ * ## Why
+ * A GUI-launched IDE (Dock, app icon, Spotlight) starts in a bare environment that
+ * never sourced the user's interactive shell config (`.zshrc`/`.bashrc`). Version
+ * managers like nvm/fnm/mise add their bin dirs there, so the IDE's inherited PATH
+ * is missing them — and any `node`/`claude` spawned from the IDE can't be found (#59).
+ *
+ * Asking the shell itself for its PATH is the only robust fix: it works for every
+ * version manager at once, instead of hard-coding each one's install layout.
+ *
+ * ## How
+ * Runs `$SHELL -lic "printf '<UUID>'; command printenv PATH; printf '<UUID>'"`:
+ * - `-lic` = login + interactive, so both `.zprofile`/`.zlogin` AND `.zshrc` are read.
+ * - The PATH is sandwiched between two random-UUID markers so we can slice it out of
+ *   any startup noise (prompts, banners, `.zshrc` echo) the shell prints.
+ * - `command printenv` bypasses user aliases/functions.
+ *
+ * This mirrors the approach the official Claude Code VS Code extension uses
+ * (`resolveShellPath`). Results are cached per shell; Windows is skipped (no POSIX shell).
+ */
+object ShellPathResolver {
+
+    private val logger = Logger.getInstance(ShellPathResolver::class.java)
+
+    private const val TIMEOUT_SECONDS = 10L
+
+    // Cached PATH per shell binary. Empty string = resolved-but-failed (don't retry).
+    private val cache = HashMap<String, String>()
+
+    /**
+     * Resolve the user's shell PATH, or null when unavailable (Windows, no $SHELL,
+     * shell failure, or invalid output). Cached per shell binary.
+     */
+    @Synchronized
+    fun resolve(): String? {
+        if (SystemInfo.isWindows) return null
+        val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: return null
+
+        cache[shell]?.let { return it.ifEmpty { null } }
+
+        val resolved = runShell(shell)
+        cache[shell] = resolved ?: ""
+        return resolved
+    }
+
+    /** Launch the shell and capture its PATH. Returns null on any failure. */
+    private fun runShell(shell: String): String? {
+        val marker = UUID.randomUUID().toString().replace("-", "")
+        return try {
+            val pb = ProcessBuilder(shell, "-lic", buildShellCommand(marker))
+                .redirectErrorStream(true)
+            val proc = pb.start()
+            val output = proc.inputStream.bufferedReader().use { it.readText() }
+            val finished = proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (!finished) {
+                proc.destroyForcibly()
+                logger.info("resolveShellPath: $shell timed out after ${TIMEOUT_SECONDS}s")
+                return null
+            }
+            val path = extractBetweenMarkers(output, marker)
+            if (looksLikePath(path)) {
+                logger.info("resolveShellPath: $shell -> ${path!!.split(":").size} entries")
+                path
+            } else {
+                logger.info("resolveShellPath: $shell returned empty/invalid PATH")
+                null
+            }
+        } catch (e: Exception) {
+            logger.info("resolveShellPath: $shell failed: ${e.message}")
+            null
+        }
+    }
+
+    /** Clear the per-shell cache (for tests / settings changes). */
+    @Synchronized
+    fun clearCache() = cache.clear()
+
+    // ─── Pure helpers (unit-tested) ─────────────────────────────────
+
+    /** The shell command that prints the marker-wrapped PATH. */
+    fun buildShellCommand(marker: String): String =
+        "printf '$marker'; command printenv PATH; printf '$marker'"
+
+    /**
+     * Slice the text between the first pair of [marker] occurrences and trim it.
+     * Returns null when fewer than two markers are present.
+     */
+    fun extractBetweenMarkers(output: String, marker: String): String? {
+        val escaped = Regex.escape(marker)
+        val match = Regex("$escaped([\\s\\S]*?)$escaped").find(output) ?: return null
+        return match.groupValues[1].trim()
+    }
+
+    /** A real PATH has at least one separator; reject blank / single-entry noise. */
+    fun looksLikePath(value: String?): Boolean =
+        !value.isNullOrBlank() && value.contains(":")
+
+    /**
+     * Merge the captured [shellPath] (which carries nvm/fnm/etc.) ahead of [basePath]
+     * (the IDE-inherited PATH), de-duplicating and preserving first-seen order. Shell
+     * entries win so version-manager binaries take precedence; the base survives as a
+     * fallback when capture failed. [separator] is the platform path separator.
+     */
+    fun mergePaths(shellPath: String?, basePath: String, separator: String): String {
+        val seen = LinkedHashSet<String>()
+        (shellPath.orEmpty().split(separator) + basePath.split(separator))
+            .filter { it.isNotEmpty() }
+            .forEach { seen.add(it) }
+        return seen.joinToString(separator)
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeExecutableResolverTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeExecutableResolverTest.kt
@@ -1,0 +1,79 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class NodeExecutableResolverTest {
+
+    @Nested
+    inner class SelectNvmVersion {
+        @Test
+        fun `should return null when no versions installed`() {
+            assertNull(NodeExecutableResolver.selectNvmVersion(emptyList(), null))
+            assertNull(NodeExecutableResolver.selectNvmVersion(emptyList(), "v24.16.0"))
+        }
+
+        @Test
+        fun `should pick the only installed version`() {
+            val result = NodeExecutableResolver.selectNvmVersion(listOf("v24.16.0"), null)
+            assertEquals("v24.16.0", result)
+        }
+
+        @Test
+        fun `should pick newest version by semver when no default alias`() {
+            val installed = listOf("v18.20.4", "v20.10.0", "v24.16.0")
+            val result = NodeExecutableResolver.selectNvmVersion(installed, null)
+            assertEquals("v24.16.0", result)
+        }
+
+        @Test
+        fun `should sort by numeric semver not string order`() {
+            // String sort would put v24.9.0 above v24.16.0 (9 > 1); numeric must not.
+            val installed = listOf("v24.9.0", "v24.16.0", "v24.2.0")
+            val result = NodeExecutableResolver.selectNvmVersion(installed, null)
+            assertEquals("v24.16.0", result)
+        }
+
+        @Test
+        fun `should match exact version from default alias`() {
+            val installed = listOf("v18.20.4", "v20.10.0", "v24.16.0")
+            assertEquals("v20.10.0", NodeExecutableResolver.selectNvmVersion(installed, "v20.10.0"))
+            assertEquals("v20.10.0", NodeExecutableResolver.selectNvmVersion(installed, "20.10.0"))
+        }
+
+        @Test
+        fun `should match major prefix from default alias picking newest minor`() {
+            val installed = listOf("v24.2.0", "v24.16.0", "v20.10.0")
+            assertEquals("v24.16.0", NodeExecutableResolver.selectNvmVersion(installed, "24"))
+            assertEquals("v24.16.0", NodeExecutableResolver.selectNvmVersion(installed, "v24"))
+        }
+
+        @Test
+        fun `should fall back to newest when default alias is an lts codename`() {
+            val installed = listOf("v18.20.4", "v24.16.0")
+            // We cannot resolve "lts/iron" without nvm's alias map; fall back to newest installed.
+            assertEquals("v24.16.0", NodeExecutableResolver.selectNvmVersion(installed, "lts/iron"))
+        }
+
+        @Test
+        fun `should fall back to newest when default alias matches nothing`() {
+            val installed = listOf("v18.20.4", "v24.16.0")
+            assertEquals("v24.16.0", NodeExecutableResolver.selectNvmVersion(installed, "v99.0.0"))
+        }
+
+        @Test
+        fun `should ignore non-version directory names`() {
+            // nvm versions dir never contains these, but be defensive.
+            val installed = listOf("v24.16.0", ".DS_Store", "default")
+            assertEquals("v24.16.0", NodeExecutableResolver.selectNvmVersion(installed, null))
+        }
+
+        @Test
+        fun `should trim whitespace and newline from default alias`() {
+            val installed = listOf("v20.10.0", "v24.16.0")
+            assertEquals("v20.10.0", NodeExecutableResolver.selectNvmVersion(installed, "v20.10.0\n"))
+            assertEquals("v20.10.0", NodeExecutableResolver.selectNvmVersion(installed, "  20.10.0  "))
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolverTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolverTest.kt
@@ -1,0 +1,127 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class ShellPathResolverTest {
+
+    @Nested
+    inner class ExtractBetweenMarkers {
+        @Test
+        fun `should extract the PATH sandwiched between two markers`() {
+            val marker = "abc123"
+            val output = "noise before${marker}/usr/local/bin:/usr/bin:/bin${marker}noise after"
+            assertEquals("/usr/local/bin:/usr/bin:/bin", ShellPathResolver.extractBetweenMarkers(output, marker))
+        }
+
+        @Test
+        fun `should trim surrounding whitespace and newlines`() {
+            val marker = "M"
+            val output = "${marker}\n  /usr/bin:/bin  \n${marker}"
+            assertEquals("/usr/bin:/bin", ShellPathResolver.extractBetweenMarkers(output, marker))
+        }
+
+        @Test
+        fun `should ignore shell startup noise outside the markers`() {
+            val marker = "ZZ"
+            // Simulates a noisy interactive shell: banner + prompt then the marked PATH.
+            val output = "Welcome to zsh!\n[32m➜[0m ${marker}/opt/homebrew/bin:/usr/bin${marker}\nbye"
+            assertEquals("/opt/homebrew/bin:/usr/bin", ShellPathResolver.extractBetweenMarkers(output, marker))
+        }
+
+        @Test
+        fun `should return null when markers are absent`() {
+            assertNull(ShellPathResolver.extractBetweenMarkers("/usr/bin:/bin", "M"))
+        }
+
+        @Test
+        fun `should return null when only one marker is present`() {
+            assertNull(ShellPathResolver.extractBetweenMarkers("M/usr/bin:/bin", "M"))
+        }
+
+        @Test
+        fun `should take the first marker pair only`() {
+            val marker = "Q"
+            val output = "${marker}/first:/path${marker}middle${marker}/second${marker}"
+            assertEquals("/first:/path", ShellPathResolver.extractBetweenMarkers(output, marker))
+        }
+
+        @Test
+        fun `should handle a marker that contains regex-special characters`() {
+            val marker = "a.b*c+"
+            val output = "${marker}/usr/bin:/bin${marker}"
+            assertEquals("/usr/bin:/bin", ShellPathResolver.extractBetweenMarkers(output, marker))
+        }
+    }
+
+    @Nested
+    inner class LooksLikePath {
+        @Test
+        fun `should accept a colon-separated PATH`() {
+            assertTrue(ShellPathResolver.looksLikePath("/usr/local/bin:/usr/bin:/bin"))
+        }
+
+        @Test
+        fun `should reject a single directory without colon`() {
+            assertFalse(ShellPathResolver.looksLikePath("/usr/bin"))
+        }
+
+        @Test
+        fun `should reject blank or null`() {
+            assertFalse(ShellPathResolver.looksLikePath(null))
+            assertFalse(ShellPathResolver.looksLikePath(""))
+            assertFalse(ShellPathResolver.looksLikePath("   "))
+        }
+    }
+
+    @Nested
+    inner class BuildShellCommand {
+        @Test
+        fun `should wrap printenv PATH with the marker on both sides`() {
+            val cmd = ShellPathResolver.buildShellCommand("MARK")
+            // command printenv bypasses aliases/functions; markers sandwich the value.
+            assertTrue(cmd.contains("printf 'MARK'"), "command was: $cmd")
+            assertTrue(cmd.contains("command printenv PATH"), "command was: $cmd")
+            // marker must appear exactly twice so the extractor can find a pair
+            assertEquals(2, Regex("MARK").findAll(cmd).count())
+        }
+    }
+
+    @Nested
+    inner class MergePaths {
+        @Test
+        fun `should put the shell PATH entries first then the base entries`() {
+            val result = ShellPathResolver.mergePaths("/nvm/bin:/usr/bin", "/usr/bin:/sbin", ":")
+            assertEquals("/nvm/bin:/usr/bin:/sbin", result)
+        }
+
+        @Test
+        fun `should de-duplicate while preserving first-seen order`() {
+            val result = ShellPathResolver.mergePaths("/a:/b", "/b:/c:/a", ":")
+            assertEquals("/a:/b:/c", result)
+        }
+
+        @Test
+        fun `should drop empty segments`() {
+            val result = ShellPathResolver.mergePaths("/a::/b", ":/c:", ":")
+            assertEquals("/a:/b:/c", result)
+        }
+
+        @Test
+        fun `should return base when shell PATH is null`() {
+            assertEquals("/usr/bin:/sbin", ShellPathResolver.mergePaths(null, "/usr/bin:/sbin", ":"))
+        }
+
+        @Test
+        fun `should return shell PATH when base is empty`() {
+            assertEquals("/nvm/bin", ShellPathResolver.mergePaths("/nvm/bin", "", ":"))
+        }
+
+        @Test
+        fun `should honour a custom separator`() {
+            val result = ShellPathResolver.mergePaths("C:\\node", "C:\\sys;C:\\node", ";")
+            assertEquals("C:\\node;C:\\sys", result)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Closes #59.

A user on KUbuntu installed Node.js via nvm. `which node`, `node -v`, and `$PATH` all looked correct in their terminal, yet the plugin failed with `Node.js executable not found`. They had to manually `ln -s ... /usr/local/bin/node` to work around it.

### Root cause

A GUI-launched IDE (Dock, app icon, Spotlight, app launcher) starts in a **bare environment that never sourced the user's interactive shell config** (`.zshrc`/`.bashrc`) — which is exactly where version managers (nvm, fnm, volta, mise, rbenv) add their `bin` directories. The plugin's backend inherits the IDE process environment, so those paths are missing. The user's terminal resolves `node` fine because it *did* source those files; the IDE never did.

On top of that, the nvm fallback path was looking for `~/.nvm/current/bin/node`, but **nvm never creates a `current` symlink** — so nvm users weren't matched by the fallback either.

## Fix

Rather than hard-coding each version manager's install layout, **ask the shell itself for its PATH** — the only approach that covers every manager at once. This mirrors what the official Claude Code VS Code extension does (`resolveShellPath`).

- **`ShellPathResolver`** (new): runs `$SHELL -lic "printf '<UUID>'; command printenv PATH; printf '<UUID>'"`.
  - `-lic` = login + interactive, so both `.zprofile` and `.zshrc` are read.
  - The PATH is sandwiched between two random-UUID markers and sliced out, so any shell startup noise (prompts, banners, `.zshrc` echo, `zle` warnings) is discarded.
  - `command printenv` bypasses aliases/functions. Result cached per shell; Windows skipped; 10s timeout for heavy rc files.
- **`NodeProcessManager.effectivePath()`**: merges the captured shell PATH **ahead of** the IDE-inherited PATH (de-duplicated), falling back to the inherited PATH when capture fails (no `$SHELL`, Windows, timeout). Used for **both**:
  - `which node` discovery → fixes #59 at the root.
  - the **backend's spawn environment** → anything it later spawns (claude, npx, git) is found too.
- **nvm directory scan** (`NodeExecutableResolver` + `findNvmNode`): scans `~/.nvm/versions/node/` honouring `~/.nvm/alias/default`, replacing the dead `~/.nvm/current` path. Kept as a **second-line fallback** for environments where shell capture can't run.
- **Better error message**: actionable guidance (check PATH, `nvm alias default <version>`, `NODE_PATH_OVERRIDE`) — the reporter called the old one "useless".

## Tests & verification

TDD: tests written first. 27 unit tests total — version-selection policy (exact / major-prefix / codename fallback / numeric semver) and the shell-capture pure logic (marker extraction / PATH validation / merge). `./scripts/build.sh build` → BUILD SUCCESSFUL.

**Verified on macOS**: interactive-only entries (`volta`, `rbenv`) are captured, and the `(eval):1: can't change option: zle` noise that `-i` emits without a tty is correctly stripped by the marker sandwich.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
