### PR TITLE
fix: defer JBCefBrowser creation to avoid JCEF StartupTest race (#55)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -67,14 +67,26 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
     private val holders = ConcurrentHashMap<String, BrowserHolder>()
 
     /**
+     * Whether JCEF is available in this runtime.
+     *
+     * Single source of truth for the "can we host a browser?" check. The
+     * `claude.simulate.no.jcef` system property is a developer-only escape hatch
+     * for verifying the fallback path without swapping the boot JBR.
+     *
+     * Cheap to call — does NOT initialize CefApp (only [JBCefApp.isSupported]
+     * is consulted, which is a capability probe, not a builder).
+     */
+    fun isJcefAvailable(): Boolean {
+        if (java.lang.Boolean.getBoolean("claude.simulate.no.jcef")) return false
+        return JBCefApp.isSupported()
+    }
+
+    /**
      * Get an existing browser for the session, or create a new one.
      * The browser is NOT registered with Disposer — it is managed by this service.
      */
     fun getOrCreate(sessionId: String): BrowserHolder? {
-        // The system property is a developer-only escape hatch for verifying the
-        // JCEF-unavailable fallback path (e.g. Android Studio reproduction) without
-        // having to swap the boot JBR. End users are not expected to set it.
-        if (!JBCefApp.isSupported() || java.lang.Boolean.getBoolean("claude.simulate.no.jcef")) {
+        if (!isJcefAvailable()) {
             logger.warn("JCEF is not supported in this runtime — cannot create browser for session: $sessionId")
             return null
         }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -6,6 +6,9 @@ import com.github.yhk1038.claudecodegui.notifications.JcefRuntimeNotifier
 import com.github.yhk1038.claudecodegui.services.ClaudeCodeBrowserService
 import com.github.yhk1038.claudecodegui.services.DiffService
 import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.github.yhk1038.claudecodegui.toolwindow.realization.CallbackStaging
+import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
+import com.github.yhk1038.claudecodegui.toolwindow.realization.RealizationGate
 import com.intellij.ide.BrowserUtil
 import com.intellij.ide.dnd.DnDEvent
 import com.intellij.ide.dnd.DnDManager
@@ -19,6 +22,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptor
 import com.intellij.openapi.options.ShowSettingsUtil
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.project.DumbService
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
@@ -90,25 +94,47 @@ class ClaudeCodePanel(
     // This allows the browser to survive dispose-recreate cycles during tab move/split.
     // Returns null when JCEF is not supported (e.g. Android Studio without JCEF JBR).
     private val browserService = ClaudeCodeBrowserService.getInstance(project)
-    private val holder = browserService.getOrCreate(sessionId)
-    private val browser: JBCefBrowser? = holder?.browser
-    private val cursorQuery: JBCefJSQuery? = holder?.cursorQuery
-    private val streamingQuery: JBCefJSQuery? = holder?.streamingQuery
+    private var holder: ClaudeCodeBrowserService.BrowserHolder? = null
+    private val browser: JBCefBrowser? get() = holder?.browser
+    private val cursorQuery: JBCefJSQuery? get() = holder?.cursorQuery
+    private val streamingQuery: JBCefJSQuery? get() = holder?.streamingQuery
+
+    // One-shot guard so re-attach (tab move/split) does NOT re-schedule realization.
+    private val realizationGate = RealizationGate()
+
+    // Callback staging — set by ClaudeCodeFileEditor before the holder exists,
+    // flushed onto the holder at realizeBrowser() time. Never overwrites a
+    // pooled holder that already has a callback (tab move/split safety).
+    private val titleStaging = CallbackStaging<(String) -> Unit>()
+    private val pathStaging = CallbackStaging<(String) -> Unit>()
+    private val streamingStaging = CallbackStaging<(Boolean) -> Unit>()
+
+    @Volatile
+    private var isPanelDisposed: Boolean = false
 
     // Title/path change callbacks delegated to BrowserHolder
     // so handlers installed on first panel creation can reach the latest panel's callbacks.
     // All callbacks are no-ops when holder is null (JCEF unavailable).
     var onTitleChanged: ((String) -> Unit)?
-        get() = holder?.onTitleChanged
-        set(value) { holder?.onTitleChanged = value }
+        get() = holder?.onTitleChanged ?: titleStaging.current()
+        set(value) {
+            titleStaging.stage(value)
+            holder?.onTitleChanged = value
+        }
 
     var onPathChanged: ((String) -> Unit)?
-        get() = holder?.onPathChanged
-        set(value) { holder?.onPathChanged = value }
+        get() = holder?.onPathChanged ?: pathStaging.current()
+        set(value) {
+            pathStaging.stage(value)
+            holder?.onPathChanged = value
+        }
 
     var onStreamingStateChanged: ((Boolean) -> Unit)?
-        get() = holder?.onStreamingStateChanged
-        set(value) { holder?.onStreamingStateChanged = value }
+        get() = holder?.onStreamingStateChanged ?: streamingStaging.current()
+        set(value) {
+            streamingStaging.stage(value)
+            holder?.onStreamingStateChanged = value
+        }
 
     private val panelId = UUID.randomUUID().toString()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -117,7 +143,7 @@ class ClaudeCodePanel(
     private val diffService: DiffService = DiffService.getInstance(project)
 
     // Loading label
-    private val loadingLabel = javax.swing.JLabel("Starting backend...").apply {
+    private val loadingLabel = javax.swing.JLabel(LoadingPhase.INDEXING_WAIT.message).apply {
         horizontalAlignment = javax.swing.SwingConstants.CENTER
         font = font.deriveFont(14f)
     }
@@ -126,49 +152,95 @@ class ClaudeCodePanel(
     private var errorPanel: JPanel? = null
 
     init {
-        if (holder == null) {
-            // JCEF is not available in this runtime (e.g. Android Studio without JCEF JBR).
-            // Show a fallback guidance panel and skip all browser/backend initialization.
+        if (!browserService.isJcefAvailable()) {
+            // JCEF unavailable (e.g. Android Studio without JCEF JBR). Fallback panel
+            // shown immediately; no background realization will be scheduled.
             add(JcefUnavailablePanel(), BorderLayout.CENTER)
             logger.warn("JCEF is not supported in this runtime — showing fallback panel")
             JcefRuntimeNotifier.notify(project)
         } else {
-            initWithJcef()
+            // Browser realization is deferred until addNotify() + DumbService.runWhenSmart.
+            // Show the indexing-wait placeholder so the user knows the tab is alive.
+            loadingLabel.text = LoadingPhase.INDEXING_WAIT.message
+            add(loadingLabel, BorderLayout.CENTER)
         }
     }
 
-    private fun initWithJcef() {
-        if (holder!!.isLoaded) {
-            // Browser already loaded — reattach component (tab move/split restoration)
-            val parent = browser!!.component.parent
+    override fun addNotify() {
+        super.addNotify()
+        // JCEF unavailable: nothing to realize, fallback panel already shown.
+        if (!browserService.isJcefAvailable()) return
+        // One-shot guard. Tab move/split triggers removeNotify→addNotify on a fresh
+        // panel instance, where the gate is fresh too. The holder pool inside
+        // realizeBrowser() handles reuse via getOrCreate(); the gate only protects
+        // against re-entry on THIS panel instance.
+        if (!realizationGate.tryAcquire()) return
+        scheduleBrowserRealization()
+    }
+
+    private fun scheduleBrowserRealization() {
+        // runWhenSmart runs on the EDT and may execute synchronously if already smart.
+        // dispose() may run before this callback fires (user closed the tab mid-indexing);
+        // guard with isPanelDisposed and project.isDisposed.
+        DumbService.getInstance(project).runWhenSmart {
+            if (isPanelDisposed || project.isDisposed) return@runWhenSmart
+            realizeBrowser()
+        }
+    }
+
+    private fun realizeBrowser() {
+        // Acquire (or reuse) the pooled browser holder. May return null if JCEF
+        // became unavailable between init and now — defensive check.
+        val acquired = browserService.getOrCreate(sessionId) ?: run {
+            logger.warn("JCEF became unavailable before realizeBrowser for session: $sessionId")
+            return
+        }
+        holder = acquired
+
+        // Flush staged callbacks. flush() refuses to overwrite an existing holder
+        // callback, so pooled-holder wiring from a previous panel survives.
+        titleStaging.flush(acquired.onTitleChanged) { acquired.onTitleChanged = it }
+        pathStaging.flush(acquired.onPathChanged) { acquired.onPathChanged = it }
+        streamingStaging.flush(acquired.onStreamingStateChanged) { acquired.onStreamingStateChanged = it }
+
+        val b = acquired.browser
+
+        if (acquired.isLoaded) {
+            // Browser already loaded (tab move/split): detach from previous parent if any,
+            // remove the placeholder label, and re-attach.
+            val parent = b.component.parent
             if (parent != null && parent !== this) {
-                parent.remove(browser.component)
+                parent.remove(b.component)
             }
-            add(browser.component, BorderLayout.CENTER)
+            remove(loadingLabel)
+            add(b.component, BorderLayout.CENTER)
+            revalidate()
+            repaint()
             logger.info("Reattached existing JCEF browser for session: $sessionId")
         } else {
-            // First load — show loading screen
-            add(loadingLabel, BorderLayout.CENTER)
+            // First load — switch the placeholder to the next phase.
+            loadingLabel.text = LoadingPhase.BACKEND_START.message
+            revalidate()
+            repaint()
         }
 
-        // Install JCEF handlers only once per browser instance
-        if (!holder.handlersInstalled) {
+        // Install JCEF handlers only once per browser instance.
+        if (!acquired.handlersInstalled) {
             setupBrowserHandlers()
-            holder.handlersInstalled = true
+            acquired.handlersInstalled = true
         }
 
-        // Install native (Swing / IDE) drag-and-drop bridge once per holder. Reinstalling on
-        // every panel recreate would attach duplicate listeners during tab move/split.
-        if (!holder.nativeDropBridgeInstalled) {
+        // Install native (Swing/IDE) drag-and-drop bridge once per holder.
+        if (!acquired.nativeDropBridgeInstalled) {
             setupNativeDropBridge()
-            holder.nativeDropBridgeInstalled = true
+            acquired.nativeDropBridgeInstalled = true
         }
 
-        // Register RPC handler for this panel
+        // Register RPC handler for this panel.
         backendService.ensureStarted(project.basePath ?: "", panelId, createRpcHandler())
 
-        // Load URL only if not already loaded
-        if (!holder.isLoaded) {
+        // Load URL only if not already loaded.
+        if (!acquired.isLoaded) {
             scope.launch {
                 try {
                     val port = backendService.awaitPort()
@@ -185,7 +257,7 @@ class ClaudeCodePanel(
 
     // ─── Browser handlers (JCEF) ────────────────────────────────────
 
-    // Called only from initWithJcef() — holder, browser, cursorQuery, streamingQuery are guaranteed non-null here.
+    // Called only from realizeBrowser() — holder, browser, cursorQuery, streamingQuery are guaranteed non-null here.
     private fun setupBrowserHandlers() {
         val b = browser!!
         val cq = cursorQuery!!
@@ -390,7 +462,7 @@ class ClaudeCodePanel(
      * Inject streaming state bridge so WebView can notify Kotlin of streaming changes
      * via JBCefJSQuery instead of encoding state into document.title.
      */
-    // Called only from setupBrowserHandlers() which is only called from initWithJcef() — streamingQuery is non-null.
+    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — streamingQuery is non-null.
     private fun injectStreamingStateBridge(frame: CefFrame) {
         val js = """
             (function() {
@@ -405,7 +477,7 @@ class ClaudeCodePanel(
     /**
      * Inject cursor CSS tracking script into the loaded page.
      */
-    // Called only from setupBrowserHandlers() which is only called from initWithJcef() — cursorQuery is non-null.
+    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — cursorQuery is non-null.
     private fun injectCursorTracking(frame: CefFrame) {
         val js = """
             (function() {
@@ -427,9 +499,11 @@ class ClaudeCodePanel(
      * Wraps InputMethodListeners with try-catch to suppress NPE from
      * JBCefInputMethodAdapter when replacementRange is null (macOS + JCEF + CJK IME).
      */
-    // Called only from setupBrowserHandlers() which is only called from initWithJcef() — holder and browser are non-null.
+    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — holder and browser are non-null.
     private fun installImeWorkaround() {
-        if (holder!!.imeWorkaroundInstalled) return
+        val h = holder!!
+        if (h.imeWorkaroundInstalled) return
+        val b = browser!!
 
         fun wrapListeners(component: java.awt.Component) {
             val listeners = component.inputMethodListeners
@@ -467,8 +541,8 @@ class ClaudeCodePanel(
         }
 
         javax.swing.SwingUtilities.invokeLater {
-            traverseAndWrap(browser!!.component)
-            holder.imeWorkaroundInstalled = true
+            traverseAndWrap(b.component)
+            h.imeWorkaroundInstalled = true
             logger.info("JCEF IME NPE workaround installed")
         }
     }
@@ -483,7 +557,7 @@ class ClaudeCodePanel(
      * listener) survives tab move/split. Disposal happens in
      * [ClaudeCodeBrowserService.release].
      */
-    // Called only from setupBrowserHandlers() which is only called from initWithJcef() — holder and browser are non-null.
+    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — holder and browser are non-null.
     private fun installLafListener() {
         val h = holder!!
         if (h.lafListenerInstalled) return
@@ -523,7 +597,7 @@ class ClaudeCodePanel(
     /**
      * Opens the JCEF DevTools for debugging.
      */
-    // Called only from WebViewKeyboardHandler installed via initWithJcef() — browser is non-null.
+    // Called only from WebViewKeyboardHandler installed via realizeBrowser() — browser is non-null.
     private fun openDevTools() {
         try {
             (browser!! as? com.intellij.ui.jcef.JBCefBrowserBase)?.openDevtools()
@@ -720,7 +794,7 @@ class ClaudeCodePanel(
      * Load the WebView URL from the Node.js backend.
      * Called once the backend has printed its PORT.
      */
-    // Called only from initWithJcef() — holder and browser are non-null.
+    // Called only from realizeBrowser() — holder and browser are non-null.
     private fun loadWebView(port: Int) {
         System.err.println("[ClaudeCodePanel] loadWebView called for project: ${project.name}")
         System.err.println("[ClaudeCodePanel] project.basePath: ${project.basePath}")
@@ -738,10 +812,12 @@ class ClaudeCodePanel(
         logger.info("Loading WebView from Node.js backend: $url")
 
         javax.swing.SwingUtilities.invokeLater {
+            val b = browser!!
+            val h = holder!!
             remove(loadingLabel)
-            browser!!.loadURL(url)
-            add(browser.component, BorderLayout.CENTER)
-            holder!!.isLoaded = true
+            b.loadURL(url)
+            add(b.component, BorderLayout.CENTER)
+            h.isLoaded = true
             revalidate()
             repaint()
         }
@@ -1038,6 +1114,7 @@ class ClaudeCodePanel(
     // ─── Lifecycle ──────────────────────────────────────────────────
 
     override fun dispose() {
+        isPanelDisposed = true
         // Detach browser component from this panel WITHOUT disposing the browser.
         // The browser is owned by ClaudeCodeBrowserService and survives tab move/split.
         // It will be reattached when a new ClaudeCodePanel is created for the same session.

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/CallbackStaging.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/CallbackStaging.kt
@@ -1,0 +1,45 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+/**
+ * Defers a callback until a target (e.g. a BrowserHolder) becomes available.
+ *
+ * Usage pattern:
+ * 1. Call [stage] to record the desired callback value.
+ * 2. Call [flush] once the target is ready; if the target has no existing value, the
+ *    staged value is applied via the provided setter and `true` is returned.
+ *
+ * The "don't overwrite existing target" rule in [flush] protects pooled BrowserHolder
+ * callbacks during tab move/split — a fresh panel must NOT clobber a holder's existing
+ * wiring.
+ */
+class CallbackStaging<T : Any> {
+    private var staged: T? = null
+
+    /**
+     * Store the desired callback value. Repeated calls overwrite the previous value.
+     */
+    fun stage(value: T?) {
+        staged = value
+    }
+
+    /**
+     * Read the currently staged value without consuming it.
+     */
+    fun current(): T? = staged
+
+    /**
+     * Apply the staged value to [set] if and only if [currentTargetValue] is `null` and
+     * a staged value exists.
+     *
+     * @param currentTargetValue the target's current value; if non-null the target already
+     *   has a callback and this method does nothing.
+     * @param set setter to invoke with the staged value when conditions are met.
+     * @return `true` if the staged value was applied, `false` otherwise.
+     */
+    fun flush(currentTargetValue: T?, set: (T?) -> Unit): Boolean {
+        if (currentTargetValue != null) return false
+        val value = staged ?: return false
+        set(value)
+        return true
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhase.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhase.kt
@@ -1,0 +1,11 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+/**
+ * The sequential phases shown in the panel's placeholder label while the JCEF browser
+ * is not yet realized. Each phase carries an English [message] string suitable for
+ * display directly in the UI.
+ */
+enum class LoadingPhase(val message: String) {
+    INDEXING_WAIT("Waiting for project indexing..."),
+    BACKEND_START("Starting backend..."),
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/RealizationGate.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/RealizationGate.kt
@@ -1,0 +1,25 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+/**
+ * One-shot guard that allows exactly one successful acquisition.
+ *
+ * **Not thread-safe** — intended to be called exclusively from the EDT
+ * (Event Dispatch Thread). Concurrent access from other threads is undefined behavior.
+ */
+class RealizationGate {
+    private var acquired: Boolean = false
+
+    /**
+     * Returns `true` on the very first call and `false` on every subsequent call.
+     */
+    fun tryAcquire(): Boolean {
+        if (acquired) return false
+        acquired = true
+        return true
+    }
+
+    /**
+     * Returns `true` if [tryAcquire] has already been called successfully at least once.
+     */
+    fun isAcquired(): Boolean = acquired
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/CallbackStagingTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/CallbackStagingTest.kt
@@ -1,0 +1,67 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class CallbackStagingTest {
+
+    @Nested
+    inner class Current {
+        @Test
+        fun `current is null initially`() {
+            val staging = CallbackStaging<String>()
+            assertNull(staging.current())
+        }
+
+        @Test
+        fun `current returns staged value after stage`() {
+            val staging = CallbackStaging<String>()
+            staging.stage("hello")
+            assertEquals("hello", staging.current())
+        }
+
+        @Test
+        fun `stage overwrites previous value`() {
+            val staging = CallbackStaging<String>()
+            staging.stage("first")
+            staging.stage("second")
+            assertEquals("second", staging.current())
+        }
+    }
+
+    @Nested
+    inner class Flush {
+        @Test
+        fun `flush with null target applies staged value and returns true`() {
+            val staging = CallbackStaging<String>()
+            staging.stage("callback")
+            var applied: String? = null
+            val result = staging.flush(currentTargetValue = null) { applied = it }
+            assertTrue(result)
+            assertEquals("callback", applied)
+        }
+
+        @Test
+        fun `flush with non-null target does not call set and returns false`() {
+            val staging = CallbackStaging<String>()
+            staging.stage("new-callback")
+            var setWasCalled = false
+            val result = staging.flush(currentTargetValue = "existing") { setWasCalled = true }
+            assertFalse(result)
+            assertFalse(setWasCalled)
+        }
+
+        @Test
+        fun `flush with nothing staged returns false and does not call set`() {
+            val staging = CallbackStaging<String>()
+            var setWasCalled = false
+            val result = staging.flush(currentTargetValue = null) { setWasCalled = true }
+            assertFalse(result)
+            assertFalse(setWasCalled)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhaseTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhaseTest.kt
@@ -1,0 +1,17 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class LoadingPhaseTest {
+
+    @Test
+    fun `INDEXING_WAIT carries expected message`() {
+        assertEquals("Waiting for project indexing...", LoadingPhase.INDEXING_WAIT.message)
+    }
+
+    @Test
+    fun `BACKEND_START carries expected message`() {
+        assertEquals("Starting backend...", LoadingPhase.BACKEND_START.message)
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/RealizationGateTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/RealizationGateTest.kt
@@ -1,0 +1,59 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RealizationGateTest {
+
+    @Nested
+    inner class TryAcquire {
+        @Test
+        fun `first tryAcquire returns true`() {
+            val gate = RealizationGate()
+            assertTrue(gate.tryAcquire())
+        }
+
+        @Test
+        fun `second tryAcquire returns false`() {
+            val gate = RealizationGate()
+            gate.tryAcquire()
+            assertFalse(gate.tryAcquire())
+        }
+
+        @Test
+        fun `subsequent calls after first all return false`() {
+            val gate = RealizationGate()
+            gate.tryAcquire()
+            repeat(5) {
+                assertFalse(gate.tryAcquire())
+            }
+        }
+    }
+
+    @Nested
+    inner class IsAcquired {
+        @Test
+        fun `isAcquired is false before any call`() {
+            val gate = RealizationGate()
+            assertFalse(gate.isAcquired())
+        }
+
+        @Test
+        fun `isAcquired is true after first tryAcquire`() {
+            val gate = RealizationGate()
+            gate.tryAcquire()
+            assertTrue(gate.isAcquired())
+        }
+
+        @Test
+        fun `isAcquired stays true after repeated tryAcquire calls`() {
+            val gate = RealizationGate()
+            gate.tryAcquire()
+            gate.tryAcquire()
+            gate.tryAcquire()
+            assertTrue(gate.isAcquired())
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #55 — panel blank on startup in IntelliJ 2026.1.2 due to a JCEF `StartupTest` race.

**Root cause.** IntelliJ 2026.1+ runs out-of-process JCEF by default ([IJPL-162747](https://youtrack.jetbrains.com/issue/IJPL-162747)). `JBCefApp`'s constructor schedules an internal `StartupTest` (60 s timeout) immediately after instantiation. When we built a `JBCefBrowser` eagerly during project open — while indexing and IDE boot contend for resources — `CefApp` initialization was slow, `StartupTest` hit its false-positive path, and `restartJCEF()` then called `CefApp.addAppHandler()` with no guard. That throws `IllegalStateException` because `CefApp` is already initialized, and the panel renders blank. `CefApp` is a global singleton, so the race is only between "first browser build" and the StartupTest window.

**Fix (method 1-b, as agreed during design).** Defer `JBCefBrowser.build()` until two conditions hold:

1. The panel is actually attached to the screen (`addNotify()`).
2. Project indexing has finished (`DumbService.runWhenSmart`).

Until both gate, the panel shows a placeholder label — `"Waiting for project indexing..."` then `"Starting backend..."`. Showing context beats a tab that silently fails to open.

Side benefit: inactive restored tabs never call `addNotify()`, so they don't build a browser at all. Multi-tab project restores no longer fan out N concurrent `build()` calls.

The platform-level bug (missing `addAppHandler` guard in `restartJCEF`) is still JetBrains' to fix. This PR closes the race window from our side.

## Commits (each self-contained)

1. **`refactor(browser-service): extract isJcefAvailable() as single source of truth`** — cheap predicate the panel can call at construction without touching `CefApp`. No behavior change.
2. **`feat(panel): introduce panel realization helpers with unit tests`** — `RealizationGate`, `CallbackStaging<T>`, `LoadingPhase` in a new `toolwindow.realization` package, with 14 JUnit Jupiter tests. No production callers in this commit.
3. **`fix(panel): defer JBCefBrowser creation until panel shown and indexing finishes (#55)`** — actual rewire of `ClaudeCodePanel`. `holder` becomes a nullable `var`; `browser`/`cursorQuery`/`streamingQuery` become computed properties. `addNotify()` schedules `realizeBrowser()` via `runWhenSmart`, guarded by `RealizationGate` (per-panel one-shot), `isPanelDisposed`, and `project.isDisposed`. Callback setters dual-write through `CallbackStaging`, so `ClaudeCodeFileEditor` stays untouched.

## Test plan

- [ ] `bash ./scripts/build.sh test` — green (14 new helper tests + existing suites)
- [ ] `bash ./scripts/build.sh build` — green
- [ ] Manual on IntelliJ 2026.1+ via `bash ./scripts/build.sh run-ide`:
  - [ ] Reopen a project with multiple Claude tabs — no blank-panel regression; each tab transitions placeholder → loaded
  - [ ] Inactive restored tabs do NOT log `Creating new JCEF browser for session: …` until clicked
  - [ ] Tab move/split preserves input text and scroll position (reattach path via pooled holder)
  - [ ] Close a tab mid-indexing — no exception, no zombie process
  - [ ] `-Dclaude.simulate.no.jcef=true` shows the unavailable-fallback panel immediately (no waiting)