### PR TITLE
fix: find claude installed via migrate-installer (~/.claude/local)

### DIFF
--- a/backend/src/core/__tests__/claude-bin-paths.test.ts
+++ b/backend/src/core/__tests__/claude-bin-paths.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'path';
+import { candidateBinDirs } from '../claude-bin-paths';
+
+describe('candidateBinDirs', () => {
+  const home = '/Users/me';
+
+  it('returns [] when no home directory can be determined', () => {
+    expect(candidateBinDirs({}, 'darwin')).toEqual([]);
+  });
+
+  it('includes the claude migrate-installer location (~/.claude/local)', () => {
+    const dirs = candidateBinDirs({ HOME: home }, 'darwin');
+    expect(dirs).toContain(join(home, '.claude', 'local'));
+  });
+
+  it('ranks ~/.claude/local ahead of ~/.local/bin', () => {
+    const dirs = candidateBinDirs({ HOME: home }, 'darwin');
+    expect(dirs.indexOf(join(home, '.claude', 'local')))
+      .toBeLessThan(dirs.indexOf(join(home, '.local', 'bin')));
+  });
+
+  it('includes the common manager bin dirs on macOS', () => {
+    const dirs = candidateBinDirs({ HOME: home }, 'darwin');
+    expect(dirs).toEqual(
+      expect.arrayContaining([
+        join(home, '.local', 'bin'),
+        join(home, '.npm-global', 'bin'),
+        join(home, '.volta', 'bin'),
+        join(home, '.fnm', 'aliases', 'default', 'bin'),
+        '/usr/local/bin',
+        '/opt/homebrew/bin',
+      ]),
+    );
+  });
+
+  it('does not include unix-only dirs on Windows', () => {
+    const dirs = candidateBinDirs({ HOME: home }, 'win32');
+    expect(dirs).not.toContain('/usr/local/bin');
+    expect(dirs).not.toContain('/opt/homebrew/bin');
+  });
+
+  it('includes Windows bin dirs and still includes ~/.claude/local', () => {
+    const dirs = candidateBinDirs(
+      { HOME: home, APPDATA: 'C:\\Users\\me\\AppData\\Roaming', LOCALAPPDATA: 'C:\\Users\\me\\AppData\\Local' },
+      'win32',
+    );
+    expect(dirs).toContain(join(home, '.claude', 'local'));
+    expect(dirs).toContain(join('C:\\Users\\me\\AppData\\Roaming', 'npm'));
+    expect(dirs).toContain(join('C:\\Users\\me\\AppData\\Local', 'Volta', 'bin'));
+    expect(dirs).toContain(join(home, 'scoop', 'shims'));
+  });
+
+  it('falls back to USERPROFILE when HOME is absent', () => {
+    const dirs = candidateBinDirs({ USERPROFILE: home }, 'darwin');
+    expect(dirs).toContain(join(home, '.claude', 'local'));
+  });
+});

