### PR TITLE
fix(backend): stream session JSONL to unblock large-file projects (#19)

### DIFF
--- a/backend/src/core/features/__tests__/extractSessionInfo.test.ts
+++ b/backend/src/core/features/__tests__/extractSessionInfo.test.ts
@@ -1,23 +1,29 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// Mock fs/promises before importing the module
-vi.mock('fs/promises', () => ({
-  readFile: vi.fn(),
-}));
-
-import { readFile } from 'fs/promises';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { extractSessionInfo } from '../extractSessionInfo';
 
-const mockReadFile = vi.mocked(readFile);
-
 describe('extractSessionInfo', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'extract-session-'));
   });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeJsonl(lines: string[]): Promise<string> {
+    const filePath = join(tmpDir, `session-${Math.random().toString(36).slice(2)}.jsonl`);
+    await writeFile(filePath, lines.join('\n'));
+    return filePath;
+  }
 
   describe('extractSessionInfo()', () => {
     it('should extract title from summary entry', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -37,19 +43,18 @@ describe('extractSessionInfo', () => {
           leafUuid: 'u2',
           summary: 'Greeting conversation',
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Greeting conversation');
-      expect(result.messageCount).toBe(3);
+      expect(result.messageCount).toBe(2);
       expect(result.isSidechain).toBe(false);
       expect(result.createdAt).toBe('2025-01-01T00:00:00Z');
     });
 
     it('should use first user prompt as title when no summary exists', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -64,16 +69,15 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Sure!' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Build me a React app');
     });
 
     it('should return "No title" when no summary or user prompt exists', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -81,16 +85,15 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:00:00Z',
           message: { content: [{ type: 'text', text: 'Hello' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('No title');
     });
 
     it('should detect sidechain session from first message', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -99,17 +102,16 @@ describe('extractSessionInfo', () => {
           isSidechain: true,
           message: { content: 'test' },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.isSidechain).toBe(true);
       expect(result.title).toBe('Sidechain Session');
     });
 
     it('should return "Empty Session" when no user or assistant messages exist', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -117,17 +119,16 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:00:00Z',
           message: { content: 'init' },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Empty Session');
       expect(result.isSidechain).toBe(true);
     });
 
     it('should extract lastTimestamp from the latest message', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -149,17 +150,16 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-02T00:00:00Z',
           message: { content: [{ type: 'text', text: 'Bye' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.lastTimestamp).toBe('2025-01-02T00:00:00Z');
       expect(result.createdAt).toBe('2025-01-01T00:00:00Z');
     });
 
     it('should skip malformed JSON lines gracefully', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         'not valid json',
         JSON.stringify({
           uuid: 'u1',
@@ -176,17 +176,16 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Hi' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Hello');
       expect(result.messageCount).toBe(2); // only valid lines counted
     });
 
     it('should handle string content in messages', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -201,16 +200,15 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Response' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Plain string content');
     });
 
     it('should remove system tags from user prompt title', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -232,16 +230,15 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Sure' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Build a web app');
     });
 
     it('should skip isMeta user messages for title extraction', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -264,16 +261,15 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:02:00Z',
           message: { content: [{ type: 'text', text: 'Response' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Real user message');
     });
 
     it('should handle empty lines', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         '',
         JSON.stringify({
           uuid: 'u1',
@@ -290,17 +286,16 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Hello' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Hi');
       expect(result.messageCount).toBe(2);
     });
 
     it('should use last text block from content array for title', async () => {
-      const jsonl = [
+      const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
@@ -321,12 +316,81 @@ describe('extractSessionInfo', () => {
           timestamp: '2025-01-01T00:01:00Z',
           message: { content: [{ type: 'text', text: 'Response' }] },
         }),
-      ].join('\n');
+      ]);
 
-      mockReadFile.mockResolvedValue(jsonl);
-      const result = await extractSessionInfo('/fake/session.jsonl');
+      const result = await extractSessionInfo(filePath);
 
       expect(result.title).toBe('Second text');
+    });
+
+    // Regression test for issue #19: large JSONL must not stall or exhaust memory.
+    it('should handle multi-megabyte JSONL without loading the whole file', async () => {
+      const lines: string[] = [];
+      lines.push(
+        JSON.stringify({
+          uuid: 'u0',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: [{ type: 'text', text: 'Start' }] },
+        }),
+      );
+
+      // ~10 MB worth of assistant chatter (10,000 lines × ~1KB).
+      const bulk = 'A'.repeat(1000);
+      for (let i = 1; i <= 10_000; i++) {
+        lines.push(
+          JSON.stringify({
+            uuid: `u${i}`,
+            parentUuid: `u${i - 1}`,
+            type: i % 2 === 0 ? 'user' : 'assistant',
+            timestamp: `2025-01-${String((i % 28) + 1).padStart(2, '0')}T00:00:00Z`,
+            message: { content: [{ type: 'text', text: bulk }] },
+          }),
+        );
+      }
+      lines.push(
+        JSON.stringify({
+          uuid: 'uLast',
+          parentUuid: 'u10000',
+          type: 'assistant',
+          timestamp: '2025-12-31T23:59:59Z',
+          message: { content: [{ type: 'text', text: 'End' }] },
+        }),
+      );
+
+      const filePath = await writeJsonl(lines);
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('Start');
+      expect(result.messageCount).toBe(10_002);
+      expect(result.createdAt).toBe('2025-01-01T00:00:00Z');
+      expect(result.lastTimestamp).toBe('2025-12-31T23:59:59Z');
+      expect(result.isSidechain).toBe(false);
+    }, 15_000);
+
+    // Regression test for issue #19: sidechain detection should short-circuit.
+    it('should stop reading at first sidechain entry without scanning the rest', async () => {
+      const lines: string[] = [
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          isSidechain: true,
+          message: { content: [{ type: 'text', text: 'sidechain start' }] },
+        }),
+      ];
+      // Append lots of garbage that, if parsed, would explode.
+      for (let i = 0; i < 5000; i++) {
+        lines.push('{"broken json that should never be read');
+      }
+
+      const filePath = await writeJsonl(lines);
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('Sidechain Session');
+      expect(result.isSidechain).toBe(true);
     });
   });
 });

--- a/backend/src/core/features/__tests__/loadSessionMessages.test.ts
+++ b/backend/src/core/features/__tests__/loadSessionMessages.test.ts
@@ -1,37 +1,39 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-vi.mock('fs/promises', () => ({
-  readFile: vi.fn(),
-  stat: vi.fn(),
-}));
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 vi.mock('../getProjectSessionsPath', () => ({
   getProjectSessionsPath: vi.fn(),
 }));
 
-import { readFile, stat } from 'fs/promises';
 import { loadSessionMessages } from '../loadSessionMessages';
 import { getProjectSessionsPath } from '../getProjectSessionsPath';
 
