### PR TITLE
fix(webview): eliminate keystroke lag in long conversations (#31)

### DIFF
--- a/webview/src/__tests__/chat-streaming.integration.test.tsx
+++ b/webview/src/__tests__/chat-streaming.integration.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import React from 'react';
 import { ChatStreamProvider, useChatStreamContext } from '../contexts/ChatStreamContext';
+import { ChatInputStateProvider, useChatInputState } from '../contexts/ChatInputStateContext';
 
 // Mock requestAnimationFrame/cancelAnimationFrame
 global.requestAnimationFrame = vi.fn((cb) => {
@@ -60,9 +61,25 @@ vi.mock('../contexts/SessionContext', () => ({
   SessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const inputRef = React.useRef('');
+  const setInputCallbackRef = React.useRef<(value: string) => void>(() => {});
+  const setInput = React.useCallback((value: string) => {
+    setInputCallbackRef.current(value);
+  }, []);
+  return (
+    <ChatStreamProvider setInput={setInput} inputRef={inputRef}>
+      <ChatInputStateProvider inputRef={inputRef} setInputCallbackRef={setInputCallbackRef}>
+        {children}
+      </ChatInputStateProvider>
+    </ChatStreamProvider>
+  );
+}
+
 // Test component that uses ChatStreamContext
 function TestChatComponent() {
   const ctx = useChatStreamContext();
+  const { input, setInput } = useChatInputState();
   return (
     <div>
       <div data-testid="messages-count">{ctx.messages.length}</div>
@@ -71,8 +88,8 @@ function TestChatComponent() {
       <div data-testid="streaming-id">{ctx.streamingMessageId || 'none'}</div>
       <input
         data-testid="input"
-        value={ctx.input}
-        onChange={(e) => ctx.setInput(e.target.value)}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
       />
       <button data-testid="submit" onClick={() => ctx.handleSubmit(undefined, 'ask_before_edit')}>
         Send
@@ -142,9 +159,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
 
   it('초기 상태가 올바르다', () => {
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     expect(screen.getByTestId('messages-count')).toHaveTextContent('0');
@@ -158,9 +175,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'existing-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');
@@ -195,9 +212,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'existing-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const submitWithMode = screen.getByTestId('submit-with-mode');
@@ -220,9 +237,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');
@@ -282,9 +299,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     // Start streaming
@@ -323,9 +340,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     await act(async () => {
@@ -346,9 +363,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     // Start streaming
@@ -393,9 +410,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, useRef, ReactNode } from 'react';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { getAdapter } from '@/adapters';
@@ -46,6 +47,7 @@ interface CommandPaletteProviderProps {
 
 export function CommandPaletteProvider({ children }: CommandPaletteProviderProps) {
   const chatStream = useChatStreamContext();
+  const chatInputState = useChatInputState();
   const session = useSessionContext();
   const { controlResponse } = useCliConfig();
 
@@ -54,8 +56,8 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     chatStream: {
       messages: chatStream.messages,
       isStreaming: chatStream.isStreaming,
-      input: chatStream.input,
-      setInput: chatStream.setInput,
+      input: chatInputState.input,
+      setInput: chatInputState.setInput,
       sendMessage: chatStream.sendMessage,
       stop: chatStream.stop,
       continue: chatStream.continue,
@@ -84,8 +86,8 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     chatStream: {
       messages: chatStream.messages,
       isStreaming: chatStream.isStreaming,
-      input: chatStream.input,
-      setInput: chatStream.setInput,
+      input: chatInputState.input,
+      setInput: chatInputState.setInput,
       sendMessage: chatStream.sendMessage,
       stop: chatStream.stop,
       continue: chatStream.continue,

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { BridgeProvider, useBridgeContext } from './BridgeContext';
 import { ApiProvider, useApiContext } from './ApiContext';
@@ -9,6 +9,7 @@ import { SettingsProvider } from './SettingsContext';
 import { ClaudeSettingsProvider } from './ClaudeSettingsContext';
 import { CliConfigProvider } from './CliConfigContext';
 import { ChatInputFocusProvider } from './ChatInputFocusContext';
+import { ChatInputStateProvider } from './ChatInputStateContext';
 import { WorkingDirProvider } from './WorkingDirContext';
 import { CommandPaletteProvider } from '../commandPalette/CommandPaletteProvider';
 import { useApi } from './ApiContext';
@@ -154,6 +155,50 @@ function SessionLoader({ children }: { children: ReactNode }) {
  * 11. ThemeProvider - Theme management (depends on Settings)
  * 12. SessionLoader - Reactive session management (depends on Session + ChatStream + Api)
  */
+
+interface ChatProviderBridgeProps {
+  children: ReactNode;
+}
+
+/**
+ * Bridges ChatInputStateProvider and ChatStreamProvider as siblings.
+ *
+ * ChatStreamProvider must NOT be nested inside ChatInputStateProvider —
+ * otherwise every keystroke (which triggers ChatInputStateProvider re-render)
+ * would propagate into ChatStreamProvider and all its consumers
+ * (MessageBubble, ChatMessageArea, etc.), causing the keystroke lag described
+ * in #31.
+ *
+ * The shared inputRef + setInputCallbackRef let ChatStreamProvider read/clear
+ * input without subscribing to ChatInputStateContext.
+ */
+function ChatProviderBridge(props: ChatProviderBridgeProps) {
+  const { children } = props;
+  const inputRef = useRef('');
+  const setInputCallbackRef = useRef<(value: string) => void>(() => {});
+
+  const setInput = useCallback((value: string) => {
+    setInputCallbackRef.current(value);
+  }, []);
+
+  return (
+    <ChatStreamProvider setInput={setInput} inputRef={inputRef}>
+      <ChatInputStateProvider
+        inputRef={inputRef}
+        setInputCallbackRef={setInputCallbackRef}
+      >
+        <CommandPaletteProvider>
+          <ThemeProvider>
+            <ChatInputFocusProvider>
+              <SessionLoader>{children}</SessionLoader>
+            </ChatInputFocusProvider>
+          </ThemeProvider>
+        </CommandPaletteProvider>
+      </ChatInputStateProvider>
+    </ChatStreamProvider>
+  );
+}
+
 export function AppProviders({ children }: AppProvidersProps) {
   return (
     <BridgeProvider>
@@ -164,15 +209,7 @@ export function AppProviders({ children }: AppProvidersProps) {
             <SettingsProvider>
               <ClaudeSettingsProvider>
                 <SessionProvider>
-                  <ChatStreamProvider>
-                    <CommandPaletteProvider>
-                      <ThemeProvider>
-                        <ChatInputFocusProvider>
-                          <SessionLoader>{children}</SessionLoader>
-                        </ChatInputFocusProvider>
-                      </ThemeProvider>
-                    </CommandPaletteProvider>
-                  </ChatStreamProvider>
+                  <ChatProviderBridge>{children}</ChatProviderBridge>
                 </SessionProvider>
               </ClaudeSettingsProvider>
             </SettingsProvider>

--- a/webview/src/contexts/ChatInputStateContext.tsx
+++ b/webview/src/contexts/ChatInputStateContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react';
+import { useSessionContext } from './SessionContext';
+
+interface ChatInputStateContextType {
+  input: string;
+  setInput: (input: string) => void;
+}
+
+const ChatInputStateContext = createContext<ChatInputStateContextType>({
+  input: '',
+  setInput: () => {},
+});
+
+export function useChatInputState() {
+  return useContext(ChatInputStateContext);
+}
+
+interface Props {
+  children: ReactNode;
+  inputRef?: React.MutableRefObject<string>;
+  setInputCallbackRef?: React.MutableRefObject<(value: string) => void>;
+}
+
+export function ChatInputStateProvider(props: Props) {
+  const { children, inputRef, setInputCallbackRef } = props;
+  const [input, setInputRaw] = useState('');
+  const session = useSessionContext();
+
+  // Keep shared ref in sync so sibling providers (ChatStreamProvider) can read
+  // the latest input without subscribing to this context.
+  // Updating refs in an effect avoids mutating refs during render (React anti-pattern).
+  useEffect(() => {
+    if (inputRef) inputRef.current = input;
+  }, [input, inputRef]);
+
+  const setInput = useCallback((value: string) => {
+    setInputRaw(value);
+  }, []);
+
+  // Wire the external callback ref so ChatStreamProvider can call setInput
+  // without being a consumer of this context.
+  useEffect(() => {
+    if (setInputCallbackRef) setInputCallbackRef.current = setInput;
+  }, [setInput, setInputCallbackRef]);
+
+  // Save input draft to localStorage for tab move/split restoration.
+  // Skip the first mount to prevent the initial empty input from clearing
+  // a saved draft (JCEF may reload the page on browser component reattach).
+  const draftInitializedRef = useRef(false);
+  useEffect(() => {
+    if (!session.currentSessionId) return;
+    if (!draftInitializedRef.current) {
+      draftInitializedRef.current = true;
+      return;
+    }
+    const key = `claude-gui:draft:${session.currentSessionId}`;
+    try {
+      if (input) {
+        localStorage.setItem(key, input);
+      } else {
+        localStorage.removeItem(key);
+      }
+    } catch {
+      // localStorage may be unavailable in some environments (e.g., tests)
+    }
+  }, [input, session.currentSessionId]);
+
+  return (
+    <ChatInputStateContext.Provider value={{ input, setInput }}>
+      {children}
+    </ChatInputStateContext.Provider>
+  );
+}

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, useEffect, useCallback, useState, useRef } from 'react';
+import { createContext, useContext, ReactNode, useEffect, useCallback, useState, useRef, useMemo } from 'react';
 import { useChatStream } from '../hooks/useChatStream';
 import { useDiffs } from '../hooks/useDiffs';
 import { useTools } from '../hooks/useTools';
@@ -27,10 +27,6 @@ interface ChatStreamContextType {
   streamingMessageId: string | null;
   error: Error | null;
   authDiagnosis: { envApiKeys: string[]; message: string } | null;
-
-  // Local input state
-  input: string;
-  setInput: (input: string) => void;
 
   // Actions
   sendMessage: (content: string, inputMode: InputMode, context?: Context[], attachments?: Attachment[]) => void;
@@ -76,36 +72,26 @@ export function useChatStreamContext() {
 
 interface ChatStreamProviderProps {
   children: ReactNode;
+  setInput: (value: string) => void;
+  inputRef: React.MutableRefObject<string>;
 }
 
-export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
+/**
+ * ChatStreamProvider receives setInput and inputRef from a sibling provider
+ * (ChatInputStateProvider via ChatProviderBridge) so that it does NOT consume
+ * ChatInputStateContext. This prevents every keystroke from re-rendering all
+ * ChatStreamContext subscribers (e.g. MessageBubble, ChatMessageArea).
+ */
+export function ChatStreamProvider(props: ChatStreamProviderProps) {
+  const { children, setInput, inputRef } = props;
   const bridge = useBridgeContext();
   const session = useSessionContext();
   const tools = useTools();
   const diffs = useDiffs();
 
-  const [input, setInput] = useState('');
   const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
   const toggleThinkingExpanded = useCallback(() => setIsThinkingExpanded(prev => !prev), []);
   const [sessionModel, setSessionModel] = useState<string | null>(null);
-
-  // Save input draft to localStorage for tab move/split restoration.
-  // Skip the first mount to prevent the initial empty input from clearing
-  // a saved draft (JCEF may reload the page on browser component reattach).
-  const draftInitializedRef = useRef(false);
-  useEffect(() => {
-    if (!session.currentSessionId) return;
-    if (!draftInitializedRef.current) {
-      draftInitializedRef.current = true;
-      return;
-    }
-    const key = `claude-gui:draft:${session.currentSessionId}`;
-    if (input) {
-      localStorage.setItem(key, input);
-    } else {
-      localStorage.removeItem(key);
-    }
-  }, [input, session.currentSessionId]);
 
   // EnterPlanMode 진입 전의 모드를 저장 (ExitPlanMode 시 복원용)
   const prePlanModeRef = useRef<InputMode | null>(null);
@@ -149,6 +135,18 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     },
   });
 
+  // Destructure stable callbacks out of chatStream so downstream useCallbacks
+  // don't depend on the plain-object chatStream reference (new every render).
+  const {
+    addUserMessage,
+    clearMessages: chatStreamClearMessages,
+    loadMessages: chatStreamLoadMessages,
+    appendMessage: chatStreamAppendMessage,
+    updateMessage: chatStreamUpdateMessage,
+    resetStreamState: chatStreamResetStreamState,
+    retry: chatStreamRetry,
+  } = chatStream;
+
   // systemInit 변경 시 sessionModel 동기화
   useEffect(() => {
     if (chatStream.systemInit) {
@@ -159,20 +157,25 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
 
   // 모든 세션별 상태를 한 번에 리셋하는 통합 함수
   const resetForSessionSwitch = useCallback(() => {
-    chatStream.clearMessages();
-    chatStream.resetStreamState();
+    chatStreamClearMessages();
+    chatStreamResetStreamState();
     // Restore draft input from cache (tab move/split restoration)
-    const draft = session.currentSessionId
-      ? localStorage.getItem(`claude-gui:draft:${session.currentSessionId}`)
-      : null;
-    setInput(draft || '');
+    let draft: string | null = null;
+    try {
+      draft = session.currentSessionId
+        ? localStorage.getItem(`claude-gui:draft:${session.currentSessionId}`)
+        : null;
+    } catch {
+      // localStorage may be unavailable in some environments (e.g., tests)
+    }
+    setInput(draft ?? '');
     setIsThinkingExpanded(false);
     setSessionModel(null);
     tools.clearToolUses();
     diffs.clearDiffs();
     queuedMessageRef.current = null;
     prePlanModeRef.current = null;
-  }, [chatStream.clearMessages, chatStream.resetStreamState, tools.clearToolUses, diffs.clearDiffs, session.currentSessionId]);
+  }, [chatStreamClearMessages, chatStreamResetStreamState, setInput, tools.clearToolUses, diffs.clearDiffs, session.currentSessionId]);
 
   // resetForSessionSwitch is called directly by SessionLoader
   // when currentSessionId changes (URL-driven reactive pattern)
@@ -221,7 +224,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
       }
 
       // Add to local chat state (항상 — UI에는 즉시 표시)
-      chatStream.addUserMessage(content, context, attachments);
+      addUserMessage(content, context, attachments);
 
       const payload: QueuedMessage = {
         sessionId,
@@ -250,7 +253,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
         console.error('[ChatStreamContext] Failed to send message to bridge:', error);
       });
     },
-    [chatStream, bridge, session]
+    [addUserMessage, chatStream.isStreaming, bridge, session]
   );
 
   // 스트리밍 종료(result 수신) 시 큐잉된 메시지 자동 전송.
@@ -270,16 +273,18 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     }
   }, [chatStream.isStreaming, bridge]);
 
-  // handleSubmit: convenience wrapper for form submission
+  // handleSubmit: convenience wrapper for form submission.
+  // Reads input via inputRef so this callback stays stable across keystrokes
+  // — otherwise every key press would invalidate contextValue.
   const handleSubmit = useCallback(
     (e: React.FormEvent | undefined, inputMode: InputMode, attachments?: Attachment[]) => {
       if (e) e.preventDefault();
-      const trimmedInput = input.trim();
+      const trimmedInput = inputRef.current.trim();
       if (!trimmedInput && (!attachments || attachments.length === 0)) return;
       sendMessage(trimmedInput, inputMode, undefined, attachments);
       setInput('');
     },
-    [input, sendMessage]
+    [inputRef, sendMessage, setInput]
   );
 
   // stop: stdin interrupt를 백엔드에 전송.
@@ -306,22 +311,21 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
   const retry = useCallback(
     (messageId: string) => {
       console.log('[ChatStreamContext] Retrying message:', messageId);
-      chatStream.retry(messageId);
+      chatStreamRetry(messageId);
     },
-    [chatStream]
+    [chatStreamRetry]
   );
 
-  const contextValue: ChatStreamContextType = {
+  // Memoize contextValue so consumers don't re-render unless one of the
+  // tracked dependencies actually changes. Input/setInput are no longer
+  // part of this context — they live in ChatInputStateContext.
+  const contextValue: ChatStreamContextType = useMemo(() => ({
     // From useChatStream
     messages: chatStream.messages,
     isStreaming: chatStream.isStreaming,
     streamingMessageId: chatStream.streamingMessageId,
     error: chatStream.error,
     authDiagnosis: chatStream.authDiagnosis,
-
-    // Local input state
-    input,
-    setInput,
 
     // Actions
     sendMessage,
@@ -330,13 +334,13 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     continue: continueGeneration,
     retry,
 
-    resetStreamState: chatStream.resetStreamState,
+    resetStreamState: chatStreamResetStreamState,
 
     // Message manipulation
-    clearMessages: chatStream.clearMessages,
-    loadMessages: chatStream.loadMessages,
-    appendMessage: chatStream.appendMessage,
-    updateMessage: chatStream.updateMessage,
+    clearMessages: chatStreamClearMessages,
+    loadMessages: chatStreamLoadMessages,
+    appendMessage: chatStreamAppendMessage,
+    updateMessage: chatStreamUpdateMessage,
 
     // Subsystems
     tools,
@@ -354,7 +358,31 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
 
     // Context window usage
     contextWindowUsage: chatStream.contextWindowUsage,
-  };
+  }), [
+    chatStream.messages,
+    chatStream.isStreaming,
+    chatStream.streamingMessageId,
+    chatStream.error,
+    chatStream.authDiagnosis,
+    chatStream.systemInit,
+    chatStream.contextWindowUsage,
+    chatStreamResetStreamState,
+    chatStreamClearMessages,
+    chatStreamLoadMessages,
+    chatStreamAppendMessage,
+    chatStreamUpdateMessage,
+    sendMessage,
+    handleSubmit,
+    stop,
+    continueGeneration,
+    retry,
+    tools,
+    diffs,
+    isThinkingExpanded,
+    toggleThinkingExpanded,
+    sessionModel,
+    resetForSessionSwitch,
+  ]);
 
   return (
     <ChatStreamContext.Provider value={contextValue}>

--- a/webview/src/contexts/index.ts
+++ b/webview/src/contexts/index.ts
@@ -9,3 +9,4 @@ export { ClaudeSettingsProvider, useClaudeSettings, ClaudeSettingsContext } from
 export { ChatInputFocusProvider, useChatInputFocus } from './ChatInputFocusContext';
 export { WorkingDirProvider, useWorkingDir } from './WorkingDirContext';
 export { CliConfigProvider, useCliConfig } from './CliConfigContext';
+export * from './ChatInputStateContext';

--- a/webview/src/examples/StreamingExample.tsx
+++ b/webview/src/examples/StreamingExample.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useChatStreamContext } from '../contexts/ChatStreamContext';
+import { useChatInputState } from '../contexts/ChatInputStateContext';
 import { MessageRole, LoadedMessageType } from '../dto/common';
 
 /**
@@ -11,12 +12,11 @@ export const StreamingExample: React.FC = () => {
     messages,
     isStreaming,
     streamingMessageId,
-    input,
-    setInput,
     handleSubmit,
     stop,
     error,
   } = useChatStreamContext();
+  const { input, setInput } = useChatInputState();
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -9,6 +9,7 @@ import { useChatInputFocus } from '../../../contexts/ChatInputFocusContext';
 import { useInputHistory } from './hooks/useInputHistory';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { getTextContent, SessionState } from '@/types';
 import { LoadedMessageType } from '@/dto';
@@ -39,15 +40,14 @@ interface NativeDropEntry {
 export function ChatInput() {
   const { textareaRef } = useChatInputFocus();
   const { currentSessionId, sessionState, workingDirectory, inputMode: mode, cycleInputMode: cycleMode, syncInitialInputMode, modeResetTrigger } = useSessionContext();
-  const {
-    messages,
-    input: value,
-    setInput: onChange,
-    handleSubmit: onSubmit,
-    isStreaming,
-    stop: onStop,
-  } = useChatStreamContext();
+  const chatStream = useChatStreamContext();
+  const { handleSubmit: onSubmit, isStreaming, stop: onStop } = chatStream;
+  const { input: value, setInput: onChange } = useChatInputState();
   const inputHistory = useInputHistory();
+  const { initHistory, pushToHistory, navigateUp, navigateDown } = inputHistory;
+  // Read messages lazily via ref so ChatInput does not re-render every streaming token.
+  const messagesRef = useRef(chatStream.messages);
+  messagesRef.current = chatStream.messages;
   const bridge = useBridgeContext();
   const { subscribe } = bridge;
   const [isFocused, setIsFocused] = useState(false);
@@ -280,10 +280,10 @@ export function ChatInput() {
     if (prev !== null && prev !== currentSessionId) {
       clearAttachments();
       setPathTokens([]);
-      inputHistory.initHistory([]);
+      initHistory([]);
       lastInitSessionRef.current = undefined;
     }
-  }, [currentSessionId, clearAttachments, inputHistory]);
+  }, [currentSessionId, clearAttachments, initHistory]);
 
   const isActive = isStreaming
     || sessionState === SessionState.WaitingPermission
@@ -316,19 +316,21 @@ export function ChatInput() {
     return () => window.removeEventListener('keydown', handleArrowCapture, true);
   }, []);
 
-  // Populate input history from session messages on session change
+  // Populate input history from session messages on session change.
+  // Read messages via ref to avoid re-running this effect on every streaming token —
+  // we only care about the messages snapshot at session-switch time.
   useEffect(() => {
     if (!currentSessionId || currentSessionId === lastInitSessionRef.current) return;
-    if (messages.length === 0) return;
+    if (messagesRef.current.length === 0) return;
 
     lastInitSessionRef.current = currentSessionId;
 
-    const userTexts = messages
+    const userTexts = messagesRef.current
       .filter(m => m.type === LoadedMessageType.User)
       .map(m => getTextContent(m))
       .filter((t): t is string => Boolean(t));
-    inputHistory.initHistory(userTexts);
-  }, [currentSessionId, messages, inputHistory]);
+    initHistory(userTexts);
+  }, [currentSessionId, initHistory]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key.startsWith('Arrow')) console.log('[KeyDebug:textarea-keydown]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
@@ -396,7 +398,7 @@ export function ChatInput() {
       if (willSubmit) {
         e.preventDefault();
         if (!disabled && (value.trim() || attachments.length > 0)) {
-          inputHistory.pushToHistory(value);
+          pushToHistory(value);
           onSubmit(undefined, mode, attachments.length > 0 ? attachments : undefined);
           clearAttachments();
           setPathTokens([]);
@@ -409,7 +411,7 @@ export function ChatInput() {
       const pos = getCaretOffset(e.currentTarget);
       if (value.lastIndexOf('\n', pos - 1) !== -1) return;
 
-      const historyValue = inputHistory.navigateUp(value);
+      const historyValue = navigateUp(value);
       if (historyValue === null) return;
       e.preventDefault();
       onChange(historyValue);
@@ -419,12 +421,12 @@ export function ChatInput() {
       const pos = getCaretOffset(e.currentTarget);
       if (value.indexOf('\n', pos) !== -1) return;
 
-      const historyValue = inputHistory.navigateDown();
+      const historyValue = navigateDown();
       if (historyValue === null) return;
       e.preventDefault();
       onChange(historyValue);
     }
-  }, [disabled, value, attachments.length, onSubmit, inputHistory, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
+  }, [disabled, value, attachments.length, onSubmit, pushToHistory, navigateUp, navigateDown, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
 
   const handleRichChange = useCallback((newValue: string) => {
     onChange(newValue);

--- a/webview/src/pages/ChatPage/ChatMessageArea.tsx
+++ b/webview/src/pages/ChatPage/ChatMessageArea.tsx
@@ -81,7 +81,12 @@ export function ChatMessageArea(props: Props) {
       }
     }
 
-    // Build tool_use_id → ToolUseBlockDto lookup from all assistant messages
+    // Build tool_use_id → cloned ToolUseBlockDto lookup from all assistant messages.
+    // Cloning prevents mutation of the original block objects (which live on the
+    // shared messages array). In-place mutation would break React.memo bailouts on
+    // MessageBubble — referential equality holds, but the cloned inner block would
+    // be wrong — and could also duplicate runtime fields on re-render
+    // (e.g. React StrictMode).
     const toolUseMap = new Map<string, ToolUseBlockDto>();
     for (const msg of messages) {
       if (msg.type !== LoadedMessageType.Assistant) continue;
@@ -89,16 +94,15 @@ export function ChatMessageArea(props: Props) {
       if (!isContentBlockArray(content)) continue;
       for (const block of content) {
         if (block.type === ContentBlockType.ToolUse) {
-          toolUseMap.set((block as ToolUseBlockDto).id, block as ToolUseBlockDto);
+          const orig = block as ToolUseBlockDto;
+          toolUseMap.set(orig.id, {
+            ...orig,
+            tool_result: undefined,
+            childMessages: undefined,
+            subAgentMessages: undefined,
+          });
         }
       }
-    }
-
-    // Reset runtime-only fields to prevent duplication on re-render (e.g. React StrictMode)
-    for (const toolUseBlock of toolUseMap.values()) {
-      toolUseBlock.tool_result = undefined;
-      toolUseBlock.childMessages = undefined;
-      toolUseBlock.subAgentMessages = undefined;
     }
 
     // Phase 1.5: Attach progress entries to Task tool_use blocks

--- a/webview/src/pages/ChatPage/MessageBubble.tsx
+++ b/webview/src/pages/ChatPage/MessageBubble.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { LoadedMessageDto } from '../../types';
 import {
   UserMessageRenderer,
@@ -12,7 +13,11 @@ interface MessageBubbleProps {
   onRetry?: (messageId: string) => void;
 }
 
-export function MessageBubble({ message, onRetry }: MessageBubbleProps) {
+// React.memo skips re-rendering when props (message identity, onRetry) are
+// unchanged. ChatMessageArea must clone any objects it modifies — otherwise
+// in-place mutation defeats this bailout.
+export const MessageBubble = memo(function MessageBubble(props: MessageBubbleProps) {
+  const { message, onRetry } = props;
   switch (message.type) {
     case 'user':
       return <UserMessageRenderer message={message} />;
@@ -27,4 +32,4 @@ export function MessageBubble({ message, onRetry }: MessageBubbleProps) {
     default:
       return null;
   }
-}
+});


### PR DESCRIPTION
Closes #31.

## Summary
- Splits the chat input state out of `ChatStreamContext` into a new `ChatInputStateContext`, so keystrokes no longer cascade re-renders into every `MessageBubble`.
- Inverts the provider tree via a new `ChatProviderBridge`: `ChatStreamProvider` becomes the parent, `ChatInputStateProvider` the child. They communicate through `inputRef` / `setInputCallbackRef` instead of context subscription.
- Memoizes `MessageBubble` with `React.memo` so identical messages skip re-render.
- Stops mutating `toolUseBlock` inside `ChatMessageArea`'s `useMemo`; clones it instead, so the `React.memo` bailout actually holds.

## Why
@panique diagnosed the root cause in #31 and shared a patch. The patch base is v0.13.6 and the current tree is v0.17.2 — `git apply` no longer applies cleanly (most notably `ChatInput/index.tsx` has 16 commits of drift since the patch was authored). This PR reimplements the same design against the current code, with two deliberate deviations:
1. `inputRef` / `setInputCallbackRef` are synced inside a `useEffect`, not during render — avoids the React anti-pattern of mutating refs in the render body.
2. Provider props follow this repo's convention: `(props: Props)` argument, destructured in the function body.

The `pnpm-workspace.yaml` edits and other authoring-environment artifacts from the original patch are intentionally not included.

## Commits (split for review)
1. `feat(webview): add ChatInputStateContext for isolated input state`
2. `refactor(webview): invert provider tree to isolate keystroke renders`
3. `perf(webview): memoize MessageBubble to skip identical re-renders`
4. `fix(webview): clone toolUseBlock instead of mutating to preserve memo bailout`

## Verification

Tested against a long session (~2400 JSONL entries, the longest session in the local cache).

**Desktop — Chrome DevTools Performance, Interaction `H` marker:**

| Metric | Value | Meaning |
| --- | --- | --- |
| Input delay | 0μs | JS thread is no longer blocked on keystrokes |
| Processing time | 0μs | React re-render cost effectively eliminated |
| Presentation delay | 75.6ms | Pure paint/layout cost of the large DOM |

The 75ms presentation cost is below the perceptual jank threshold (~100ms) and well within the INP "Good" range (<200ms). It is a property of the DOM size, not the React render path this PR addresses.

**Mobile (real device):** typing lag is gone. The reporter's symptom no longer reproduces.

Conclusion: this PR resolves #31 as reported. Further reductions (e.g. message virtualization to drive down the 75ms paint cost) are deferred until a separate, heavier scenario (500+ messages, mobile scroll jank) is reported.

## Test plan
- [x] `./scripts/build.sh wv-lint`
- [x] `./scripts/build.sh wv-build`
- [x] Desktop: typed in a long conversation, no per-keystroke lag, Input delay 0μs on DevTools
- [x] Mobile: typing is responsive, no perceived lag
- [x] Input draft restoration on tab move/split still works
- [x] Slash command palette (`/`) still receives input updates
- [x] Streaming, stop, continue, retry still work
