### PR TITLE
fix: strip non-JSON prefix from ccb usage output (#62)

### DIFF
--- a/backend/src/core/handlers/__tests__/getUsage.test.ts
+++ b/backend/src/core/handlers/__tests__/getUsage.test.ts
@@ -248,6 +248,37 @@ describe('getUsageHandler', () => {
     }));
   });
 
+  // Issue #62: Linux .bashrc often emits printf "\e[?2004l" (disable bracketed paste).
+  // Under `bash -l -i -c`, this escape sequence is written to stdout before the JSON,
+  // and trim() cannot strip the ESC control char, so JSON.parse fails.
+  it('should parse JSON despite a leading bracketed-paste escape sequence (issue #62)', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = { type: 'GET_USAGE', payload: {}, timestamp: 0, requestId: 'req-1' };
+    setupExecFileStdout(`\x1b[?2004l${JSON.stringify(SAMPLE_USAGE)}`);
+
+    await getUsageHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-1',
+      status: 'ok',
+      usage: SAMPLE_USAGE,
+    });
+  });
+
+  it('should parse JSON despite surrounding shell noise on stdout', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = { type: 'GET_USAGE', payload: {}, timestamp: 0, requestId: 'req-1' };
+    setupExecFileStdout(`\x1b[?2004l\n${JSON.stringify(SAMPLE_USAGE)}\n\x1b[?2004h`);
+
+    await getUsageHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-1',
+      status: 'ok',
+      usage: SAMPLE_USAGE,
+    });
+  });
+
   describe('shellInvocation', () => {
     const originalPlatform = process.platform;
     const originalShell = process.env.SHELL;

--- a/backend/src/core/handlers/getUsage.ts
+++ b/backend/src/core/handlers/getUsage.ts
@@ -105,9 +105,13 @@ export function resetUsageCache(): void {
 async function runCcbUsage(): Promise<CcbUsageResponse> {
   const { shell, args } = shellInvocation('ccb oauth usage --json');
   const { stdout } = await execFileAsync(shell, args, { timeout: 15000 });
-  const trimmed = stdout.trim();
-  if (!trimmed) throw new Error('Empty response from ccb');
-  return JSON.parse(trimmed);
+  // Interactive login shells (`-l -i`) source startup files like .bashrc, which on
+  // Linux often emit control sequences such as printf "\e[?2004l" (disable bracketed
+  // paste) to stdout before our output. trim() cannot strip the ESC char, so extract
+  // the JSON object itself rather than parsing the raw stdout. (issue #62)
+  const match = stdout.match(/\{[\s\S]*\}/);
+  if (!match) throw new Error('Empty response from ccb');
+  return JSON.parse(match[0]);
 }
 
 export async function getUsageHandler(


### PR DESCRIPTION
## Problem

On Linux, `.bashrc` commonly contains `printf "\e[?2004l"` (to disable bracketed paste). Because the usage handler runs `ccb oauth usage --json` through an **interactive login shell** (`bash -l -i -c`), that escape sequence is written to stdout **before** the JSON, and `trim()` cannot strip the ESC control char — so `JSON.parse` fails.

Reported in #62.

## Fix

Extract the JSON object with `/\{[\s\S]*\}/` instead of parsing trimmed stdout, mirroring the pattern already used in `classifyError()`. This is robust against leading/trailing shell noise (ESC sequences, npm warnings, etc.) and does **not** require users to edit their `.bashrc`.

`backend/src/core/handlers/getUsage.ts`:
```ts
const match = stdout.match(/\{[\s\S]*\}/);
if (!match) throw new Error('Empty response from ccb');
return JSON.parse(match[0]);
```

## Tests (TDD)

Added two cases to `getUsage.test.ts`:
- parses JSON despite a leading `\e[?2004l` escape sequence
- parses JSON despite surrounding shell noise (ESC before and after)

Regression-safe: existing "invalid JSON" / "empty stdout" tests still pass (`{{{` has no closing `}` → match fails → error path preserved).

## Verification

- Backend test suite: **254 passed** (27 files)
- TypeScript typecheck: clean
- esbuild: success

Closes #62