### PR TITLE
feat: inline session rename in the session dropdown

### DIFF
--- a/backend/src/core/features/__tests__/getSessionsList.test.ts
+++ b/backend/src/core/features/__tests__/getSessionsList.test.ts
@@ -17,21 +17,28 @@ vi.mock('../extractSessionInfo', () => ({
   extractSessionInfo: vi.fn(),
 }));
 
+vi.mock('../sessionTitleOverrides', () => ({
+  readSessionTitleOverrides: vi.fn(),
+}));
+
 import { readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { getSessionsList } from '../getSessionsList';
 import { getProjectSessionsPath } from '../getProjectSessionsPath';
 import { extractSessionInfo } from '../extractSessionInfo';
+import { readSessionTitleOverrides } from '../sessionTitleOverrides';
 
 const mockReaddir = vi.mocked(readdir);
 const mockExistsSync = vi.mocked(existsSync);
 const mockGetPath = vi.mocked(getProjectSessionsPath);
 const mockExtractInfo = vi.mocked(extractSessionInfo);
+const mockReadOverrides = vi.mocked(readSessionTitleOverrides);
 
 describe('getSessionsList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetPath.mockResolvedValue('/home/.claude/projects/-test');
+    mockReadOverrides.mockResolvedValue({});
   });
 
   it('should return empty array when sessions dir does not exist', async () => {
@@ -99,5 +106,49 @@ describe('getSessionsList', () => {
     const result = await getSessionsList('/test');
     expect(result).toHaveLength(1);
     expect(result[0].title).toBe('Good');
+  });
+
+  it('should override the title with a stored override when one exists', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddir.mockResolvedValue(['sess-1.jsonl', 'sess-2.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+    mockExtractInfo
+      .mockResolvedValueOnce({
+        title: 'Original 1',
+        lastTimestamp: '2025-01-02T00:00:00Z',
+        createdAt: '2025-01-02T00:00:00Z',
+        messageCount: 1,
+        isSidechain: false,
+      })
+      .mockResolvedValueOnce({
+        title: 'Original 2',
+        lastTimestamp: '2025-01-01T00:00:00Z',
+        createdAt: '2025-01-01T00:00:00Z',
+        messageCount: 1,
+        isSidechain: false,
+      });
+    mockReadOverrides.mockResolvedValue({ 'sess-1': 'Renamed 1' });
+
+    const result = await getSessionsList('/test');
+
+    const sess1 = result.find((s) => s.sessionId === 'sess-1');
+    const sess2 = result.find((s) => s.sessionId === 'sess-2');
+    expect(sess1?.title).toBe('Renamed 1');
+    expect(sess2?.title).toBe('Original 2');
+  });
+
+  it('should keep the original title when no override exists', async () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReaddir.mockResolvedValue(['sess-1.jsonl'] as unknown as Awaited<ReturnType<typeof readdir>>);
+    mockExtractInfo.mockResolvedValue({
+      title: 'Original',
+      lastTimestamp: '2025-01-01T00:00:00Z',
+      createdAt: '2025-01-01T00:00:00Z',
+      messageCount: 1,
+      isSidechain: false,
+    });
+    mockReadOverrides.mockResolvedValue({ 'other-session': 'Irrelevant' });
+
+    const result = await getSessionsList('/test');
+    expect(result[0].title).toBe('Original');
   });
 });

