### PR TITLE
fix: detect out-of-process JCEF via CefApp, not a system property (#79)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -35,6 +35,24 @@ internal fun indexOfReusableHolder(panelRefCounts: List<Int>): Int? =
     panelRefCounts.indexOfFirst { shouldReleasePooledBrowser(it) }.takeIf { it >= 0 }
 
 /**
+ * Decide whether JCEF is in out-of-process ("remote") mode, given the
+ * authoritative CefApp signal and the legacy system-property fallback.
+ *
+ * [cefRemoteEnabled] is the result of `CefApp.isRemoteEnabled()` (queried via
+ * reflection, exactly as JBCefApp does internally), or null when that method
+ * can't be reached (older JCEF without it). When non-null it is authoritative;
+ * only when null do we fall back to the `jcef.remote.enabled` system property.
+ *
+ * Pure so the decision is unit-testable. Regression guard for issue #79: since
+ * 2025.1 remote mode is the default but is NOT advertised via the system
+ * property, so keying off the property alone mis-detected remote builds as
+ * in-process and forced windowed rendering, which remote mode rejects
+ * (IJPL-184288) → blank panel.
+ */
+internal fun resolveRemoteJcef(cefRemoteEnabled: Boolean?, legacySystemProperty: String?): Boolean =
+    cefRemoteEnabled ?: ("true" == legacySystemProperty)
+
+/**
  * Project-level service that pools JCEF browser instances by tabId.
  *
  * When a tab is moved or split, JetBrains disposes the FileEditor and creates
@@ -165,13 +183,20 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
         // panel has no other Swing widgets that need to overlay the browser, so
         // the z-order trade-off does not apply.
         //
-        // IntelliJ 2026.1+ runs JCEF out-of-process (remote-mode) where windowed
-        // (non-OSR) browsers are unsupported; setOffScreenRendering(false) is
-        // silently ignored and the browser paints as a black rectangle (issue #51,
-        // IJPL-184288). JBCefApp.isRemoteEnabled() is package-private and cannot
-        // be called from a plugin, so detect remote-mode via the JVM system
-        // property that JBCefApp sets at class-load time.
-        val isRemoteJcef = "true" == System.getProperty("jcef.remote.enabled")
+        // IntelliJ runs JCEF out-of-process (remote-mode) by default since 2025.1,
+        // where windowed (non-OSR) browsers are unsupported; setOffScreenRendering(false)
+        // makes remote mode reject the browser and the panel renders blank
+        // (issues #51/#79, IJPL-184288).
+        //
+        // Detect remote-mode the same way JBCefApp does internally — by reflectively
+        // calling CefApp.isRemoteEnabled() — instead of reading the jcef.remote.enabled
+        // system property. That property is NOT set on modern builds (remote is the
+        // silent default), so the old property check mis-detected 2025.1+/2026.1 as
+        // in-process and forced windowed rendering → blank screen (#79).
+        val isRemoteJcef = resolveRemoteJcef(
+            queryCefRemoteEnabled(),
+            System.getProperty("jcef.remote.enabled"),
+        )
         val builder = JBCefBrowser.createBuilder()
         if (!isRemoteJcef) {
             builder.setOffScreenRendering(false)
@@ -180,6 +205,20 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
         val cursorQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
         val streamingQuery = JBCefJSQuery.create(browser as JBCefBrowserBase)
         return BrowserHolder(browser, cursorQuery, streamingQuery)
+    }
+
+    /**
+     * Query out-of-process JCEF state the way JBCefApp does internally: reflectively
+     * invoke `org.cef.CefApp.isRemoteEnabled()`. Returns the boolean result, or null
+     * when the class/method is unavailable (older JCEF) so the caller can fall back
+     * to the legacy system-property signal. Reflection is required because the method
+     * only exists on recent JCEF builds and isn't exposed by the platform API.
+     */
+    private fun queryCefRemoteEnabled(): Boolean? = try {
+        val method = Class.forName("org.cef.CefApp").getMethod("isRemoteEnabled")
+        method.invoke(null) as? Boolean
+    } catch (_: Throwable) {
+        null
     }
 
     /**

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ResolveRemoteJcefTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ResolveRemoteJcefTest.kt
@@ -1,0 +1,54 @@
+package com.github.yhk1038.claudecodegui.services
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [resolveRemoteJcef], which decides whether JCEF is running in
+ * out-of-process ("remote") mode so the browser holder can avoid forcing
+ * windowed (non-OSR) rendering.
+ *
+ * Regression guard for issue #79: PyCharm 2026.1.3 RC2 (and every 2025.1+
+ * build) runs JCEF out-of-process by default, but does NOT signal it via the
+ * `jcef.remote.enabled` system property — JBCefApp itself detects remote mode
+ * by reflectively calling `CefApp.isRemoteEnabled()`. The old code keyed off the
+ * system property alone, mis-detected remote builds as in-process, forced
+ * `setOffScreenRendering(false)`, and remote mode rejected windowed rendering
+ * (IJPL-184288) → blank panel.
+ *
+ * The rule: trust the CefApp signal when available; only fall back to the legacy
+ * system property when CefApp can't be queried (older JCEF without the method).
+ */
+class ResolveRemoteJcefTest {
+
+    @Test
+    fun `trusts CefApp when it reports remote enabled`() {
+        assertTrue(resolveRemoteJcef(cefRemoteEnabled = true, legacySystemProperty = null))
+    }
+
+    @Test
+    fun `trusts CefApp when it reports remote disabled`() {
+        assertFalse(resolveRemoteJcef(cefRemoteEnabled = false, legacySystemProperty = null))
+    }
+
+    @Test
+    fun `CefApp signal overrides a stale system property`() {
+        // Property says "true" but CefApp authoritatively says not remote.
+        assertFalse(resolveRemoteJcef(cefRemoteEnabled = false, legacySystemProperty = "true"))
+    }
+
+    @Test
+    fun `falls back to the system property when CefApp cannot be queried`() {
+        assertTrue(resolveRemoteJcef(cefRemoteEnabled = null, legacySystemProperty = "true"))
+    }
+
+    @Test
+    fun `fallback treats a missing property as not remote`() {
+        assertFalse(resolveRemoteJcef(cefRemoteEnabled = null, legacySystemProperty = null))
+    }
+
+    @Test
+    fun `fallback treats a non-true property as not remote`() {
+        assertFalse(resolveRemoteJcef(cefRemoteEnabled = null, legacySystemProperty = "false"))
+    }
+}


### PR DESCRIPTION
Closes #79.

## Symptom

On PyCharm 2026.1.3 RC2 the plugin panel renders blank — "starting backend" → "cleaning up skeletons" → empty window — while the backend is healthy (localhost:19836 works in a browser). The reporter correctly narrowed it to a JCEF rendering issue.

## Root cause

`ClaudeCodeBrowserService.createHolder` detected remote (out-of-process) JCEF by reading the `jcef.remote.enabled` **system property**:

```kotlin
val isRemoteJcef = "true" == System.getProperty("jcef.remote.enabled")
```

But out-of-process JCEF has been the **default since 2025.1** (IJPL-162747) and is **not advertised via that property** — JBCefApp itself detects it by reflectively calling `CefApp.isRemoteEnabled()`. So on 2025.1+/2026.1 the property is unset → we mis-detected in-process mode → called `setOffScreenRendering(false)` (windowed). Remote mode rejects windowed rendering ([IJPL-184288](https://youtrack.jetbrains.com/issue/IJPL-184288), "Can't create remote browser with Windowed_rendering"), so the browser painted nothing.

This is the same OSR/non-OSR trade-off behind #51 — the detection just stopped being correct once remote became the silent default.

## Fix

Detect remote mode the way JBCefApp does — reflectively invoke `CefApp.isRemoteEnabled()` — and only fall back to the legacy system property when that method is unavailable (older JCEF). When present, the CefApp signal is authoritative.

- Decision logic extracted into a pure, unit-tested function `resolveRemoteJcef(cefRemoteEnabled, legacySystemProperty)`.
- Reflection isolated in a small private helper `queryCefRemoteEnabled()` returning `Boolean?` (null = unavailable → fall back).
- On remote builds we now skip `setOffScreenRendering(false)` → OSR is kept → the panel renders.

## Tests

`ResolveRemoteJcefTest` (6 cases, all green): CefApp true/false authoritative, CefApp overrides a stale property, and the system-property fallback (true / missing / non-true) when CefApp can't be queried.

## Verification

- `build` (Kotlin compile + tests) — BUILD SUCCESSFUL; `ResolveRemoteJcefTest` 6 passed / 0 failed.
- **Limitation**: a blank screen needs visual confirmation on an affected build (2026.1.x). This change fixes the detection that forced the unsupported render path; final confirmation should be done in a 2026.1 sandbox or by the reporter.