### PR TITLE
fix: render PowerShell tool with the Bash card on Windows (#84)

### DIFF
--- a/webview/src/hooks/__tests__/usePendingPermissions.test.ts
+++ b/webview/src/hooks/__tests__/usePendingPermissions.test.ts
@@ -88,6 +88,29 @@ function emitBashRequest(
   });
 }
 
+/** Emit a CLI_EVENT control_request for a PowerShell tool. */
+function emitPowerShellRequest(
+  emit: typeof mockEmit,
+  opts: { controlRequestId?: string; toolUseId?: string; command?: string } = {},
+) {
+  const {
+    controlRequestId = 'ctrl-ps',
+    toolUseId = 'tool-ps',
+    command = 'Get-ChildItem',
+  } = opts;
+
+  emit('CLI_EVENT', {
+    type: 'control_request',
+    request_id: controlRequestId,
+    request: {
+      subtype: 'can_use_tool',
+      tool_name: 'PowerShell',
+      tool_use_id: toolUseId,
+      input: { command },
+    },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -222,6 +245,27 @@ describe('usePendingPermissions', () => {
           result.current.deny('sig-test', 'some reason');
         });
       }).not.toThrow();
+    });
+  });
+
+  describe('PowerShell tool', () => {
+    it('treats PowerShell as a pending permission with high risk and command description', () => {
+      const { result } = renderHook(() => usePendingPermissions());
+
+      act(() => {
+        emitPowerShellRequest(mockEmit, {
+          controlRequestId: 'ctrl-ps-1',
+          toolUseId: 'tool-ps-1',
+          command: 'Get-Process | Where-Object CPU -gt 100',
+        });
+      });
+
+      expect(result.current.pending).not.toBeNull();
+      expect(result.current.pending?.toolName).toBe('PowerShell');
+      expect(result.current.pending?.riskLevel).toBe('high');
+      expect(result.current.pending?.description).toBe(
+        'Execute: Get-Process | Where-Object CPU -gt 100',
+      );
     });
   });
 

--- a/webview/src/hooks/usePendingPermissions.ts
+++ b/webview/src/hooks/usePendingPermissions.ts
@@ -16,7 +16,7 @@ export interface PendingPermission {
 }
 
 function assessRiskLevel(toolName: string, input: Record<string, unknown>): PermissionRiskLevel {
-  if (toolName === 'Bash') return 'high';
+  if (toolName === 'Bash' || toolName === 'PowerShell') return 'high';
   if (toolName === 'Write' || toolName === 'Edit') {
     const path = (input.file_path as string) || (input.path as string) || '';
     if (path.includes('/etc/') || path.includes('/System/') || path.includes('C:\\Windows\\')) {
@@ -31,6 +31,7 @@ function assessRiskLevel(toolName: string, input: Record<string, unknown>): Perm
 function generateDescription(toolName: string, input: Record<string, unknown>): string {
   switch (toolName) {
     case 'Bash':
+    case 'PowerShell':
       return `Execute: ${(input.command as string) || 'Unknown command'}`;
     case 'Write':
       return `Write file: ${(input.file_path as string) || 'Unknown'}`;

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/index.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/index.tsx
@@ -33,6 +33,7 @@ interface ToolRendererProps {
 
 export const ToolRendererMap = new Map<string, FC<ToolRendererProps>>([
     ['Bash', BashRenderer],
+    ['PowerShell', BashRenderer],
     ['TodoWrite', TodoWriteRenderer],
     ['Task', TaskRenderer],
     ['Agent', TaskRenderer],


### PR DESCRIPTION
## Summary
- Claude Code CLI 2.1 ships a separate `PowerShell` tool that replaces Bash as the primary shell on native Windows (env `CLAUDE_CODE_USE_POWERSHELL_TOOL`, statsig `tengu_cobalt_ridge`). The webview only knew about `Bash`, so PowerShell tool calls fell through to the generic fallback card showing "PowerShell unknown" (see #84).
- Verified by extracting the tool definition from the 2.1.169 native binary: `name: "PowerShell"`, `userFacingName: "PowerShell"`, and the `inputSchema` is **identical** to Bash (`command` / `description?` / `timeout?` / `run_in_background?` / `dangerouslyDisableSandbox?`). Reuse `BashRenderer` as-is; the header label comes from `props.toolUse.name` so it correctly renders "PowerShell".
- Extend `usePendingPermissions` so the permission banner classifies PowerShell as `high` risk and produces the `Execute: <command>` description instead of the `Use tool: PowerShell` fallback.

## Test plan
- [x] `bash ./scripts/build.sh wv-lint`
- [x] `bash ./scripts/build.sh wv-test` (660/660 incl. new PowerShell case)
- [ ] Manual: on Windows with `CLAUDE_CODE_USE_POWERSHELL_TOOL=1`, request a PowerShell command and confirm the tool card shows the command + output and the permission banner shows `Execute: ...`

Closes #84