### PR TITLE
fix: keep conversation alive when dragging chat tab across splits (#29)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
@@ -1,31 +1,22 @@
 package com.github.yhk1038.claudecodegui.editor
 
-import com.github.yhk1038.claudecodegui.services.ClaudeCodeBrowserService
-import com.github.yhk1038.claudecodegui.services.EditorTabStateService
-import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
-import com.intellij.openapi.vfs.VirtualFile
 
 /**
- * Listens for actual file close events to clean up session state.
+ * Clears the unread badge when a Claude Code tab becomes selected.
  *
- * JetBrains calls FileEditor.dispose() both when a tab is closed AND when
- * a tab is moved/split between editor groups. This listener ensures that
- * session cleanup (removeSession, removeTab, browser release) only happens
- * on real tab close, not on tab move/split.
+ * Session/browser cleanup on tab close is intentionally NOT done here.
+ * JetBrains fires `fileClosed` on BOTH a real tab close AND a tab move/split,
+ * so releasing the pooled JCEF browser from `fileClosed` destroyed it during a
+ * move and forced a full reload (issue #29). Cleanup now lives in
+ * [com.github.yhk1038.claudecodegui.toolwindow.ClaudeCodePanel.dispose] via
+ * [com.github.yhk1038.claudecodegui.services.ClaudeCodeBrowserService.releaseRef],
+ * which distinguishes a real close from a move/split by reference counting.
  */
 class ClaudeCodeEditorManagerListener : FileEditorManagerListener {
 
-    override fun fileClosed(source: FileEditorManager, file: VirtualFile) {
-        if (file !is ClaudeCodeVirtualFile) return
-
-        val project = source.project
-        ClaudeCodeVirtualFile.removeSession(project, file.sessionId)
-        EditorTabStateService.getInstance(project).removeTab(file.sessionId)
-        ClaudeCodeBrowserService.getInstance(project).release(file.sessionId)
-    }
-
-    override fun selectionChanged(event: com.intellij.openapi.fileEditor.FileEditorManagerEvent) {
+    override fun selectionChanged(event: FileEditorManagerEvent) {
         val file = event.newFile
         if (file is ClaudeCodeVirtualFile && file.badgeState == TabBadge.UNREAD) {
             file.setBadge(TabBadge.NONE)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -1,6 +1,7 @@
 package com.github.yhk1038.claudecodegui.services
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
@@ -9,7 +10,16 @@ import com.intellij.ui.jcef.JBCefApp
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefBrowserBase
 import com.intellij.ui.jcef.JBCefJSQuery
+import com.intellij.util.Alarm
 import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Pure release rule for the pooled JCEF browser: a holder may be disposed only
+ * when no panel still references it. Extracted as a top-level function so the
+ * rule can be unit-tested without an IDE fixture. (issue #29)
+ */
+internal fun shouldReleasePooledBrowser(remainingPanelRefs: Int): Boolean =
+    remainingPanelRefs <= 0
 
 /**
  * Project-level service that pools JCEF browser instances by sessionId.
@@ -62,9 +72,33 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
          * disposed in [release] and the service's [dispose].
          */
         var lafListenerDisposable: Disposable? = null
+
+        /**
+         * Number of live panels referencing this browser. Incremented on
+         * [getOrCreate] (panel acquires the browser) and decremented on
+         * [releaseRef] (panel disposed). EDT-only access. (issue #29)
+         */
+        var panelRefCount: Int = 0
+
+        /**
+         * Monotonic token bumped on every acquire. A scheduled release captures
+         * the token at schedule time and aborts if the token changed meanwhile —
+         * i.e. the browser was re-acquired by a new panel during a tab move. This
+         * makes release cancellation independent of EDT-tick timing. (issue #29)
+         */
+        var releaseToken: Int = 0
     }
 
     private val holders = ConcurrentHashMap<String, BrowserHolder>()
+
+    /**
+     * Grace timer for deferred release. A tab move disposes the old panel
+     * (refCount → 0) and re-acquires from the new slot a few dozen ms later;
+     * the delay lets that re-acquire cancel the release. A real tab close has
+     * no re-acquire, so the release fires after the grace period. The delay
+     * being generous is harmless — the browser simply lingers in the pool.
+     */
+    private val releaseAlarm = Alarm(Alarm.ThreadToUse.SWING_THREAD, this)
 
     /**
      * Whether JCEF is available in this runtime.
@@ -82,15 +116,18 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
     }
 
     /**
-     * Get an existing browser for the session, or create a new one.
-     * The browser is NOT registered with Disposer — it is managed by this service.
+     * Get an existing browser for the session, or create a new one. Marks the
+     * browser as referenced by one more panel (refCount++) and bumps the
+     * release token so any pending deferred release for this session aborts —
+     * this is what keeps the browser alive across a tab move/split. The browser
+     * is NOT registered with Disposer — it is managed by this service.
      */
     fun getOrCreate(sessionId: String): BrowserHolder? {
         if (!isJcefAvailable()) {
             logger.warn("JCEF is not supported in this runtime — cannot create browser for session: $sessionId")
             return null
         }
-        return holders.getOrPut(sessionId) {
+        val holder = holders.getOrPut(sessionId) {
             logger.info("Creating new JCEF browser for session: $sessionId")
             // Disable JCEF off-screen rendering so the browser renders natively.
             // OSR (default since 2023.2) fails to forward HiDPI scale to Chromium on
@@ -114,13 +151,46 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
             val streamingQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
             BrowserHolder(browser, cursorQuery, streamingQuery)
         }
+        holder.panelRefCount += 1
+        // Bump the token so any release scheduled before this acquire aborts.
+        holder.releaseToken += 1
+        return holder
     }
 
     /**
-     * Release and dispose the browser for the given session.
-     * Called only on real tab close (via [ClaudeCodeEditorManagerListener.fileClosed]).
+     * Drop one panel's reference to the session's browser. When the last
+     * reference is gone, the browser is NOT disposed immediately: a tab
+     * move/split disposes the old panel and re-acquires from the new slot a
+     * short time later, and that re-acquire must keep the browser alive. So the
+     * release is deferred by a grace period and aborts if the browser was
+     * re-acquired meanwhile (token changed) or re-referenced (refCount > 0).
+     * Only a genuine tab close — with no re-acquire — actually disposes it.
+     *
+     * [onReleased] runs only when the browser is truly disposed, letting the
+     * caller perform the matching session/tab cleanup. (issue #29)
      */
-    fun release(sessionId: String) {
+    fun releaseRef(sessionId: String, onReleased: () -> Unit) {
+        val holder = holders[sessionId] ?: return
+        holder.panelRefCount -= 1
+        if (!shouldReleasePooledBrowser(holder.panelRefCount)) return
+
+        val tokenAtSchedule = holder.releaseToken
+        releaseAlarm.addRequest({
+            val current = holders[sessionId] ?: return@addRequest
+            // Re-acquired during the grace period → keep the pooled browser.
+            if (current.releaseToken != tokenAtSchedule) return@addRequest
+            if (!shouldReleasePooledBrowser(current.panelRefCount)) return@addRequest
+            release(sessionId)
+            onReleased()
+        }, RELEASE_GRACE_MS)
+    }
+
+    /**
+     * Dispose the pooled browser for the session and drop it from the pool.
+     * Private: callers go through [releaseRef] so the refcount + grace-period
+     * guard is always applied. (issue #29)
+     */
+    private fun release(sessionId: String) {
         holders.remove(sessionId)?.let { holder ->
             logger.info("Releasing JCEF browser for session: $sessionId")
             try { holder.lafListenerDisposable?.let { Disposer.dispose(it) } } catch (_: Exception) {}
@@ -141,6 +211,14 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
     }
 
     companion object {
+        /**
+         * Grace period before a zero-reference browser is disposed. Must comfortably
+         * exceed the tab-move dispose→re-acquire gap (observed 37–48ms) so a move
+         * never disposes the browser, while still being imperceptible on a real
+         * close. Generous on purpose — a lingering pooled browser is harmless.
+         */
+        private const val RELEASE_GRACE_MS = 750
+
         fun getInstance(project: Project): ClaudeCodeBrowserService =
             project.getService(ClaudeCodeBrowserService::class.java)
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -2,9 +2,11 @@ package com.github.yhk1038.claudecodegui.toolwindow
 
 import com.github.yhk1038.claudecodegui.actions.OpenClaudeCodeAction
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
 import com.github.yhk1038.claudecodegui.notifications.JcefRuntimeNotifier
 import com.github.yhk1038.claudecodegui.services.ClaudeCodeBrowserService
 import com.github.yhk1038.claudecodegui.services.DiffService
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
 import com.github.yhk1038.claudecodegui.services.NodeBackendService
 import com.github.yhk1038.claudecodegui.toolwindow.realization.CallbackStaging
 import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
@@ -1124,9 +1126,17 @@ class ClaudeCodePanel(
         scope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
         if (holder != null) {
             backendService.releasePanel(project.basePath ?: "", panelId)
+            // Drop this panel's reference to the pooled browser. The service
+            // disposes the browser (and runs the cleanup below) only if no new
+            // panel re-acquires the same session within the grace period — i.e.
+            // a real tab close, not a tab move/split. (issue #29)
+            browserService.releaseRef(sessionId) {
+                ClaudeCodeVirtualFile.removeSession(project, sessionId)
+                EditorTabStateService.getInstance(project).removeTab(sessionId)
+            }
         }
         // NOTE: Do NOT call Disposer.dispose(cursorQuery) or Disposer.dispose(browser).
-        // They are managed by ClaudeCodeBrowserService and released in fileClosed().
+        // They are managed by ClaudeCodeBrowserService and released via releaseRef().
         logger.info("ClaudeCodePanel disposed (browser retained in pool)")
     }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserServiceReleaseRuleTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserServiceReleaseRuleTest.kt
@@ -1,0 +1,49 @@
+package com.github.yhk1038.claudecodegui.services
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for the pooled-browser release rule used by
+ * [ClaudeCodeBrowserService.releaseRef].
+ *
+ * Regression guard for issue #29: dragging a Claude chat tab to a different
+ * split/position disposes the panel and recreates it in the new slot. The
+ * earlier fix keyed the release decision on `FileEditorManager.isFileOpen`
+ * checked one EDT tick later, but the tab-move close→open gap raced that tick
+ * (37–48ms in practice), so the pooled JCEF browser was released
+ * non-deterministically — sometimes reattached (no flicker), sometimes
+ * recreated (visible blank + reload).
+ *
+ * The deterministic rule: release the pooled browser only when NO panel still
+ * references it (refCount == 0). A tab move briefly drops the count to 0 and
+ * then re-acquires it; a grace delay + re-acquire cancellation (verified via
+ * run-ide) keeps the browser alive across that gap. These tests pin the pure
+ * count rule.
+ */
+class ClaudeCodeBrowserServiceReleaseRuleTest {
+
+    @Test
+    fun `retains pooled browser while at least one panel still references it`() {
+        assertFalse(
+            shouldReleasePooledBrowser(remainingPanelRefs = 1),
+            "Must NOT release while a panel still references the pooled browser",
+        )
+    }
+
+    @Test
+    fun `releases pooled browser only when no panel references it`() {
+        assertTrue(
+            shouldReleasePooledBrowser(remainingPanelRefs = 0),
+            "Must release once no panel references the pooled browser",
+        )
+    }
+
+    @Test
+    fun `treats a negative ref count as released (defensive against double-release)`() {
+        assertTrue(
+            shouldReleasePooledBrowser(remainingPanelRefs = -1),
+            "A negative count must still be treated as fully released",
+        )
+    }
+}


### PR DESCRIPTION
## Problem

Closes #29. Dragging the Claude chat editor tab to a different split/position blanked out the conversation and reloaded it — reported via a Marketplace review.

## Root cause (found by measurement, not assumption)

JetBrains fires `fileClosed` on **both** a real tab close **and** a tab move/split. `ClaudeCodeEditorManagerListener.fileClosed` unconditionally released the pooled JCEF browser, so a move destroyed it; the new slot recreated the browser, reloaded the page, and refetched the session — the visible blank-then-reload.

Two hypotheses were **disproved by run-ide measurement**:
1. *"windowed (non-OSR) reparent reloads the page"* — **false.** On IntelliJ 2024.2 (windowed) the page does **not** reload on reparent; pooling alone keeps it alive.
2. *"old vs new IntelliJ need different handling"* — **false.** A single fix works on both generations, so no generation split / WebView cache workaround was needed.

An interim `isFileOpen`-on-next-tick guard proved **non-deterministic**: the close→open gap (37–48ms) raced the EDT tick, so pooling worked only intermittently.

## Fix

Reference-count the pooled browser instead of guessing close-vs-move:
- `getOrCreate` increments the holder's `panelRefCount` and bumps a release token
- `ClaudeCodePanel.dispose` drops the ref via `releaseRef`
- release is **deferred by a grace period** and aborts if the browser is re-acquired (token changed) or re-referenced (`refCount > 0`) — a tab move re-acquires within the window, a real close does not
- session/tab cleanup runs only in the genuine-release callback
- `fileClosed` no longer performs cleanup (it cannot distinguish close from move)

## Verification

- Unit: `ClaudeCodeBrowserServiceReleaseRuleTest` pins the pure release rule (3 tests, green)
- Integration: `run-ide` on **2024.2 (windowed)** and **2026.1.2 (remote/OSR)** — every drag reattaches the pooled browser with **zero** reload/refetch (5/5 and 7/7 reattach, `Releasing`/`Creating`/`WebView loaded` = 0 during drags)