### PR TITLE
fix: prevent IDE SIGKILL on port reclaim + restore last session per tab (#66)

### DIFF
--- a/backend/src/core/__tests__/port-utils.test.ts
+++ b/backend/src/core/__tests__/port-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { selectKillablePids } from '../port-utils';
+
+describe('selectKillablePids', () => {
+  it('parses one PID per line', () => {
+    expect(selectKillablePids('123\n456', 999)).toEqual([123, 456]);
+  });
+
+  it('excludes our own PID so the backend never kills itself', () => {
+    expect(selectKillablePids('123\n777\n456', 777)).toEqual([123, 456]);
+  });
+
+  it('ignores blank lines and whitespace', () => {
+    expect(selectKillablePids('  123 \n\n  456\n', 999)).toEqual([123, 456]);
+  });
+
+  it('drops non-numeric and non-positive values', () => {
+    expect(selectKillablePids('abc\n0\n-5\n123', 999)).toEqual([123]);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(selectKillablePids('', 999)).toEqual([]);
+    expect(selectKillablePids('   \n  ', 999)).toEqual([]);
+  });
+
+  it('de-duplicates repeated PIDs', () => {
+    expect(selectKillablePids('123\n123\n456', 999)).toEqual([123, 456]);
+  });
+});

--- a/backend/src/core/port-utils.ts
+++ b/backend/src/core/port-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Parse the PID output of `lsof -t` / netstat and return the PIDs that are safe
+ * to kill when reclaiming a port: valid positive integers, de-duplicated, and
+ * excluding our own process.
+ *
+ * Critically, the *caller* must already have restricted the query to LISTENING
+ * sockets (lsof `-sTCP:LISTEN`, netstat `LISTENING`). Without that restriction a
+ * plain `lsof -ti :PORT` also returns processes merely *connected* to the port —
+ * e.g. the IDE JVM's RPC WebSocket — and killing those takes the whole IDE down
+ * (observed as exit 137 / SIGKILL). This helper is the second line of defence:
+ * even if a connected PID slipped through, our own PID is filtered out here.
+ */
+export function selectKillablePids(rawPids: string, selfPid: number): number[] {
+  const seen = new Set<number>();
+  const result: number[] = [];
+  for (const line of rawPids.split('\n')) {
+    const pid = parseInt(line.trim(), 10);
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    if (pid === selfPid) continue;
+    if (seen.has(pid)) continue;
+    seen.add(pid);
+    result.push(pid);
+  }
+  return result;
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -1,4 +1,5 @@
 import { execFileSync, execSync } from 'child_process';
+import { selectKillablePids } from './core/port-utils';
 import { startWebSocketServer, type BridgeMap } from './ws/ws-server';
 import { BrowserBridge } from './bridge/browser-bridge';
 import { JetBrainsBridge } from './bridge/jetbrains-bridge';
@@ -34,22 +35,26 @@ import type { NativeDropEntry } from './core/types';
  */
 
 function killProcessOnPort(port: number): void {
+  // CRITICAL: only ever target processes *LISTENING* on the port. A plain
+  // `lsof -ti :PORT` also returns processes merely connected to it — including the
+  // IDE JVM's RPC WebSocket — and SIGKILLing those kills the entire IDE (exit 137).
+  // Restricting to LISTEN sockets + filtering our own PID (selectKillablePids)
+  // ensures we only reclaim the port from a stale backend, never the IDE.
   if (process.platform === 'win32') {
     try {
-      // Find PIDs listening on the port via netstat, then parse the last column
-      const output = execSync(`netstat -ano | findstr :${port}`, { encoding: 'utf8' }).trim();
+      const output = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, {
+        encoding: 'utf8',
+      }).trim();
       if (!output) return;
-      const pids = new Set<number>();
-      output.split('\n').forEach((line) => {
-        const parts = line.trim().split(/\s+/);
-        const pidStr = parts[parts.length - 1];
-        const pid = parseInt(pidStr, 10);
-        if (Number.isFinite(pid) && pid > 0) pids.add(pid);
-      });
-      pids.forEach((pid) => {
+      // Last column of each netstat row is the PID.
+      const rawPids = output
+        .split('\n')
+        .map((line) => line.trim().split(/\s+/).pop() ?? '')
+        .join('\n');
+      selectKillablePids(rawPids, process.pid).forEach((pid) => {
         try {
           execFileSync('taskkill', ['/F', '/PID', String(pid)]);
-          console.error('[node-backend]', `Killed process ${pid} occupying port ${port}`);
+          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
         } catch {
           // Process may have already exited — ignore
         }
@@ -59,19 +64,16 @@ function killProcessOnPort(port: number): void {
     }
   } else {
     try {
-      const pids = execFileSync('lsof', ['-ti', `:${port}`], { encoding: 'utf8' }).trim();
-      if (pids) {
-        pids.split('\n').forEach((pidStr) => {
-          const pid = parseInt(pidStr.trim(), 10);
-          if (!Number.isFinite(pid) || pid <= 0) return;
-          try {
-            process.kill(pid, 'SIGKILL');
-            console.error('[node-backend]', `Killed process ${pid} occupying port ${port}`);
-          } catch {
-            // Process may have already exited — ignore
-          }
-        });
-      }
+      // -sTCP:LISTEN restricts the query to listening sockets only.
+      const raw = execFileSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' });
+      selectKillablePids(raw, process.pid).forEach((pid) => {
+        try {
+          process.kill(pid, 'SIGKILL');
+          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
+        } catch {
+          // Process may have already exited — ignore
+        }
+      });
     } catch {
       // lsof returns non-zero when no process found — ignore
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -41,6 +41,23 @@ class NodeProcessManager(
     private var stderrJob: Job? = null
 
     /**
+     * Lifecycle of the managed process. [start] runs asynchronously, so for a window
+     * after start() returns the OS process does not yet exist and [isAlive] is false.
+     * Distinguishing STARTING from DEAD prevents callers (NodeBackendService.ensureStarted)
+     * from mistaking a still-spawning backend for a dead one and racing a second spawn —
+     * which collides on the port and triggers the port-reclaim kill path. See issue: the
+     * duplicate spawn was the trigger behind the IDE-killing EADDRINUSE storm.
+     */
+    enum class Lifecycle { STARTING, RUNNING, DEAD }
+
+    @Volatile
+    private var lifecycle = Lifecycle.STARTING
+
+    /** True only once the process has actually started and later exited (or failed to start). */
+    val isDead: Boolean
+        get() = lifecycle == Lifecycle.DEAD
+
+    /**
      * Handler interface for JSON-RPC requests coming from the Node.js backend.
      * The Node.js backend calls these when it needs IDE-native functionality.
      */
@@ -80,6 +97,7 @@ class NodeProcessManager(
                         "  3. Or set the NODE_PATH_OVERRIDE environment variable to your node binary " +
                         "(e.g. ~/.nvm/versions/node/v24.16.0/bin/node)."
                 )
+                lifecycle = Lifecycle.DEAD
                 _portDeferred.completeExceptionally(
                     IllegalStateException("Node.js executable not found")
                 )
@@ -89,6 +107,7 @@ class NodeProcessManager(
             val backendFile = findBackendFile()
             if (backendFile == null) {
                 logger.error("Backend entry file (backend.mjs) not found.")
+                lifecycle = Lifecycle.DEAD
                 _portDeferred.completeExceptionally(
                     IllegalStateException("Backend entry file not found")
                 )
@@ -121,6 +140,7 @@ class NodeProcessManager(
 
                 val proc = pb.start()
                 process = proc
+                lifecycle = Lifecycle.RUNNING
 
                 // Read stdout: first line is PORT, rest are logged
                 stdoutJob = scope.launch(Dispatchers.IO) {
@@ -151,6 +171,7 @@ class NodeProcessManager(
 
                 // Wait for process to exit and log the result
                 val exitCode = proc.waitFor()
+                lifecycle = Lifecycle.DEAD
                 logger.info("Node.js backend exited with code $exitCode")
 
                 if (!_portDeferred.isCompleted) {
@@ -161,6 +182,7 @@ class NodeProcessManager(
             } catch (e: CancellationException) {
                 // Normal shutdown
             } catch (e: Exception) {
+                lifecycle = Lifecycle.DEAD
                 logger.error("Failed to start Node.js backend", e)
                 if (!_portDeferred.isCompleted) {
                     _portDeferred.completeExceptionally(e)
@@ -713,6 +735,7 @@ class NodeProcessManager(
 
     override fun dispose() {
         logger.info("Disposing NodeProcessManager")
+        lifecycle = Lifecycle.DEAD
 
         stdoutJob?.cancel()
         stderrJob?.cancel()

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
@@ -1,5 +1,6 @@
 package com.github.yhk1038.claudecodegui.editor
 
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
 import com.github.yhk1038.claudecodegui.toolwindow.ClaudeCodePanel
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorLocation
@@ -35,8 +36,10 @@ class ClaudeCodeFileEditor(
         }
 
         // WebView의 URL 변경을 VirtualFile에 전달 (탭 이동/분할 시 복원용)
+        // 그리고 IDE 재시작 후에도 복원되도록 영속 저장소에도 반영.
         panel.onPathChanged = { path ->
             virtualFile.currentPath = path
+            EditorTabStateService.getInstance(project).updatePath(virtualFile.sessionId, path)
         }
 
         // Streaming state change: show unread badge when streaming ends on inactive tab

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateService.kt
@@ -15,7 +15,11 @@ class EditorTabStateService : PersistentStateComponent<EditorTabStateService.Edi
 
     data class EditorTabState(
         var openSessionIds: MutableList<String> = mutableListOf(),
-        var activeSessionId: String? = null
+        var activeSessionId: String? = null,
+        // Last WebView path per session, so a restored tab lands on the
+        // conversation the user was actually viewing at shutdown rather than
+        // the panel's original sessionId page.
+        var sessionPaths: MutableMap<String, String> = mutableMapOf()
     )
 
     private var state = EditorTabState()
@@ -35,10 +39,24 @@ class EditorTabStateService : PersistentStateComponent<EditorTabStateService.Edi
 
     fun removeTab(sessionId: String) {
         state.openSessionIds.remove(sessionId)
+        state.sessionPaths.remove(sessionId)
         if (state.activeSessionId == sessionId) {
             state.activeSessionId = state.openSessionIds.lastOrNull()
         }
     }
+
+    fun updatePath(sessionId: String, path: String) {
+        state.sessionPaths[sessionId] = path
+    }
+
+    fun getPath(sessionId: String): String? = state.sessionPaths[sessionId]
+
+    /**
+     * Path to restore a tab to: the last-viewed WebView path if known,
+     * otherwise the session's own page.
+     */
+    fun getRestorePath(sessionId: String): String =
+        state.sessionPaths[sessionId] ?: "/sessions/$sessionId"
 
     fun getOpenSessionIds(): List<String> = state.openSessionIds.toList()
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -141,7 +141,12 @@ class NodeBackendService : Disposable {
         rpcHandlers[key] = Pair(projectBasePath, rpcHandler)
         if (nodeProcessManager == null && rpcClient == null) {
             startBackend()
-        } else if (nodeProcessManager?.isAlive == false && !isBackendAlreadyRunning(DEFAULT_PORT)) {
+        } else if (nodeProcessManager?.isDead == true && !isBackendAlreadyRunning(DEFAULT_PORT)) {
+            // Only restart when the process actually STARTED and then EXITED. A manager
+            // that is still asynchronously starting (process not yet spawned) reports
+            // isDead == false, so a second panel initialising concurrently will NOT race
+            // a duplicate spawn — the duplicate spawn was the trigger for the EADDRINUSE
+            // storm that ended up killing the IDE.
             logger.info("Node.js backend process is dead, restarting...")
             restart()
         }
@@ -343,36 +348,37 @@ class NodeBackendService : Disposable {
     }
 
     /**
-     * Kill any process listening on the given port.
+     * Kill a *stale backend* listening on the given port.
+     *
+     * CRITICAL: only target processes LISTENING on the port. A plain `lsof -ti :PORT`
+     * also returns processes merely connected to it — including this very IDE JVM's RPC
+     * WebSocket — and `kill -9`ing those takes the whole IDE down (observed as exit 137 /
+     * SIGKILL). We restrict to LISTEN sockets (lsof -sTCP:LISTEN / netstat LISTENING) and
+     * filter out our own PID via [selectKillablePids] as a second line of defence.
      */
     private fun killProcessOnPort(port: Int) {
         try {
+            val selfPid = ProcessHandle.current().pid()
             val os = System.getProperty("os.name").lowercase()
             if (os.contains("win")) {
-                val output = ProcessBuilder("cmd", "/c", "netstat -ano | findstr :$port")
+                val output = ProcessBuilder("cmd", "/c", "netstat -ano | findstr :$port | findstr LISTENING")
                     .start().inputStream.bufferedReader().readText().trim()
-                val pids = output.lines()
-                    .mapNotNull { it.trim().split("\\s+".toRegex()).lastOrNull()?.toIntOrNull() }
-                    .filter { it > 0 }
-                    .toSet()
-                pids.forEach { pid ->
+                val raw = output.lines()
+                    .mapNotNull { it.trim().split("\\s+".toRegex()).lastOrNull() }
+                    .joinToString("\n")
+                selectKillablePids(raw, selfPid).forEach { pid ->
                     ProcessBuilder("taskkill", "/F", "/PID", pid.toString())
                         .start().waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
                 }
             } else {
-                val pids = ProcessBuilder("lsof", "-ti", ":$port")
-                    .start().inputStream.bufferedReader().readText().trim()
-                if (pids.isNotEmpty()) {
-                    pids.split("\n").forEach { pidStr ->
-                        val pid = pidStr.trim().toIntOrNull()
-                        if (pid != null && pid > 0) {
-                            ProcessBuilder("kill", "-9", pid.toString())
-                                .start().waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
-                        }
-                    }
+                val raw = ProcessBuilder("lsof", "-ti", ":$port", "-sTCP:LISTEN")
+                    .start().inputStream.bufferedReader().readText()
+                selectKillablePids(raw, selfPid).forEach { pid ->
+                    ProcessBuilder("kill", "-9", pid.toString())
+                        .start().waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
                 }
             }
-            logger.info("Killed stale backend process on port $port")
+            logger.info("Killed stale backend process(es) listening on port $port")
         } catch (e: Exception) {
             logger.warn("Failed to kill process on port $port", e)
         }
@@ -432,6 +438,21 @@ class NodeBackendService : Disposable {
  * The optional [caseSensitive] parameter overrides the system default and is intended
  * for unit testing on any host platform.
  */
+/**
+ * Parse the PID output of `lsof -t` / netstat and return the PIDs that are safe to kill
+ * when reclaiming a port: valid positive integers, de-duplicated (preserving order), and
+ * excluding [selfPid] so the IDE never kills itself. See [NodeBackendService.killProcessOnPort].
+ */
+internal fun selectKillablePids(raw: String, selfPid: Long): List<Long> {
+    val seen = LinkedHashSet<Long>()
+    for (line in raw.split("\n")) {
+        val pid = line.trim().toLongOrNull() ?: continue
+        if (pid <= 0 || pid == selfPid) continue
+        seen.add(pid)
+    }
+    return seen.toList()
+}
+
 internal fun pathMatchesBase(
     path: String,
     basePath: String,

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/EditorTabRestoreActivity.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/EditorTabRestoreActivity.kt
@@ -25,15 +25,15 @@ class EditorTabRestoreActivity : ProjectActivity {
         val activeSessionId = stateService.getActiveSessionId()
 
         ApplicationManager.getApplication().invokeLater {
-            // 비활성 탭 먼저 복원
+            // 비활성 탭 먼저 복원 (마지막으로 보던 경로로, 없으면 세션 페이지로)
             for (sessionId in sessionIds) {
                 if (sessionId != activeSessionId) {
-                    OpenClaudeCodeAction.openSession(project, sessionId, "/sessions/$sessionId")
+                    OpenClaudeCodeAction.openSession(project, sessionId, stateService.getRestorePath(sessionId))
                 }
             }
             // 활성 탭은 마지막에 열어서 포커스 획득
             if (activeSessionId != null && activeSessionId in sessionIds) {
-                OpenClaudeCodeAction.openSession(project, activeSessionId, "/sessions/$activeSessionId")
+                OpenClaudeCodeAction.openSession(project, activeSessionId, stateService.getRestorePath(activeSessionId))
             }
 
             logger.info("Editor tabs restored successfully")

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
@@ -1,0 +1,27 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class NodeProcessManagerLifecycleTest {
+
+    @Test
+    fun `freshly created manager is not dead and not alive (STARTING)`() {
+        val mgr = NodeProcessManager(CoroutineScope(Dispatchers.Default))
+        // The key invariant behind the duplicate-spawn fix: a manager that exists but
+        // hasn't finished starting must NOT look dead. ensureStarted only restarts when
+        // isDead == true, so this prevents a concurrent second panel from racing a spawn.
+        assertFalse(mgr.isDead, "a freshly created (still STARTING) manager must not report dead")
+        assertFalse(mgr.isAlive, "no OS process has been spawned yet")
+    }
+
+    @Test
+    fun `dispose transitions manager to dead`() {
+        val mgr = NodeProcessManager(CoroutineScope(Dispatchers.Default))
+        mgr.dispose()
+        assertTrue(mgr.isDead, "after dispose the manager is dead")
+        assertFalse(mgr.isAlive)
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateServiceTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateServiceTest.kt
@@ -1,0 +1,99 @@
+package com.github.yhk1038.claudecodegui.services
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class EditorTabStateServiceTest {
+
+    private lateinit var service: EditorTabStateService
+
+    @BeforeEach
+    fun setup() {
+        service = EditorTabStateService()
+    }
+
+    @Test
+    fun `addTab should register session and mark it active`() {
+        service.addTab("session-1")
+        assertEquals(listOf("session-1"), service.getOpenSessionIds())
+        assertEquals("session-1", service.getActiveSessionId())
+    }
+
+    @Test
+    fun `addTab should not duplicate existing session but still activate it`() {
+        service.addTab("session-1")
+        service.addTab("session-2")
+        service.addTab("session-1")
+        assertEquals(listOf("session-1", "session-2"), service.getOpenSessionIds())
+        assertEquals("session-1", service.getActiveSessionId())
+    }
+
+    @Test
+    fun `removeTab should drop session and reselect last remaining as active`() {
+        service.addTab("session-1")
+        service.addTab("session-2")
+        service.removeTab("session-2")
+        assertEquals(listOf("session-1"), service.getOpenSessionIds())
+        assertEquals("session-1", service.getActiveSessionId())
+    }
+
+    @Test
+    fun `updatePath should store current path for a session`() {
+        service.addTab("session-1")
+        service.updatePath("session-1", "/sessions/abc/conversations/xyz")
+        assertEquals("/sessions/abc/conversations/xyz", service.getPath("session-1"))
+    }
+
+    @Test
+    fun `getPath should return null for a session without a stored path`() {
+        service.addTab("session-1")
+        assertNull(service.getPath("session-1"))
+    }
+
+    @Test
+    fun `updatePath should overwrite a previously stored path`() {
+        service.updatePath("session-1", "/sessions/new")
+        service.updatePath("session-1", "/sessions/session-1")
+        assertEquals("/sessions/session-1", service.getPath("session-1"))
+    }
+
+    @Test
+    fun `removeTab should also discard the stored path`() {
+        service.addTab("session-1")
+        service.updatePath("session-1", "/sessions/session-1")
+        service.removeTab("session-1")
+        assertNull(service.getPath("session-1"))
+    }
+
+    @Test
+    fun `getRestorePath should prefer the stored path`() {
+        service.addTab("session-1")
+        service.updatePath("session-1", "/sessions/session-1/conversations/c1")
+        assertEquals("/sessions/session-1/conversations/c1", service.getRestorePath("session-1"))
+    }
+
+    @Test
+    fun `getRestorePath should fall back to the session page when no path stored`() {
+        service.addTab("session-1")
+        assertEquals("/sessions/session-1", service.getRestorePath("session-1"))
+    }
+
+    @Test
+    fun `state should survive a persist-reload round trip including paths`() {
+        service.addTab("session-1")
+        service.addTab("session-2")
+        service.updatePath("session-1", "/sessions/session-1")
+        service.updatePath("session-2", "/sessions/session-2/conversations/c2")
+
+        // Simulate IDE shutdown -> restart: serialize then reload into a fresh service.
+        val persisted = service.state
+        val reloaded = EditorTabStateService()
+        reloaded.loadState(persisted)
+
+        assertEquals(listOf("session-1", "session-2"), reloaded.getOpenSessionIds())
+        assertEquals("session-2", reloaded.getActiveSessionId())
+        assertEquals("/sessions/session-1", reloaded.getPath("session-1"))
+        assertEquals("/sessions/session-2/conversations/c2", reloaded.getPath("session-2"))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/SelectKillablePidsTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/SelectKillablePidsTest.kt
@@ -1,0 +1,38 @@
+package com.github.yhk1038.claudecodegui.services
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class SelectKillablePidsTest {
+
+    @Test
+    fun `parses one PID per line`() {
+        assertEquals(listOf(123L, 456L), selectKillablePids("123\n456", 999L))
+    }
+
+    @Test
+    fun `excludes our own PID so the IDE never kills itself`() {
+        assertEquals(listOf(123L, 456L), selectKillablePids("123\n777\n456", 777L))
+    }
+
+    @Test
+    fun `ignores blank lines and surrounding whitespace`() {
+        assertEquals(listOf(123L, 456L), selectKillablePids("  123 \n\n  456\n", 999L))
+    }
+
+    @Test
+    fun `drops non-numeric and non-positive values`() {
+        assertEquals(listOf(123L), selectKillablePids("abc\n0\n-5\n123", 999L))
+    }
+
+    @Test
+    fun `returns empty list for empty input`() {
+        assertEquals(emptyList<Long>(), selectKillablePids("", 999L))
+        assertEquals(emptyList<Long>(), selectKillablePids("   \n  ", 999L))
+    }
+
+    @Test
+    fun `de-duplicates repeated PIDs`() {
+        assertEquals(listOf(123L, 456L), selectKillablePids("123\n123\n456", 999L))
+    }
+}

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -5,8 +5,14 @@ import { SessionHeader } from '../SessionHeader/index';
 import { SessionMetaDto } from '../../../dto';
 import type { SessionState } from '../../../types';
 
-// 테스트 시점 기준 상대 날짜 생성 헬퍼
-const now = new Date();
+// 테스트 시점 기준 상대 날짜 생성 헬퍼.
+// 기준 시각을 "오늘 정오"로 고정한다. 자정 직후(예: 00:00~02:00)에 실행하면
+// hoursAgo(2)가 어제로 넘어가 "Today" 그룹이 사라지는 시각 의존 flaky를 막는다.
+const now = (() => {
+  const d = new Date();
+  d.setHours(12, 0, 0, 0);
+  return d;
+})();
 const daysAgo = (days: number) => new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
 const hoursAgo = (hours: number) => new Date(now.getTime() - hours * 60 * 60 * 1000);
 


### PR DESCRIPTION
## Summary

Fixes issue #66 (editor tab restore loses last-visited session) **and** a separate, more serious production crash discovered while verifying it: the IDE being SIGKILLed (exit 137) on startup whenever multiple Claude Code tabs were restored.

## The crash (root cause, 2-stage)

- **Trigger — duplicate backend spawn.** `NodeProcessManager.start()` is async, so a freshly created manager reports `isAlive == false` before the OS process exists. When two tabs restore concurrently, the second one mistook this for a dead backend and spawned a duplicate, colliding on port 19836 (`EADDRINUSE`).
- **Weapon — port reclaim killed the IDE.** `killProcessOnPort` used `lsof -ti :PORT`, which returns not only the process *LISTENing* on the port but also processes merely *connected* to it — including the IDE JVM's RPC WebSocket. SIGKILLing those took the whole IDE down.

This affected **both** real WebStorm and sandbox `run-ide` (the run-ide 137 was previously misattributed to a dev CEF signing problem).

## Fixes

1. **Restrict kill to LISTEN sockets** (`lsof -sTCP:LISTEN` / netstat `LISTENING`) and filter out our own PID, in both `server.ts` and `NodeBackendService.kt` (`selectKillablePids`).
2. **Remove the spawn race**: add `NodeProcessManager.Lifecycle` (STARTING/RUNNING/DEAD); `ensureStarted` restarts only when `isDead`, never during async startup.
3. **Issue #66**: persist per-tab `sessionPaths` in `EditorTabStateService`; forward WebView path changes from `ClaudeCodeFileEditor`; restore via `getRestorePath` (last path, falling back to `/sessions/$id`).
4. Stabilize a date-grouping webview test that failed between 00:00–02:00.

## Verification

- Real WebStorm: IDE survives 90s+, backend spawns exactly once, zero EADDRINUSE; #66 restore confirmed manually.
- Sandbox run-ide: 137 gone, same stability.
- Tests: Kotlin + Backend (260) + WebView (648) all pass, including new `selectKillablePids`, `NodeProcessManagerLifecycle`, and `EditorTabStateService` tests.