### PR TITLE
fix: route RPC requests to the owning IDE when backends are shared

### DIFF
--- a/backend/src/bridge/__tests__/jetbrains-bridge-routing.test.ts
+++ b/backend/src/bridge/__tests__/jetbrains-bridge-routing.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizePathForMatch,
+  pathIsUnder,
+  extractRoutingPath,
+  selectRpcClientIndex,
+} from '../rpc-routing';
+
+describe('normalizePathForMatch', () => {
+  it('converts backslashes to forward slashes', () => {
+    expect(normalizePathForMatch('C:\\Users\\me\\proj')).toBe(
+      normalizePathForMatch('C:/Users/me/proj'),
+    );
+  });
+
+  it('strips trailing slashes', () => {
+    expect(normalizePathForMatch('/a/b/')).toBe(normalizePathForMatch('/a/b'));
+  });
+});
+
+describe('pathIsUnder', () => {
+  it('matches an exact path', () => {
+    expect(pathIsUnder('/a/b/c', '/a/b/c')).toBe(true);
+  });
+
+  it('matches a child path', () => {
+    expect(pathIsUnder('/a/b/c/file.ts', '/a/b/c')).toBe(true);
+  });
+
+  it('is segment-boundary safe (/foo does not match /foobar)', () => {
+    expect(pathIsUnder('/foobar/x', '/foo')).toBe(false);
+  });
+
+  it('does not match an unrelated path', () => {
+    expect(pathIsUnder('/x/y', '/a/b')).toBe(false);
+  });
+
+  it('treats an empty base as no match', () => {
+    expect(pathIsUnder('/a/b', '')).toBe(false);
+  });
+});
+
+describe('extractRoutingPath', () => {
+  it('prefers filePath', () => {
+    expect(extractRoutingPath({ filePath: '/a/b.ts', workingDir: '/c' })).toBe('/a/b.ts');
+  });
+
+  it('falls back to path', () => {
+    expect(extractRoutingPath({ path: '/a/b.ts' })).toBe('/a/b.ts');
+  });
+
+  it('falls back to workingDir', () => {
+    expect(extractRoutingPath({ workingDir: '/proj' })).toBe('/proj');
+  });
+
+  it('uses first entry of paths[]', () => {
+    expect(extractRoutingPath({ paths: ['/a/x.ts', '/a/y.ts'] })).toBe('/a/x.ts');
+  });
+
+  it('returns undefined when no routable key is present', () => {
+    expect(extractRoutingPath({ url: 'https://x', toolUseId: 't1' })).toBeUndefined();
+  });
+
+  it('ignores empty string values', () => {
+    expect(extractRoutingPath({ workingDir: '' })).toBeUndefined();
+  });
+});
+
+describe('selectRpcClientIndex', () => {
+  const open = (roots: string[]) => ({ roots, isOpen: true });
+
+  it('returns -1 when there are no clients', () => {
+    expect(selectRpcClientIndex([], '/a/b')).toBe(-1);
+  });
+
+  it('returns -1 when every client is closed', () => {
+    expect(selectRpcClientIndex([{ roots: ['/a'], isOpen: false }], '/a/b')).toBe(-1);
+  });
+
+  it('falls back to the first open client when no routingPath is given', () => {
+    const entries = [open(['/a']), open(['/b'])];
+    expect(selectRpcClientIndex(entries, undefined)).toBe(0);
+  });
+
+  it('routes to the client owning the path', () => {
+    const entries = [open(['/projA']), open(['/projB'])];
+    expect(selectRpcClientIndex(entries, '/projB/src/file.ts')).toBe(1);
+  });
+
+  it('skips closed clients even when they own the path', () => {
+    const entries = [
+      { roots: ['/projA'], isOpen: true },
+      { roots: ['/projB'], isOpen: false },
+    ];
+    // /projB owner is closed → fall back to first open client
+    expect(selectRpcClientIndex(entries, '/projB/x.ts')).toBe(0);
+  });
+
+  it('prefers the longest matching root (nested projects)', () => {
+    const entries = [open(['/work']), open(['/work/nested'])];
+    expect(selectRpcClientIndex(entries, '/work/nested/file.ts')).toBe(1);
+  });
+
+  it('falls back to the first open client when the path matches no root', () => {
+    const entries = [open(['/projA']), open(['/projB'])];
+    expect(selectRpcClientIndex(entries, '/elsewhere/file.ts')).toBe(0);
+  });
+
+  it('handles a client that serves multiple roots', () => {
+    const entries = [open(['/x', '/projB']), open(['/projA'])];
+    expect(selectRpcClientIndex(entries, '/projB/file.ts')).toBe(0);
+  });
+});

