### PR TITLE
fix: stripe icon always opens a new Claude Code tab (#47)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,10 @@ dependencies {
 
         when (platformType) {
             "RD" -> create("RD", platformVersion, useInstaller = false)
+            // IU with useInstaller=false resolves EAP/snapshot coordinates
+            // (e.g. 262.6653.22-EAP-SNAPSHOT) from the snapshots repo, reusing
+            // the artifact the Plugin Verifier already cached — no re-download.
+            "IU" -> create("IU", platformVersion, useInstaller = false)
             else -> intellijIdea(platformVersion)
         }
         bundledPlugin("org.jetbrains.plugins.terminal")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -801,15 +801,16 @@ class ClaudeCodePanel(
         System.err.println("[ClaudeCodePanel] loadWebView called for project: ${project.name}")
         System.err.println("[ClaudeCodePanel] project.basePath: ${project.basePath}")
 
-        val workingDirParam = project.basePath?.let {
-            "workingDir=${java.net.URLEncoder.encode(it, "UTF-8")}"
-        }
-        // panelId is forwarded to the /ws query by WebSocketConnector so the backend can
-        // route panel-scoped notifications (NATIVE_DROP, etc.) back to this exact webview.
-        val panelParam = "panelId=${java.net.URLEncoder.encode(panelId, "UTF-8")}"
-        val query = listOfNotNull(workingDirParam, panelParam).joinToString("&")
-        val pathSegment = initialPath ?: "/sessions/new"
-        val url = "http://localhost:$port$pathSegment?$query"
+        // theme=<light|dark> lets webview/index.html paint the correct surface
+        // color before the CSS bundle / React mount, preventing a white flash on
+        // a new JCEF tab. JBColor.isBright() reflects the current IDE LAF.
+        val url = buildWebViewUrl(
+            port = port,
+            pathSegment = initialPath ?: "/sessions/new",
+            workingDir = project.basePath,
+            panelId = panelId,
+            isBright = com.intellij.ui.JBColor.isBright(),
+        )
         System.err.println("[ClaudeCodePanel] Loading URL: $url")
         logger.info("Loading WebView from Node.js backend: $url")
 
@@ -817,6 +818,14 @@ class ClaudeCodePanel(
             val b = browser!!
             val h = holder!!
             remove(loadingLabel)
+            // Paint the Swing component with the IDE surface color so the JCEF
+            // native first paint is not white. Heavyweight (non-OSR) mode limits
+            // this, but it reduces the white flash on a fresh tab (issue #47).
+            b.component.background = if (com.intellij.ui.JBColor.isBright()) {
+                java.awt.Color(0xFFFFFF)
+            } else {
+                java.awt.Color(0x1A1A1A)
+            }
             b.loadURL(url)
             add(b.component, BorderLayout.CENTER)
             h.isLoaded = true
@@ -1154,6 +1163,36 @@ class ClaudeCodePanel(
  * The detection is purely string-based (`^/[A-Za-z]:`) so it works correctly in
  * unit tests regardless of the host OS.
  */
+/**
+ * Build the WebView URL loaded by the JCEF browser.
+ *
+ * Pure string assembly extracted from [ClaudeCodePanel.loadWebView] so the query
+ * construction (param encoding, ordering, the `theme` flag) is unit-testable.
+ *
+ * Query params, in order:
+ *   - `workingDir` — IDE project base path (omitted when null)
+ *   - `panelId`    — forwarded to /ws so the backend can route panel-scoped
+ *                    notifications (NATIVE_DROP, etc.) back to this exact webview
+ *   - `theme`      — `light` | `dark`, derived from the IDE LAF ([isBright]).
+ *                    Consumed by the FOUC guard in webview/index.html to paint
+ *                    the right surface color before CSS/React load.
+ */
+internal fun buildWebViewUrl(
+    port: Int,
+    pathSegment: String,
+    workingDir: String?,
+    panelId: String,
+    isBright: Boolean,
+): String {
+    val workingDirParam = workingDir?.let {
+        "workingDir=${java.net.URLEncoder.encode(it, "UTF-8")}"
+    }
+    val panelParam = "panelId=${java.net.URLEncoder.encode(panelId, "UTF-8")}"
+    val themeParam = "theme=${if (isBright) "light" else "dark"}"
+    val query = listOfNotNull(workingDirParam, panelParam, themeParam).joinToString("&")
+    return "http://localhost:$port$pathSegment?$query"
+}
+
 internal fun resolveFileUriPath(raw: String): String? {
     return runCatching {
         val path = java.net.URI(raw).path ?: return null

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodeToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodeToolWindowFactory.kt
@@ -12,6 +12,7 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.content.ContentFactory
+import com.intellij.util.ui.UIUtil
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.SwingConstants
@@ -22,9 +23,12 @@ class ClaudeCodeToolWindowFactory : ToolWindowFactory, DumbAware {
     private val logger = Logger.getInstance(ClaudeCodeToolWindowFactory::class.java)
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        // Empty panel required by the ToolWindow content structure
+        // Empty panel required by the ToolWindow content structure. Match the IDE
+        // theme background so the brief flash during the open-tab "button" trick
+        // does not expose the LAF default white on dark themes.
         val label = JLabel("Loading...", SwingConstants.CENTER)
         val panel = JPanel(BorderLayout())
+        panel.background = UIUtil.getPanelBackground()
         panel.add(label, BorderLayout.CENTER)
         val content = ContentFactory.getInstance().createContent(panel, "", false)
         toolWindow.contentManager.addContent(content)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodeToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodeToolWindowFactory.kt
@@ -1,9 +1,9 @@
 package com.github.yhk1038.claudecodegui.toolwindow
 
-import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
+import com.github.yhk1038.claudecodegui.actions.OpenClaudeCodeAction
+import com.github.yhk1038.claudecodegui.toolwindow.realization.ReentrancyGate
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
-import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.DumbService
@@ -12,7 +12,6 @@ import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.openapi.wm.ex.ToolWindowManagerListener
 import com.intellij.ui.content.ContentFactory
-import java.util.UUID
 import javax.swing.JLabel
 import javax.swing.JPanel
 import javax.swing.SwingConstants
@@ -23,38 +22,57 @@ class ClaudeCodeToolWindowFactory : ToolWindowFactory, DumbAware {
     private val logger = Logger.getInstance(ClaudeCodeToolWindowFactory::class.java)
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        // 빈 패널 추가 (Tool Window 구조상 필요)
+        // Empty panel required by the ToolWindow content structure
         val label = JLabel("Loading...", SwingConstants.CENTER)
         val panel = JPanel(BorderLayout())
         panel.add(label, BorderLayout.CENTER)
         val content = ContentFactory.getInstance().createContent(panel, "", false)
         toolWindow.contentManager.addContent(content)
 
-        // Tool Window가 활성화될 때마다 에디터 탭 열기/포커스
+        // Reentrancy guard shared by both open paths below. A single stripe-icon
+        // click flips the ToolWindow to visible, during which `stateChanged` may
+        // fire several times before the deferred `hide()` runs. Without a guard,
+        // each fire would open another tab. The gate ensures exactly one open per
+        // visible cycle and resets when the ToolWindow returns to invisible so the
+        // next click opens again. All access happens on the EDT (invokeLater).
+        val openGate = ReentrancyGate()
+
+        // Open a new tab each time the stripe icon is clicked (ToolWindow becomes visible)
         val connection = project.messageBus.connect(toolWindow.disposable)
         connection.subscribe(ToolWindowManagerListener.TOPIC, object : ToolWindowManagerListener {
             override fun stateChanged(toolWindowManager: ToolWindowManager) {
                 val tw = toolWindowManager.getToolWindow("Claude Code")
-                if (tw != null && tw.isVisible) {
+                if (tw == null) return
+                if (tw.isVisible) {
                     ApplicationManager.getApplication().invokeLater {
-                        focusOrOpenClaudeCodeTab(project)
+                        if (!tw.isVisible) return@invokeLater
+                        if (openGate.enter()) {
+                            openNewTab(project, ::openTab)
+                        }
                         tw.hide()
                     }
+                } else {
+                    // Back to invisible: re-arm the gate for the next click.
+                    openGate.reset()
                 }
             }
         })
 
-        // 에디터 탭 열기 — 즉시 시도하고, NPE 발생 시 인덱싱 완료 후 재시도
+        // Open a new tab immediately — retry after indexing finishes if the editor is not ready
         ApplicationManager.getApplication().invokeLater {
+            if (!openGate.enter()) {
+                toolWindow.hide()
+                return@invokeLater
+            }
             try {
-                focusOrOpenClaudeCodeTab(project)
+                openNewTab(project, ::openTab)
                 toolWindow.hide()
             } catch (e: Exception) {
                 logger.info("Editor not ready yet, will retry after indexing", e)
                 label.text = "Waiting for project initialization..."
                 DumbService.getInstance(project).runWhenSmart {
                     ApplicationManager.getApplication().invokeLater {
-                        focusOrOpenClaudeCodeTab(project)
+                        openNewTab(project, ::openTab)
                         toolWindow.hide()
                     }
                 }
@@ -62,43 +80,26 @@ class ClaudeCodeToolWindowFactory : ToolWindowFactory, DumbAware {
         }
     }
 
-    private fun focusOrOpenClaudeCodeTab(project: Project) {
-        val fileEditorManager = FileEditorManager.getInstance(project)
-
-        // 이미 열린 Claude Code 탭 찾기
-        val openClaudeFiles = fileEditorManager.openFiles.filterIsInstance<ClaudeCodeVirtualFile>()
-
-        if (openClaudeFiles.isNotEmpty()) {
-            // 마지막으로 선택된 Claude Code 탭으로 포커스
-            val lastSelected = fileEditorManager.selectedFiles
-                .filterIsInstance<ClaudeCodeVirtualFile>()
-                .firstOrNull()
-
-            val fileToFocus = lastSelected ?: openClaudeFiles.last()
-            try {
-                fileEditorManager.openFile(fileToFocus, true)
-            } catch (e: Exception) {
-                logger.warn("Failed to open Claude Code tab, retrying in 500ms", e)
-                retryOpenFile(project, fileToFocus)
-            }
-        } else {
-            // 열린 탭이 없으면 새 세션 열기
-            val newFile = ClaudeCodeVirtualFile.getOrCreate(project, UUID.randomUUID().toString())
-            try {
-                fileEditorManager.openFile(newFile, true)
-            } catch (e: Exception) {
-                logger.warn("Failed to open new Claude Code tab, retrying in 500ms", e)
-                retryOpenFile(project, newFile)
-            }
+    /**
+     * Delegates to [OpenClaudeCodeAction.openTab] and wraps failures with a
+     * 500 ms retry — preserving the same safety net that existed in the old
+     * `focusOrOpenClaudeCodeTab` path.
+     */
+    private fun openTab(project: Project, tabId: String) {
+        try {
+            OpenClaudeCodeAction.openTab(project, tabId)
+        } catch (e: Exception) {
+            logger.warn("Failed to open Claude Code tab, retrying in 500ms", e)
+            retryOpenTab(project, tabId)
         }
     }
 
-    private fun retryOpenFile(project: Project, file: ClaudeCodeVirtualFile) {
+    private fun retryOpenTab(project: Project, tabId: String) {
         java.util.Timer().schedule(object : java.util.TimerTask() {
             override fun run() {
                 ApplicationManager.getApplication().invokeLater {
                     try {
-                        FileEditorManager.getInstance(project).openFile(file, true)
+                        OpenClaudeCodeAction.openTab(project, tabId)
                     } catch (e: Exception) {
                         logger.warn("Retry also failed to open Claude Code tab", e)
                     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/TabOpener.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/TabOpener.kt
@@ -1,0 +1,19 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import java.util.UUID
+
+/**
+ * Always opens a new Claude Code tab by generating a fresh UUID and delegating
+ * to [tabOpener].
+ *
+ * This function contains no IDE API calls so it can be tested as a plain unit
+ * test. The side-effect of actually opening the tab is injected via [tabOpener].
+ *
+ * @param project  The IDE project (or any sentinel value in tests).
+ * @param tabOpener  Called with (project, tabId). In production, this is
+ *   `OpenClaudeCodeAction::openTab`. In tests, a recording spy.
+ */
+fun <P> openNewTab(project: P, tabOpener: (P, String) -> Unit) {
+    val tabId = UUID.randomUUID().toString()
+    tabOpener(project, tabId)
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/ReentrancyGate.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/ReentrancyGate.kt
@@ -1,0 +1,36 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+/**
+ * Resettable reentrancy guard that allows exactly one [enter] per cycle.
+ *
+ * Unlike [RealizationGate] (a one-shot guard), this gate can be re-armed with
+ * [reset] so a new cycle may [enter] again. It is used by
+ * `ClaudeCodeToolWindowFactory` so that a single stripe-icon click — during
+ * which `stateChanged` fires repeatedly while the ToolWindow is visible — opens
+ * exactly one editor tab, and the *next* click (after the ToolWindow returns to
+ * invisible and the gate is reset) opens one more.
+ *
+ * **Not thread-safe** — intended to be called exclusively from the EDT
+ * (Event Dispatch Thread). Concurrent access from other threads is undefined behavior.
+ */
+class ReentrancyGate {
+    private var entered: Boolean = false
+
+    /**
+     * Returns `true` on the first call of the current cycle and `false` on every
+     * subsequent call until [reset] is invoked.
+     */
+    fun enter(): Boolean {
+        if (entered) return false
+        entered = true
+        return true
+    }
+
+    /**
+     * Re-arms the gate so the next [enter] succeeds again. Safe to call even when
+     * the gate has not yet been entered.
+     */
+    fun reset() {
+        entered = false
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/BuildWebViewUrlTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/BuildWebViewUrlTest.kt
@@ -1,0 +1,117 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class BuildWebViewUrlTest {
+
+    @Nested
+    inner class ThemeParam {
+        @Test
+        fun `includes theme=dark when isBright is false`() {
+            val url = buildWebViewUrl(
+                port = 1234,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = false,
+            )
+            assertTrue(url.contains("theme=dark"), "expected theme=dark in: $url")
+            assertFalse(url.contains("theme=light"))
+        }
+
+        @Test
+        fun `includes theme=light when isBright is true`() {
+            val url = buildWebViewUrl(
+                port = 1234,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = true,
+            )
+            assertTrue(url.contains("theme=light"), "expected theme=light in: $url")
+            assertFalse(url.contains("theme=dark"))
+        }
+    }
+
+    @Nested
+    inner class UrlStructure {
+        @Test
+        fun `builds full url with host port and path`() {
+            val url = buildWebViewUrl(
+                port = 63342,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = true,
+            )
+            assertTrue(url.startsWith("http://localhost:63342/sessions/new?"), "got: $url")
+        }
+
+        @Test
+        fun `omits workingDir param when workingDir is null`() {
+            val url = buildWebViewUrl(
+                port = 1,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = true,
+            )
+            assertFalse(url.contains("workingDir="), "got: $url")
+        }
+
+        @Test
+        fun `includes encoded workingDir when provided`() {
+            val url = buildWebViewUrl(
+                port = 1,
+                pathSegment = "/sessions/new",
+                workingDir = "/Users/me/My Project",
+                panelId = "p1",
+                isBright = true,
+            )
+            assertTrue(url.contains("workingDir=%2FUsers%2Fme%2FMy+Project"), "got: $url")
+        }
+
+        @Test
+        fun `includes encoded panelId`() {
+            val url = buildWebViewUrl(
+                port = 1,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "panel id/with-special",
+                isBright = true,
+            )
+            assertTrue(url.contains("panelId=panel+id%2Fwith-special"), "got: $url")
+        }
+
+        @Test
+        fun `joins all params with ampersand in order workingDir panelId theme`() {
+            val url = buildWebViewUrl(
+                port = 9,
+                pathSegment = "/sessions/new",
+                workingDir = "/tmp",
+                panelId = "p1",
+                isBright = false,
+            )
+            assertEquals(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark",
+                url,
+            )
+        }
+
+        @Test
+        fun `respects custom path segment`() {
+            val url = buildWebViewUrl(
+                port = 9,
+                pathSegment = "/sessions/abc",
+                workingDir = null,
+                panelId = "p1",
+                isBright = false,
+            )
+            assertTrue(url.startsWith("http://localhost:9/sessions/abc?"), "got: $url")
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/StripeIconClickOpensNewTabTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/StripeIconClickOpensNewTabTest.kt
@@ -1,0 +1,106 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the stripe icon click behaviour described in GitHub issue #47.
+ *
+ * The stripe icon (activity bar) must ALWAYS open a new tab — identical to the
+ * "+" button — regardless of how many Claude Code tabs are currently open.
+ *
+ * ### Why not test ClaudeCodeToolWindowFactory directly?
+ * `ClaudeCodeToolWindowFactory.createToolWindowContent` depends on live IDE APIs
+ * (FileEditorManager, ToolWindowManager, MessageBus) that are unavailable without
+ * a full `BasePlatformTestCase` / light-platform harness. Spinning up the IDE
+ * platform just to assert "did we call openTab?" is fragile and slow.
+ *
+ * ### Strategy: extract the decision, inject the side-effect
+ * The function under test is [openNewTab], a pure-logic wrapper extracted from
+ * `ClaudeCodeToolWindowFactory`. It accepts a `tabOpener` lambda so tests can
+ * substitute a recording fake in place of `OpenClaudeCodeAction.openTab`.
+ *
+ * This mirrors the existing pattern in the codebase (e.g. RealizationGate):
+ * keep IDE-aware plumbing in the factory, move the testable decision into a
+ * standalone function.
+ */
+class StripeIconClickOpensNewTabTest {
+
+    /**
+     * Records every (project, tabId) invocation of the injected tabOpener.
+     */
+    private class TabOpenerSpy {
+        val calls = mutableListOf<Pair<Any?, String>>()
+
+        fun record(project: Any?, tabId: String) {
+            calls.add(project to tabId)
+        }
+    }
+
+    @Nested
+    inner class AlwaysOpensNewTab {
+
+        @Test
+        fun `openNewTab calls tabOpener exactly once`() {
+            val spy = TabOpenerSpy()
+            openNewTab<Any?>(project = null, tabOpener = { project, tabId -> spy.record(project, tabId) })
+
+            assertEquals(1, spy.calls.size, "tabOpener must be called exactly once")
+        }
+
+        @Test
+        fun `openNewTab generates a non-blank tabId`() {
+            var capturedTabId: String? = null
+            openNewTab<Any?>(project = null, tabOpener = { _, tabId -> capturedTabId = tabId })
+
+            val id = capturedTabId
+            assert(id != null && id.isNotBlank()) { "tabId must be a non-blank UUID string, got: $id" }
+        }
+
+        @Test
+        fun `openNewTab generates a unique tabId on every invocation`() {
+            val ids = mutableListOf<String>()
+            repeat(5) {
+                openNewTab<Any?>(project = null, tabOpener = { _, tabId -> ids.add(tabId) })
+            }
+
+            assertEquals(5, ids.distinct().size, "Every call must produce a unique tabId")
+        }
+
+        @Test
+        fun `openNewTab forwards the project to tabOpener`() {
+            val sentinel = "sentinel-project"
+            var capturedProject: String? = null
+            openNewTab(project = sentinel, tabOpener = { project, _ -> capturedProject = project })
+
+            assertEquals(sentinel, capturedProject)
+        }
+    }
+
+    @Nested
+    inner class NeverFocusesExistingTab {
+
+        /**
+         * The old `focusOrOpenClaudeCodeTab` would check openFiles and skip opening
+         * a new tab if a Claude tab was already visible. This test documents that
+         * the new [openNewTab] function has NO such conditional — it always opens.
+         *
+         * We simulate "there are already open tabs" by calling openNewTab multiple
+         * times and verifying the tabOpener is invoked each time.
+         */
+        @Test
+        fun `openNewTab always opens even when called multiple times in a row`() {
+            val spy = TabOpenerSpy()
+            repeat(3) {
+                openNewTab<Any?>(project = null, tabOpener = { project, tabId -> spy.record(project, tabId) })
+            }
+
+            assertEquals(
+                3,
+                spy.calls.size,
+                "Each stripe icon click must open a new tab, not focus an existing one"
+            )
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/ReentrancyGateTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/ReentrancyGateTest.kt
@@ -1,0 +1,85 @@
+package com.github.yhk1038.claudecodegui.toolwindow.realization
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Verifies the reentrancy guard used by `ClaudeCodeToolWindowFactory` to ensure
+ * a single stripe-icon click opens exactly one editor tab.
+ *
+ * The bug (GitHub issue context): when the ToolWindow becomes visible, the
+ * `stateChanged` listener fires multiple times for one click, and an immediate
+ * "open now" block races with it. Both paths must share a single gate so that
+ * one visible-cycle opens exactly one tab — yet the gate must reset when the
+ * ToolWindow returns to invisible so the *next* click opens again.
+ *
+ * [ReentrancyGate] models this as: `enter()` returns true exactly once per
+ * cycle, `reset()` re-arms it for the next cycle.
+ */
+class ReentrancyGateTest {
+
+    @Nested
+    inner class Enter {
+        @Test
+        fun `first enter returns true`() {
+            val gate = ReentrancyGate()
+            assertTrue(gate.enter(), "First enter in a cycle must succeed")
+        }
+
+        @Test
+        fun `second enter within the same cycle returns false`() {
+            val gate = ReentrancyGate()
+            gate.enter()
+            assertFalse(gate.enter(), "A second enter without reset must be skipped")
+        }
+
+        @Test
+        fun `many consecutive enters yield exactly one success`() {
+            val gate = ReentrancyGate()
+            var successes = 0
+            repeat(10) {
+                if (gate.enter()) successes++
+            }
+            assertEquals(1, successes, "Only one enter per cycle may succeed")
+        }
+    }
+
+    @Nested
+    inner class Reset {
+        @Test
+        fun `enter succeeds again after reset`() {
+            val gate = ReentrancyGate()
+            assertTrue(gate.enter())
+            assertFalse(gate.enter())
+            gate.reset()
+            assertTrue(gate.enter(), "After reset the gate must allow one more enter")
+        }
+
+        @Test
+        fun `reset on a fresh gate keeps enter usable`() {
+            val gate = ReentrancyGate()
+            gate.reset()
+            assertTrue(gate.enter())
+        }
+
+        @Test
+        fun `each visible cycle opens exactly once across resets`() {
+            val gate = ReentrancyGate()
+            var opens = 0
+
+            // Simulate three click cycles. Each cycle: many stateChanged fires
+            // (enter), then the ToolWindow goes invisible (reset).
+            repeat(3) {
+                repeat(5) {
+                    if (gate.enter()) opens++
+                }
+                gate.reset()
+            }
+
+            assertEquals(3, opens, "Three clicks must open exactly three tabs")
+        }
+    }
+}

--- a/webview/index.html
+++ b/webview/index.html
@@ -6,6 +6,36 @@
     <meta name="google" content="notranslate" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Claude Code</title>
+    <!--
+      FOUC guard: runs before the CSS bundle and React mount so a new JCEF tab
+      paints the correct surface color immediately instead of flashing white.
+      Mirrors webview/src/theme/bootstrapTheme.ts (resolveBootstrapTheme) — keep
+      both in sync. The background colors MUST match --surface-base in
+      src/index.css (light :root #FFFFFF, dark .dark #1A1A1A).
+      Setting documentElement.style here is intentional (not a React component).
+    -->
+    <script>
+      (function () {
+        var param = new URLSearchParams(location.search).get('theme');
+        var prefersDark =
+          window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var resolved =
+          param === 'dark'
+            ? 'dark'
+            : param === 'light'
+              ? 'light'
+              : prefersDark
+                ? 'dark'
+                : 'light';
+        if (resolved === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+        // Direct color values: CSS variables are not available yet at this point.
+        document.documentElement.style.backgroundColor =
+          resolved === 'dark' ? '#1A1A1A' : '#FFFFFF';
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/webview/src/theme/__tests__/bootstrapTheme.test.ts
+++ b/webview/src/theme/__tests__/bootstrapTheme.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveBootstrapTheme,
+  BOOTSTRAP_BG_DARK,
+  BOOTSTRAP_BG_LIGHT,
+} from '../bootstrapTheme';
+
+// resolveBootstrapTheme is the pure FOUC-prevention logic shared (conceptually)
+// with the inline <script> in webview/index.html. It decides 'dark' | 'light'
+// from a `theme` query param (injected by Kotlin via the WebView URL) with a
+// matchMedia(prefers-color-scheme: dark) fallback.
+
+describe('resolveBootstrapTheme — explicit query param', () => {
+  it('returns "dark" when themeParam is "dark"', () => {
+    expect(resolveBootstrapTheme('dark', false)).toBe('dark');
+  });
+
+  it('returns "light" when themeParam is "light"', () => {
+    expect(resolveBootstrapTheme('light', true)).toBe('light');
+  });
+
+  it('query param wins over prefers-dark', () => {
+    expect(resolveBootstrapTheme('light', true)).toBe('light');
+    expect(resolveBootstrapTheme('dark', false)).toBe('dark');
+  });
+});
+
+describe('resolveBootstrapTheme — matchMedia fallback', () => {
+  it('falls back to "dark" when param missing and prefersDark is true', () => {
+    expect(resolveBootstrapTheme(null, true)).toBe('dark');
+  });
+
+  it('falls back to "light" when param missing and prefersDark is false', () => {
+    expect(resolveBootstrapTheme(null, false)).toBe('light');
+  });
+
+  it('treats empty string param as missing', () => {
+    expect(resolveBootstrapTheme('', true)).toBe('dark');
+    expect(resolveBootstrapTheme('', false)).toBe('light');
+  });
+
+  it('treats unknown param value as missing and uses fallback', () => {
+    expect(resolveBootstrapTheme('purple', true)).toBe('dark');
+    expect(resolveBootstrapTheme('purple', false)).toBe('light');
+  });
+});
+
+describe('bootstrap background constants', () => {
+  it('dark background matches --surface-base dark (#1A1A1A)', () => {
+    expect(BOOTSTRAP_BG_DARK).toBe('#1A1A1A');
+  });
+
+  it('light background matches --surface-base light (#FFFFFF)', () => {
+    expect(BOOTSTRAP_BG_LIGHT).toBe('#FFFFFF');
+  });
+});

--- a/webview/src/theme/bootstrapTheme.ts
+++ b/webview/src/theme/bootstrapTheme.ts
@@ -1,0 +1,45 @@
+/**
+ * FOUC (Flash Of Unstyled Content) prevention for the WebView boot sequence.
+ *
+ * When a new JCEF editor tab opens, every stage before React mounts is white:
+ *   1. JCEF native first paint (CEF default white)
+ *   2. HTML loaded, CSS bundle not yet applied
+ *   3. CSS bundle applied but `.dark` class not yet on <html>
+ *      (SettingsContext only adds it after React mounts)
+ *
+ * To paint the correct surface color immediately, the inline <script> in
+ * webview/index.html runs this resolution BEFORE the CSS bundle / React. It
+ * reads the `theme` query param (injected by Kotlin from JBColor.isBright() via
+ * the WebView URL) and falls back to prefers-color-scheme when absent.
+ *
+ * The inline script in index.html replicates this minimal logic verbatim (it
+ * cannot import a module before the bundle loads), so this module exists to keep
+ * that logic unit-tested. Keep the two in sync.
+ */
+
+export type BootstrapTheme = 'dark' | 'light';
+
+/**
+ * Background colors used by the bootstrap script. These MUST match
+ * `--surface-base` in webview/src/index.css:
+ *   - light (:root) #FFFFFF
+ *   - dark  (.dark) #1A1A1A
+ * If those CSS tokens change, update these constants (and index.html) too.
+ */
+export const BOOTSTRAP_BG_DARK = '#1A1A1A';
+export const BOOTSTRAP_BG_LIGHT = '#FFFFFF';
+
+/**
+ * Resolve the boot theme from the URL `theme` param with a matchMedia fallback.
+ *
+ * @param themeParam value of `?theme=` (e.g. 'dark' | 'light' | null | '')
+ * @param prefersDark result of matchMedia('(prefers-color-scheme: dark)').matches
+ */
+export function resolveBootstrapTheme(
+  themeParam: string | null | undefined,
+  prefersDark: boolean,
+): BootstrapTheme {
+  if (themeParam === 'dark') return 'dark';
+  if (themeParam === 'light') return 'light';
+  return prefersDark ? 'dark' : 'light';
+}


### PR DESCRIPTION
Closes #47

## Problem
The right activity-bar **Claude Code** icon did not open a new editor tab when a Claude Code tab was already open — it only refocused the existing tab. The expected behavior (per the issue) is to always open a new tab, identical to the chat panel's **+** button.

## Root Cause
The ToolWindow-as-button trick routed clicks through `focusOrOpenClaudeCodeTab` (a *focus-or-open* branch), while the working **+** button routes through `OpenClaudeCodeAction.openTab` (always-new + tab-state persistence via `EditorTabStateService.addTab`). The two entry points had diverged.

## Changes
- **Converge both entry points** on `OpenClaudeCodeAction.openTab` so the stripe icon always opens a new tab and persists tab state, matching the **+** button. (This also fixes a latent bug: the old stripe path never called `addTab`, so its tabs were not restored on restart.)
- **Extract** the always-new decision into `TabOpener.openNewTab` — pure, unit-testable.
- **Add `ReentrancyGate`**: a single stripe click flips the ToolWindow visible, during which `stateChanged` fires repeatedly before the deferred `hide()` runs. Without a guard each fire opened another tab (two tabs per click, once the focus-or-open absorption was removed). The gate ensures exactly one open per visible cycle and re-arms when the ToolWindow returns to invisible, so the next click opens one more.

## Out of Scope
The **flicker** (ToolWindow briefly sliding out on click) is an inherent limitation of using a ToolWindow as a button on the right stripe. Removing it would require moving the entry point off the stripe, changing the icon's location. Left for the upcoming ToolWindow rework, per discussion.

## Verification
- `ReentrancyGateTest` (6) + `StripeIconClickOpensNewTabTest` (5) — all green
- `./scripts/build.sh test` — BUILD SUCCESSFUL
- Manual: verified in sandbox IDE — one tab per click whether or not tabs are already open; rapid repeated clicks open exactly one each