--- a/backend/src/core/features/__tests__/sessionTitleOverrides.test.ts
+++ b/backend/src/core/features/__tests__/sessionTitleOverrides.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  readSessionTitleOverrides,
+  writeSessionTitleOverride,
+  removeSessionTitleOverride,
+} from '../sessionTitleOverrides';
+
+const OVERRIDES_FILE = '.claude-code-gui-session-titles.json';
+
+describe('sessionTitleOverrides', () => {
+  let sessionsPath: string;
+
+  beforeEach(async () => {
+    sessionsPath = await mkdtemp(join(tmpdir(), 'session-titles-'));
+  });
+
+  afterEach(async () => {
+    await rm(sessionsPath, { recursive: true, force: true });
+  });
+
+  describe('readSessionTitleOverrides', () => {
+    it('returns an empty object when the overrides file does not exist', async () => {
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({});
+    });
+
+    it('returns an empty object when the file contains invalid JSON', async () => {
+      await writeFile(join(sessionsPath, OVERRIDES_FILE), 'not json', 'utf-8');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({});
+    });
+
+    it('returns an empty object when the JSON is an array', async () => {
+      await writeFile(join(sessionsPath, OVERRIDES_FILE), '["a","b"]', 'utf-8');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({});
+    });
+
+    it('filters out non-string and blank values', async () => {
+      await writeFile(
+        join(sessionsPath, OVERRIDES_FILE),
+        JSON.stringify({ a: 'Title A', b: 42, c: '   ', d: 'Title D' }),
+        'utf-8',
+      );
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({ a: 'Title A', d: 'Title D' });
+    });
+  });
+
+  describe('writeSessionTitleOverride', () => {
+    it('persists a title and reads it back', async () => {
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'My Title');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({ 'session-1': 'My Title' });
+    });
+
+    it('merges with existing overrides without dropping others', async () => {
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'First');
+      await writeSessionTitleOverride(sessionsPath, 'session-2', 'Second');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({
+        'session-1': 'First',
+        'session-2': 'Second',
+      });
+    });
+
+    it('overwrites the title for an existing session', async () => {
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'Old');
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'New');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({ 'session-1': 'New' });
+    });
+
+    it('creates the sessions directory if it is missing', async () => {
+      const nested = join(sessionsPath, 'does', 'not', 'exist');
+      await writeSessionTitleOverride(nested, 'session-1', 'Nested');
+      expect(await readSessionTitleOverrides(nested)).toEqual({ 'session-1': 'Nested' });
+    });
+  });
+
+  describe('removeSessionTitleOverride', () => {
+    it('removes an existing override', async () => {
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'First');
+      await writeSessionTitleOverride(sessionsPath, 'session-2', 'Second');
+      await removeSessionTitleOverride(sessionsPath, 'session-1');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({ 'session-2': 'Second' });
+    });
+
+    it('is a no-op when the session has no override', async () => {
+      await writeSessionTitleOverride(sessionsPath, 'session-1', 'First');
+      await removeSessionTitleOverride(sessionsPath, 'unknown');
+      expect(await readSessionTitleOverrides(sessionsPath)).toEqual({ 'session-1': 'First' });
+    });
+
+    it('does not throw when the overrides file is missing', async () => {
+      await expect(removeSessionTitleOverride(sessionsPath, 'whatever')).resolves.toBeUndefined();
+    });
+  });
+});

--- a/backend/src/core/features/getSessionsList.ts
+++ b/backend/src/core/features/getSessionsList.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { extractSessionInfo, type SessionInfo } from './extractSessionInfo';
 import { getProjectSessionsPath } from './getProjectSessionsPath';
+import { readSessionTitleOverrides } from './sessionTitleOverrides';
 
 export type SessionListEntry = SessionInfo & { sessionId: string };
 
@@ -62,6 +63,16 @@ export async function getSessionsList(workingDir: string): Promise<SessionListEn
     });
 
     const sessions = maybeSessions.filter((s): s is SessionListEntry => s !== null);
+
+    // Apply user-specified title overrides. The CLI-derived title is preserved as
+    // the source of truth; an override only replaces what the user explicitly renamed.
+    const overrides = await readSessionTitleOverrides(sessionsPath);
+    for (const session of sessions) {
+      const override = overrides[session.sessionId];
+      if (override) {
+        session.title = override;
+      }
+    }
 
     // Sort by lastTimestamp descending
     sessions.sort((a, b) => {

--- a/backend/src/core/features/sessionTitleOverrides.ts
+++ b/backend/src/core/features/sessionTitleOverrides.ts
@@ -1,0 +1,45 @@
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { join } from 'path';
+
+const OVERRIDES_FILE = '.claude-code-gui-session-titles.json';
+
+type TitleOverrides = Record<string, string>;
+
+function getOverridesFile(sessionsPath: string): string {
+  return join(sessionsPath, OVERRIDES_FILE);
+}
+
+export async function readSessionTitleOverrides(sessionsPath: string): Promise<TitleOverrides> {
+  try {
+    const raw = await readFile(getOverridesFile(sessionsPath), 'utf-8');
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>)
+        .filter(([, value]) => typeof value === 'string' && value.trim().length > 0)
+    ) as TitleOverrides;
+  } catch {
+    return {};
+  }
+}
+
+export async function writeSessionTitleOverride(
+  sessionsPath: string,
+  sessionId: string,
+  title: string,
+): Promise<void> {
+  await mkdir(sessionsPath, { recursive: true });
+  const overrides = await readSessionTitleOverrides(sessionsPath);
+  overrides[sessionId] = title;
+  await writeFile(getOverridesFile(sessionsPath), JSON.stringify(overrides, null, 2), 'utf-8');
+}
+
+export async function removeSessionTitleOverride(
+  sessionsPath: string,
+  sessionId: string,
+): Promise<void> {
+  const overrides = await readSessionTitleOverrides(sessionsPath);
+  if (!(sessionId in overrides)) return;
+  delete overrides[sessionId];
+  await writeFile(getOverridesFile(sessionsPath), JSON.stringify(overrides, null, 2), 'utf-8');
+}

