### PR TITLE
fix: reload edited files in IDE tabs after CLI writes (#72)

### DIFF
--- a/backend/src/bridge/bridge-interface.ts
+++ b/backend/src/bridge/bridge-interface.ts
@@ -12,6 +12,12 @@ export interface Bridge {
     toolUseId?: string;
   }): Promise<{ applied: boolean }>;
   rejectDiff(params: { toolUseId?: string }): Promise<void>;
+  /**
+   * Ask the IDE host to reload the given files from disk. Used after the CLI
+   * edits files directly, so open editor tabs reflect the new content even when
+   * the IDE's native filesystem watcher misses the change (e.g. on Windows).
+   */
+  refreshFiles(params: { paths: string[] }): Promise<void>;
   createSession(workingDir?: string): Promise<void>;
   openNewTab(workingDir?: string): Promise<void>;
   openSettings(workingDir?: string): Promise<void>;

--- a/backend/src/bridge/browser-bridge.ts
+++ b/backend/src/bridge/browser-bridge.ts
@@ -40,6 +40,10 @@ export class BrowserBridge implements Bridge {
     // no-op
   }
 
+  async refreshFiles(): Promise<void> {
+    // no-op: browser mode has no IDE editor tabs to reload
+  }
+
   async createSession(_workingDir?: string): Promise<void> {
     // no-op: handled by session reset in browser mode
   }

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -162,6 +162,10 @@ export class JetBrainsBridge implements Bridge {
     await this.request('REJECT_DIFF', params ?? {});
   }
 
+  async refreshFiles(params: { paths: string[] }): Promise<void> {
+    await this.request('REFRESH_FILES', { paths: params.paths });
+  }
+
   async createSession(workingDir?: string): Promise<void> {
     await this.request('CREATE_SESSION', workingDir ? { workingDir } : {});
   }

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -1,7 +1,13 @@
 import type { ConnectionManager } from '../ws/connection-manager';
+import type { Bridge } from '../bridge/bridge-interface';
 import { Claude } from './claude';
 import { diagnoseAuthError } from './features/auth-diagnosis';
 import { getStrippableAuthEnvKeys } from './features/claude-settings';
+import { EditedFileTracker } from './features/editedFileTracker';
+
+// Tracks files Claude edits so the IDE can be told to reload them once the
+// edit completes on disk. Shared across sessions — tool_use ids are unique.
+const editedFileTracker = new EditedFileTracker();
 
 // InputMode -> CLI --permission-mode flag mapping
 const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