--- a/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
+++ b/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi } from 'vitest';
+import { JetBrainsBridge, parseProjectRoots } from '../jetbrains-bridge';
+
+type MsgHandler = (data: Buffer) => void;
+type CloseHandler = () => void;
+
+function createMockWs() {
+  const handlers: { message?: MsgHandler; close?: CloseHandler } = {};
+  const ws = {
+    readyState: 1,
+    send: vi.fn(),
+    on: vi.fn((event: string, cb: MsgHandler | CloseHandler) => {
+      if (event === 'message') handlers.message = cb as MsgHandler;
+      if (event === 'close') handlers.close = cb as CloseHandler;
+    }),
+    // test helpers
+    emitMessage: (obj: unknown) =>
+      handlers.message?.(Buffer.from(JSON.stringify(obj))),
+    emitClose: () => handlers.close?.(),
+  };
+  return ws as typeof ws & { emitMessage: (o: unknown) => void; emitClose: () => void };
+}
+
+function registerRoots(ws: ReturnType<typeof createMockWs>, roots: string[]) {
+  ws.emitMessage({ jsonrpc: '2.0', method: 'REGISTER_PROJECT_ROOTS', params: { roots } });
+}
+
+/** The JSON-RPC method name sent on the wire for a given request. */
+function sentMethod(ws: ReturnType<typeof createMockWs>): string | undefined {
+  const call = ws.send.mock.calls[0]?.[0];
+  return call ? (JSON.parse(call) as { method: string }).method : undefined;
+}
+
+describe('parseProjectRoots', () => {
+  it('extracts a string array', () => {
+    expect(parseProjectRoots({ roots: ['/a', '/b'] })).toEqual(['/a', '/b']);
+  });
+  it('drops non-string and empty entries', () => {
+    expect(parseProjectRoots({ roots: ['/a', 1, '', null] })).toEqual(['/a']);
+  });
+  it('returns [] when absent or malformed', () => {
+    expect(parseProjectRoots(undefined)).toEqual([]);
+    expect(parseProjectRoots({})).toEqual([]);
+    expect(parseProjectRoots({ roots: 'oops' })).toEqual([]);
+  });
+});
+
+describe('JetBrainsBridge cross-IDE routing', () => {
+  it('routes a request to the IDE that owns the path', async () => {
+    const bridge = new JetBrainsBridge();
+    const wsA = createMockWs();
+    const wsB = createMockWs();
+    bridge.addRpcClient(wsA as never);
+    bridge.addRpcClient(wsB as never);
+    registerRoots(wsA, ['/projA']);
+    registerRoots(wsB, ['/projB']);
+
+    const pending = bridge
+      .openDiff({ filePath: '/projB/src/x.ts', oldContent: '', newContent: '' })
+      .catch(() => {}); // request resolves only on a response; we assert the send target
+
+    expect(wsB.send).toHaveBeenCalledTimes(1);
+    expect(wsA.send).not.toHaveBeenCalled();
+    expect(sentMethod(wsB)).toBe('OPEN_DIFF');
+    await Promise.resolve();
+    void pending;
+  });
+
+  it('does not record project roots as a normal notification request', () => {
+    const bridge = new JetBrainsBridge();
+    const ws = createMockWs();
+    const handler = vi.fn();
+    bridge.onNotification('REGISTER_PROJECT_ROOTS', handler);
+    bridge.addRpcClient(ws as never);
+    registerRoots(ws, ['/projA']);
+    // The built-in interception must consume it, not the user handler.
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the remaining client after the owner disconnects', async () => {
+    const bridge = new JetBrainsBridge();
+    const wsA = createMockWs();
+    const wsB = createMockWs();
+    bridge.addRpcClient(wsA as never);
+    bridge.addRpcClient(wsB as never);
+    registerRoots(wsA, ['/projA']);
+    registerRoots(wsB, ['/projB']);
+
+    wsB.emitClose(); // owner of /projB goes away
+
+    const pending = bridge
+      .openFile('/projB/src/x.ts')
+      .catch(() => {});
+
+    // Only wsA remains open → it receives the request as a fallback.
+    expect(wsA.send).toHaveBeenCalledTimes(1);
+    expect(sentMethod(wsA)).toBe('OPEN_FILE');
+    await Promise.resolve();
+    void pending;
+  });
+
+  it('rejects when no client is connected', async () => {
+    const bridge = new JetBrainsBridge();
+    await expect(bridge.openFile('/x.ts')).rejects.toThrow(/No RPC client connected/);
+  });
+});

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -1,5 +1,12 @@
 import type { Bridge } from './bridge-interface';
 import type { WebSocket } from 'ws';