--- a/backend/src/core/claude-bin-paths.ts
+++ b/backend/src/core/claude-bin-paths.ts
@@ -1,0 +1,48 @@
+import { join } from 'path';
+
+/**
+ * Well-known directories where the `claude` CLI (and other tools the backend
+ * spawns) may live. An IDE launched from the GUI inherits a minimal PATH that
+ * often omits these, so they are prepended to the spawn PATH in claude.ts.
+ *
+ * Pure and parameterised over env/platform so the set is unit-testable without
+ * touching the real environment. existsSync filtering and the dynamic nvm probe
+ * stay in claude.ts (those have side effects).
+ *
+ * Note: `~/.claude/local` is the location used by `claude migrate-installer`.
+ * The official installer points the user's shell alias there, but a GUI-spawned
+ * backend can't see shell aliases — without this entry, `spawn claude` fails
+ * with ENOENT for the (very common) migrated install. See issue #76.
+ */
+export function candidateBinDirs(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string[] {
+  const home = env.HOME ?? env.USERPROFILE ?? '';
+  if (!home) return [];
+
+  const dirs: string[] = [
+    join(home, '.claude', 'local'),                  // claude migrate-installer
+    join(home, '.local', 'bin'),                     // pipx / manual / claude install.sh
+    join(home, '.npm-global', 'bin'),                // npm global (custom prefix)
+    join(home, '.volta', 'bin'),                     // volta
+    join(home, '.fnm', 'aliases', 'default', 'bin'), // fnm
+  ];
+
+  if (platform === 'win32') {
+    const appData = env.APPDATA ?? join(home, 'AppData', 'Roaming');
+    const localAppData = env.LOCALAPPDATA ?? join(home, 'AppData', 'Local');
+    dirs.push(
+      join(appData, 'npm'),                // npm global install default on Windows
+      join(localAppData, 'Volta', 'bin'),  // volta (Windows)
+      join(home, 'scoop', 'shims'),        // scoop
+    );
+  } else {
+    dirs.push(
+      '/usr/local/bin',                    // macOS default / homebrew (Intel)
+      '/opt/homebrew/bin',                 // homebrew (Apple Silicon)
+    );
+  }
+
+  return dirs;
+}

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -9,6 +9,7 @@ import {
 import { existsSync } from 'fs';
 import { join, delimiter, resolve } from 'path';
 import { readSettingsFile } from './features/settings';
+import { candidateBinDirs } from './claude-bin-paths';
 
 export class Claude {
   private static augmentedPath: string = Claude.buildAugmentedPath();
@@ -85,26 +86,7 @@ export class Claude {
     const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
     if (!home) return basePath;
 
-    const extraDirs: string[] = [
-      join(home, '.local', 'bin'),          // pipx / manual installs
-      join(home, '.npm-global', 'bin'),     // npm global (custom prefix)
-      join(home, '.volta', 'bin'),          // volta
-      join(home, '.fnm', 'aliases', 'default', 'bin'), // fnm
-    ];
-    if (process.platform === 'win32') {
-      const appData = process.env.APPDATA ?? join(home, 'AppData', 'Roaming');
-      const localAppData = process.env.LOCALAPPDATA ?? join(home, 'AppData', 'Local');
-      extraDirs.push(
-        join(appData, 'npm'),                // npm global install default on Windows
-        join(localAppData, 'Volta', 'bin'),  // volta (Windows)
-        join(home, 'scoop', 'shims'),        // scoop
-      );
-    } else {
-      extraDirs.push(
-        '/usr/local/bin',                    // macOS default / homebrew (Intel)
-        '/opt/homebrew/bin',                 // homebrew (Apple Silicon)
-      );
-    }
+    const extraDirs: string[] = candidateBinDirs();
 
     // Add nvm current version bin if NVM_DIR is set
     const nvmDir = process.env.NVM_DIR ?? join(home, '.nvm');


### PR DESCRIPTION
## Background

Follow-up to #76 (`spawn claude ENOENT`). A GUI-launched IDE starts with a minimal PATH, so the backend prepends well-known bin directories before resolving the `claude` command (this is the #59 mechanism, plus a static augmented-PATH list).

## Problem

That candidate list omitted **`~/.claude/local`** — the directory `claude migrate-installer` installs into. The official installer then points the user's *shell alias* at it. A GUI-spawned backend can't see shell aliases, so for the (very common) migrated install, resolving the bare `claude` command failed with `ENOENT` — matching the #76 report.

## Fix

- Add `~/.claude/local` to the candidate bin dirs, ranked **ahead of** `~/.local/bin` so a migrated install wins.
- Extract the path-candidate logic into a pure, parameterised function (`claude-bin-paths.ts`). It was previously untestable because it ran at class-load time inside `Claude`. `existsSync` filtering and the dynamic nvm probe stay in `claude.ts`.
- Every other directory is unchanged, so existing installs resolve exactly as before.

## Tests

`claude-bin-paths.test.ts` covers: `~/.claude/local` present and ranked ahead of `~/.local/bin`, the macOS manager dirs, Windows dirs (and no unix-only dirs on win32), `USERPROFILE` fallback, and the empty-home case.

## Verification

- `be-test` — 290 passed (31 files), incl. new bin-paths tests; existing `claude.test.ts` unaffected
- `be-lint` — clean
- `be-build` — bundled OK

Backend-only change (Kotlin/WebView untouched).

## Scope note

This addresses the `claude` PATH miss. The other #76 symptom — `GET_USAGE` timeout — has a different cause (ccb runs through an interactive login shell, `$SHELL -l -i -c`, whose slow startup can exceed the request timeout) and is tracked separately.