@@ -37,6 +43,7 @@ export async function ensureClaudeProcess(
   workingDir: string,
   targetSessionId: string,
   inputMode: string,
+  bridge: Bridge,
 ): Promise<void> {
   const existingSession = connections.getSession(targetSessionId);
   if (existingSession?.process) {
@@ -148,7 +155,7 @@ export async function ensureClaudeProcess(
       try {
         const event = JSON.parse(line) as Record<string, unknown>;
         console.error('[node-backend]', `JSON event type: ${event.type}`);
-        handleStreamEvent(targetSessionId, event, connections);
+        handleStreamEvent(targetSessionId, event, connections, bridge);
       } catch {
         console.error('[node-backend]', `Non-JSON output (unexpected in stream-json mode): ${line}`);
       }
@@ -169,7 +176,7 @@ export async function ensureClaudeProcess(
     if (remainingBuffer.trim()) {
       try {
         const event = JSON.parse(remainingBuffer) as Record<string, unknown>;
-        handleStreamEvent(targetSessionId, event, connections);
+        handleStreamEvent(targetSessionId, event, connections, bridge);
       } catch {
         console.error('[node-backend]', `Remaining buffer (non-JSON): ${remainingBuffer}`);
       }
@@ -387,8 +394,21 @@ function handleStreamEvent(
   targetSessionId: string,
   event: Record<string, unknown>,
   connections: ConnectionManager,
+  bridge: Bridge,
 ): void {
   const eventType = event.type as string;
+
+  // Detect files Claude edited and, once each edit completes on disk, ask the
+  // IDE to reload them (issue #72 — CLI writes bypass the IDE, and the native
+  // file watcher misses changes on Windows). Record intents from assistant
+  // events; emit refreshes when the matching tool_result succeeds.
+  editedFileTracker.recordEdits(event);
+  const pathsToRefresh = editedFileTracker.collectRefreshPaths(event);
+  if (pathsToRefresh.length > 0) {
+    bridge.refreshFiles({ paths: pathsToRefresh }).catch((err) => {
+      console.error('[node-backend]', 'Failed to refresh files in IDE:', err);
+    });
+  }
 
   // 백엔드 고유 사이드이펙트 (WebView 전달과 무관한 서버 내부 로직)
   if (eventType === 'result') {

--- a/backend/src/core/features/__tests__/editedFileTracker.test.ts
+++ b/backend/src/core/features/__tests__/editedFileTracker.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+  extractEditTargets,
+  extractSucceededToolUseIds,
+  EditedFileTracker,
+} from '../editedFileTracker';
+
+/**
+ * Builds a Claude CLI stream-json `assistant` event carrying tool_use blocks.
+ */
+function assistantEvent(blocks: Array<Record<string, unknown>>): Record<string, unknown> {
+  return {
+    type: 'assistant',
+    message: { role: 'assistant', content: blocks },
+    session_id: 'sess-1',
+  };
+}
+
+/**
+ * Builds a Claude CLI stream-json `user` event carrying tool_result blocks.
+ */
+function userEvent(blocks: Array<Record<string, unknown>>): Record<string, unknown> {
+  return {
+    type: 'user',
+    message: { role: 'user', content: blocks },
+    session_id: 'sess-1',
+  };
+}
+
+describe('extractEditTargets', () => {
+  it('extracts file_path from an Edit tool_use', () => {
+    const event = assistantEvent([
+      { type: 'tool_use', id: 'tu-1', name: 'Edit', input: { file_path: '/repo/a.ts', old_string: 'x', new_string: 'y' } },
+    ]);
+    expect(extractEditTargets(event)).toEqual([{ toolUseId: 'tu-1', filePath: '/repo/a.ts' }]);
+  });
+
+  it('extracts file_path from Write and MultiEdit tools', () => {
+    const event = assistantEvent([
+      { type: 'tool_use', id: 'tu-w', name: 'Write', input: { file_path: '/repo/new.ts', content: 'hi' } },
+      { type: 'tool_use', id: 'tu-m', name: 'MultiEdit', input: { file_path: '/repo/multi.ts', edits: [] } },
+    ]);
+    expect(extractEditTargets(event)).toEqual([
+      { toolUseId: 'tu-w', filePath: '/repo/new.ts' },
+      { toolUseId: 'tu-m', filePath: '/repo/multi.ts' },
+    ]);
+  });
+
+  it('extracts notebook_path from a NotebookEdit tool', () => {
+    const event = assistantEvent([
+      { type: 'tool_use', id: 'tu-nb', name: 'NotebookEdit', input: { notebook_path: '/repo/nb.ipynb', new_source: 'print(1)' } },
+    ]);
+    expect(extractEditTargets(event)).toEqual([{ toolUseId: 'tu-nb', filePath: '/repo/nb.ipynb' }]);
+  });
+
+  it('ignores non-editing tools like Read and Bash', () => {
+    const event = assistantEvent([
+      { type: 'tool_use', id: 'tu-r', name: 'Read', input: { file_path: '/repo/a.ts' } },
+      { type: 'tool_use', id: 'tu-b', name: 'Bash', input: { command: 'ls' } },
+    ]);
+    expect(extractEditTargets(event)).toEqual([]);
+  });
+
+  it('ignores text blocks and tool_use without a path', () => {
+    const event = assistantEvent([
+      { type: 'text', text: 'editing now' },
+      { type: 'tool_use', id: 'tu-x', name: 'Edit', input: {} },
+    ]);
+    expect(extractEditTargets(event)).toEqual([]);
+  });
+
+  it('returns empty for non-assistant events', () => {
+    expect(extractEditTargets(userEvent([]))).toEqual([]);
+    expect(extractEditTargets({ type: 'result' })).toEqual([]);
+    expect(extractEditTargets({})).toEqual([]);
+  });
+});
+
+describe('extractSucceededToolUseIds', () => {
+  it('returns tool_use_ids of successful tool_result blocks', () => {
+    const event = userEvent([
+      { type: 'tool_result', tool_use_id: 'tu-1', content: 'ok', is_error: false },
+    ]);
+    expect(extractSucceededToolUseIds(event)).toEqual(['tu-1']);
+  });
+
+  it('treats a missing is_error as success', () => {
+    const event = userEvent([
+      { type: 'tool_result', tool_use_id: 'tu-2', content: 'ok' },
+    ]);
+    expect(extractSucceededToolUseIds(event)).toEqual(['tu-2']);
+  });
+
+  it('excludes errored tool_result blocks', () => {
+    const event = userEvent([
+      { type: 'tool_result', tool_use_id: 'tu-err', content: 'boom', is_error: true },
+      { type: 'tool_result', tool_use_id: 'tu-ok', content: 'ok', is_error: false },
+    ]);
+    expect(extractSucceededToolUseIds(event)).toEqual(['tu-ok']);
+  });
+
+  it('returns empty for non-user events', () => {
+    expect(extractSucceededToolUseIds(assistantEvent([]))).toEqual([]);
+    expect(extractSucceededToolUseIds({})).toEqual([]);
+  });
+});
+
+describe('EditedFileTracker', () => {
+  it('returns a path only after the matching tool_result succeeds', () => {
+    const tracker = new EditedFileTracker();
+
+    // assistant announces the edit — file not written yet (default/ask mode)
+    tracker.recordEdits(
+      assistantEvent([
+        { type: 'tool_use', id: 'tu-1', name: 'Edit', input: { file_path: '/repo/a.ts', old_string: 'x', new_string: 'y' } },
+      ]),
+    );
+    // no refresh until the tool actually completes
+    expect(tracker.collectRefreshPaths(assistantEvent([]))).toEqual([]);
+
+    // tool_result arrives → the file is now on disk
+    const paths = tracker.collectRefreshPaths(
+      userEvent([{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok', is_error: false }]),
+    );
+    expect(paths).toEqual(['/repo/a.ts']);
+  });
+
+  it('does not refresh when the edit failed', () => {
+    const tracker = new EditedFileTracker();
+    tracker.recordEdits(
+      assistantEvent([
+        { type: 'tool_use', id: 'tu-1', name: 'Edit', input: { file_path: '/repo/a.ts', old_string: 'x', new_string: 'y' } },
+      ]),
+    );
+    const paths = tracker.collectRefreshPaths(
+      userEvent([{ type: 'tool_result', tool_use_id: 'tu-1', content: 'boom', is_error: true }]),
+    );
+    expect(paths).toEqual([]);
+  });
+
+  it('does not yield the same tool_use twice', () => {
+    const tracker = new EditedFileTracker();
+    tracker.recordEdits(
+      assistantEvent([
+        { type: 'tool_use', id: 'tu-1', name: 'Write', input: { file_path: '/repo/a.ts', content: 'hi' } },
+      ]),
+    );
+    const result = userEvent([{ type: 'tool_result', tool_use_id: 'tu-1', content: 'ok', is_error: false }]);
+    expect(tracker.collectRefreshPaths(result)).toEqual(['/repo/a.ts']);
+    // a duplicated result event must not re-emit the path
+    expect(tracker.collectRefreshPaths(result)).toEqual([]);
+  });
+
+  it('deduplicates repeated paths within one result event', () => {
+    const tracker = new EditedFileTracker();
+    tracker.recordEdits(
+      assistantEvent([
+        { type: 'tool_use', id: 'tu-1', name: 'Edit', input: { file_path: '/repo/a.ts', old_string: 'x', new_string: 'y' } },
+        { type: 'tool_use', id: 'tu-2', name: 'Edit', input: { file_path: '/repo/a.ts', old_string: 'y', new_string: 'z' } },
+      ]),
+    );
+    const paths = tracker.collectRefreshPaths(
+      userEvent([
+        { type: 'tool_result', tool_use_id: 'tu-1', content: 'ok', is_error: false },
+        { type: 'tool_result', tool_use_id: 'tu-2', content: 'ok', is_error: false },
+      ]),
+    );
+    expect(paths).toEqual(['/repo/a.ts']);
+  });
+
+  it('ignores tool_results for unknown tool_use ids', () => {
+    const tracker = new EditedFileTracker();
+    const paths = tracker.collectRefreshPaths(
+      userEvent([{ type: 'tool_result', tool_use_id: 'never-seen', content: 'ok', is_error: false }]),
+    );
+    expect(paths).toEqual([]);
+  });
+});

--- a/backend/src/core/features/editedFileTracker.ts
+++ b/backend/src/core/features/editedFileTracker.ts
@@ -1,0 +1,111 @@
+/**
+ * Tracks which files Claude Code edits so the IDE can be told to reload them.
+ *
+ * Why this exists: the Claude CLI writes files to disk directly (after a
+ * permission is granted, or automatically in acceptEdits/bypass modes). The
+ * plugin never goes through the IDE to perform the write, so the IDE only
+ * learns about the change through its native filesystem watcher. On Windows
+ * that watcher is unreliable, leaving open editor tabs showing stale content
+ * (issue #72). To work around it we detect completed edit tools in the CLI
+ * stream and explicitly ask the IDE to refresh the affected paths.
+ *
+ * Timing matters: an `assistant` event only announces the *intent* to edit —
+ * in ask-before-edit mode the file is not written until the user approves and
+ * the matching `tool_result` comes back. So we record edit targets when the
+ * tool_use is seen, but only emit a refresh once the corresponding successful
+ * `tool_result` arrives (= the write has actually happened on disk).
+ */
+
+/** Tools that mutate a file on disk and therefore require an IDE reload. */
+const FILE_EDIT_TOOLS = new Set(['Edit', 'Write', 'MultiEdit', 'NotebookEdit']);
+
+export interface EditTarget {
+  toolUseId: string;
+  filePath: string;
+}
+
+function getContentBlocks(event: Record<string, unknown>): Array<Record<string, unknown>> {
+  const message = event['message'] as { content?: unknown } | undefined;
+  const content = message?.content;
+  return Array.isArray(content) ? (content as Array<Record<string, unknown>>) : [];
+}
+
+/**
+ * Pulls the editable file targets out of an `assistant` event's tool_use blocks.
+ * Non-assistant events, non-editing tools, and tool_use without a path yield nothing.
+ */
+export function extractEditTargets(event: Record<string, unknown>): EditTarget[] {
+  if (event['type'] !== 'assistant') return [];
+
+  const targets: EditTarget[] = [];
+  for (const block of getContentBlocks(event)) {
+    if (block['type'] !== 'tool_use') continue;
+    const name = block['name'];
+    if (typeof name !== 'string' || !FILE_EDIT_TOOLS.has(name)) continue;
+
+    const input = (block['input'] as Record<string, unknown> | undefined) ?? {};
+    // Edit/Write/MultiEdit use `file_path`; NotebookEdit uses `notebook_path`.
+    const rawPath = input['file_path'] ?? input['notebook_path'];
+    const toolUseId = block['id'];
+    if (typeof rawPath === 'string' && rawPath.length > 0 && typeof toolUseId === 'string') {
+      targets.push({ toolUseId, filePath: rawPath });
+    }
+  }
+  return targets;
+}
+
+/**
+ * Returns the tool_use_ids of successful tool_result blocks in a `user` event.
+ * A missing `is_error` is treated as success (the CLI omits it on success).
+ */
+export function extractSucceededToolUseIds(event: Record<string, unknown>): string[] {
+  if (event['type'] !== 'user') return [];
+
+  const ids: string[] = [];
+  for (const block of getContentBlocks(event)) {
+    if (block['type'] !== 'tool_result') continue;
+    if (block['is_error'] === true) continue;
+    const id = block['tool_use_id'];
+    if (typeof id === 'string' && id.length > 0) ids.push(id);
+  }
+  return ids;
+}
+
+/**
+ * Stateful bridge between edit announcements and edit completions.
+ *
+ * Feed every CLI stream event to both [recordEdits] and [collectRefreshPaths];
+ * the latter returns the deduplicated file paths that just finished writing and
+ * should be refreshed in the IDE.
+ */
+export class EditedFileTracker {
+  /** toolUseId -> filePath for edits announced but not yet completed. */
+  private readonly pending = new Map<string, string>();
+
+  /** Record edit intents from an `assistant` event. No-op for other events. */
+  recordEdits(event: Record<string, unknown>): void {
+    for (const target of extractEditTargets(event)) {
+      this.pending.set(target.toolUseId, target.filePath);
+    }
+  }
+
+  /**
+   * Given a `user` event, return the file paths whose edits just succeeded.
+   * Consumed entries are removed so a path is never emitted twice. The result
+   * is deduplicated (two edits to one file refresh it once).
+   */
+  collectRefreshPaths(event: Record<string, unknown>): string[] {
+    const paths: string[] = [];
+    const seen = new Set<string>();
+    for (const toolUseId of extractSucceededToolUseIds(event)) {
+      const filePath = this.pending.get(toolUseId);
+      if (filePath === undefined) continue;
+      this.pending.delete(toolUseId);
+      if (!seen.has(filePath)) {
+        seen.add(filePath);
+        paths.push(filePath);
+      }
+    }
+    return paths;
+  }
+}

--- a/backend/src/core/handlers/sendMessage.ts
+++ b/backend/src/core/handlers/sendMessage.ts
@@ -8,7 +8,7 @@ export async function sendMessageHandler(
   connectionId: string,
   message: IPCMessage,
   connections: ConnectionManager,
-  _bridge: Bridge,
+  bridge: Bridge,
 ): Promise<void> {
   const content = message.payload?.content as string;
   const workingDir = message.payload?.workingDir as string | undefined;
@@ -33,7 +33,7 @@ export async function sendMessageHandler(
     if (content || (attachments && attachments.length > 0)) {
       // Subscribe and ensure process is running (waits for spawn)
       connections.subscribe(connectionId, resolvedSessionId);
-      await ensureClaudeProcess(connections, connectionId, workingDir, resolvedSessionId, inputMode);
+      await ensureClaudeProcess(connections, connectionId, workingDir, resolvedSessionId, inputMode, bridge);
 
       // Send content to process stdin
       sendMessageToProcess(connections, resolvedSessionId, content, attachments);

--- a/backend/src/core/handlers/startSession.ts
+++ b/backend/src/core/handlers/startSession.ts
@@ -7,7 +7,7 @@ export async function startSessionHandler(
   connectionId: string,
   message: IPCMessage,
   connections: ConnectionManager,
-  _bridge: Bridge,
+  bridge: Bridge,
 ): Promise<void> {
   const workingDir = message.payload?.workingDir as string | undefined;
   const sessionId = message.payload?.sessionId as string | undefined;
@@ -24,7 +24,7 @@ export async function startSessionHandler(
   try {
     if (sessionId) {
       connections.subscribe(connectionId, sessionId);
-      await ensureClaudeProcess(connections, connectionId, workingDir, sessionId, inputMode);
+      await ensureClaudeProcess(connections, connectionId, workingDir, sessionId, inputMode, bridge);
     }
   } catch (err) {
     // ensureClaudeProcess already broadcasts SERVICE_ERROR to the session.

--- a/backend/src/ws/__tests__/connection-bridge-routing.test.ts
+++ b/backend/src/ws/__tests__/connection-bridge-routing.test.ts
@@ -18,6 +18,7 @@ function createMockBridge(name: string): Bridge {
     openDiff: vi.fn(),
     applyDiff: vi.fn().mockResolvedValue({ applied: false }),
     rejectDiff: vi.fn(),
+    refreshFiles: vi.fn(),
     createSession: vi.fn(),
     openNewTab: vi.fn(),
     openSettings: vi.fn(),

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -198,6 +198,7 @@ class SendSelectionToClaudeAction : AnAction() {
         override suspend fun openDiff(filePath: String, oldContent: String, newContent: String, toolUseId: String?) {}
         override suspend fun applyDiff(filePath: String, newContent: String, toolUseId: String?): Boolean = false
         override suspend fun rejectDiff(toolUseId: String?) {}
+        override suspend fun refreshFiles(paths: List<String>) {}
         override suspend fun createSession(workingDir: String) {}
         override suspend fun openNewTab(workingDir: String) {}
         override suspend fun openSettings(workingDir: String) {}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -66,6 +66,7 @@ class NodeProcessManager(
         suspend fun openDiff(filePath: String, oldContent: String, newContent: String, toolUseId: String?)
         suspend fun applyDiff(filePath: String, newContent: String, toolUseId: String?): Boolean
         suspend fun rejectDiff(toolUseId: String?)
+        suspend fun refreshFiles(paths: List<String>)
         suspend fun createSession(workingDir: String)
         suspend fun openNewTab(workingDir: String)
         suspend fun openSettings(workingDir: String)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -210,6 +210,10 @@ class RpcWebSocketClient(
                 rpcHandler.rejectDiff(toolUseId)
                 buildJsonObject {}
             }
+            "REFRESH_FILES" -> {
+                rpcHandler.refreshFiles(parseRefreshFilePaths(params))
+                buildJsonObject {}
+            }
             "CREATE_SESSION" -> {
                 val workingDir = params["workingDir"]?.jsonPrimitive?.content ?: ""
                 rpcHandler.createSession(workingDir)
@@ -296,5 +300,18 @@ class RpcWebSocketClient(
         }
         webSocket = null
         logger.info("RpcWebSocketClient disposed")
+    }
+}
+
+/**
+ * Extracts the "paths" string array from REFRESH_FILES params, skipping any
+ * non-string entries. Returns an empty list when the param is missing, empty,
+ * or not an array. Kept top-level and internal so it can be unit-tested without
+ * a live WebSocket.
+ */
+internal fun parseRefreshFilePaths(params: JsonObject): List<String> {
+    val array = params["paths"] as? JsonArray ?: return emptyList()
+    return array.mapNotNull { element ->
+        (element as? JsonPrimitive)?.takeIf { it.isString }?.content
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/DiffService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/DiffService.kt
@@ -11,6 +11,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.LocalFileSystem
+import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.vfs.VirtualFile
 import java.io.File
 
@@ -154,6 +155,43 @@ class DiffService(private val project: Project) {
             logger.error("Failed to apply edit to: $filePath", e)
             Result.failure(e)
         }
+    }
+
+    /**
+     * Reload the given files from disk so open editor tabs show fresh content.
+     *
+     * The Claude CLI writes files directly, bypassing the IDE. The IDE then only
+     * notices via its native filesystem watcher, which is unreliable on Windows
+     * (issue #72), leaving tabs stale until a manual "Reload from Disk". This
+     * triggers that refresh explicitly.
+     *
+     * Uses an asynchronous VFS refresh ([VfsUtil.markDirtyAndRefresh] with
+     * async = true) so the EDT is never blocked. Files not yet known to the VFS
+     * (newly created) are discovered by refreshing their parent directory.
+     *
+     * @param paths Absolute file paths that were just written.
+     */
+    fun refreshFiles(paths: List<String>) {
+        if (paths.isEmpty()) return
+        val lfs = LocalFileSystem.getInstance()
+
+        val knownFiles = paths.mapNotNull { lfs.findFileByPath(it) }
+        if (knownFiles.isNotEmpty()) {
+            VfsUtil.markDirtyAndRefresh(true, false, false, *knownFiles.toTypedArray())
+        }
+
+        // Newly created files are not in the VFS yet — refresh their parent dirs
+        // (with reloadChildren = true) so the IDE discovers them.
+        val newFileParents = paths
+            .filter { lfs.findFileByPath(it) == null }
+            .mapNotNull { File(it).parent }
+            .distinct()
+            .mapNotNull { lfs.findFileByPath(it) }
+        if (newFileParents.isNotEmpty()) {
+            VfsUtil.markDirtyAndRefresh(true, false, true, *newFileParents.toTypedArray())
+        }
+
+        logger.info("Requested VFS refresh for ${paths.size} path(s)")
     }
 
     /**

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -86,6 +86,15 @@ class NodeBackendService : Disposable {
                 ?: logger.warn("No active panel handler for rejectDiff")
         }
 
+        override suspend fun refreshFiles(paths: List<String>) {
+            if (paths.isEmpty()) return
+            // Files may belong to different projects — route each to its own panel.
+            paths.groupBy { handlerForPath(it) }.forEach { (handler, group) ->
+                handler?.refreshFiles(group)
+                    ?: logger.warn("No handler for refreshFiles: $group")
+            }
+        }
+
         override suspend fun createSession(workingDir: String) {
             handlerForWorkingDir(workingDir)?.createSession(workingDir)
                 ?: logger.warn("No handler for createSession: $workingDir")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -940,6 +940,11 @@ class ClaudeCodePanel(
                 logger.info("Diff rejected (toolUseId=$toolUseId)")
             }
 
+            override suspend fun refreshFiles(paths: List<String>) {
+                diffService.refreshFiles(paths)
+                logger.info("Requested IDE refresh for ${paths.size} file(s)")
+            }
+
             override suspend fun createSession(workingDir: String) {
                 logger.info("Session cleared (workingDir=$workingDir)")
             }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/RefreshFilesParamsTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/RefreshFilesParamsTest.kt
@@ -1,0 +1,44 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [parseRefreshFilePaths] — the pure JSON-RPC param parsing used
+ * by the REFRESH_FILES handler. Verifies it tolerates the shapes the Node.js
+ * backend may send (issue #72 file-reload feature).
+ */
+class RefreshFilesParamsTest {
+
+    private fun params(jsonText: String) =
+        Json.parseToJsonElement(jsonText).jsonObject
+
+    @Test
+    fun `extracts the string paths in order`() {
+        val result = parseRefreshFilePaths(params("""{"paths":["/repo/a.ts","/repo/b.ts"]}"""))
+        assertEquals(listOf("/repo/a.ts", "/repo/b.ts"), result)
+    }
+
+    @Test
+    fun `returns empty list when paths param is missing`() {
+        assertEquals(emptyList<String>(), parseRefreshFilePaths(params("{}")))
+    }
+
+    @Test
+    fun `returns empty list for an empty array`() {
+        assertEquals(emptyList<String>(), parseRefreshFilePaths(params("""{"paths":[]}""")))
+    }
+
+    @Test
+    fun `skips non-string entries`() {
+        val result = parseRefreshFilePaths(params("""{"paths":["/repo/a.ts",123,null,"/repo/b.ts"]}"""))
+        assertEquals(listOf("/repo/a.ts", "/repo/b.ts"), result)
+    }
+
+    @Test
+    fun `returns empty list when paths is not an array`() {
+        assertEquals(emptyList<String>(), parseRefreshFilePaths(params("""{"paths":"/repo/a.ts"}""")))
+    }
+}


### PR DESCRIPTION
## 배경

Closes #72.

플러그인을 통해 Claude가 파일을 수정해도, IntelliJ의 열린 에디터 탭에 변경 내용이 반영되지 않고 옛 내용이 남아 있었습니다. Windows에서 특히 재현되며, 사용자는 매번 `Ctrl+Alt+Y`(Reload from Disk)를 수동으로 눌러야 했습니다.

## 원인

파일은 **Claude Code CLI가 디스크에 직접 씁니다** — 권한 승인 후, 또는 `acceptEdits`/`bypass` 모드에서 자동으로. 플러그인은 그 쓰기를 IDE를 통해 수행하지 않으므로, IDE는 변경을 오직 네이티브 파일시스템 워처로만 감지합니다. 이 워처가 Windows 네이티브 FS에서 신뢰성이 낮아 탭이 갱신되지 않았습니다. (`APPLY_DIFF` 경로만 `document.setText`로 IDE가 직접 써서 갱신됐고, 일반 CLI 편집 흐름은 갱신 트리거가 전혀 없었습니다.)

## 해결

CLI 스트림에서 편집 도구(`Edit`/`Write`/`MultiEdit`/`NotebookEdit`)를 감지하고, 해당 `tool_result`가 성공한 시점(= 디스크 쓰기 완료)에 영향받은 경로를 IDE에 명시적으로 새로고침 요청합니다.

`tool_use`(편집 의도) 시점이 아니라 `tool_result`(쓰기 완료) 시점에 새로고침하므로, ask-before-edit 모드에서 "아직 안 써진 파일을 새로고침"하는 경합이 없습니다.

### 레이어별 변경

- **백엔드**: `EditedFileTracker`가 `tool_use → file_path`를 매핑하고, 성공한 `tool_result`에서 새로고침 경로를 산출(중복 제거). 스트림 핸들러에 연결. 신규 `REFRESH_FILES` Bridge 메서드 추가(브라우저 모드는 no-op).
- **Kotlin**: `REFRESH_FILES` RPC 디스패치 + 모든 `RpcHandler` 구현체에 `refreshFiles` 추가. `DiffService.refreshFiles`는 `VfsUtil.markDirtyAndRefresh`로 **비동기** VFS 새로고침(EDT 미차단). 신규 생성 파일은 부모 디렉토리 새로고침으로 발견.

## 테스트

- 백엔드: `EditedFileTracker` 단위 테스트 15건 (도구 추출, 완료 감지, 중복 제거, 실패 시 미새로고침 등)
- Kotlin: `REFRESH_FILES` 파라미터 파싱 단위 테스트 5건
- 전체 빌드(be + wv + plugin) 통과, 백엔드 283건 / Kotlin 테스트 통과

## 비고

- WebView 레이어는 이 기능에 코드 변경이 없습니다(`REFRESH_FILES`는 Node 백엔드 → Kotlin RPC 경로이며 WebView를 거치지 않음).
- `webview` 테스트 중 `useDocumentTitle > falls back to "Claude Code" when title is null` 1건이 실패하나, 이 브랜치의 변경을 모두 제외한 `main` 상태에서도 동일하게 실패하는 **기존 결함**이며 본 PR과 무관합니다.