### PR TITLE
fix: stop auto-scroll from pinning the view to the bottom (#87)

### DIFF
--- a/webview/src/hooks/__tests__/useStaticDocumentTitle.test.ts
+++ b/webview/src/hooks/__tests__/useStaticDocumentTitle.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useStaticDocumentTitle } from '../useStaticDocumentTitle';
+
+describe('useStaticDocumentTitle', () => {
+  it('sets document.title to the given value on mount', () => {
+    renderHook(() => useStaticDocumentTitle('Settings'));
+    expect(document.title).toBe('Settings');
+  });
+
+  it('updates document.title when the value changes', () => {
+    const { rerender } = renderHook(
+      ({ title }) => useStaticDocumentTitle(title),
+      { initialProps: { title: 'Settings' } },
+    );
+    expect(document.title).toBe('Settings');
+
+    rerender({ title: 'Appearance' });
+    expect(document.title).toBe('Appearance');
+  });
+
+  it('does nothing for an empty title (keeps the existing one)', () => {
+    document.title = 'Existing';
+    renderHook(() => useStaticDocumentTitle(''));
+    expect(document.title).toBe('Existing');
+  });
+});

--- a/webview/src/hooks/index.ts
+++ b/webview/src/hooks/index.ts
@@ -6,6 +6,7 @@ export { useTools } from './useTools';
 export { useTheme } from './useTheme';
 export { useContext } from './useContext';
 export { useDocumentTitle } from './useDocumentTitle';
+export { useStaticDocumentTitle } from './useStaticDocumentTitle';
 export { useAwaitingNotifications } from './useAwaitingNotifications';
 export type { LoadedMessage } from './useChatStream';
 export type { AttachedContext } from './useContext';

--- a/webview/src/hooks/useStaticDocumentTitle.ts
+++ b/webview/src/hooks/useStaticDocumentTitle.ts
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+
+/**
+ * Sets `document.title` to a fixed string for pages that have a stable label
+ * (e.g. Settings), as opposed to the session-driven `useDocumentTitle`.
+ *
+ * The JetBrains editor tab derives its label from the WebView's document.title
+ * (see ClaudeCodeFileEditor). Pages that never set a title leave JCEF to fall
+ * back to the raw URL as the tab label — which is how the Settings tab ended up
+ * showing "localhost:PORT/settings...". Setting a title here fixes that.
+ *
+ * An empty title is ignored so we never clobber an existing label with a blank.
+ */
+export function useStaticDocumentTitle(title: string) {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+    }
+  }, [title]);
+}

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -21,6 +21,7 @@ import { useNotificationSound } from '@/notifications';
 import {isMobile} from "@/config/environment.ts";
 import { useSettings } from '@/contexts/SettingsContext';
 import { SettingKey } from '@/types/settings';