--- a/backend/src/core/handlers/__tests__/deleteSession.test.ts
+++ b/backend/src/core/handlers/__tests__/deleteSession.test.ts
@@ -8,15 +8,21 @@ vi.mock('../../features/getProjectSessionsPath', () => ({
   getProjectSessionsPath: vi.fn(),
 }));
 
+vi.mock('../../features/sessionTitleOverrides', () => ({
+  removeSessionTitleOverride: vi.fn(),
+}));
+
 import { unlink } from 'fs/promises';
 import { deleteSessionHandler } from '../deleteSession';
 import { getProjectSessionsPath } from '../../features/getProjectSessionsPath';
+import { removeSessionTitleOverride } from '../../features/sessionTitleOverrides';
 import type { ConnectionManager } from '../../../ws/connection-manager';
 import type { Bridge } from '../../../bridge/bridge-interface';
 import type { IPCMessage } from '../../types';
 
 const mockUnlink = vi.mocked(unlink);
 const mockGetPath = vi.mocked(getProjectSessionsPath);
+const mockRemoveOverride = vi.mocked(removeSessionTitleOverride);
 
 function createMockConnections() {
   return {
@@ -110,6 +116,7 @@ describe('deleteSessionHandler', () => {
     await deleteSessionHandler('conn-1', message, connections, mockBridge);
 
     expect(mockUnlink).toHaveBeenCalled();
+    expect(mockRemoveOverride).toHaveBeenCalledWith('/home/user/.claude/projects/-test', 'abc123');
     expect(connections.broadcastToAll).toHaveBeenCalledWith('SESSIONS_UPDATED', {
       action: 'delete',
       session: { sessionId: 'abc123' },

--- a/backend/src/core/handlers/__tests__/renameSession.test.ts
+++ b/backend/src/core/handlers/__tests__/renameSession.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock('../../features/getProjectSessionsPath', () => ({
+  getProjectSessionsPath: vi.fn(),
+}));
+
+vi.mock('../../features/sessionTitleOverrides', () => ({
+  writeSessionTitleOverride: vi.fn(),
+}));
+
+import { existsSync } from 'fs';
+import { renameSessionHandler } from '../renameSession';
+import { getProjectSessionsPath } from '../../features/getProjectSessionsPath';
+import { writeSessionTitleOverride } from '../../features/sessionTitleOverrides';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+const mockExistsSync = vi.mocked(existsSync);
+const mockGetPath = vi.mocked(getProjectSessionsPath);
+const mockWriteOverride = vi.mocked(writeSessionTitleOverride);
+
+function createMockConnections() {
+  return {
+    sendTo: vi.fn(),
+    broadcastToAll: vi.fn(),
+  } as unknown as ConnectionManager;
+}
+
+const mockBridge = {} as Bridge;
+
+describe('renameSessionHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPath.mockResolvedValue('/home/user/.claude/projects/-test');
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  it('returns an error when sessionId is missing', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { title: 'New', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when title is missing or blank', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'abc123', title: '   ', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when workingDir is missing', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'abc123', title: 'New' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects path traversal with .. in sessionId', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: '../../../etc/passwd', title: 'New', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+      error: 'Invalid sessionId',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('rejects sessionId with a path separator', async () => {
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'subdir/file', title: 'New', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+      error: 'Invalid sessionId',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when the session file does not exist', async () => {
+    const connections = createMockConnections();
+    mockExistsSync.mockReturnValue(false);
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'abc123', title: 'New', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+      error: 'Session not found',
+    }));
+    expect(mockWriteOverride).not.toHaveBeenCalled();
+  });
+
+  it('persists the title, broadcasts the rename, and acks ok for a valid request', async () => {
+    const connections = createMockConnections();
+    mockWriteOverride.mockResolvedValue(undefined);
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'abc123', title: '  My Renamed Session  ', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(mockWriteOverride).toHaveBeenCalledWith(
+      '/home/user/.claude/projects/-test',
+      'abc123',
+      'My Renamed Session',
+    );
+    expect(connections.broadcastToAll).toHaveBeenCalledWith('SESSIONS_UPDATED', {
+      action: 'rename',
+      session: { sessionId: 'abc123', title: 'My Renamed Session' },
+    });
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'ok',
+    }));
+  });
+
+  it('returns an error when persistence throws', async () => {
+    const connections = createMockConnections();
+    mockWriteOverride.mockRejectedValue(new Error('disk full'));
+    const message: IPCMessage = {
+      type: 'RENAME_SESSION',
+      payload: { sessionId: 'abc123', title: 'New', workingDir: '/test' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await renameSessionHandler('conn-1', message, connections, mockBridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', expect.objectContaining({
+      status: 'error',
+      error: 'disk full',
+    }));
+  });
+});