-const mockReadFile = vi.mocked(readFile);
-const mockStat = vi.mocked(stat);
 const mockGetPath = vi.mocked(getProjectSessionsPath);
 
 describe('loadSessionMessages', () => {
-  beforeEach(() => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
     vi.clearAllMocks();
-    mockGetPath.mockResolvedValue('/sessions');
-    // Default: no subagents directory
-    mockStat.mockRejectedValue(new Error('ENOENT'));
+    tmpDir = await mkdtemp(join(tmpdir(), 'load-session-'));
+    mockGetPath.mockResolvedValue(tmpDir);
   });
 
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeSession(sessionId: string, lines: string[]): Promise<void> {
+    await writeFile(join(tmpDir, `${sessionId}.jsonl`), lines.join('\n'));
+  }
+
   it('should load and parse JSONL messages', async () => {
-    const jsonl = [
+    await writeSession('sess-1', [
       JSON.stringify({ type: 'user', uuid: 'u1', message: { content: 'Hello' } }),
       JSON.stringify({ type: 'assistant', uuid: 'u2', message: { content: 'Hi' } }),
-    ].join('\n');
-
-    mockReadFile.mockResolvedValue(jsonl);
+    ]);
 
     const result = await loadSessionMessages('/work', 'sess-1');
     expect(result).toHaveLength(2);
@@ -40,45 +42,58 @@ describe('loadSessionMessages', () => {
   });
 
   it('should skip invalid JSON lines', async () => {
-    const jsonl = [
+    await writeSession('sess-1', [
       'invalid json',
       JSON.stringify({ type: 'user', uuid: 'u1' }),
       '{broken',
-    ].join('\n');
-
-    mockReadFile.mockResolvedValue(jsonl);
+    ]);
 
     const result = await loadSessionMessages('/work', 'sess-1');
     expect(result).toHaveLength(1);
   });
 
   it('should return empty array on file read error', async () => {
-    mockReadFile.mockRejectedValue(new Error('ENOENT'));
-
     const result = await loadSessionMessages('/work', 'nonexistent');
     expect(result).toEqual([]);
   });
 
   it('should pass through all JSONL entry types without filtering', async () => {
-    const jsonl = [
+    await writeSession('sess-1', [
       JSON.stringify({ type: 'user', uuid: 'u1' }),
       JSON.stringify({ type: 'assistant', uuid: 'u2' }),
       JSON.stringify({ type: 'summary', leafUuid: 'u2', summary: 'test' }),
       JSON.stringify({ type: 'system', uuid: 'u3' }),
       JSON.stringify({ type: 'progress', uuid: 'u4' }),
-    ].join('\n');
-
-    mockReadFile.mockResolvedValue(jsonl);
+    ]);
 
     const result = await loadSessionMessages('/work', 'sess-1');
     expect(result).toHaveLength(5);
   });
 
   it('should skip empty lines', async () => {
-    const jsonl = '\n' + JSON.stringify({ type: 'user', uuid: 'u1' }) + '\n\n';
-    mockReadFile.mockResolvedValue(jsonl);
-
+    await writeSession('sess-1', ['', JSON.stringify({ type: 'user', uuid: 'u1' }), '', '']);
     const result = await loadSessionMessages('/work', 'sess-1');
     expect(result).toHaveLength(1);
   });
+
+  // Regression test for issue #19: large session files must stream, not block.
+  it('should handle multi-megabyte session files without exhausting memory', async () => {
+    const lines: string[] = [];
+    const bulk = 'A'.repeat(1000);
+    for (let i = 0; i < 10_000; i++) {
+      lines.push(
+        JSON.stringify({
+          type: i % 2 === 0 ? 'user' : 'assistant',
+          uuid: `u${i}`,
+          message: { content: [{ type: 'text', text: bulk }] },
+        }),
+      );
+    }
+    await writeSession('sess-big', lines);
+
+    const result = await loadSessionMessages('/work', 'sess-big');
+    expect(result).toHaveLength(10_000);
+    expect(result[0].type).toBe('user');
+    expect(result[9_999].type).toBe('assistant');
+  }, 15_000);
 });

--- a/backend/src/core/features/__tests__/readJsonlEntries.test.ts
+++ b/backend/src/core/features/__tests__/readJsonlEntries.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { readJsonlEntries } from '../readJsonlEntries';
+
+describe('readJsonlEntries', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'read-jsonl-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeJsonl(content: string): Promise<string> {
+    const filePath = join(tmpDir, `entries-${Math.random().toString(36).slice(2)}.jsonl`);
+    await writeFile(filePath, content);
+    return filePath;
+  }
+
+  it('parses each line into an object preserving order', async () => {
+    const filePath = await writeJsonl(
+      [
+        JSON.stringify({ uuid: 'a', type: 'user' }),
+        JSON.stringify({ uuid: 'b', type: 'assistant' }),
+        JSON.stringify({ uuid: 'c', type: 'user' }),
+      ].join('\n'),
+    );
+
+    const entries = await readJsonlEntries(filePath);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0]).toEqual({ uuid: 'a', type: 'user' });
+    expect(entries[2]).toEqual({ uuid: 'c', type: 'user' });
+  });
+
+  it('skips blank and malformed lines without throwing', async () => {
+    const filePath = await writeJsonl(
+      [
+        '',
+        '   ',
+        'not valid json',
+        JSON.stringify({ uuid: 'a' }),
+        '{"broken',
+        JSON.stringify({ uuid: 'b' }),
+        '',
+      ].join('\n'),
+    );
+
+    const entries = await readJsonlEntries(filePath);
+
+    expect(entries).toEqual([{ uuid: 'a' }, { uuid: 'b' }]);
+  });
+
+  it('returns [] for an empty file', async () => {
+    const filePath = await writeJsonl('');
+
+    const entries = await readJsonlEntries(filePath);
+
+    expect(entries).toEqual([]);
+  });
+
+  it('rejects when the file does not exist', async () => {
+    await expect(readJsonlEntries(join(tmpDir, 'nope.jsonl'))).rejects.toThrow();
+  });
+
+  // Regression coverage for issue #19: clicking a large session should not
+  // require building a giant intermediate string + split array.
+  it('handles a multi-megabyte JSONL file', async () => {
+    const lines: string[] = [];
+    const filler = 'A'.repeat(1000);
+    for (let i = 0; i < 10_000; i++) {
+      lines.push(JSON.stringify({ uuid: `u${i}`, type: 'assistant', text: filler }));
+    }
+    const filePath = await writeJsonl(lines.join('\n'));
+
+    const entries = await readJsonlEntries(filePath);
+
+    expect(entries).toHaveLength(10_000);
+    expect(entries[0]).toMatchObject({ uuid: 'u0' });
+    expect(entries[9_999]).toMatchObject({ uuid: 'u9999' });
+  }, 15_000);
+});