+import { extractRoutingPath, selectRpcClientIndex } from './rpc-routing';
+
+/**
+ * Notification (IDE → backend) by which each IDE host advertises the project
+ * roots it serves, so cross-IDE requests can be routed to the right client.
+ */
+const REGISTER_PROJECT_ROOTS = 'REGISTER_PROJECT_ROOTS';
 
 interface JsonRpcRequest {
   jsonrpc: '2.0';
@@ -44,6 +51,9 @@ export class JetBrainsBridge implements Bridge {
   private idCounter = 0;
   private pendingRequests = new Map<string, PendingRequest>();
   private rpcClients = new Set<WebSocket>();
+  // Project roots each IDE client serves, used to route cross-IDE requests.
+  // An entry is added on REGISTER_PROJECT_ROOTS and removed when the socket closes.
+  private clientRoots = new Map<WebSocket, string[]>();
   private notificationHandlers = new Map<string, NotificationHandler>();
 
   onNotification(method: string, handler: NotificationHandler): void {
@@ -69,6 +79,12 @@ export class JetBrainsBridge implements Bridge {
       // Notification (Kotlin → Node, no id): dispatch to registered handler.
       if (!('id' in parsed) || !parsed.id) {
         const notification = parsed as JsonRpcNotification;
+        // Built-in: an IDE advertising the project roots it serves. Handled here
+        // (not via notificationHandlers) because it is bound to *this* socket.
+        if (notification.method === REGISTER_PROJECT_ROOTS) {
+          this.clientRoots.set(ws, parseProjectRoots(notification.params));
+          return;
+        }
         const handler = this.notificationHandlers.get(notification.method);
         if (handler) {
           handler(notification.method, notification.params ?? {});
@@ -95,20 +111,29 @@ export class JetBrainsBridge implements Bridge {
 
     ws.on('close', () => {
       this.rpcClients.delete(ws);
+      this.clientRoots.delete(ws);
       console.error('[node-backend]', 'RPC client disconnected');
     });
   }
 
-  private getRpcClient(): WebSocket | null {
-    for (const client of this.rpcClients) {
-      if (client.readyState === 1) return client;
-    }
-    return null;
+  /**
+   * Pick the RPC client for an outgoing request. When several IDE hosts share
+   * this backend, [routingPath] (a file path or workingDir) selects the client
+   * whose registered project root best matches. Falls back to the first open
+   * client when there is no path or no match — preserving single-IDE behaviour.
+   */
+  private getRpcClient(routingPath?: string): WebSocket | null {
+    const clients = [...this.rpcClients];
+    const idx = selectRpcClientIndex(
+      clients.map((ws) => ({ roots: this.clientRoots.get(ws) ?? [], isOpen: ws.readyState === 1 })),
+      routingPath,
+    );
+    return idx >= 0 ? clients[idx] : null;
   }
 
   private request(method: string, params: Record<string, unknown> = {}): Promise<Record<string, unknown>> {
     return new Promise<Record<string, unknown>>((resolve, reject) => {
-      const client = this.getRpcClient();
+      const client = this.getRpcClient(extractRoutingPath(params));
       console.error('[node-backend]', `[DEBUG:bridge.request] method=${method}, rpcClients.size=${this.rpcClients.size}, client=${client ? `readyState=${client.readyState}` : 'null'}`);
       if (!client) {
         reject(new Error(`No RPC client connected — cannot send JSON-RPC request "${method}"`));
@@ -209,4 +234,14 @@ export class JetBrainsBridge implements Bridge {
     const ideRoot = result['ideRoot'];
     return typeof ideRoot === 'string' && ideRoot.length > 0 ? ideRoot : null;
   }
+}
+
+/**
+ * Extract the `roots` string array from a REGISTER_PROJECT_ROOTS notification's
+ * params, dropping any non-string entries. Returns [] when absent or malformed.
+ */
+export function parseProjectRoots(params: Record<string, unknown> | undefined): string[] {
+  const roots = params?.['roots'];
+  if (!Array.isArray(roots)) return [];
+  return roots.filter((r): r is string => typeof r === 'string' && r.length > 0);
 }

--- a/backend/src/bridge/rpc-routing.ts
+++ b/backend/src/bridge/rpc-routing.ts
@@ -1,0 +1,100 @@
+/**
+ * Routing helpers that pick the correct IDE RPC client when several IDE hosts
+ * (separate JVMs — e.g. WebStorm + RubyMine) share the single app-level Node.js
+ * backend. Each IDE registers the project roots it serves; an outgoing RPC is
+ * routed to the client whose root best matches the request's path/workingDir.
+ *
+ * Kept as pure functions so the selection logic is unit-testable without a live
+ * WebSocket. See JetBrainsBridge for the stateful wiring.
+ */
+
+// macOS and Windows file systems are case-insensitive; Linux is case-sensitive.
+const CASE_INSENSITIVE_FS = process.platform === 'darwin' || process.platform === 'win32';
+
+/**
+ * Normalize a path for prefix comparison: backslashes → forward slashes, trailing
+ * slashes trimmed, and lowercased on case-insensitive file systems.
+ */
+export function normalizePathForMatch(p: string): string {
+  const slashFixed = p.replace(/\\/g, '/').replace(/\/+$/, '');
+  return CASE_INSENSITIVE_FS ? slashFixed.toLowerCase() : slashFixed;
+}
+
+/**
+ * True if [path] equals or is nested under [base], compared at segment boundaries
+ * so that `/foo` does not match `/foobar/x`. An empty base never matches.
+ */
+export function pathIsUnder(path: string, base: string): boolean {
+  const nb = normalizePathForMatch(base);
+  if (nb === '') return false;
+  const np = normalizePathForMatch(path);
+  return np === nb || np.startsWith(nb + '/');
+}
+
+/**
+ * Pull the routable path out of a JSON-RPC request's params. Most IDE-bound
+ * methods carry one of these keys (filePath / path / workingDir / paths[]);
+ * methods that don't (OPEN_URL, PICK_FILES, UPDATE_PLUGIN…) return undefined and
+ * fall back to the first available client.
+ */
+export function extractRoutingPath(params: Record<string, unknown>): string | undefined {
+  for (const key of ['filePath', 'path', 'workingDir'] as const) {
+    const v = params[key];
+    if (typeof v === 'string' && v.length > 0) return v;
+  }
+  const paths = params['paths'];
+  if (Array.isArray(paths)) {
+    const first = paths.find((p) => typeof p === 'string' && p.length > 0);
+    if (typeof first === 'string') return first;
+  }
+  return undefined;
+}
+
+export interface RpcClientRouting {
+  roots: string[];
+  isOpen: boolean;
+}
+
+/**
+ * Choose which RPC client should receive a request.
+ *
+ * - Closed clients are never selected.
+ * - With no routingPath, the first open client is used (single-IDE behaviour).
+ * - With a routingPath, the open client whose registered root is the longest
+ *   prefix of the path wins (correct for nested projects).
+ * - If the path matches no registered root, fall back to the first open client
+ *   so a freshly-connected IDE that hasn't registered yet still works.
+ *
+ * Returns the index into [entries], or -1 when no open client exists.
+ */
+export function selectRpcClientIndex(
+  entries: RpcClientRouting[],
+  routingPath: string | undefined,
+): number {
+  let firstOpen = -1;
+  for (let i = 0; i < entries.length; i++) {
+    if (entries[i].isOpen) {
+      firstOpen = i;
+      break;
+    }
+  }
+  if (firstOpen === -1) return -1;
+  if (!routingPath) return firstOpen;
+
+  let best = -1;
+  let bestLen = -1;
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (!entry.isOpen) continue;
+    for (const root of entry.roots) {
+      if (pathIsUnder(routingPath, root)) {
+        const len = normalizePathForMatch(root).length;
+        if (len > bestLen) {
+          bestLen = len;
+          best = i;
+        }
+      }
+    }
+  }
+  return best >= 0 ? best : firstOpen;
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -21,7 +21,8 @@ import java.util.concurrent.CompletableFuture
 class RpcWebSocketClient(
     private val scope: CoroutineScope,
     private val rpcHandler: NodeProcessManager.RpcHandler,
-    private val onPersistentFailure: (() -> Unit)? = null
+    private val onPersistentFailure: (() -> Unit)? = null,
+    private val onConnected: (() -> Unit)? = null
 ) : Disposable {
 
     private val logger = Logger.getInstance(RpcWebSocketClient::class.java)
@@ -79,6 +80,14 @@ class RpcWebSocketClient(
                 webSocket = ws
                 consecutiveFailures = 0
                 logger.info("RPC WebSocket connected to port $port")
+                // Re-advertise project roots on every (re)connection so the backend
+                // can route cross-IDE requests to this host. Safe to call after the
+                // socket is assigned; reconnects re-register automatically.
+                try {
+                    onConnected?.invoke()
+                } catch (e: Exception) {
+                    logger.warn("onConnected callback failed", e)
+                }
             }
             .exceptionally { e ->
                 logger.warn("RPC WebSocket connection failed: ${e.message}")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -10,6 +10,9 @@ import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.putJsonArray
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -169,6 +172,27 @@ class NodeBackendService : Disposable {
             logger.info("Node.js backend process is dead, restarting...")
             restart()
         }
+        // Tell the backend which project roots this IDE now serves so cross-IDE
+        // requests route correctly. No-op until the RPC socket connects, after
+        // which onConnected re-sends the full set.
+        sendProjectRoots()
+    }
+
+    /**
+     * Advertise the distinct project roots this IDE host serves to the backend.
+     *
+     * When several IDEs (separate JVMs — e.g. WebStorm + RubyMine) share the one
+     * app-level Node.js backend, the backend needs to know which RPC client owns
+     * which project to route OPEN_FILE/OPEN_DIFF/etc. to the right IDE. Dropped
+     * silently when the RPC socket isn't connected yet; [RpcWebSocketClient]
+     * re-sends via its onConnected callback once (re)connected.
+     */
+    private fun sendProjectRoots() {
+        val roots = rpcHandlers.values.map { it.first }.distinct()
+        val params = buildJsonObject {
+            putJsonArray("roots") { roots.forEach { add(it) } }
+        }
+        rpcClient?.sendNotification("REGISTER_PROJECT_ROOTS", params)
     }
 
     /**
@@ -205,6 +229,9 @@ class NodeBackendService : Disposable {
         val key = "$projectBasePath::$panelId"
         rpcHandlers.remove(key)
         logger.info("Panel released: $key (remaining handlers: ${rpcHandlers.size})")
+        // Refresh the backend's view of which roots this IDE still serves so a
+        // closed project stops receiving routed requests.
+        sendProjectRoots()
         // Node.js manages its own lifecycle — no shutdown scheduling here
     }
 
@@ -271,10 +298,19 @@ class NodeBackendService : Disposable {
      */
     private fun connectRpcWebSocket(port: Int) {
         rpcClient?.dispose()
-        val client = RpcWebSocketClient(scope, CompositeRpcHandler()) {
-            // Backend seems dead — force restart
-            forceRestart()
-        }
+        val client = RpcWebSocketClient(
+            scope,
+            CompositeRpcHandler(),
+            onPersistentFailure = {
+                // Backend seems dead — force restart
+                forceRestart()
+            },
+            onConnected = {
+                // Register this IDE's project roots once the socket is up so the
+                // backend can route cross-IDE requests to the correct host.
+                sendProjectRoots()
+            },
+        )
         rpcClient = client
         client.connect(port)
         logger.info("RPC WebSocket client connecting to port $port")


### PR DESCRIPTION
## Background

Follow-up to the multi-instance investigation around #76. The app-level Node.js backend is intentionally shared across IDE hosts ("one backend per machine"). But when two **separate JVMs** — e.g. WebStorm + RubyMine running at once — connect to that one backend, the backend had no way to tell them apart.

## Problem

`JetBrainsBridge` kept every IDE's RPC socket in a `Set<WebSocket>` and `getRpcClient()` always returned the **first open one**, ignoring `projectBasePath` entirely. So a callback (open file, diff viewer, new tab, refresh) for a project owned by the *second* IDE could be delivered to the *first*, or simply time out — surfacing as the kind of `Request timeout` seen in #76.

The Kotlin-side `CompositeRpcHandler` only routes *within* a JVM; nothing routed *across* JVMs.

## Fix

- Each IDE advertises the project roots it serves via a `REGISTER_PROJECT_ROOTS` notification, sent on RPC (re)connect and whenever panels are added/removed.
- The backend records roots per socket and routes each request to the client whose registered root is the **longest prefix** of the request's `path`/`filePath`/`workingDir`.
- No path or no match → fall back to the first open client. **Single-IDE behaviour is unchanged.**

## Tests

Routing logic is extracted into pure functions (`rpc-routing.ts`):
- exact / child / nested-root (longest-prefix) matching
- segment-boundary safety (`/foo` ≠ `/foobar`)
- closed-client skipping, fallback when no match / no path

Bridge integration tests (`jetbrains-bridge.test.ts`):
- `REGISTER_PROJECT_ROOTS` is intercepted, not surfaced as a user notification
- a request reaches the socket owning its path
- routing falls back to the remaining client after the owner disconnects

## Verification

- `be-test` — 311 passed (32 files)
- `be-lint` — clean
- `be-build` — bundled OK
- `build` (plugin: Kotlin compile + tests) — BUILD SUCCESSFUL

WebView layer is untouched (backend routing + Kotlin registration only).

## Scope note

This addresses the cross-IDE RPC routing blind spot. The remaining #76 follow-up — `spawn claude ENOENT` PATH resolution in multi-instance scenarios (#59 continuation) — is tracked separately.