### PR TITLE
test: align useDocumentTitle null-title test with intended behavior

### DIFF
--- a/webview/src/hooks/__tests__/useDocumentTitle.test.ts
+++ b/webview/src/hooks/__tests__/useDocumentTitle.test.ts
@@ -42,9 +42,14 @@ describe('useDocumentTitle', () => {
     expect(document.title).toBe('My Session');
   });
 
-  it('falls back to "Claude Code" when title is null', () => {
+  it('leaves the existing tab title untouched when title is null', () => {
+    // A null title means the session is still loading. The hook must NOT fall
+    // back to APP_NAME here — doing so would clobber the cached tab title the
+    // JetBrains side restores from EditorTabStateService, flashing "Claude Code"
+    // mid-load (see useDocumentTitle.ts).
+    document.title = 'Cached Session';
     renderHook(() => useDocumentTitle(null, false, SOUND_OFF, null));
-    expect(document.title).toBe('Claude Code');
+    expect(document.title).toBe('Cached Session');
   });
 
   it('calls notify(SESSION_COMPLETE) when streaming ends while hidden', () => {


### PR DESCRIPTION
## 배경

`webview` 테스트 스위트에서 `useDocumentTitle > falls back to "Claude Code" when title is null` 1건이 실패하던 사전 결함입니다. (#74 작업 중 발견)

## 원인

`useDocumentTitle`은 #73(452b5b2)에서 **의도적으로** 동작이 바뀌었습니다. title이 null일 때(세션 로딩 중) `document.title`을 건드리지 않습니다 — APP_NAME("Claude Code")으로 폴백하면 JetBrains 측이 `EditorTabStateService`에서 복원한 캐시 탭 제목을 덮어써, 로딩 중 제목이 "Claude Code"로 깜빡이기 때문입니다. (구현 주석에 명시)

그런데 이 동작을 검증하던 테스트(2026-05-25 작성)는 옛 폴백 동작을 그대로 기대한 채 남아 깨졌습니다. 실패 메시지 `expected 'My Session' to be 'Claude Code'`가 이를 보여줍니다 — 폴백하지 않아 이전 제목이 보존된 것이고, 이것이 #73이 의도한 동작입니다.

## 변경

구현이 옳고 테스트가 stale이므로, 테스트를 현재 계약에 맞게 수정합니다: **title이 null이면 기존 탭 제목을 그대로 보존**하는지 검증.

## 테스트

- `webview` 657건 전부 통과 (이전: 1 failed)
- wv-lint(tsc) 통과