+import { clampAutoScrollThreshold, isNearBottom, AUTO_SCROLL_THRESHOLD_DEFAULT } from '@/utils/autoScroll';
 
 export function ChatPage() {
   const { textareaRef, focus: focusInput } = useChatInputFocus();
@@ -31,7 +32,9 @@ export function ChatPage() {
   const { pending: pendingPlan, approve: approvePlan, deny: denyPlan } = usePendingPlanApproval();
   const { selection: soundSelection } = useNotificationSound();
   const { settings } = useSettings();
-  const autoScrollThreshold = settings[SettingKey.AUTO_SCROLL_THRESHOLD] ?? 80;
+  const autoScrollThreshold = clampAutoScrollThreshold(
+    settings[SettingKey.AUTO_SCROLL_THRESHOLD] ?? AUTO_SCROLL_THRESHOLD_DEFAULT,
+  );
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const bottomPanelRef = useRef<HTMLDivElement>(null);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -44,8 +47,21 @@ export function ChatPage() {
     const measure = () => {
       const s = sentinelRef.current;
       if (!s) return;
-      const rect = s.getBoundingClientRect();
-      const isNear = rect.top <= window.innerHeight + autoScrollThreshold;
+      // Anchor the near-bottom test to the top of the sticky input panel, not
+      // window.innerHeight. The sentinel sits just above the input panel, so
+      // using innerHeight adds the panel height as a hidden offset and forces
+      // the user to scroll up panelHeight + threshold before auto-follow
+      // releases (issue #87). Falling back to innerHeight only if the panel
+      // ref is not mounted yet.
+      const panel = bottomPanelRef.current;
+      const referenceBottom = panel
+        ? panel.getBoundingClientRect().top
+        : window.innerHeight;
+      const isNear = isNearBottom(
+        s.getBoundingClientRect().top,
+        referenceBottom,
+        autoScrollThreshold,
+      );
       setIsUserNearBottom(prev => (prev === isNear ? prev : isNear));
     };
     measure();

--- a/webview/src/pages/SettingsPage/Appearance/index.tsx
+++ b/webview/src/pages/SettingsPage/Appearance/index.tsx
@@ -3,6 +3,12 @@ import { useSettings } from '@/contexts/SettingsContext';
 import { SettingKey, ThemeMode } from '@/types/settings';
 import { ROUTE_META, Route } from '@/router/routes';
 import { isJetBrains } from '@/config/environment';
+import {
+  AUTO_SCROLL_THRESHOLD_DEFAULT,
+  AUTO_SCROLL_THRESHOLD_MIN,
+  AUTO_SCROLL_THRESHOLD_MAX,
+  clampAutoScrollThreshold,
+} from '@/utils/autoScroll';
 
 const NOT_SET_VALUE = '__NOT_SET__';
 
@@ -86,13 +92,14 @@ export function AppearanceSettings() {
       <SettingSection title="Scrolling">
         <SettingRow
           label="Auto-scroll threshold"
-          description="Pixel distance from the bottom within which the chat keeps following the stream. Increase to make following more forgiving when you scroll up slightly."
+          description={`Pixel distance from the bottom within which the chat keeps auto-scrolling. Scroll up past it to read freely; smaller releases sooner. Default ${AUTO_SCROLL_THRESHOLD_DEFAULT}.`}
         >
           <input
             type="number"
-            min="1"
+            min={AUTO_SCROLL_THRESHOLD_MIN}
+            max={AUTO_SCROLL_THRESHOLD_MAX}
             step="1"
-            value={isAutoScrollThresholdNotSet ? '' : (rawAutoScrollThreshold ?? 80)}
+            value={isAutoScrollThresholdNotSet ? '' : (rawAutoScrollThreshold ?? AUTO_SCROLL_THRESHOLD_DEFAULT)}
             placeholder={isAutoScrollThresholdNotSet ? 'Not set' : undefined}
             onChange={(e) => {
               const value = e.target.value;
@@ -103,8 +110,8 @@ export function AppearanceSettings() {
                 return;
               }
               const parsed = parseInt(value, 10);
-              if (!Number.isInteger(parsed) || parsed < 1) return;
-              updateSetting(SettingKey.AUTO_SCROLL_THRESHOLD, parsed);
+              if (!Number.isInteger(parsed)) return;
+              updateSetting(SettingKey.AUTO_SCROLL_THRESHOLD, clampAutoScrollThreshold(parsed));
             }}
             className={`w-24 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm ${
               isAutoScrollThresholdNotSet ? 'text-text-tertiary italic' : 'text-text-primary'

--- a/webview/src/pages/SettingsPage/index.tsx
+++ b/webview/src/pages/SettingsPage/index.tsx
@@ -1,4 +1,6 @@
 import { useRouter, Route } from '@/router';
+import { ROUTE_META } from '@/router/routes';
+import { useStaticDocumentTitle } from '@/hooks';
 import { SettingsLayout } from './SettingsLayout';
 import { GeneralSettings } from './General';
 import { AppearanceSettings } from './Appearance';
@@ -17,6 +19,11 @@ import { BrowserSettings } from './Browser';
  */
 export function SettingsPage() {
   const { route } = useRouter();
+
+  // Report a stable tab label to the IDE. Without this the JetBrains editor tab
+  // falls back to the raw URL (e.g. "localhost:PORT/settings...") because the
+  // settings screen never sets document.title.
+  useStaticDocumentTitle(ROUTE_META[Route.SETTINGS].label);
 
   const renderContent = () => {
     switch (route) {

--- a/webview/src/types/settings.ts
+++ b/webview/src/types/settings.ts
@@ -1,3 +1,5 @@
+import { AUTO_SCROLL_THRESHOLD_DEFAULT } from '@/utils/autoScroll';
+
 /**
  * 설정 키 정의 - Kotlin SettingsManager와 동기화 (settings.js 파일 기반)
  */
@@ -60,7 +62,7 @@ export const DEFAULT_SETTINGS: SettingsState = {
   [SettingKey.NODE_PATH]: null,
   [SettingKey.THEME]: ThemeMode.SYSTEM,
   [SettingKey.FONT_SIZE]: 13,
-  [SettingKey.AUTO_SCROLL_THRESHOLD]: 80,
+  [SettingKey.AUTO_SCROLL_THRESHOLD]: AUTO_SCROLL_THRESHOLD_DEFAULT,
   [SettingKey.DEBUG_MODE]: false,
   [SettingKey.LOG_LEVEL]: LogLevel.INFO,
   [SettingKey.TERMINAL_APP]: null,

--- a/webview/src/utils/__tests__/autoScroll.test.ts
+++ b/webview/src/utils/__tests__/autoScroll.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  clampAutoScrollThreshold,
+  isNearBottom,
+  AUTO_SCROLL_THRESHOLD_DEFAULT,
+  AUTO_SCROLL_THRESHOLD_MAX,
+  AUTO_SCROLL_THRESHOLD_MIN,
+} from '../autoScroll';
+
+describe('clampAutoScrollThreshold', () => {
+  it('keeps in-range values unchanged', () => {
+    expect(clampAutoScrollThreshold(80)).toBe(80);
+    expect(clampAutoScrollThreshold(200)).toBe(200);
+  });
+
+  it('caps absurdly large values (issue #87: user set 20000)', () => {
+    expect(clampAutoScrollThreshold(20000)).toBe(AUTO_SCROLL_THRESHOLD_MAX);
+  });
+
+  it('floors values below the minimum', () => {
+    expect(clampAutoScrollThreshold(0)).toBe(AUTO_SCROLL_THRESHOLD_MIN);
+    expect(clampAutoScrollThreshold(-5)).toBe(AUTO_SCROLL_THRESHOLD_MIN);
+  });
+
+  it('falls back to the default for non-finite input', () => {
+    expect(clampAutoScrollThreshold(NaN)).toBe(AUTO_SCROLL_THRESHOLD_DEFAULT);
+    expect(clampAutoScrollThreshold(Infinity)).toBe(AUTO_SCROLL_THRESHOLD_DEFAULT);
+  });
+
+  it('rounds fractional values', () => {
+    expect(clampAutoScrollThreshold(80.6)).toBe(81);
+  });
+});
+
+describe('isNearBottom', () => {
+  // referenceBottom is the top edge of the sticky input panel.
+  // When scrolled to the bottom, the sentinel sits at the panel top.
+  it('is true when the sentinel rests at the panel top', () => {
+    expect(isNearBottom(500, 500, 80)).toBe(true);
+  });
+
+  it('is true while scrolled up within the threshold', () => {
+    // scrolled up 50px -> sentinel is 50px below the panel top
+    expect(isNearBottom(550, 500, 80)).toBe(true);
+  });
+
+  it('is false once scrolled up beyond the threshold', () => {
+    expect(isNearBottom(581, 500, 80)).toBe(false);
+  });
+
+  it('regression (issue #87): input panel height must not shift the boundary', () => {
+    // Anchored to the panel top, only `threshold` governs release —
+    // the panel's own height is irrelevant. With the old window.innerHeight
+    // basis a tall panel would force the user to scroll panelHeight + threshold.
+    const panelTop = 400; // e.g. innerHeight 800 minus a 400px input panel
+    expect(isNearBottom(panelTop + 80, panelTop, 80)).toBe(true);
+    expect(isNearBottom(panelTop + 81, panelTop, 80)).toBe(false);
+  });
+});

--- a/webview/src/utils/autoScroll.ts
+++ b/webview/src/utils/autoScroll.ts
@@ -1,0 +1,38 @@
+/** Default auto-scroll threshold in pixels. */
+export const AUTO_SCROLL_THRESHOLD_DEFAULT = 80;
+/** Smallest meaningful threshold. */
+export const AUTO_SCROLL_THRESHOLD_MIN = 1;
+/**
+ * Upper bound for the threshold. The threshold is a distance from the bottom of
+ * the message list; values larger than a typical viewport make the chat follow
+ * the stream no matter where the user scrolls, which is the bug reported in
+ * issue #87 (user had set it to 20000). Cap it to keep the setting usable.
+ */
+export const AUTO_SCROLL_THRESHOLD_MAX = 1000;
+
+/** Clamp a user-supplied threshold into the supported range. */
+export function clampAutoScrollThreshold(value: number): number {
+  if (!Number.isFinite(value)) return AUTO_SCROLL_THRESHOLD_DEFAULT;
+  const rounded = Math.round(value);
+  return Math.min(AUTO_SCROLL_THRESHOLD_MAX, Math.max(AUTO_SCROLL_THRESHOLD_MIN, rounded));
+}
+
+/**
+ * Decide whether the view is "near the bottom" and should keep auto-following
+ * the stream.
+ *
+ * `referenceBottom` MUST be the top edge of the sticky input panel, NOT
+ * window.innerHeight. The sentinel element sits directly above the input panel,
+ * so anchoring to the panel top keeps `threshold` meaning a literal pixel
+ * distance from the bottom of the message list. Comparing against
+ * window.innerHeight instead adds the panel's height as a hidden offset, forcing
+ * the user to scroll up `panelHeight + threshold` before auto-follow releases
+ * (issue #87).
+ */
+export function isNearBottom(
+  sentinelTop: number,
+  referenceBottom: number,
+  threshold: number,
+): boolean {
+  return sentinelTop <= referenceBottom + threshold;
+}


### PR DESCRIPTION
## Summary

Fixes #87. The chat kept snapping back to the bottom after a response, so users could not scroll up to read the beginning of an answer. While investigating, the Settings tab was also found to show the raw URL as its tab label instead of "Settings".

## Root cause (scroll)

The near-bottom test compared the sentinel element against `window.innerHeight`, but the sentinel sits just above the sticky input panel. This added the panel's height as a hidden offset, so releasing auto-follow required scrolling up `panelHeight + threshold`. With a tall input panel even the default threshold of 80 was never enough, and the reporter only got relief by lowering it to 10.

## Changes

- **Anchor near-bottom to the input panel top** instead of `window.innerHeight`, so the threshold means a literal pixel distance from the bottom of the message list. Default 80 now behaves intuitively.
- **Clamp the setting** to `max 1000` and simplify its description, which previously nudged users to "increase" the value into the broken range (the reporter cited this wording directly).
- **Settings tab label**: add `useStaticDocumentTitle` and report "Settings" from the settings route, matching how chat tabs report their session title.

## Tests

- New `autoScroll` unit tests (clamp + panel-height regression) and `useStaticDocumentTitle` tests.
- Full suite: 672 passing, tsc clean.

## Verification

Built and ran the sandbox IDE; confirmed the view now holds position when scrolling up (with a "Scroll to bottom" button), the threshold caps at 1000, and the settings tab reads "Settings".