--- a/backend/src/core/handlers/deleteSession.ts
+++ b/backend/src/core/handlers/deleteSession.ts
@@ -1,5 +1,5 @@
 import { unlink } from 'fs/promises';
-import { join, resolve, basename } from 'path';
+import { resolve, basename, relative, isAbsolute } from 'path';
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
@@ -47,8 +47,11 @@ export async function deleteSessionHandler(
     const sessionsDir = await getProjectSessionsPath(workingDir);
     const sessionFile = resolve(sessionsDir, `${sessionId}.jsonl`);
 
-    // Ensure resolved path stays within sessionsDir
-    if (!sessionFile.startsWith(resolve(sessionsDir) + '/')) {
+    // Ensure the resolved path stays within sessionsDir. Compare via path.relative
+    // rather than a hardcoded "/" separator so the check holds on Windows too
+    // (matches the guard in renameSession).
+    const relativeSessionFile = relative(resolve(sessionsDir), sessionFile);
+    if (relativeSessionFile.startsWith('..') || isAbsolute(relativeSessionFile)) {
       connections.sendTo(connectionId, 'ACK', {
         requestId: message.requestId,
         status: 'error',

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -10,6 +10,7 @@ import { toolResponseHandler } from './toolResponse';
 import { getSessionsHandler } from './getSessions';
 import { loadSessionHandler } from './loadSession';
 import { deleteSessionHandler } from './deleteSession';
+import { renameSessionHandler } from './renameSession';
 import { getSettingsHandler } from './getSettings';
 import { saveSettingsHandler } from './saveSettings';
 import { getProjectsHandler } from './getProjects';
@@ -86,6 +87,9 @@ export async function handleMessage(
       break;
     case 'DELETE_SESSION':
       await deleteSessionHandler(connectionId, message, connections, bridge);
+      break;
+    case 'RENAME_SESSION':
+      await renameSessionHandler(connectionId, message, connections, bridge);
       break;
     case 'GET_SETTINGS':
       await getSettingsHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/renameSession.ts
+++ b/backend/src/core/handlers/renameSession.ts
@@ -1,30 +1,31 @@
-import { unlink } from 'fs/promises';
-import { join, resolve, basename } from 'path';
+import { existsSync } from 'fs';
+import { basename, isAbsolute, relative, resolve } from 'path';
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { getProjectSessionsPath } from '../features/getProjectSessionsPath';
-import { removeSessionTitleOverride } from '../features/sessionTitleOverrides';
+import { writeSessionTitleOverride } from '../features/sessionTitleOverrides';
 
-export async function deleteSessionHandler(
+export async function renameSessionHandler(
   connectionId: string,
   message: IPCMessage,
   connections: ConnectionManager,
   _bridge: Bridge,
 ): Promise<void> {
   const sessionId = message.payload?.sessionId as string | undefined;
+  const title = (message.payload?.title as string | undefined)?.trim();
+  const workingDir = message.payload?.workingDir as string | undefined;
 
-  if (!sessionId) {
+  if (!sessionId || !title || !workingDir) {
     connections.sendTo(connectionId, 'ACK', {
       requestId: message.requestId,
       status: 'error',
-      error: 'Missing sessionId',
+      error: 'sessionId, title, and workingDir are required',
     });
     return;
   }
 
   try {
-    // Validate sessionId to prevent path traversal (must be a simple filename component)
     if (sessionId !== basename(sessionId) || sessionId.includes('..')) {
       connections.sendTo(connectionId, 'ACK', {
         requestId: message.requestId,
@@ -34,38 +35,23 @@ export async function deleteSessionHandler(
       return;
     }
 
-    const workingDir = message.payload?.workingDir as string | undefined;
-    if (!workingDir) {
-      connections.sendTo(connectionId, 'ACK', {
-        requestId: message.requestId,
-        status: 'error',
-        error: 'workingDir is required',
-      });
-      return;
-    }
-
     const sessionsDir = await getProjectSessionsPath(workingDir);
     const sessionFile = resolve(sessionsDir, `${sessionId}.jsonl`);
-
-    // Ensure resolved path stays within sessionsDir
-    if (!sessionFile.startsWith(resolve(sessionsDir) + '/')) {
+    const relativeSessionFile = relative(resolve(sessionsDir), sessionFile);
+    if (relativeSessionFile.startsWith('..') || isAbsolute(relativeSessionFile) || !existsSync(sessionFile)) {
       connections.sendTo(connectionId, 'ACK', {
         requestId: message.requestId,
         status: 'error',
-        error: 'Invalid sessionId',
+        error: 'Session not found',
       });
       return;
     }
 
-    await unlink(sessionFile);
-
-    // Drop any stored title override so a future session reusing this id does not
-    // inherit a stale custom title.
-    await removeSessionTitleOverride(sessionsDir, sessionId);
+    await writeSessionTitleOverride(sessionsDir, sessionId, title);
 
     connections.broadcastToAll('SESSIONS_UPDATED', {
-      action: 'delete',
-      session: { sessionId },
+      action: 'rename',
+      session: { sessionId, title },
     });
 
     connections.sendTo(connectionId, 'ACK', { requestId: message.requestId, status: 'ok' });

--- a/webview/src/api/modules/SessionsApi.ts
+++ b/webview/src/api/modules/SessionsApi.ts
@@ -75,6 +75,15 @@ export class SessionsApi {
   }
 
   /**
+   * Rename a session (persists a user-specified title override)
+   * PATCH /sessions/:id
+   */
+  async rename(sessionId: string, title: string, workingDir?: string): Promise<void> {
+    const dir = workingDir ?? this.getConfig().workingDir;
+    await this.bridge.request('RENAME_SESSION', { sessionId, title, workingDir: dir });
+  }
+
+  /**
    * Activate (switch to) a session
    * POST /sessions/:id/activate
    */

--- a/webview/src/contexts/SessionContext.tsx
+++ b/webview/src/contexts/SessionContext.tsx
@@ -41,7 +41,7 @@ interface SessionContextValue {
   openSettings: () => void;
   switchSession: (sessionId: string) => void;
   deleteSession: (sessionId: string) => Promise<void>;
-  renameSession: (sessionId: string, title: string) => void;
+  renameSession: (sessionId: string, title: string) => Promise<void>;
   addNewSession: (sessionId: string, firstPrompt: string) => void;
   setSessionState: (state: SessionState) => void;
   setWorkingDirectory: (dir: string | null) => void;
@@ -179,8 +179,14 @@ export function SessionProvider({ children }: SessionProviderProps) {
   // Subscribe to SESSIONS_UPDATED for cross-tab session list sync
   useEffect(() => {
     const unsubscribe = subscribe('SESSIONS_UPDATED', (message) => {
-      const { action, session } = message.payload as { action: string; session: { sessionId: string } };
-      if (action === 'upsert' && session?.sessionId) {
+      const { action, session } = message.payload as { action: string; session: { sessionId: string; title?: string } };
+      if (action === 'rename' && session?.sessionId && session.title) {
+        setSessions(prev => prev.map(s =>
+          s.id === session.sessionId
+            ? Object.assign(Object.create(Object.getPrototypeOf(s)), s, { title: session.title })
+            : s
+        ));
+      } else if (action === 'upsert' && session?.sessionId) {
         setSessions(prev => {
           const exists = prev.find(s => s.id === session.sessionId);
           if (exists) {
@@ -246,13 +252,24 @@ export function SessionProvider({ children }: SessionProviderProps) {
     }
   }, [currentSessionId, api.sessions, navigateToNewSession, workingDirectory]);
 
-  const renameSession = useCallback((sessionId: string, title: string) => {
+  const renameSession = useCallback(async (sessionId: string, title: string) => {
+    const trimmed = title.trim();
+    if (!trimmed) return;
+
+    // Optimistic update so the new title shows immediately; the backend
+    // persists the override and broadcasts SESSIONS_UPDATED to other tabs.
     setSessions(prev => prev.map(s =>
       s.id === sessionId
-        ? { ...s, title, updatedAt: new Date() }
+        ? Object.assign(Object.create(Object.getPrototypeOf(s)), s, { title: trimmed })
         : s
     ));
-  }, []);
+
+    try {
+      await api.sessions.rename(sessionId, trimmed, workingDirectory ?? undefined);
+    } catch (error) {
+      console.error('[SessionContext] Failed to rename session:', error);
+    }
+  }, [api.sessions, workingDirectory]);
 
   const addNewSession = useCallback((sessionId: string, firstPrompt: string) => {
     const now = new Date();

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/DropdownMenu.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/DropdownMenu.tsx
@@ -10,6 +10,7 @@ interface Props {
   currentSessionId: string | null;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
+  onRenameSession: (sessionId: string, title: string) => void;
 }
 
 export function DropdownMenu(props: Props) {
@@ -21,6 +22,7 @@ export function DropdownMenu(props: Props) {
     currentSessionId,
     onSelectSession,
     onDeleteSession,
+    onRenameSession,
   } = props;
 
   return (
@@ -33,6 +35,7 @@ export function DropdownMenu(props: Props) {
           currentSessionId={currentSessionId}
           onSelectSession={onSelectSession}
           onDeleteSession={onDeleteSession}
+          onRenameSession={onRenameSession}
         />
       ) : (
         <div className="px-2.5 py-3 text-xs text-text-tertiary text-center">

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/SessionItem.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/SessionItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { SessionMetaDto } from '@/dto';
 import { getRelativeTime } from './utils';
 
@@ -7,16 +7,86 @@ interface Props {
   isSelected: boolean;
   onSelect: () => void;
   onDelete: () => void;
+  onRename: (title: string) => void;
 }
 
 export function SessionItem(props: Props) {
-  const { session, isSelected, onSelect, onDelete } = props;
+  const { session, isSelected, onSelect, onDelete, onRename } = props;
   const [isHovered, setIsHovered] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [draft, setDraft] = useState(session.title);
+  const inputRef = useRef<HTMLInputElement>(null);
+  // Escape cancels editing by unmounting the input, which can fire a trailing
+  // blur. This flag tells the blur handler to skip committing in that case.
+  const skipCommitRef = useRef(false);
+
+  useEffect(() => {
+    if (isEditing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [isEditing]);
+
+  const startEditing = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    setDraft(session.title);
+    skipCommitRef.current = false;
+    setIsEditing(true);
+  };
+
+  const commit = () => {
+    if (skipCommitRef.current) {
+      skipCommitRef.current = false;
+      setIsEditing(false);
+      return;
+    }
+    const trimmed = draft.trim();
+    if (trimmed && trimmed !== session.title) {
+      onRename(trimmed);
+    }
+    setIsEditing(false);
+  };
+
+  const cancel = () => {
+    skipCommitRef.current = true;
+    setIsEditing(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      cancel();
+    }
+  };
 
   const handleDelete = (e: React.MouseEvent) => {
     e.stopPropagation();
     onDelete();
   };
+
+  if (isEditing) {
+    return (
+      <div
+        className={`w-full px-2 py-1.5 rounded flex items-center ${
+          isSelected ? 'bg-[var(--surface-selected)]' : ''
+        }`}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={commit}
+          onClick={(e) => e.stopPropagation()}
+          className="w-full bg-transparent text-xs text-text-primary outline-none border-b border-text-tertiary/40"
+        />
+      </div>
+    );
+  }
 
   return (
     <button
@@ -32,33 +102,57 @@ export function SessionItem(props: Props) {
     >
       <span className="truncate flex-1">{session.title}</span>
       {isHovered ? (
-        <span
-          role="button"
-          onClick={handleDelete}
-          className="flex-shrink-0 text-text-tertiary hover:text-state-error-fg transition-colors flex items-center justify-center"
-          title="Delete session"
-        >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+        <span className="flex-shrink-0 flex items-center gap-1.5">
+          <span
+            role="button"
+            onClick={startEditing}
+            className="text-text-tertiary hover:text-text-primary transition-colors flex items-center justify-center"
+            title="Rename session"
           >
-            <path
-              d="M1.5 3h9M4.5 3V2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v1M2.5 3l.5 7a.5.5 0 0 0 .5.5h5a.5.5 0 0 0 .5-.5l.5-7"
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            />
-            <path
-              d="M5 5.5v3M7 5.5v3"
-              stroke="currentColor"
-              strokeWidth="1"
-              strokeLinecap="round"
-            />
-          </svg>
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8.25 1.75l2 2M9.5 1.5a.7.7 0 0 1 1 1l-6 6L2 9.5l.5-2.5z"
+                stroke="currentColor"
+                strokeWidth="1"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </span>
+          <span
+            role="button"
+            onClick={handleDelete}
+            className="text-text-tertiary hover:text-state-error-fg transition-colors flex items-center justify-center"
+            title="Delete session"
+          >
+            <svg
+              width="12"
+              height="12"
+              viewBox="0 0 12 12"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M1.5 3h9M4.5 3V2a.5.5 0 0 1 .5-.5h2a.5.5 0 0 1 .5.5v1M2.5 3l.5 7a.5.5 0 0 0 .5.5h5a.5.5 0 0 0 .5-.5l.5-7"
+                stroke="currentColor"
+                strokeWidth="1"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M5 5.5v3M7 5.5v3"
+                stroke="currentColor"
+                strokeWidth="1"
+                strokeLinecap="round"
+              />
+            </svg>
+          </span>
         </span>
       ) : session.updatedAt ? (
         <span className="flex-shrink-0 text-[0.8461rem] text-text-tertiary">

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/SessionList.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/SessionList.tsx
@@ -6,10 +6,11 @@ interface Props {
   currentSessionId: string | null;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
+  onRenameSession: (sessionId: string, title: string) => void;
 }
 
 export function SessionList(props: Props) {
-  const { groupedSessions, currentSessionId, onSelectSession, onDeleteSession } = props;
+  const { groupedSessions, currentSessionId, onSelectSession, onDeleteSession, onRenameSession } = props;
 
   return (
     <div className="max-h-80 overflow-y-auto p-1.5 pt-0 flex flex-col gap-0.5">
@@ -29,6 +30,7 @@ export function SessionList(props: Props) {
                 isSelected={session.id === currentSessionId}
                 onSelect={() => onSelectSession(session.id)}
                 onDelete={() => onDeleteSession(session.id)}
+                onRename={(title) => onRenameSession(session.id, title)}
               />
             ))}
           </div>

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/__tests__/SessionItem.test.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/__tests__/SessionItem.test.tsx
@@ -18,96 +18,142 @@ const createMockSession = (overrides: Partial<SessionMetaDto> = {}): SessionMeta
 describe('SessionItem', () => {
   let onSelect: ReturnType<typeof vi.fn>;
   let onDelete: ReturnType<typeof vi.fn>;
+  let onRename: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     onSelect = vi.fn();
     onDelete = vi.fn();
+    onRename = vi.fn();
   });
 
-  it('renders the session title', () => {
-    const session = createMockSession({ title: 'My Session' });
-
+  const renderItem = (session: SessionMetaDto, isSelected = false) =>
     render(
       <SessionItem
         session={session}
-        isSelected={false}
+        isSelected={isSelected}
         onSelect={onSelect}
         onDelete={onDelete}
+        onRename={onRename}
       />
     );
 
+  it('renders the session title', () => {
+    renderItem(createMockSession({ title: 'My Session' }));
     expect(screen.getByText('My Session')).toBeDefined();
   });
 
   it('calls onSelect when the button is clicked', () => {
-    const session = createMockSession();
-
-    render(
-      <SessionItem
-        session={session}
-        isSelected={false}
-        onSelect={onSelect}
-        onDelete={onDelete}
-      />
-    );
-
+    renderItem(createMockSession());
     fireEvent.click(screen.getByRole('button', { name: /Test Session/i }));
-
     expect(onSelect).toHaveBeenCalledTimes(1);
   });
 
   it('shows delete button on hover', () => {
-    const session = createMockSession();
-
-    render(
-      <SessionItem
-        session={session}
-        isSelected={false}
-        onSelect={onSelect}
-        onDelete={onDelete}
-      />
-    );
-
+    renderItem(createMockSession());
     expect(screen.queryByTitle('Delete session')).toBeNull();
-
     fireEvent.mouseEnter(screen.getByRole('button', { name: /Test Session/i }));
-
     expect(screen.getByTitle('Delete session')).toBeDefined();
   });
 
   it('calls onDelete when delete button is clicked', () => {
-    const session = createMockSession();
-
-    render(
-      <SessionItem
-        session={session}
-        isSelected={false}
-        onSelect={onSelect}
-        onDelete={onDelete}
-      />
-    );
-
+    renderItem(createMockSession());
     fireEvent.mouseEnter(screen.getByRole('button', { name: /Test Session/i }));
     fireEvent.click(screen.getByTitle('Delete session'));
-
     expect(onDelete).toHaveBeenCalledTimes(1);
   });
 
   it('does not call onSelect when delete button is clicked', () => {
-    const session = createMockSession();
-
-    render(
-      <SessionItem
-        session={session}
-        isSelected={false}
-        onSelect={onSelect}
-        onDelete={onDelete}
-      />
-    );
-
+    renderItem(createMockSession());
     fireEvent.mouseEnter(screen.getByRole('button', { name: /Test Session/i }));
     fireEvent.click(screen.getByTitle('Delete session'));
-
     expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  // --- Inline rename ---
+
+  it('shows the rename button on hover', () => {
+    renderItem(createMockSession());
+    expect(screen.queryByTitle('Rename session')).toBeNull();
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Test Session/i }));
+    expect(screen.getByTitle('Rename session')).toBeDefined();
+  });
+
+  it('enters inline edit mode with the current title prefilled when rename is clicked', () => {
+    renderItem(createMockSession({ title: 'Original Title' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Original Title/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input).toBeDefined();
+    expect(input.value).toBe('Original Title');
+  });
+
+  it('does not call onSelect when the rename button is clicked', () => {
+    renderItem(createMockSession());
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Test Session/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('commits the new title with onRename when Enter is pressed', () => {
+    renderItem(createMockSession({ title: 'Old' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Old/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'New Title' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).toHaveBeenCalledWith('New Title');
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('commits the new title on blur', () => {
+    renderItem(createMockSession({ title: 'Old' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Old/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Blurred Title' } });
+    fireEvent.blur(input);
+
+    expect(onRename).toHaveBeenCalledWith('Blurred Title');
+  });
+
+  it('cancels editing without calling onRename when Escape is pressed', () => {
+    renderItem(createMockSession({ title: 'Keep Me' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Keep Me/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: 'Discarded' } });
+    fireEvent.keyDown(input, { key: 'Escape' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('does not call onRename when the title is empty or only whitespace', () => {
+    renderItem(createMockSession({ title: 'Original' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Original/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, { target: { value: '   ' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('does not call onRename when the title is unchanged', () => {
+    renderItem(createMockSession({ title: 'Same' }));
+    fireEvent.mouseEnter(screen.getByRole('button', { name: /Same/i }));
+    fireEvent.click(screen.getByTitle('Rename session'));
+
+    const input = screen.getByRole('textbox');
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onRename).not.toHaveBeenCalled();
   });
 });

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
@@ -6,7 +6,7 @@ import { useSessionContext } from '@/contexts/SessionContext';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
 
 export function SessionDropdown() {
-  const { sessions, currentSessionId, currentSession, switchSession, deleteSession } = useSessionContext();
+  const { sessions, currentSessionId, currentSession, switchSession, deleteSession, renameSession } = useSessionContext();
   const { confirmDialog, confirm } = useConfirmDialog();
   const [isOpen, setIsOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -83,6 +83,7 @@ export function SessionDropdown() {
           currentSessionId={currentSessionId}
           onSelectSession={handleSelectSession}
           onDeleteSession={handleDeleteSession}
+          onRenameSession={renameSession}
         />
       )}
 


### PR DESCRIPTION
## Summary

Brings the **session rename** feature from the stalled PR #30 onto current `main`, but rebuilt with the UI/UX we actually want: an **inline edit in the dropdown** instead of a modal dialog.

Hover a session row → a pencil icon appears to the left of the delete icon → click it to edit the title in place (Enter/blur saves, Esc cancels). The custom title is persisted on the backend and survives a refresh.

## What this does

**Backend**
- New `RENAME_SESSION` handler persists user-specified titles to `.claude-code-gui-session-titles.json` beside the CLI session files — the original Claude Code JSONL is never touched.
- `getSessionsList` merges these overrides over the CLI-derived title. *(PR #30 saved overrides but never surfaced them in the list — fixed here.)*
- `deleteSession` drops a session's override so a reused id can't inherit a stale title.

**WebView**
- Inline rename UI in `SessionItem` (pencil icon + in-place input). No modal dialog.
- `SessionsApi.rename` + `SessionContext.renameSession` now persist through the backend with an optimistic update.
- The `SESSIONS_UPDATED` handler applies the `rename` broadcast so other tabs/IDEs stay in sync.

## Relation to PR #30 / #14

- Ported the solid backend persistence from PR #30; **discarded** its `RenameSessionDialog` modal in favor of inline editing.
- Partially addresses #14 (manual rename). Auto-titling for Skill-created sessions ("No title") remains open and is tracked separately.
- This is one of the two remaining pieces of PR #30; once the ToolWindow-as-an-option work also lands, PR #30 can be closed.

## Tests

- Backend: `sessionTitleOverrides` (read/write/remove), `renameSession` handler (validation + path-traversal guards + broadcast), `getSessionsList` override merge, `deleteSession` override cleanup.
- WebView: `SessionItem` inline edit behavior (enter/blur/escape/blank/unchanged).
- All backend (345) and webview (680) tests pass; both type-check clean. No Kotlin changes — rename uses the same pure-Node path as delete.