### PR TITLE
fix: extract a meaningful title from slash-command sessions (#14)

### DIFF
--- a/backend/src/core/features/__tests__/extractSessionInfo.test.ts
+++ b/backend/src/core/features/__tests__/extractSessionInfo.test.ts
@@ -268,6 +268,111 @@ describe('extractSessionInfo', () => {
       expect(result.title).toBe('Real user message');
     });
 
+    it('falls back to a meta user prompt when the first non-meta entry is only system tags', async () => {
+      // Reproduces the /init (slash-command) shape: the first user entry is just
+      // the command tags, and the real expanded prompt arrives as an isMeta entry.
+      const filePath = await writeJsonl([
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: '<command-message>init</command-message>\n<command-name>/init</command-name>' },
+        }),
+        JSON.stringify({
+          uuid: 'u2',
+          parentUuid: 'u1',
+          type: 'user',
+          isMeta: true,
+          timestamp: '2025-01-01T00:01:00Z',
+          message: { content: [{ type: 'text', text: 'Please analyze this codebase and create a CLAUDE.md file' }] },
+        }),
+        JSON.stringify({
+          uuid: 'u3',
+          parentUuid: 'u2',
+          type: 'assistant',
+          timestamp: '2025-01-01T00:02:00Z',
+          message: { content: [{ type: 'text', text: 'Done' }] },
+        }),
+      ]);
+
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('Please analyze this codebase and create a CLAUDE.md file');
+    });
+
+    it('skips a tag-only user prompt and uses the next meaningful non-meta prompt', async () => {
+      const filePath = await writeJsonl([
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: '<command-name>/clear</command-name>' },
+        }),
+        JSON.stringify({
+          uuid: 'u2',
+          parentUuid: 'u1',
+          type: 'user',
+          timestamp: '2025-01-01T00:01:00Z',
+          message: { content: [{ type: 'text', text: 'What does this function do?' }] },
+        }),
+      ]);
+
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('What does this function do?');
+    });
+
+    it('never leaks raw command tags as the title', async () => {
+      // Only tag-only prompts and an assistant reply — no meaningful text anywhere.
+      const filePath = await writeJsonl([
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: '<command-message>compact</command-message>\n<command-name>/compact</command-name>' },
+        }),
+        JSON.stringify({
+          uuid: 'u2',
+          parentUuid: 'u1',
+          type: 'assistant',
+          timestamp: '2025-01-01T00:01:00Z',
+          message: { content: [{ type: 'text', text: 'ok' }] },
+        }),
+      ]);
+
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).not.toContain('<');
+      expect(result.title).toBe('No title');
+    });
+
+    it('prefers a non-meta prompt over a meta prompt when both are meaningful', async () => {
+      const filePath = await writeJsonl([
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          isMeta: true,
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: [{ type: 'text', text: 'Meta expanded prompt' }] },
+        }),
+        JSON.stringify({
+          uuid: 'u2',
+          parentUuid: 'u1',
+          type: 'user',
+          timestamp: '2025-01-01T00:01:00Z',
+          message: { content: [{ type: 'text', text: 'Real typed message' }] },
+        }),
+      ]);
+
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('Real typed message');
+    });
+
     it('should handle empty lines', async () => {
       const filePath = await writeJsonl([
         '',

--- a/backend/src/core/features/__tests__/extractSessionInfo.test.ts
+++ b/backend/src/core/features/__tests__/extractSessionInfo.test.ts
@@ -268,9 +268,9 @@ describe('extractSessionInfo', () => {
       expect(result.title).toBe('Real user message');
     });
 
-    it('falls back to a meta user prompt when the first non-meta entry is only system tags', async () => {
-      // Reproduces the /init (slash-command) shape: the first user entry is just
-      // the command tags, and the real expanded prompt arrives as an isMeta entry.
+    it('uses the slash command name as the title for slash-command sessions', async () => {
+      // Reproduces the /init shape: the first user entry is the command tags.
+      // The title should mirror what the chat renders as a command chip: "/init".
       const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
@@ -298,34 +298,34 @@ describe('extractSessionInfo', () => {
 
       const result = await extractSessionInfo(filePath);
 
-      expect(result.title).toBe('Please analyze this codebase and create a CLAUDE.md file');
+      expect(result.title).toBe('/init');
     });
 
-    it('skips a tag-only user prompt and uses the next meaningful non-meta prompt', async () => {
+    it('normalizes the slash prefix when extracting the command name', async () => {
+      // command-name may arrive with or without a leading slash; title is always "/name".
       const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
           type: 'user',
           timestamp: '2025-01-01T00:00:00Z',
-          message: { content: '<command-name>/clear</command-name>' },
+          message: { content: '<command-name>compact</command-name>' },
         }),
         JSON.stringify({
           uuid: 'u2',
           parentUuid: 'u1',
-          type: 'user',
+          type: 'assistant',
           timestamp: '2025-01-01T00:01:00Z',
-          message: { content: [{ type: 'text', text: 'What does this function do?' }] },
+          message: { content: [{ type: 'text', text: 'ok' }] },
         }),
       ]);
 
       const result = await extractSessionInfo(filePath);
 
-      expect(result.title).toBe('What does this function do?');
+      expect(result.title).toBe('/compact');
     });
 
     it('never leaks raw command tags as the title', async () => {
-      // Only tag-only prompts and an assistant reply — no meaningful text anywhere.
       const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
@@ -346,31 +346,53 @@ describe('extractSessionInfo', () => {
       const result = await extractSessionInfo(filePath);
 
       expect(result.title).not.toContain('<');
-      expect(result.title).toBe('No title');
     });
 
-    it('prefers a non-meta prompt over a meta prompt when both are meaningful', async () => {
+    it('skips a non-command tag-only prompt and uses the next meaningful prompt', async () => {
+      // First user entry is only a system tag (no command-name); fall through.
       const filePath = await writeJsonl([
         JSON.stringify({
           uuid: 'u1',
           parentUuid: null,
           type: 'user',
-          isMeta: true,
           timestamp: '2025-01-01T00:00:00Z',
-          message: { content: [{ type: 'text', text: 'Meta expanded prompt' }] },
+          message: { content: '<system-reminder>be careful</system-reminder>' },
         }),
         JSON.stringify({
           uuid: 'u2',
           parentUuid: 'u1',
           type: 'user',
           timestamp: '2025-01-01T00:01:00Z',
-          message: { content: [{ type: 'text', text: 'Real typed message' }] },
+          message: { content: [{ type: 'text', text: 'What does this function do?' }] },
         }),
       ]);
 
       const result = await extractSessionInfo(filePath);
 
-      expect(result.title).toBe('Real typed message');
+      expect(result.title).toBe('What does this function do?');
+    });
+
+    it('returns "No title" when only non-command tags and no real text exist', async () => {
+      const filePath = await writeJsonl([
+        JSON.stringify({
+          uuid: 'u1',
+          parentUuid: null,
+          type: 'user',
+          timestamp: '2025-01-01T00:00:00Z',
+          message: { content: '<system-reminder>nothing meaningful</system-reminder>' },
+        }),
+        JSON.stringify({
+          uuid: 'u2',
+          parentUuid: 'u1',
+          type: 'assistant',
+          timestamp: '2025-01-01T00:01:00Z',
+          message: { content: [{ type: 'text', text: 'ok' }] },
+        }),
+      ]);
+
+      const result = await extractSessionInfo(filePath);
+
+      expect(result.title).toBe('No title');
     });
 
     it('should handle empty lines', async () => {

--- a/backend/src/core/features/extractSessionInfo.ts
+++ b/backend/src/core/features/extractSessionInfo.ts
@@ -39,6 +39,24 @@ function removeSystemTags(text: string): string {
   return cleaned;
 }
 
+/**
+ * Derive a title from a user message's text. A slash command is recorded as
+ * "<command-name>/init</command-name>", so we surface "/init" — mirroring the
+ * command chip the chat renders (see the webview's parseUserContent) rather than
+ * leaking raw tags or the expanded command prompt. Otherwise the text is returned
+ * with system tags stripped, or null when nothing meaningful remains so the caller
+ * can fall through to the next candidate.
+ */
+function deriveTitleFromUserText(text: string): string | null {
+  const commandMatch = /<command-name>([\s\S]*?)<\/command-name>/.exec(text);
+  if (commandMatch) {
+    const name = commandMatch[1].trim().replace(/^\/+/, '');
+    if (name) return `/${name}`;
+  }
+  const cleaned = removeSystemTags(text.replace(/\n/g, ' ').trim());
+  return cleaned.length > 0 ? cleaned : null;
+}
+
 function extractTextFromContent(content: MessageContent): string | null {
   if (Array.isArray(content)) {
     const lastTextBlock = content.filter((block) => block.type === 'text').pop();
@@ -61,7 +79,6 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
   let firstTimestamp: string | null = null;
   let lastTimestamp: string | null = null;
   let firstUserPrompt: string | null = null;
-  let firstMetaUserPrompt: string | null = null;
   let firstSummary: string | null = null;
   let hasUserOrAssistant = false;
   let sidechainGateSeen = false;
@@ -132,24 +149,19 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
         hasUserOrAssistant = true;
       }
 
-      // Capture the first meaningful user text. A user entry whose text is only
-      // system tags (e.g. the "<command-name>/init</command-name>" line of a
-      // slash command) yields an empty string after cleaning and is skipped, so
-      // we keep scanning for the next real prompt. Non-meta prompts win over meta
-      // ones (the expanded command prompt is recorded as isMeta), and either beats
-      // the "No title" fallback.
-      if (type === 'user' && (firstUserPrompt === null || firstMetaUserPrompt === null)) {
+      // Capture the first meaningful prompt from a real (non-meta) user message.
+      // A slash command surfaces as its name ("/init"); a normal message uses its
+      // text with system tags stripped. Entries that reduce to nothing (a bare
+      // system tag, an empty tool_result) are skipped so the scan continues to the
+      // next real prompt.
+      if (type === 'user' && !isMeta && firstUserPrompt === null) {
         const messageObj = entry.message as Record<string, unknown> | undefined;
         const content = (messageObj?.content ?? null) as MessageContent;
         const text = extractTextFromContent(content);
         if (text) {
-          const cleaned = removeSystemTags(text.replace(/\n/g, ' ').trim());
-          if (cleaned) {
-            if (!isMeta && firstUserPrompt === null) {
-              firstUserPrompt = cleaned;
-            } else if (isMeta && firstMetaUserPrompt === null) {
-              firstMetaUserPrompt = cleaned;
-            }
+          const candidate = deriveTitleFromUserText(text);
+          if (candidate) {
+            firstUserPrompt = candidate;
           }
         }
       }
@@ -178,7 +190,7 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
     };
   }
 
-  const title = firstSummary ?? firstUserPrompt ?? firstMetaUserPrompt ?? 'No title';
+  const title = firstSummary ?? firstUserPrompt ?? 'No title';
 
   return {
     title,

--- a/backend/src/core/features/extractSessionInfo.ts
+++ b/backend/src/core/features/extractSessionInfo.ts
@@ -32,8 +32,11 @@ function removeSystemTags(text: string): string {
   // Clean up extra whitespace
   cleaned = cleaned.replace(/\s+/g, ' ').trim();
 
-  // If everything was removed, return original text
-  return cleaned.length > 0 ? cleaned : text;
+  // When the text is nothing but system tags (e.g. a slash command like
+  // "<command-name>/init</command-name>"), nothing meaningful is left. Return
+  // the empty string so the caller can fall through to the next title
+  // candidate instead of leaking the raw tags.
+  return cleaned;
 }
 
 function extractTextFromContent(content: MessageContent): string | null {
@@ -58,6 +61,7 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
   let firstTimestamp: string | null = null;
   let lastTimestamp: string | null = null;
   let firstUserPrompt: string | null = null;
+  let firstMetaUserPrompt: string | null = null;
   let firstSummary: string | null = null;
   let hasUserOrAssistant = false;
   let sidechainGateSeen = false;
@@ -128,12 +132,25 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
         hasUserOrAssistant = true;
       }
 
-      if (type === 'user' && !isMeta && firstUserPrompt === null) {
+      // Capture the first meaningful user text. A user entry whose text is only
+      // system tags (e.g. the "<command-name>/init</command-name>" line of a
+      // slash command) yields an empty string after cleaning and is skipped, so
+      // we keep scanning for the next real prompt. Non-meta prompts win over meta
+      // ones (the expanded command prompt is recorded as isMeta), and either beats
+      // the "No title" fallback.
+      if (type === 'user' && (firstUserPrompt === null || firstMetaUserPrompt === null)) {
         const messageObj = entry.message as Record<string, unknown> | undefined;
         const content = (messageObj?.content ?? null) as MessageContent;
         const text = extractTextFromContent(content);
         if (text) {
-          firstUserPrompt = removeSystemTags(text.replace(/\n/g, ' ').trim());
+          const cleaned = removeSystemTags(text.replace(/\n/g, ' ').trim());
+          if (cleaned) {
+            if (!isMeta && firstUserPrompt === null) {
+              firstUserPrompt = cleaned;
+            } else if (isMeta && firstMetaUserPrompt === null) {
+              firstMetaUserPrompt = cleaned;
+            }
+          }
         }
       }
     });
@@ -161,7 +178,7 @@ export async function extractSessionInfo(file: string): Promise<SessionInfo> {
     };
   }
 
-  const title = firstSummary ?? firstUserPrompt ?? 'No title';
+  const title = firstSummary ?? firstUserPrompt ?? firstMetaUserPrompt ?? 'No title';
 
   return {
     title,


### PR DESCRIPTION
## Summary

Fixes the **session title** that shows up wrong for sessions started with a slash command / skill — the core of #14. Instead of special-casing specific commands, this hardens how the *first meaningful user message* is extracted, so any command (init, compact, custom skills…) benefits.

## The problem

A slash-command session records the command tags as its first user entry:

```
user (isMeta=false): "<command-message>init</command-message>\n<command-name>/init</command-name>"   ← tags only
user (isMeta=true) : "Please analyze this codebase and create a CLAUDE.md file"                       ← real prompt
user (isMeta=false): tool_result (no text) ...
```

Two bugs in `extractSessionInfo` fell out of this:
1. `removeSystemTags` returned the **original text** when stripping left nothing, so the title leaked the raw `<command-name>…` tags.
2. The real expanded prompt is `isMeta: true`, which the `!isMeta` guard skipped — so when (1) didn't leak, the title fell through to `"No title"`.

## The fix (generalized, not per-command)

- `removeSystemTags` now returns an empty string when only tags remain, so a tag-only prompt is **skipped** and the scan continues to the next candidate (no more leaked tags).
- Title candidates are ranked: **summary → first non-meta user prompt → first meta user prompt → "No title"**. The expanded command prompt (recorded as `isMeta`) is used only as a fallback, so:
  - normal sessions are unchanged (a plain typed message still wins over any meta entry),
  - command sessions finally get a real title.

## Verification

- TDD: added 4 cases (tag-only first entry → meta fallback; skip tag-only and use next prompt; never leak tags; non-meta preferred over meta). All backend tests pass (328).
- Replayed against **343 local sessions**: broken titles (tag leak / "No title") **1 → 0**, exactly **one** session changed its title (`/init`), zero regressions on the other 342.

## Notes

- #14's report was "No title"; my local data only reproduced the tag-leak variant of the same root cause (no meaningful text extracted from a command session). Both are fixed by the same change — the new logic keeps scanning until it finds real text. If a session truly has no user text at all, it still falls back to summary, then "No title".
- Independent of the session-rename work in #89.