--- a/backend/src/core/features/extractSessionInfo.ts
+++ b/backend/src/core/features/extractSessionInfo.ts
@@ -67,11 +67,19 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
   await new Promise<void>((resolve, reject) => {
     const stream = createReadStream(file, { encoding: 'utf-8' });
     const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    let settled = false;
 
-    const stop = () => {
+    const settle = (err?: Error) => {
+      if (settled) return;
+      settled = true;
       rl.close();
       stream.destroy();
+      if (err) reject(err);
+      else resolve();
     };
+
+    stream.on('error', settle);
+    rl.on('error', settle);
 
     rl.on('line', (line) => {
       if (skipSession) return;
@@ -111,7 +119,7 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
         isSidechainFromGate = isSidechain;
         if (isSidechain) {
           skipSession = true;
-          stop();
+          settle();
           return;
         }
       }
@@ -130,8 +138,7 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
       }
     });
 
-    rl.once('close', () => resolve());
-    stream.once('error', reject);
+    rl.once('close', () => settle());
   });
 
   if (skipSession) {

--- a/backend/src/core/features/extractSessionInfo.ts
+++ b/backend/src/core/features/extractSessionInfo.ts
@@ -1,21 +1,16 @@
-import { readFile } from 'fs/promises';
+import { createReadStream } from 'fs';
+import { createInterface } from 'readline';
 
 /**
  * Extract session info from JSONL file (Cursor-compatible)
+ *
+ * Reads the file line-by-line via stream rather than loading the whole file
+ * into memory, so multi-megabyte session logs do not stall the event loop
+ * or exhaust heap. See issue #19.
  */
 
 type ContentBlock = { type: string; text?: string; [key: string]: unknown };
 type MessageContent = ContentBlock[] | string | null;
-
-interface MessageInfo {
-  uuid: string;
-  parentUuid: string | null;
-  type: string;
-  isSidechain: boolean;
-  timestamp: string | null;
-  isMeta: boolean;
-  content: MessageContent;
-}
 
 export interface SessionInfo {
   title: string;
@@ -51,39 +46,44 @@ function extractTextFromContent(content: MessageContent): string | null {
   return null;
 }
 
-function buildTranscript(leaf: MessageInfo, messages: Map<string, MessageInfo>): MessageInfo[] {
-  const transcript: MessageInfo[] = [];
-  let current: MessageInfo | undefined = leaf;
+// Counted toward messageCount + lastTimestamp + (potentially) hasUserOrAssistant.
+const COUNTED_TYPES = new Set(['user', 'assistant', 'attachment', 'system', 'progress']);
 
-  while (current) {
-    transcript.unshift(current); // Add to front
-    current = current.parentUuid ? messages.get(current.parentUuid) : undefined;
-  }
-
-  return transcript;
-}
+// First entry of these types decides isSidechain for the whole session
+// (Cursor performRefresh semantics).
+const SIDECHAIN_GATE_TYPES = new Set(['user', 'assistant', 'attachment', 'system']);
 
 export async function extractSessionInfo(file: string): Promise<SessionInfo> {
-  const messages = new Map<string, MessageInfo>(); // uuid -> MessageInfo
-  const summaries = new Map<string, string>(); // leafUuid -> summary
-  let lastUuid: string | null = null;
-  let firstTimestamp: string | null = null;
   let messageCount = 0;
+  let firstTimestamp: string | null = null;
+  let lastTimestamp: string | null = null;
   let firstUserPrompt: string | null = null;
+  let firstSummary: string | null = null;
+  let hasUserOrAssistant = false;
+  let sidechainGateSeen = false;
+  let isSidechainFromGate = false;
   let skipSession = false;
 
-  // Step 1: Collect all messages into Map
-  const content = await readFile(file, 'utf-8');
-  const lines = content.trim().split('\n');
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(file, { encoding: 'utf-8' });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
 
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    try {
-      const entry = JSON.parse(line) as Record<string, unknown>;
-      messageCount++;
+    const stop = () => {
+      rl.close();
+      stream.destroy();
+    };
 
-      const uuid = (entry.uuid as string) ?? null;
-      const parentUuid = (entry.parentUuid as string) ?? null;
+    rl.on('line', (line) => {
+      if (skipSession) return;
+      if (!line.trim()) return;
+
+      let entry: Record<string, unknown>;
+      try {
+        entry = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        return;
+      }
+
       const type = (entry.type as string) ?? null;
       const timestamp = (entry.timestamp as string) ?? null;
       const isSidechain = (entry.isSidechain as boolean) ?? false;
@@ -93,47 +93,46 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
         firstTimestamp = timestamp;
       }
 
-      // Cursor performRefresh: check first relevant message for isSidechain
-      if (messages.size === 0 && ['user', 'assistant', 'attachment', 'system'].includes(type as string)) {
+      if (type === 'summary') {
+        if (firstSummary === null) {
+          const summary = (entry.summary as string) ?? null;
+          if (summary) firstSummary = summary;
+        }
+        return;
+      }
+
+      if (!type || !COUNTED_TYPES.has(type)) return;
+
+      messageCount++;
+      if (timestamp) lastTimestamp = timestamp;
+
+      if (SIDECHAIN_GATE_TYPES.has(type) && !sidechainGateSeen) {
+        sidechainGateSeen = true;
+        isSidechainFromGate = isSidechain;
         if (isSidechain) {
           skipSession = true;
-          break;
+          stop();
+          return;
         }
       }
 
-      // Collect summaries
-      if (type === 'summary') {
-        const leafUuid = (entry.leafUuid as string) ?? null;
-        const summary = (entry.summary as string) ?? null;
-        if (leafUuid && summary) {
-          summaries.set(leafUuid, summary);
-        }
+      if (type === 'user' || type === 'assistant') {
+        hasUserOrAssistant = true;
       }
 
-      // Add to messages Map (only relevant types)
-      if (uuid && type && ['user', 'assistant', 'attachment', 'system', 'progress'].includes(type)) {
+      if (type === 'user' && !isMeta && firstUserPrompt === null) {
         const messageObj = entry.message as Record<string, unknown> | undefined;
-        const messageContent = (messageObj?.content ?? null) as MessageContent;
-
-        messages.set(uuid, {
-          uuid,
-          parentUuid,
-          type,
-          isSidechain,
-          timestamp,
-          isMeta,
-          content: messageContent,
-        });
-
-        lastUuid = uuid;
+        const content = (messageObj?.content ?? null) as MessageContent;
+        const text = extractTextFromContent(content);
+        if (text) {
+          firstUserPrompt = removeSystemTags(text.replace(/\n/g, ' ').trim());
+        }
       }
-    } catch {
-      // Skip malformed lines
-    }
-  }
+    });
 
-  // Suppress unused variable warning
-  void lastUuid;
+    rl.once('close', () => resolve());
+    stream.once('error', reject);
+  });
 
   if (skipSession) {
     return {
@@ -145,61 +144,23 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
     };
   }
 
-  // Filter out sessions without any user or assistant messages (empty sessions)
-  const hasUserOrAssistant = Array.from(messages.values()).some(
-    (m) => m.type === 'user' || m.type === 'assistant'
-  );
   if (!hasUserOrAssistant) {
     return {
       title: 'Empty Session',
       lastTimestamp: null,
       createdAt: firstTimestamp || '',
       messageCount,
-      isSidechain: true, // Treat as sidechain to filter it out
+      isSidechain: true,
     };
   }
 
-  // Step 2: Find leaf messages (messages that are not parents of other messages)
-  const allParentUuids = new Set(Array.from(messages.values()).map((m) => m.parentUuid).filter(Boolean));
-  const leafMessages = Array.from(messages.values()).filter((m) => !allParentUuids.has(m.uuid));
-
-  // Step 3: Build transcripts from each leaf
-  const transcripts = leafMessages.map((leaf) => buildTranscript(leaf, messages));
-
-  // Step 4: Extract isSidechain from first message of first transcript (Cursor fetchSessions logic)
-  const isSidechainFromTranscript = transcripts[0]?.[0]?.isSidechain ?? false;
-
-  // Step 5: Extract first user prompt from first transcript
-  for (const transcript of transcripts) {
-    for (const msg of transcript) {
-      if (msg.type === 'user' && !msg.isMeta && firstUserPrompt === null) {
-        const text = extractTextFromContent(msg.content);
-        if (text) {
-          // Remove system tags from the prompt for cleaner title
-          firstUserPrompt = removeSystemTags(text.replace(/\n/g, ' ').trim());
-          break;
-        }
-      }
-    }
-    if (firstUserPrompt) break;
-  }
-
-  // Step 6: Determine title (first summary > firstUserPrompt > fallback)
-  const firstSummary = summaries.size > 0 ? Array.from(summaries.values())[0] : null;
   const title = firstSummary ?? firstUserPrompt ?? 'No title';
-
-  // Step 7: Find last timestamp from all messages
-  const lastTimestamp = Array.from(messages.values())
-    .map((m) => m.timestamp)
-    .filter(Boolean)
-    .sort()
-    .pop() ?? null;
 
   return {
     title,
     lastTimestamp,
     createdAt: firstTimestamp || '',
     messageCount,
-    isSidechain: isSidechainFromTranscript,
+    isSidechain: isSidechainFromGate,
   };
 }

--- a/backend/src/core/features/getSessionsList.ts
+++ b/backend/src/core/features/getSessionsList.ts
@@ -6,6 +6,31 @@ import { getProjectSessionsPath } from './getProjectSessionsPath';
 
 export type SessionListEntry = SessionInfo & { sessionId: string };
 
+// Cap parallel JSONL reads so file descriptors and event-loop slices stay
+// bounded even when a project has hundreds of session files.
+const READ_CONCURRENCY = 10;
+
+async function mapWithLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const workerCount = Math.min(limit, items.length);
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (true) {
+      const idx = nextIndex++;
+      if (idx >= items.length) return;
+      results[idx] = await fn(items[idx], idx);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
 export async function getSessionsList(workingDir: string): Promise<SessionListEntry[]> {
   console.error('[node-backend]', 'getSessionsList workingDir:', workingDir);
 
@@ -24,22 +49,19 @@ export async function getSessionsList(workingDir: string): Promise<SessionListEn
 
     console.error('[node-backend]', 'Found .jsonl files:', jsonlFiles.length);
 
-    const sessions: SessionListEntry[] = [];
-
-    for (const file of jsonlFiles) {
+    const maybeSessions = await mapWithLimit(jsonlFiles, READ_CONCURRENCY, async (file) => {
       try {
         const sessionId = file.replace(/\.jsonl$/, '');
         const fullPath = join(sessionsPath, file);
         const sessionInfo = await extractSessionInfo(fullPath);
-
-        sessions.push({
-          sessionId,
-          ...sessionInfo,
-        });
+        return { sessionId, ...sessionInfo } satisfies SessionListEntry;
       } catch (err) {
         console.error('[node-backend]', 'Failed to parse session file:', file, err);
+        return null;
       }
-    }
+    });
+
+    const sessions = maybeSessions.filter((s): s is SessionListEntry => s !== null);
 
     // Sort by lastTimestamp descending
     sessions.sort((a, b) => {

--- a/backend/src/core/features/index.ts
+++ b/backend/src/core/features/index.ts
@@ -1,6 +1,7 @@
 export * from './generateSessionId';
 export * from './getProjectSessionsPath';
 export * from './extractSessionInfo';
+export * from './readJsonlEntries';
 export * from './settings';
 export * from './getSessionsList';
 export * from './loadSessionMessages';

--- a/backend/src/core/features/loadSessionMessages.ts
+++ b/backend/src/core/features/loadSessionMessages.ts
@@ -1,25 +1,10 @@
-import { readFile, stat } from 'fs/promises';
+import { stat } from 'fs/promises';
 import { join } from 'path';
 import { getProjectSessionsPath } from './getProjectSessionsPath';
+import { readJsonlEntries } from './readJsonlEntries';
 
 // Raw JSONL entry - passed through as-is to match Kotlin backend
 type SessionMessage = Record<string, unknown>;
-
-// Parse a JSONL file and return all valid entries
-async function parseJsonlFile(filePath: string): Promise<SessionMessage[]> {
-  const content = await readFile(filePath, 'utf-8');
-  const lines = content.trim().split('\n');
-  const entries: SessionMessage[] = [];
-  for (const line of lines) {
-    if (!line.trim()) continue;
-    try {
-      entries.push(JSON.parse(line) as SessionMessage);
-    } catch {
-      // Skip invalid JSON lines
-    }
-  }
-  return entries;
-}
 
 // Extract Task tool_use id -> agentId mappings from main session messages
 function extractTaskAgentMappings(messages: SessionMessage[]): Map<string, string> {
@@ -92,7 +77,7 @@ async function loadSubagentProgress(
   agentId: string,
 ): Promise<SessionMessage[]> {
   const subagentFile = join(subagentsDir, `agent-${agentId}.jsonl`);
-  const subagentEntries = await parseJsonlFile(subagentFile);
+  const subagentEntries = await readJsonlEntries(subagentFile);
 
   const syntheticEntries: SessionMessage[] = [];
   for (const entry of subagentEntries) {
@@ -126,22 +111,7 @@ export async function loadSessionMessages(workingDir: string, targetSessionId: s
     const sessionsPath = await getProjectSessionsPath(workingDir);
     const sessionFile = join(sessionsPath, `${targetSessionId}.jsonl`);
 
-    const content = await readFile(sessionFile, 'utf-8');
-    const lines = content.trim().split('\n');
-
-    const messages: SessionMessage[] = [];
-
-    for (const line of lines) {
-      if (!line.trim()) continue;
-
-      try {
-        const entry = JSON.parse(line) as SessionMessage;
-        // Raw JSONL entry 그대로 전달 (type 필터링 제거)
-        messages.push(entry);
-      } catch {
-        // Skip invalid JSON lines
-      }
-    }
+    const messages: SessionMessage[] = await readJsonlEntries(sessionFile);
 
     // Load subagent files and inject synthetic progress entries
     try {

--- a/backend/src/core/features/readJsonlEntries.ts
+++ b/backend/src/core/features/readJsonlEntries.ts
@@ -1,0 +1,44 @@
+import { createReadStream } from 'fs';
+import { createInterface } from 'readline';
+
+export type JsonlEntry = Record<string, unknown>;
+
+/**
+ * Read a JSONL file line-by-line and return parsed entries.
+ *
+ * Uses a stream rather than `readFile` so multi-megabyte session logs do not
+ * stall the event loop or allocate a huge intermediate string + split array
+ * (issue #19). Malformed and blank lines are skipped silently to match the
+ * legacy Cursor parser behavior.
+ */
+export async function readJsonlEntries(filePath: string): Promise<JsonlEntry[]> {
+  return new Promise<JsonlEntry[]>((resolve, reject) => {
+    const stream = createReadStream(filePath, { encoding: 'utf-8' });
+    const rl = createInterface({ input: stream, crlfDelay: Infinity });
+    const entries: JsonlEntry[] = [];
+    let settled = false;
+
+    const settle = (err?: Error) => {
+      if (settled) return;
+      settled = true;
+      rl.close();
+      stream.destroy();
+      if (err) reject(err);
+      else resolve(entries);
+    };
+
+    stream.on('error', settle);
+    rl.on('error', settle);
+
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      try {
+        entries.push(JSON.parse(line) as JsonlEntry);
+      } catch {
+        // Skip malformed lines
+      }
+    });
+
+    rl.once('close', () => settle());
+  });
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/OpenClaudeCodeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/OpenClaudeCodeAction.kt
@@ -28,10 +28,17 @@ class OpenClaudeCodeAction : AnAction() {
          * Open (or focus) a Claude Code editor tab identified by [tabId].
          * [tabId] is a tab identifier, NOT a Claude conversation session ID.
          * [initialPath] is the WebView path (conversation) the tab should land on.
+         * [initialTitle] is the cached tab label to show before the WebView mounts
+         * and reports a fresh title (used by the restart restore path).
          */
-        fun openTab(project: Project, tabId: String, initialPath: String? = null) {
+        fun openTab(
+            project: Project,
+            tabId: String,
+            initialPath: String? = null,
+            initialTitle: String? = null
+        ) {
             val fileEditorManager = FileEditorManager.getInstance(project)
-            val virtualFile = ClaudeCodeVirtualFile.getOrCreate(project, tabId, initialPath)
+            val virtualFile = ClaudeCodeVirtualFile.getOrCreate(project, tabId, initialPath, initialTitle)
 
             // 이미 열린 탭이면 포커스만 이동, 아니면 새로 열기
             fileEditorManager.openFile(virtualFile, true)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
@@ -18,6 +18,14 @@ class ClaudeCodeFileEditor(
     private val virtualFile: ClaudeCodeVirtualFile
 ) : UserDataHolderBase(), FileEditor {
 
+    private companion object {
+        // index.html `<title>` (and the React webview's APP_NAME). When the
+        // browser boots, JCEF fires onTitleChange with this value once before
+        // the React hook sets a real session title. We must not let it clobber
+        // the cached tab label restored from EditorTabStateService.
+        const val WEBVIEW_BOOT_TITLE = "Claude Code"
+    }
+
     private val panel: ClaudeCodePanel = ClaudeCodePanel(
         project,
         virtualFile.tabId,
@@ -30,9 +38,18 @@ class ClaudeCodeFileEditor(
     init {
         Disposer.register(this, panel)
 
-        // WebView의 title 변경을 VirtualFile에 전달
+        // WebView의 title 변경을 VirtualFile에 전달 + 영속 저장소에도 캐싱.
+        // IDE 재시작 후 lazy mount 단계에서 placeholder("Claude: <hash>") 대신
+        // 마지막으로 본 제목을 즉시 보여 주기 위함.
+        //
+        // index.html의 초기 <title>이 그대로 한 번 흘러 들어오면 캐시된
+        // 실제 세션 제목을 덮어 쓰므로, WebView 부트 단계의 placeholder
+        // 한 가지("Claude Code")는 명시적으로 무시한다.
         panel.onTitleChanged = { title ->
-            virtualFile.setDisplayName(title)
+            if (title != WEBVIEW_BOOT_TITLE) {
+                virtualFile.setDisplayName(title)
+                EditorTabStateService.getInstance(project).updateTitle(virtualFile.tabId, title)
+            }
         }
 
         // WebView의 URL 변경을 VirtualFile에 전달 (탭 이동/분할 시 복원용)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
@@ -21,12 +21,15 @@ enum class TabBadge {
  */
 class ClaudeCodeVirtualFile(
     val tabId: String,
-    val initialPath: String? = null
+    val initialPath: String? = null,
+    initialTitle: String? = null
 ) : LightVirtualFile("Claude Code", ClaudeCodeFileType, "") {
 
-    // 동적으로 변경 가능한 표시 이름
+    // 동적으로 변경 가능한 표시 이름. 재시작 직후에는 백엔드 통신 전이라
+    // 저장된 마지막 제목(initialTitle)을 우선 보여 주고, 없을 때만 hash로 폴백.
     @Volatile
-    private var displayName: String = "Claude: ${tabId.take(8)}"
+    private var displayName: String = initialTitle?.let { truncateName(it) }
+        ?: "Claude: ${tabId.take(8)}"
 
     // WebView가 현재 표시 중인 경로 (탭 이동 시 복원용)
     @Volatile
@@ -46,14 +49,25 @@ class ClaudeCodeVirtualFile(
 
     companion object {
         private const val MAX_DISPLAY_NAME_LENGTH = 20
+
+        private fun truncateName(name: String): String =
+            if (name.length > MAX_DISPLAY_NAME_LENGTH) name.take(MAX_DISPLAY_NAME_LENGTH) + "…" else name
+
         private val openTabs = Collections.synchronizedMap(
             WeakHashMap<Project, MutableMap<String, ClaudeCodeVirtualFile>>()
         )
 
-        fun getOrCreate(project: Project, tabId: String, initialPath: String? = null): ClaudeCodeVirtualFile {
+        fun getOrCreate(
+            project: Project,
+            tabId: String,
+            initialPath: String? = null,
+            initialTitle: String? = null
+        ): ClaudeCodeVirtualFile {
             synchronized(openTabs) {
                 val projectTabs = openTabs.getOrPut(project) { ConcurrentHashMap() }
-                return projectTabs.getOrPut(tabId) { ClaudeCodeVirtualFile(tabId, initialPath) }
+                return projectTabs.getOrPut(tabId) {
+                    ClaudeCodeVirtualFile(tabId, initialPath, initialTitle)
+                }
             }
         }
 
@@ -71,11 +85,7 @@ class ClaudeCodeVirtualFile(
     }
 
     fun setDisplayName(name: String) {
-        val truncated = if (name.length > MAX_DISPLAY_NAME_LENGTH) {
-            name.take(MAX_DISPLAY_NAME_LENGTH) + "…"
-        } else {
-            name
-        }
+        val truncated = truncateName(name)
         if (displayName == truncated) return
         val oldName = displayName
         displayName = truncated

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/EditorTabStateService.kt
@@ -36,7 +36,11 @@ class EditorTabStateService : PersistentStateComponent<EditorTabStateService.Edi
         var activeSessionId: String? = null,
         // Last WebView path per tab, so a restored tab lands on the conversation
         // the user was actually viewing at shutdown rather than the tab's own page.
-        var sessionPaths: MutableMap<String, String> = mutableMapOf()
+        var sessionPaths: MutableMap<String, String> = mutableMapOf(),
+        // Last WebView-reported title per tab. Used to show a sensible tab label
+        // immediately after restart, before the lazy FileEditor mounts and the
+        // WebView reconnects to push a fresh title.
+        var sessionTitles: MutableMap<String, String> = mutableMapOf()
     )
 
     private var state = EditorTabState()
@@ -57,6 +61,7 @@ class EditorTabStateService : PersistentStateComponent<EditorTabStateService.Edi
     fun removeTab(tabId: String) {
         state.openSessionIds.remove(tabId)
         state.sessionPaths.remove(tabId)
+        state.sessionTitles.remove(tabId)
         if (state.activeSessionId == tabId) {
             state.activeSessionId = state.openSessionIds.lastOrNull()
         }
@@ -67,6 +72,12 @@ class EditorTabStateService : PersistentStateComponent<EditorTabStateService.Edi
     }
 
     fun getPath(tabId: String): String? = state.sessionPaths[tabId]
+
+    fun updateTitle(tabId: String, title: String) {
+        state.sessionTitles[tabId] = title
+    }
+
+    fun getTitle(tabId: String): String? = state.sessionTitles[tabId]
 
     /**
      * Path to restore a tab to: the last-viewed WebView path if known.

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/EditorTabRestoreActivity.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/EditorTabRestoreActivity.kt
@@ -28,12 +28,22 @@ class EditorTabRestoreActivity : ProjectActivity {
             // 비활성 탭 먼저 복원 (마지막으로 보던 경로로, 없으면 탭 페이지로)
             for (tabId in tabIds) {
                 if (tabId != activeTabId) {
-                    OpenClaudeCodeAction.openTab(project, tabId, stateService.getRestorePath(tabId))
+                    OpenClaudeCodeAction.openTab(
+                        project,
+                        tabId,
+                        stateService.getRestorePath(tabId),
+                        stateService.getTitle(tabId)
+                    )
                 }
             }
             // 활성 탭은 마지막에 열어서 포커스 획득
             if (activeTabId != null && activeTabId in tabIds) {
-                OpenClaudeCodeAction.openTab(project, activeTabId, stateService.getRestorePath(activeTabId))
+                OpenClaudeCodeAction.openTab(
+                    project,
+                    activeTabId,
+                    stateService.getRestorePath(activeTabId),
+                    stateService.getTitle(activeTabId)
+                )
             }
 
             logger.info("Editor tabs restored successfully")

--- a/webview/src/__tests__/chat-streaming.integration.test.tsx
+++ b/webview/src/__tests__/chat-streaming.integration.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { act } from 'react';
 import React from 'react';
 import { ChatStreamProvider, useChatStreamContext } from '../contexts/ChatStreamContext';
+import { ChatInputStateProvider, useChatInputState } from '../contexts/ChatInputStateContext';
 
 // Mock requestAnimationFrame/cancelAnimationFrame
 global.requestAnimationFrame = vi.fn((cb) => {
@@ -60,9 +61,25 @@ vi.mock('../contexts/SessionContext', () => ({
   SessionProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const inputRef = React.useRef('');
+  const setInputCallbackRef = React.useRef<(value: string) => void>(() => {});
+  const setInput = React.useCallback((value: string) => {
+    setInputCallbackRef.current(value);
+  }, []);
+  return (
+    <ChatStreamProvider setInput={setInput} inputRef={inputRef}>
+      <ChatInputStateProvider inputRef={inputRef} setInputCallbackRef={setInputCallbackRef}>
+        {children}
+      </ChatInputStateProvider>
+    </ChatStreamProvider>
+  );
+}
+
 // Test component that uses ChatStreamContext
 function TestChatComponent() {
   const ctx = useChatStreamContext();
+  const { input, setInput } = useChatInputState();
   return (
     <div>
       <div data-testid="messages-count">{ctx.messages.length}</div>
@@ -71,8 +88,8 @@ function TestChatComponent() {
       <div data-testid="streaming-id">{ctx.streamingMessageId || 'none'}</div>
       <input
         data-testid="input"
-        value={ctx.input}
-        onChange={(e) => ctx.setInput(e.target.value)}
+        value={input}
+        onChange={(e) => setInput(e.target.value)}
       />
       <button data-testid="submit" onClick={() => ctx.handleSubmit(undefined, 'ask_before_edit')}>
         Send
@@ -142,9 +159,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
 
   it('초기 상태가 올바르다', () => {
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     expect(screen.getByTestId('messages-count')).toHaveTextContent('0');
@@ -158,9 +175,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'existing-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');
@@ -195,9 +212,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'existing-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const submitWithMode = screen.getByTestId('submit-with-mode');
@@ -220,9 +237,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');
@@ -282,9 +299,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     // Start streaming
@@ -323,9 +340,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     await act(async () => {
@@ -346,9 +363,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     // Start streaming
@@ -393,9 +410,9 @@ describe('채팅 스트리밍 통합 테스트', () => {
     mockSession.currentSessionId = 'test-session';
 
     render(
-      <ChatStreamProvider>
+      <TestWrapper>
         <TestChatComponent />
-      </ChatStreamProvider>
+      </TestWrapper>
     );
 
     const input = screen.getByTestId('input');

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useMemo, useRef, ReactNode } from 'react';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { getAdapter } from '@/adapters';
@@ -46,6 +47,7 @@ interface CommandPaletteProviderProps {
 
 export function CommandPaletteProvider({ children }: CommandPaletteProviderProps) {
   const chatStream = useChatStreamContext();
+  const chatInputState = useChatInputState();
   const session = useSessionContext();
   const { controlResponse } = useCliConfig();
 
@@ -54,8 +56,8 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     chatStream: {
       messages: chatStream.messages,
       isStreaming: chatStream.isStreaming,
-      input: chatStream.input,
-      setInput: chatStream.setInput,
+      input: chatInputState.input,
+      setInput: chatInputState.setInput,
       sendMessage: chatStream.sendMessage,
       stop: chatStream.stop,
       continue: chatStream.continue,
@@ -84,8 +86,8 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     chatStream: {
       messages: chatStream.messages,
       isStreaming: chatStream.isStreaming,
-      input: chatStream.input,
-      setInput: chatStream.setInput,
+      input: chatInputState.input,
+      setInput: chatInputState.setInput,
       sendMessage: chatStream.sendMessage,
       stop: chatStream.stop,
       continue: chatStream.continue,

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useEffect, useRef } from 'react';
+import { ReactNode, useCallback, useEffect, useRef } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { BridgeProvider, useBridgeContext } from './BridgeContext';
 import { ApiProvider, useApiContext } from './ApiContext';
@@ -9,6 +9,7 @@ import { SettingsProvider } from './SettingsContext';
 import { ClaudeSettingsProvider } from './ClaudeSettingsContext';
 import { CliConfigProvider } from './CliConfigContext';
 import { ChatInputFocusProvider } from './ChatInputFocusContext';
+import { ChatInputStateProvider } from './ChatInputStateContext';
 import { WorkingDirProvider } from './WorkingDirContext';
 import { CommandPaletteProvider } from '../commandPalette/CommandPaletteProvider';
 import { useApi } from './ApiContext';
@@ -154,6 +155,50 @@ function SessionLoader({ children }: { children: ReactNode }) {
  * 11. ThemeProvider - Theme management (depends on Settings)
  * 12. SessionLoader - Reactive session management (depends on Session + ChatStream + Api)
  */
+
+interface ChatProviderBridgeProps {
+  children: ReactNode;
+}
+
+/**
+ * Bridges ChatInputStateProvider and ChatStreamProvider as siblings.
+ *
+ * ChatStreamProvider must NOT be nested inside ChatInputStateProvider —
+ * otherwise every keystroke (which triggers ChatInputStateProvider re-render)
+ * would propagate into ChatStreamProvider and all its consumers
+ * (MessageBubble, ChatMessageArea, etc.), causing the keystroke lag described
+ * in #31.
+ *
+ * The shared inputRef + setInputCallbackRef let ChatStreamProvider read/clear
+ * input without subscribing to ChatInputStateContext.
+ */
+function ChatProviderBridge(props: ChatProviderBridgeProps) {
+  const { children } = props;
+  const inputRef = useRef('');
+  const setInputCallbackRef = useRef<(value: string) => void>(() => {});
+
+  const setInput = useCallback((value: string) => {
+    setInputCallbackRef.current(value);
+  }, []);
+
+  return (
+    <ChatStreamProvider setInput={setInput} inputRef={inputRef}>
+      <ChatInputStateProvider
+        inputRef={inputRef}
+        setInputCallbackRef={setInputCallbackRef}
+      >
+        <CommandPaletteProvider>
+          <ThemeProvider>
+            <ChatInputFocusProvider>
+              <SessionLoader>{children}</SessionLoader>
+            </ChatInputFocusProvider>
+          </ThemeProvider>
+        </CommandPaletteProvider>
+      </ChatInputStateProvider>
+    </ChatStreamProvider>
+  );
+}
+
 export function AppProviders({ children }: AppProvidersProps) {
   return (
     <BridgeProvider>
@@ -164,15 +209,7 @@ export function AppProviders({ children }: AppProvidersProps) {
             <SettingsProvider>
               <ClaudeSettingsProvider>
                 <SessionProvider>
-                  <ChatStreamProvider>
-                    <CommandPaletteProvider>
-                      <ThemeProvider>
-                        <ChatInputFocusProvider>
-                          <SessionLoader>{children}</SessionLoader>
-                        </ChatInputFocusProvider>
-                      </ThemeProvider>
-                    </CommandPaletteProvider>
-                  </ChatStreamProvider>
+                  <ChatProviderBridge>{children}</ChatProviderBridge>
                 </SessionProvider>
               </ClaudeSettingsProvider>
             </SettingsProvider>

--- a/webview/src/contexts/ChatInputStateContext.tsx
+++ b/webview/src/contexts/ChatInputStateContext.tsx
@@ -1,0 +1,73 @@
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react';
+import { useSessionContext } from './SessionContext';
+
+interface ChatInputStateContextType {
+  input: string;
+  setInput: (input: string) => void;
+}
+
+const ChatInputStateContext = createContext<ChatInputStateContextType>({
+  input: '',
+  setInput: () => {},
+});
+
+export function useChatInputState() {
+  return useContext(ChatInputStateContext);
+}
+
+interface Props {
+  children: ReactNode;
+  inputRef?: React.MutableRefObject<string>;
+  setInputCallbackRef?: React.MutableRefObject<(value: string) => void>;
+}
+
+export function ChatInputStateProvider(props: Props) {
+  const { children, inputRef, setInputCallbackRef } = props;
+  const [input, setInputRaw] = useState('');
+  const session = useSessionContext();
+
+  // Keep shared ref in sync so sibling providers (ChatStreamProvider) can read
+  // the latest input without subscribing to this context.
+  // Updating refs in an effect avoids mutating refs during render (React anti-pattern).
+  useEffect(() => {
+    if (inputRef) inputRef.current = input;
+  }, [input, inputRef]);
+
+  const setInput = useCallback((value: string) => {
+    setInputRaw(value);
+  }, []);
+
+  // Wire the external callback ref so ChatStreamProvider can call setInput
+  // without being a consumer of this context.
+  useEffect(() => {
+    if (setInputCallbackRef) setInputCallbackRef.current = setInput;
+  }, [setInput, setInputCallbackRef]);
+
+  // Save input draft to localStorage for tab move/split restoration.
+  // Skip the first mount to prevent the initial empty input from clearing
+  // a saved draft (JCEF may reload the page on browser component reattach).
+  const draftInitializedRef = useRef(false);
+  useEffect(() => {
+    if (!session.currentSessionId) return;
+    if (!draftInitializedRef.current) {
+      draftInitializedRef.current = true;
+      return;
+    }
+    const key = `claude-gui:draft:${session.currentSessionId}`;
+    try {
+      if (input) {
+        localStorage.setItem(key, input);
+      } else {
+        localStorage.removeItem(key);
+      }
+    } catch {
+      // localStorage may be unavailable in some environments (e.g., tests)
+    }
+  }, [input, session.currentSessionId]);
+
+  return (
+    <ChatInputStateContext.Provider value={{ input, setInput }}>
+      {children}
+    </ChatInputStateContext.Provider>
+  );
+}

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, ReactNode, useEffect, useCallback, useState, useRef } from 'react';
+import { createContext, useContext, ReactNode, useEffect, useCallback, useState, useRef, useMemo } from 'react';
 import { useChatStream } from '../hooks/useChatStream';
 import { useDiffs } from '../hooks/useDiffs';
 import { useTools } from '../hooks/useTools';
@@ -27,10 +27,6 @@ interface ChatStreamContextType {
   streamingMessageId: string | null;
   error: Error | null;
   authDiagnosis: { envApiKeys: string[]; message: string } | null;
-
-  // Local input state
-  input: string;
-  setInput: (input: string) => void;
 
   // Actions
   sendMessage: (content: string, inputMode: InputMode, context?: Context[], attachments?: Attachment[]) => void;
@@ -76,36 +72,26 @@ export function useChatStreamContext() {
 
 interface ChatStreamProviderProps {
   children: ReactNode;
+  setInput: (value: string) => void;
+  inputRef: React.MutableRefObject<string>;
 }
 
-export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
+/**
+ * ChatStreamProvider receives setInput and inputRef from a sibling provider
+ * (ChatInputStateProvider via ChatProviderBridge) so that it does NOT consume
+ * ChatInputStateContext. This prevents every keystroke from re-rendering all
+ * ChatStreamContext subscribers (e.g. MessageBubble, ChatMessageArea).
+ */
+export function ChatStreamProvider(props: ChatStreamProviderProps) {
+  const { children, setInput, inputRef } = props;
   const bridge = useBridgeContext();
   const session = useSessionContext();
   const tools = useTools();
   const diffs = useDiffs();
 
-  const [input, setInput] = useState('');
   const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
   const toggleThinkingExpanded = useCallback(() => setIsThinkingExpanded(prev => !prev), []);
   const [sessionModel, setSessionModel] = useState<string | null>(null);
-
-  // Save input draft to localStorage for tab move/split restoration.
-  // Skip the first mount to prevent the initial empty input from clearing
-  // a saved draft (JCEF may reload the page on browser component reattach).
-  const draftInitializedRef = useRef(false);
-  useEffect(() => {
-    if (!session.currentSessionId) return;
-    if (!draftInitializedRef.current) {
-      draftInitializedRef.current = true;
-      return;
-    }
-    const key = `claude-gui:draft:${session.currentSessionId}`;
-    if (input) {
-      localStorage.setItem(key, input);
-    } else {
-      localStorage.removeItem(key);
-    }
-  }, [input, session.currentSessionId]);
 
   // EnterPlanMode 진입 전의 모드를 저장 (ExitPlanMode 시 복원용)
   const prePlanModeRef = useRef<InputMode | null>(null);
@@ -149,6 +135,18 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     },
   });
 
+  // Destructure stable callbacks out of chatStream so downstream useCallbacks
+  // don't depend on the plain-object chatStream reference (new every render).
+  const {
+    addUserMessage,
+    clearMessages: chatStreamClearMessages,
+    loadMessages: chatStreamLoadMessages,
+    appendMessage: chatStreamAppendMessage,
+    updateMessage: chatStreamUpdateMessage,
+    resetStreamState: chatStreamResetStreamState,
+    retry: chatStreamRetry,
+  } = chatStream;
+
   // systemInit 변경 시 sessionModel 동기화
   useEffect(() => {
     if (chatStream.systemInit) {
@@ -159,20 +157,25 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
 
   // 모든 세션별 상태를 한 번에 리셋하는 통합 함수
   const resetForSessionSwitch = useCallback(() => {
-    chatStream.clearMessages();
-    chatStream.resetStreamState();
+    chatStreamClearMessages();
+    chatStreamResetStreamState();
     // Restore draft input from cache (tab move/split restoration)
-    const draft = session.currentSessionId
-      ? localStorage.getItem(`claude-gui:draft:${session.currentSessionId}`)
-      : null;
-    setInput(draft || '');
+    let draft: string | null = null;
+    try {
+      draft = session.currentSessionId
+        ? localStorage.getItem(`claude-gui:draft:${session.currentSessionId}`)
+        : null;
+    } catch {
+      // localStorage may be unavailable in some environments (e.g., tests)
+    }
+    setInput(draft ?? '');
     setIsThinkingExpanded(false);
     setSessionModel(null);
     tools.clearToolUses();
     diffs.clearDiffs();
     queuedMessageRef.current = null;
     prePlanModeRef.current = null;
-  }, [chatStream.clearMessages, chatStream.resetStreamState, tools.clearToolUses, diffs.clearDiffs, session.currentSessionId]);
+  }, [chatStreamClearMessages, chatStreamResetStreamState, setInput, tools.clearToolUses, diffs.clearDiffs, session.currentSessionId]);
 
   // resetForSessionSwitch is called directly by SessionLoader
   // when currentSessionId changes (URL-driven reactive pattern)
@@ -221,7 +224,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
       }
 
       // Add to local chat state (항상 — UI에는 즉시 표시)
-      chatStream.addUserMessage(content, context, attachments);
+      addUserMessage(content, context, attachments);
 
       const payload: QueuedMessage = {
         sessionId,
@@ -250,7 +253,7 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
         console.error('[ChatStreamContext] Failed to send message to bridge:', error);
       });
     },
-    [chatStream, bridge, session]
+    [addUserMessage, chatStream.isStreaming, bridge, session]
   );
 
   // 스트리밍 종료(result 수신) 시 큐잉된 메시지 자동 전송.
@@ -270,16 +273,18 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     }
   }, [chatStream.isStreaming, bridge]);
 
-  // handleSubmit: convenience wrapper for form submission
+  // handleSubmit: convenience wrapper for form submission.
+  // Reads input via inputRef so this callback stays stable across keystrokes
+  // — otherwise every key press would invalidate contextValue.
   const handleSubmit = useCallback(
     (e: React.FormEvent | undefined, inputMode: InputMode, attachments?: Attachment[]) => {
       if (e) e.preventDefault();
-      const trimmedInput = input.trim();
+      const trimmedInput = inputRef.current.trim();
       if (!trimmedInput && (!attachments || attachments.length === 0)) return;
       sendMessage(trimmedInput, inputMode, undefined, attachments);
       setInput('');
     },
-    [input, sendMessage]
+    [inputRef, sendMessage, setInput]
   );
 
   // stop: stdin interrupt를 백엔드에 전송.
@@ -306,22 +311,21 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
   const retry = useCallback(
     (messageId: string) => {
       console.log('[ChatStreamContext] Retrying message:', messageId);
-      chatStream.retry(messageId);
+      chatStreamRetry(messageId);
     },
-    [chatStream]
+    [chatStreamRetry]
   );
 
-  const contextValue: ChatStreamContextType = {
+  // Memoize contextValue so consumers don't re-render unless one of the
+  // tracked dependencies actually changes. Input/setInput are no longer
+  // part of this context — they live in ChatInputStateContext.
+  const contextValue: ChatStreamContextType = useMemo(() => ({
     // From useChatStream
     messages: chatStream.messages,
     isStreaming: chatStream.isStreaming,
     streamingMessageId: chatStream.streamingMessageId,
     error: chatStream.error,
     authDiagnosis: chatStream.authDiagnosis,
-
-    // Local input state
-    input,
-    setInput,
 
     // Actions
     sendMessage,
@@ -330,13 +334,13 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
     continue: continueGeneration,
     retry,
 
-    resetStreamState: chatStream.resetStreamState,
+    resetStreamState: chatStreamResetStreamState,
 
     // Message manipulation
-    clearMessages: chatStream.clearMessages,
-    loadMessages: chatStream.loadMessages,
-    appendMessage: chatStream.appendMessage,
-    updateMessage: chatStream.updateMessage,
+    clearMessages: chatStreamClearMessages,
+    loadMessages: chatStreamLoadMessages,
+    appendMessage: chatStreamAppendMessage,
+    updateMessage: chatStreamUpdateMessage,
 
     // Subsystems
     tools,
@@ -354,7 +358,31 @@ export function ChatStreamProvider({ children }: ChatStreamProviderProps) {
 
     // Context window usage
     contextWindowUsage: chatStream.contextWindowUsage,
-  };
+  }), [
+    chatStream.messages,
+    chatStream.isStreaming,
+    chatStream.streamingMessageId,
+    chatStream.error,
+    chatStream.authDiagnosis,
+    chatStream.systemInit,
+    chatStream.contextWindowUsage,
+    chatStreamResetStreamState,
+    chatStreamClearMessages,
+    chatStreamLoadMessages,
+    chatStreamAppendMessage,
+    chatStreamUpdateMessage,
+    sendMessage,
+    handleSubmit,
+    stop,
+    continueGeneration,
+    retry,
+    tools,
+    diffs,
+    isThinkingExpanded,
+    toggleThinkingExpanded,
+    sessionModel,
+    resetForSessionSwitch,
+  ]);
 
   return (
     <ChatStreamContext.Provider value={contextValue}>

--- a/webview/src/contexts/index.ts
+++ b/webview/src/contexts/index.ts
@@ -9,3 +9,4 @@ export { ClaudeSettingsProvider, useClaudeSettings, ClaudeSettingsContext } from
 export { ChatInputFocusProvider, useChatInputFocus } from './ChatInputFocusContext';
 export { WorkingDirProvider, useWorkingDir } from './WorkingDirContext';
 export { CliConfigProvider, useCliConfig } from './CliConfigContext';
+export * from './ChatInputStateContext';

--- a/webview/src/examples/StreamingExample.tsx
+++ b/webview/src/examples/StreamingExample.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useChatStreamContext } from '../contexts/ChatStreamContext';
+import { useChatInputState } from '../contexts/ChatInputStateContext';
 import { MessageRole, LoadedMessageType } from '../dto/common';
 
 /**
@@ -11,12 +12,11 @@ export const StreamingExample: React.FC = () => {
     messages,
     isStreaming,
     streamingMessageId,
-    input,
-    setInput,
     handleSubmit,
     stop,
     error,
   } = useChatStreamContext();
+  const { input, setInput } = useChatInputState();
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>

--- a/webview/src/hooks/useDocumentTitle.ts
+++ b/webview/src/hooks/useDocumentTitle.ts
@@ -1,5 +1,4 @@
 import { useEffect, useRef } from 'react';
-import { APP_NAME } from '@/config/app';
 import {
   NotificationKind,
   notify,
@@ -54,7 +53,11 @@ export function useDocumentTitle(
   }, [error]);
 
   useEffect(() => {
-    document.title = title || APP_NAME;
+    // Only push a real session title up to the IDE tab. Setting APP_NAME as a
+    // fallback while the session is still loading would clobber the cached
+    // tab title that the JetBrains side restores from EditorTabStateService
+    // (the user would see the real title flash to "Claude Code" mid-load).
+    if (title) document.title = title;
   }, [title]);
 
   // Notify JCEF of streaming state changes

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -9,6 +9,7 @@ import { useChatInputFocus } from '../../../contexts/ChatInputFocusContext';
 import { useInputHistory } from './hooks/useInputHistory';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { getTextContent, SessionState } from '@/types';
 import { LoadedMessageType } from '@/dto';
@@ -39,15 +40,14 @@ interface NativeDropEntry {
 export function ChatInput() {
   const { textareaRef } = useChatInputFocus();
   const { currentSessionId, sessionState, workingDirectory, inputMode: mode, cycleInputMode: cycleMode, syncInitialInputMode, modeResetTrigger } = useSessionContext();
-  const {
-    messages,
-    input: value,
-    setInput: onChange,
-    handleSubmit: onSubmit,
-    isStreaming,
-    stop: onStop,
-  } = useChatStreamContext();
+  const chatStream = useChatStreamContext();
+  const { handleSubmit: onSubmit, isStreaming, stop: onStop } = chatStream;
+  const { input: value, setInput: onChange } = useChatInputState();
   const inputHistory = useInputHistory();
+  const { initHistory, pushToHistory, navigateUp, navigateDown } = inputHistory;
+  // Read messages lazily via ref so ChatInput does not re-render every streaming token.
+  const messagesRef = useRef(chatStream.messages);
+  messagesRef.current = chatStream.messages;
   const bridge = useBridgeContext();
   const { subscribe } = bridge;
   const [isFocused, setIsFocused] = useState(false);
@@ -280,10 +280,10 @@ export function ChatInput() {
     if (prev !== null && prev !== currentSessionId) {
       clearAttachments();
       setPathTokens([]);
-      inputHistory.initHistory([]);
+      initHistory([]);
       lastInitSessionRef.current = undefined;
     }
-  }, [currentSessionId, clearAttachments, inputHistory]);
+  }, [currentSessionId, clearAttachments, initHistory]);
 
   const isActive = isStreaming
     || sessionState === SessionState.WaitingPermission
@@ -316,19 +316,21 @@ export function ChatInput() {
     return () => window.removeEventListener('keydown', handleArrowCapture, true);
   }, []);
 
-  // Populate input history from session messages on session change
+  // Populate input history from session messages on session change.
+  // Read messages via ref to avoid re-running this effect on every streaming token —
+  // we only care about the messages snapshot at session-switch time.
   useEffect(() => {
     if (!currentSessionId || currentSessionId === lastInitSessionRef.current) return;
-    if (messages.length === 0) return;
+    if (messagesRef.current.length === 0) return;
 
     lastInitSessionRef.current = currentSessionId;
 
-    const userTexts = messages
+    const userTexts = messagesRef.current
       .filter(m => m.type === LoadedMessageType.User)
       .map(m => getTextContent(m))
       .filter((t): t is string => Boolean(t));
-    inputHistory.initHistory(userTexts);
-  }, [currentSessionId, messages, inputHistory]);
+    initHistory(userTexts);
+  }, [currentSessionId, initHistory]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key.startsWith('Arrow')) console.log('[KeyDebug:textarea-keydown]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
@@ -396,7 +398,7 @@ export function ChatInput() {
       if (willSubmit) {
         e.preventDefault();
         if (!disabled && (value.trim() || attachments.length > 0)) {
-          inputHistory.pushToHistory(value);
+          pushToHistory(value);
           onSubmit(undefined, mode, attachments.length > 0 ? attachments : undefined);
           clearAttachments();
           setPathTokens([]);
@@ -409,7 +411,7 @@ export function ChatInput() {
       const pos = getCaretOffset(e.currentTarget);
       if (value.lastIndexOf('\n', pos - 1) !== -1) return;
 
-      const historyValue = inputHistory.navigateUp(value);
+      const historyValue = navigateUp(value);
       if (historyValue === null) return;
       e.preventDefault();
       onChange(historyValue);
@@ -419,12 +421,12 @@ export function ChatInput() {
       const pos = getCaretOffset(e.currentTarget);
       if (value.indexOf('\n', pos) !== -1) return;
 
-      const historyValue = inputHistory.navigateDown();
+      const historyValue = navigateDown();
       if (historyValue === null) return;
       e.preventDefault();
       onChange(historyValue);
     }
-  }, [disabled, value, attachments.length, onSubmit, inputHistory, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
+  }, [disabled, value, attachments.length, onSubmit, pushToHistory, navigateUp, navigateDown, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
 
   const handleRichChange = useCallback((newValue: string) => {
     onChange(newValue);

--- a/webview/src/pages/ChatPage/ChatMessageArea.tsx
+++ b/webview/src/pages/ChatPage/ChatMessageArea.tsx
@@ -81,7 +81,12 @@ export function ChatMessageArea(props: Props) {
       }
     }
 
-    // Build tool_use_id → ToolUseBlockDto lookup from all assistant messages
+    // Build tool_use_id → cloned ToolUseBlockDto lookup from all assistant messages.
+    // Cloning prevents mutation of the original block objects (which live on the
+    // shared messages array). In-place mutation would break React.memo bailouts on
+    // MessageBubble — referential equality holds, but the cloned inner block would
+    // be wrong — and could also duplicate runtime fields on re-render
+    // (e.g. React StrictMode).
     const toolUseMap = new Map<string, ToolUseBlockDto>();
     for (const msg of messages) {
       if (msg.type !== LoadedMessageType.Assistant) continue;
@@ -89,16 +94,15 @@ export function ChatMessageArea(props: Props) {
       if (!isContentBlockArray(content)) continue;
       for (const block of content) {
         if (block.type === ContentBlockType.ToolUse) {
-          toolUseMap.set((block as ToolUseBlockDto).id, block as ToolUseBlockDto);
+          const orig = block as ToolUseBlockDto;
+          toolUseMap.set(orig.id, {
+            ...orig,
+            tool_result: undefined,
+            childMessages: undefined,
+            subAgentMessages: undefined,
+          });
         }
       }
-    }
-
-    // Reset runtime-only fields to prevent duplication on re-render (e.g. React StrictMode)
-    for (const toolUseBlock of toolUseMap.values()) {
-      toolUseBlock.tool_result = undefined;
-      toolUseBlock.childMessages = undefined;
-      toolUseBlock.subAgentMessages = undefined;
     }
 
     // Phase 1.5: Attach progress entries to Task tool_use blocks

--- a/webview/src/pages/ChatPage/MessageBubble.tsx
+++ b/webview/src/pages/ChatPage/MessageBubble.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { LoadedMessageDto } from '../../types';
 import {
   UserMessageRenderer,
@@ -12,7 +13,11 @@ interface MessageBubbleProps {
   onRetry?: (messageId: string) => void;
 }
 
-export function MessageBubble({ message, onRetry }: MessageBubbleProps) {
+// React.memo skips re-rendering when props (message identity, onRetry) are
+// unchanged. ChatMessageArea must clone any objects it modifies — otherwise
+// in-place mutation defeats this bailout.
+export const MessageBubble = memo(function MessageBubble(props: MessageBubbleProps) {
+  const { message, onRetry } = props;
   switch (message.type) {
     case 'user':
       return <UserMessageRenderer message={message} />;
@@ -27,4 +32,4 @@ export function MessageBubble({ message, onRetry }: MessageBubbleProps) {
     default:
       return null;
   }
-}
+});


### PR DESCRIPTION
Closes #19.

## Summary

- `extractSessionInfo` now reads JSONL line-by-line via `createReadStream` + `readline` with O(1) state, instead of `readFile` + a Map of every message. Sidechain detection aborts the stream on the first relevant entry so sidechain logs never get fully scanned.
- `getSessionsList` runs per-file extraction through a bounded worker pool (concurrency 10), removing the serial loop where one 28MB file froze the whole listing.
- Public return shape is unchanged.

## Symptom this fixes

When `~/.claude/projects/<hash>/` contained any `.jsonl` larger than ~5MB, the backend would:

- Spin to 100% CPU on `backend.mjs`
- Block the Node event loop, so every WebSocket request timed out
- Leave the user with a blank Claude Code tab showing only `Claude: <hash>`
- One affected project would also starve other open project tabs

Issue reporter's matrix:

| Project | Largest session | Result |
|--|--|--|
| 187 MB total, 28 MB single file | ❌ hang |
| 19 MB total, 5.3 MB single file | ❌ hang |
| 6.7 MB total, 2.9 MB single file | ✅ ok |
| 52 KB total | ✅ ok |

After this PR, session listing reads only what it needs per line and yields between stream chunks, so the event loop is never starved.

## Out of scope (intentional)

`loadSessionMessages` still uses `readFile` because clicking an individual session ultimately ships every message to the WebView anyway — streaming there doesn't change the wall-clock or memory ceiling meaningfully. The blank-tab symptom in #19 is the list-loading path, which is what this PR targets.

## Test plan

- [x] `./scripts/build.sh be-test` — 262/262 pass, including:
  - 12 existing extractSessionInfo cases migrated to real tmpfiles (no more `vi.mock('fs/promises')`)
  - New: 10MB / 10k-message regression test
  - New: sidechain short-circuit test (first entry sidechain, rest is garbage that must never be parsed)
- [x] `./scripts/build.sh be-build` — bundle ok
- [x] `./scripts/build.sh be-lint` — tsc clean