### PR TITLE
fix: stop surfacing WebView console errors as IDE Internal Errors (#76)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -352,9 +352,15 @@ class ClaudeCodePanel(
                 line: Int
             ): Boolean {
                 val logPrefix = "[WebView]"
+                // WebView console messages reflect WebView runtime state (e.g. not
+                // logged in, claude CLI not found, request timeouts) — these are
+                // recoverable conditions, not plugin defects. Never route them to
+                // logger.error(), which the IDE surfaces as a fatal "Internal Error"
+                // dialog. Cap WebView errors at WARNING so they stay in the log
+                // without alarming the user. See issue #76.
                 when (level) {
                     org.cef.CefSettings.LogSeverity.LOGSEVERITY_ERROR ->
-                        logger.error("$logPrefix $message (source: $source:$line)")
+                        logger.warn("$logPrefix $message (source: $source:$line)")
                     org.cef.CefSettings.LogSeverity.LOGSEVERITY_WARNING ->
                         logger.warn("$logPrefix $message")
                     else ->


### PR DESCRIPTION
## Summary

Fixes the immediate user-facing symptom in #76: opening a second JetBrains IDE pops fatal **"Internal Error"** dialogs.

The dialogs were triggered by `ClaudeCodePanel`'s `onConsoleMessage` handler routing **every** WebView `console.error` through `logger.error()`. In IntelliJ, `Logger.error()` surfaces a fatal Internal Error dialog. But WebView console errors reflect **recoverable runtime state** — not logged in, `claude` CLI not found on PATH, RPC request timeouts — not plugin defects. The whole WebView (React) layer uses `console.error` as standard diagnostic logging, so this was a category error that mis-reported normal conditions as fatal bugs.

## Change

Cap WebView console errors at `WARNING`. They stay in the log for diagnostics without alarming the user. User-facing error state is already handled separately via `SessionState.Error` in the WebView UI, so nothing is lost.

```kotlin
LOGSEVERITY_ERROR -> logger.warn(...)   // was logger.error(...)
```

## Scope

This closes the **exception-dialog** complaint in #76. The two underlying conditions surfaced in the report are tracked as follow-ups, not regressions of this change:

- `spawn claude ENOENT` — PATH resolution for `claude`/`ccb` in multi-instance scenarios (continuation of #59).
- cross-IDE RPC routing — when two separate JVMs (e.g. WebStorm + RubyMine) share the single app-level backend, `JetBrainsBridge.getRpcClient()` picks the first connected client without distinguishing which IDE, so callbacks can be misrouted. This is the real blind spot left by the app-level backend singleton.

## Verification

`./scripts/build.sh build` — BUILD SUCCESSFUL (tests included).