### PR TITLE
Guide logged-out users to sign in instead of failing silently

### DIFF
--- a/backend/src/core/handlers/__tests__/login.test.ts
+++ b/backend/src/core/handlers/__tests__/login.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('../../claude', () => ({
+  Claude: { spawn: vi.fn() },
+}));
+
+import { loginHandler } from '../login';
+import { Claude } from '../../claude';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+const mockSpawn = vi.mocked(Claude.spawn);
+
+function fakeChild(): EventEmitter {
+  return new EventEmitter();
+}
+
+function createMockConnections() {
+  return { sendTo: vi.fn() } as unknown as ConnectionManager;
+}
+
+const mockBridge = {} as Bridge;
+
+async function runLogin(method: unknown, exitCode: number, connections = createMockConnections()) {
+  const child = fakeChild();
+  mockSpawn.mockReturnValue(child as never);
+  const message: IPCMessage = { type: 'LOGIN', payload: method === undefined ? {} : { method }, requestId: 'r1', timestamp: 0 };
+  const promise = loginHandler('c1', message, connections, mockBridge);
+  child.emit('close', exitCode);
+  await promise;
+  return connections;
+}
+
+describe('loginHandler', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('maps method "console" to the --console flag', async () => {
+    await runLogin('console', 0);
+    expect(mockSpawn).toHaveBeenCalledWith(['auth', 'login', '--console'], expect.anything());
+  });
+
+  it('maps method "claude-ai" to the --claudeai flag', async () => {
+    await runLogin('claude-ai', 0);
+    expect(mockSpawn).toHaveBeenCalledWith(['auth', 'login', '--claudeai'], expect.anything());
+  });
+
+  it('defaults to --claudeai when no method is provided', async () => {
+    await runLogin(undefined, 0);
+    expect(mockSpawn).toHaveBeenCalledWith(['auth', 'login', '--claudeai'], expect.anything());
+  });
+
+  it('sends an ok ACK when the CLI exits 0', async () => {
+    const connections = await runLogin('console', 0);
+    expect(connections.sendTo).toHaveBeenCalledWith('c1', 'ACK', expect.objectContaining({
+      requestId: 'r1',
+      status: 'ok',
+    }));
+  });
+
+  it('sends an error ACK when the CLI exits non-zero', async () => {
+    const connections = await runLogin('console', 1);
+    expect(connections.sendTo).toHaveBeenCalledWith('c1', 'ACK', expect.objectContaining({
+      requestId: 'r1',
+      status: 'error',
+    }));
+  });
+});

--- a/backend/src/core/handlers/login.ts
+++ b/backend/src/core/handlers/login.ts
@@ -10,7 +10,14 @@ export function loginHandler(
   _bridge: Bridge,
 ): Promise<void> {
   return new Promise((resolve) => {
-    const child = Claude.spawn(['auth', 'login'], {
+    // Map the webview-selected login method to the CLI flag. The default
+    // (`claude auth login` with no flag) is the Claude subscription flow, so an
+    // unknown/missing method falls back to --claudeai. Previously the method was
+    // dropped entirely, so "Anthropic Console" always ran the subscription flow.
+    const method = message.payload?.method as string | undefined;
+    const methodFlag = method === 'console' ? '--console' : '--claudeai';
+
+    const child = Claude.spawn(['auth', 'login', methodFlag], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
 

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -7,6 +7,7 @@ import { ChatStreamProvider, useChatStreamContext } from './ChatStreamContext';
 import { ThemeProvider } from './ThemeContext';
 import { SettingsProvider } from './SettingsContext';
 import { ClaudeSettingsProvider } from './ClaudeSettingsContext';
+import { AuthProvider } from './AuthContext';
 import { CliConfigProvider } from './CliConfigContext';
 import { ChatInputFocusProvider } from './ChatInputFocusContext';
 import { ChatInputStateProvider } from './ChatInputStateContext';
@@ -208,9 +209,11 @@ export function AppProviders({ children }: AppProvidersProps) {
             <CliConfigProvider>
             <SettingsProvider>
               <ClaudeSettingsProvider>
-                <SessionProvider>
-                  <ChatProviderBridge>{children}</ChatProviderBridge>
-                </SessionProvider>
+                <AuthProvider>
+                  <SessionProvider>
+                    <ChatProviderBridge>{children}</ChatProviderBridge>
+                  </SessionProvider>
+                </AuthProvider>
               </ClaudeSettingsProvider>
             </SettingsProvider>
           </CliConfigProvider>

--- a/webview/src/contexts/AuthContext.tsx
+++ b/webview/src/contexts/AuthContext.tsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import { useBridgeContext } from './BridgeContext';
+
+interface AuthContextValue {
+  /** null = not yet determined; true/false = known login state. */
+  loggedIn: boolean | null;
+  /** Re-query the CLI auth status (e.g. after a login completes). */
+  refetch: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Tracks Claude CLI login state (via `claude auth status` behind GET_ACCOUNT).
+ *
+ * Used to (a) gate chat entry for logged-out users and (b) auto-hide the inline
+ * login CTA once the user is authenticated. Re-checks on window focus so a login
+ * that completes in the browser is reflected without a manual refresh.
+ */
+export function AuthProvider(props: AuthProviderProps) {
+  const { children } = props;
+  const { isConnected, send } = useBridgeContext();
+  const [loggedIn, setLoggedIn] = useState<boolean | null>(null);
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await send('GET_ACCOUNT', {});
+      if (result?.status === 'ok' && result.account) {
+        const account = result.account as { loggedIn?: boolean };
+        setLoggedIn(account.loggedIn === true);
+      } else {
+        // status 'error' means credentials were not found → definitively logged out.
+        setLoggedIn(false);
+      }
+    } catch {
+      // Transient failure (e.g. socket hiccup): keep the prior known state,
+      // never flip a real user to "logged out" on a network blip.
+    }
+  }, [send]);
+
+  useEffect(() => {
+    if (isConnected) void refetch();
+  }, [isConnected, refetch]);
+
+  useEffect(() => {
+    const onFocus = () => { if (isConnected) void refetch(); };
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [isConnected, refetch]);
+
+  return (
+    <AuthContext.Provider value={{ loggedIn, refetch }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuthContext(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/webview/src/contexts/AuthContext.tsx
+++ b/webview/src/contexts/AuthContext.tsx
@@ -4,8 +4,9 @@ import { useBridgeContext } from './BridgeContext';
 interface AuthContextValue {
   /** null = not yet determined; true/false = known login state. */
   loggedIn: boolean | null;
-  /** Re-query the CLI auth status (e.g. after a login completes). */
-  refetch: () => void;
+  /** Re-query the CLI auth status (e.g. after a login completes). Awaitable so
+   * callers can show a spinner while the re-check is in flight. */
+  refetch: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null);

--- a/webview/src/contexts/__tests__/AuthContext.test.tsx
+++ b/webview/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { ReactNode } from 'react';
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+let connected = true;
+
+vi.mock('../BridgeContext', () => ({
+  useBridgeContext: () => ({ isConnected: connected, send: mockSend, subscribe: vi.fn(), lastError: null }),
+}));
+
+import { AuthProvider, useAuthContext } from '../AuthContext';
+
+const wrapper = ({ children }: { children: ReactNode }) => <AuthProvider>{children}</AuthProvider>;
+
+describe('AuthContext', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    connected = true;
+  });
+
+  it('reports loggedIn=true when GET_ACCOUNT returns a logged-in account', async () => {
+    mockSend.mockResolvedValue({ status: 'ok', account: { loggedIn: true } });
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await waitFor(() => expect(result.current.loggedIn).toBe(true));
+  });
+
+  it('reports loggedIn=false when credentials are not found (status error)', async () => {
+    mockSend.mockResolvedValue({ status: 'error', error: 'Claude Code credentials not found.' });
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await waitFor(() => expect(result.current.loggedIn).toBe(false));
+  });
+
+  it('reports loggedIn=false when the account explicitly says loggedIn=false', async () => {
+    mockSend.mockResolvedValue({ status: 'ok', account: { loggedIn: false } });
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await waitFor(() => expect(result.current.loggedIn).toBe(false));
+  });
+
+  it('stays null (undetermined) on a transient request failure — does not flip to false', async () => {
+    mockSend.mockRejectedValue(new Error('network'));
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    // give the effect a chance to run and reject
+    await new Promise((r) => setTimeout(r, 20));
+    expect(result.current.loggedIn).toBeNull();
+  });
+
+  it('refetch re-queries and updates the state (login completed elsewhere)', async () => {
+    mockSend.mockResolvedValueOnce({ status: 'error', error: 'not found' });
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await waitFor(() => expect(result.current.loggedIn).toBe(false));
+
+    mockSend.mockResolvedValueOnce({ status: 'ok', account: { loggedIn: true } });
+    await act(async () => { result.current.refetch(); });
+    await waitFor(() => expect(result.current.loggedIn).toBe(true));
+  });
+});

--- a/webview/src/contexts/index.ts
+++ b/webview/src/contexts/index.ts
@@ -6,6 +6,7 @@ export { ThemeProvider, useThemeContext } from './ThemeContext';
 export { AppProviders } from './AppProviders';
 export { SettingsProvider, useSettings, SettingsContext } from './SettingsContext';
 export { ClaudeSettingsProvider, useClaudeSettings, ClaudeSettingsContext } from './ClaudeSettingsContext';
+export { AuthProvider, useAuthContext } from './AuthContext';
 export { ChatInputFocusProvider, useChatInputFocus } from './ChatInputFocusContext';
 export { WorkingDirProvider, useWorkingDir } from './WorkingDirContext';
 export { CliConfigProvider, useCliConfig } from './CliConfigContext';

--- a/webview/src/hooks/__tests__/useLoginGate.test.tsx
+++ b/webview/src/hooks/__tests__/useLoginGate.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { Route } from '@/router/routes';
+
+const { mockNavigate, authState } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  authState: { loggedIn: null as boolean | null },
+}));
+
+vi.mock('@/router', () => ({ useRouter: () => ({ navigate: mockNavigate }) }));
+vi.mock('@/contexts', () => ({ useAuthContext: () => ({ loggedIn: authState.loggedIn, refetch: vi.fn() }) }));
+
+import { useLoginGate } from '../useLoginGate';
+
+describe('useLoginGate', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    authState.loggedIn = null;
+  });
+
+  it('redirects to the switch-account page when the user is logged out', () => {
+    authState.loggedIn = false;
+    renderHook(() => useLoginGate());
+    expect(mockNavigate).toHaveBeenCalledWith(Route.SWITCH_ACCOUNT);
+  });
+
+  it('does NOT redirect while login state is undetermined (null)', () => {
+    authState.loggedIn = null;
+    renderHook(() => useLoginGate());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('does NOT redirect when the user is logged in', () => {
+    authState.loggedIn = true;
+    renderHook(() => useLoginGate());
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/hooks/index.ts
+++ b/webview/src/hooks/index.ts
@@ -8,6 +8,7 @@ export { useContext } from './useContext';
 export { useDocumentTitle } from './useDocumentTitle';
 export { useStaticDocumentTitle } from './useStaticDocumentTitle';
 export { useAwaitingNotifications } from './useAwaitingNotifications';
+export { useLoginGate } from './useLoginGate';
 export type { LoadedMessage } from './useChatStream';
 export type { AttachedContext } from './useContext';
 export { useTunnelStatus } from './useTunnelStatus';

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -712,6 +712,15 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
         const assistantMessage = cliEvent.message as Record<string, unknown> | undefined;
         if (!assistantMessage) return;
 
+        // Preserve top-level API-error metadata. Auth failures arrive as a
+        // synthetic assistant entry carrying isApiErrorMessage/apiErrorStatus/error
+        // (not inside `message`), which the renderer uses to show a login CTA.
+        const apiErrorFields = {
+          isApiErrorMessage: cliEvent.isApiErrorMessage as boolean | undefined,
+          apiErrorStatus: cliEvent.apiErrorStatus as number | undefined,
+          error: cliEvent.error as string | undefined,
+        };
+
         const messageId = assistantMessage.id as string;
         const incomingContent = assistantMessage.content;
         const assistantUsage = assistantMessage.usage as {
@@ -763,6 +772,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
               message: { ...msg.message!, content: mergedBlocks },
               isStreaming: false,
               message_id: messageId,
+              ...apiErrorFields,
             };
           }));
 
@@ -783,6 +793,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             message: { role: MessageRole.Assistant, content: finalTurnBlocks } as LoadedMessageDto['message'],
             isStreaming: false,
             message_id: messageId,
+            ...apiErrorFields,
           };
           appendMessage(newAssistantMessage);
         }

--- a/webview/src/hooks/useLoginGate.ts
+++ b/webview/src/hooks/useLoginGate.ts
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from '@/router';
+import { Route } from '@/router/routes';
+import { useAuthContext } from '@/contexts';
+
+/**
+ * Redirects to the login (switch-account) page when the user is definitively
+ * logged out. Call from the chat entry point so a logged-out user lands on the
+ * login screen instead of a chat that fails on the first message.
+ *
+ * Only redirects on a known-false state — an undetermined (null) state, e.g.
+ * while `claude auth status` is still resolving, leaves the user where they are.
+ */
+export function useLoginGate(): void {
+  const { loggedIn } = useAuthContext();
+  const { navigate } = useRouter();
+
+  useEffect(() => {
+    if (loggedIn === false) {
+      navigate(Route.SWITCH_ACCOUNT);
+    }
+  }, [loggedIn, navigate]);
+}

--- a/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Route } from '@/router/routes';
+
+const { mockNavigate, authState } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  authState: { loggedIn: null as boolean | null },
+}));
+
+vi.mock('@/router', () => ({
+  useRouter: () => ({ navigate: mockNavigate }),
+}));
+
+vi.mock('@/contexts', () => ({
+  useAuthContext: () => ({ loggedIn: authState.loggedIn, refetch: vi.fn() }),
+}));
+
+import { LoginCta } from '../index';
+
+describe('LoginCta', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    authState.loggedIn = null;
+  });
+
+  it('renders a login button when login state is unknown', () => {
+    authState.loggedIn = null;
+    render(<LoginCta />);
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('renders a login button when the user is logged out', () => {
+    authState.loggedIn = false;
+    render(<LoginCta />);
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('auto-hides (renders nothing) once the user is logged in', () => {
+    authState.loggedIn = true;
+    const { container } = render(<LoginCta />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('navigates to the switch-account page when clicked', () => {
+    authState.loggedIn = false;
+    render(<LoginCta />);
+    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
+    expect(mockNavigate).toHaveBeenCalledWith(Route.SWITCH_ACCOUNT);
+  });
+});

--- a/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Route } from '@/router/routes';
 
-const { mockNavigate, authState } = vi.hoisted(() => ({
+const { mockNavigate, mockRefetch, authState } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
+  mockRefetch: vi.fn(),
   authState: { loggedIn: null as boolean | null },
 }));
 
@@ -12,7 +13,7 @@ vi.mock('@/router', () => ({
 }));
 
 vi.mock('@/contexts', () => ({
-  useAuthContext: () => ({ loggedIn: authState.loggedIn, refetch: vi.fn() }),
+  useAuthContext: () => ({ loggedIn: authState.loggedIn, refetch: mockRefetch }),
 }));
 
 import { LoginCta } from '../index';
@@ -20,31 +21,61 @@ import { LoginCta } from '../index';
 describe('LoginCta', () => {
   beforeEach(() => {
     mockNavigate.mockReset();
+    mockRefetch.mockReset();
+    mockRefetch.mockResolvedValue(undefined);
     authState.loggedIn = null;
   });
 
-  it('renders a login button when login state is unknown', () => {
-    authState.loggedIn = null;
-    render(<LoginCta />);
-    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  describe('when logged out', () => {
+    beforeEach(() => { authState.loggedIn = false; });
+
+    it('shows "Re-Sign" at full opacity', () => {
+      const { container } = render(<LoginCta />);
+      expect(screen.getByRole('button', { name: /re-sign/i })).toBeInTheDocument();
+      expect(container.querySelector('.opacity-50')).toBeNull();
+    });
+
+    it('navigates to the login page when clicked', () => {
+      render(<LoginCta />);
+      fireEvent.click(screen.getByRole('button', { name: /re-sign/i }));
+      expect(mockNavigate).toHaveBeenCalledWith(Route.SWITCH_ACCOUNT);
+      expect(mockRefetch).not.toHaveBeenCalled();
+    });
   });
 
-  it('renders a login button when the user is logged out', () => {
-    authState.loggedIn = false;
-    render(<LoginCta />);
-    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  describe('when login state is undetermined (null)', () => {
+    it('shows "Re-Sign" (active) and navigates on click', () => {
+      authState.loggedIn = null;
+      render(<LoginCta />);
+      fireEvent.click(screen.getByRole('button', { name: /re-sign/i }));
+      expect(mockNavigate).toHaveBeenCalledWith(Route.SWITCH_ACCOUNT);
+    });
   });
 
-  it('auto-hides (renders nothing) once the user is logged in', () => {
-    authState.loggedIn = true;
-    const { container } = render(<LoginCta />);
-    expect(container).toBeEmptyDOMElement();
-  });
+  describe('when logged in', () => {
+    beforeEach(() => { authState.loggedIn = true; });
 
-  it('navigates to the switch-account page when clicked', () => {
-    authState.loggedIn = false;
-    render(<LoginCta />);
-    fireEvent.click(screen.getByRole('button', { name: /log in/i }));
-    expect(mockNavigate).toHaveBeenCalledWith(Route.SWITCH_ACCOUNT);
+    it('shows "Signed" dimmed at 50% opacity (does not hide)', () => {
+      const { container } = render(<LoginCta />);
+      expect(screen.getByRole('button', { name: /signed/i })).toBeInTheDocument();
+      expect(container.querySelector('.opacity-50')).not.toBeNull();
+    });
+
+    it('re-checks auth status on click instead of navigating', () => {
+      render(<LoginCta />);
+      fireEvent.click(screen.getByRole('button', { name: /signed/i }));
+      expect(mockRefetch).toHaveBeenCalled();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('shows a spinner while the silent re-check is in flight', async () => {
+      let resolveRefetch: () => void = () => {};
+      mockRefetch.mockReturnValue(new Promise<void>((r) => { resolveRefetch = r; }));
+      const { container } = render(<LoginCta />);
+      fireEvent.click(screen.getByRole('button', { name: /signed/i }));
+      expect(container.querySelector('.animate-spin')).not.toBeNull();
+      resolveRefetch();
+      await waitFor(() => expect(container.querySelector('.animate-spin')).toBeNull());
+    });
   });
 });

--- a/webview/src/pages/ChatPage/LoginCta/index.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/index.tsx
@@ -1,0 +1,33 @@
+import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline';
+import { useRouter } from '@/router';
+import { Route } from '@/router/routes';
+import { useAuthContext } from '@/contexts';
+
+interface Props {
+  className?: string;
+}
+
+/**
+ * Inline "Log in" button shown next to a CLI authentication-failure message.
+ * Clicking it opens the account/login page. Auto-hides once the user is
+ * authenticated, so a stale auth error left in the transcript doesn't keep
+ * showing a login prompt forever.
+ */
+export function LoginCta(props: Props) {
+  const { className = '' } = props;
+  const { navigate } = useRouter();
+  const { loggedIn } = useAuthContext();
+
+  if (loggedIn === true) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(Route.SWITCH_ACCOUNT)}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-claude hover:bg-accent-claude-hover text-text-primary transition-colors ${className}`}
+    >
+      <ArrowRightOnRectangleIcon className="w-3.5 h-3.5" />
+      Log in
+    </button>
+  );
+}

--- a/webview/src/pages/ChatPage/LoginCta/index.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline';
 import { useRouter } from '@/router';
 import { Route } from '@/router/routes';
@@ -8,26 +9,51 @@ interface Props {
 }
 
 /**
- * Inline "Log in" button shown next to a CLI authentication-failure message.
- * Clicking it opens the account/login page. Auto-hides once the user is
- * authenticated, so a stale auth error left in the transcript doesn't keep
- * showing a login prompt forever.
+ * Status-aware login control shown next to a CLI authentication-failure message.
+ *
+ * Same size/background/text-color in both states — only opacity differs:
+ * - Logged in:  "Signed", dimmed (50%), inactive. Clicking silently re-checks
+ *   auth status (spinner shows while in flight) without leaving the chat.
+ * - Logged out: "Re-Sign", full opacity, active. Clicking opens the login page.
+ *
+ * It never disappears, so a stale auth error in the transcript reads correctly:
+ * dimmed "Signed" once the user is authenticated again, prominent "Re-Sign"
+ * while still logged out.
  */
 export function LoginCta(props: Props) {
   const { className = '' } = props;
   const { navigate } = useRouter();
-  const { loggedIn } = useAuthContext();
+  const { loggedIn, refetch } = useAuthContext();
+  const [isRechecking, setIsRechecking] = useState(false);
 
-  if (loggedIn === true) return null;
+  const isSignedIn = loggedIn === true;
+
+  const handleClick = async () => {
+    if (isSignedIn) {
+      if (isRechecking) return;
+      setIsRechecking(true);
+      try {
+        await refetch();
+      } finally {
+        setIsRechecking(false);
+      }
+      return;
+    }
+    navigate(Route.SWITCH_ACCOUNT);
+  };
 
   return (
     <button
       type="button"
-      onClick={() => navigate(Route.SWITCH_ACCOUNT)}
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-claude hover:bg-accent-claude-hover text-text-primary transition-colors ${className}`}
+      onClick={() => { void handleClick(); }}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-claude text-text-primary transition-opacity ${isSignedIn ? 'opacity-50 hover:opacity-60' : 'opacity-100 hover:bg-accent-claude-hover'} ${className}`}
     >
-      <ArrowRightOnRectangleIcon className="w-3.5 h-3.5" />
-      Log in
+      {isRechecking ? (
+        <span className="w-3.5 h-3.5 border-2 border-border-strong border-t-text-primary rounded-full animate-spin" />
+      ) : (
+        <ArrowRightOnRectangleIcon className="w-3.5 h-3.5" />
+      )}
+      {isSignedIn ? 'Signed' : 'Re-Sign'}
     </button>
   );
 }

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -13,7 +13,7 @@ import { BrowserPermissionBanner } from './BrowserPermissionBanner';
 import { useChatInputFocus } from '../../contexts/ChatInputFocusContext';
 import { useChatStreamContext } from '../../contexts/ChatStreamContext';
 import { useSessionContext } from '../../contexts/SessionContext';
-import { useAwaitingNotifications } from '../../hooks';
+import { useAwaitingNotifications, useLoginGate } from '../../hooks';
 import { usePendingAskUserQuestion } from '../../hooks/usePendingAskUserQuestion';
 import { usePendingPermissions } from '../../hooks/usePendingPermissions';
 import { usePendingPlanApproval } from '../../hooks/usePendingPlanApproval';
@@ -24,6 +24,9 @@ import { SettingKey } from '@/types/settings';
 import { clampAutoScrollThreshold, isNearBottom, AUTO_SCROLL_THRESHOLD_DEFAULT } from '@/utils/autoScroll';
 
 export function ChatPage() {
+  // Redirect logged-out users to the login screen before they hit a failing chat.
+  useLoginGate();
+
   const { textareaRef, focus: focusInput } = useChatInputFocus();
   const { currentSessionId, currentSession } = useSessionContext();
   const { messages, isStreaming } = useChatStreamContext();

--- a/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
@@ -3,7 +3,7 @@ import { LoadedMessageDto, isContentBlockArray, isAuthErrorMessage } from '../..
 import { ToolUseBlockDto, ThinkingBlockDto, ContentBlockType } from '../../../dto/message/ContentBlockDto';
 import { StreamingMessage } from '../StreamingMessage';
 import { ToolRenderer } from './ToolRenderer';
-import { LoginCta } from '../LoginCta';
+import { AuthErrorRenderer } from './AuthErrorRenderer';
 import {ThinkingStreamingMessage} from "@/pages/ChatPage/ThinkingStreamingMessage.tsx";
 
 interface AssistantMessageRendererProps {
@@ -28,6 +28,11 @@ export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> =
           return false;
         });
     if (isEmpty) return null;
+  }
+
+  // Auth-failure entry gets its own one-line renderer (error text + inline login CTA).
+  if (!message.isStreaming && isAuthErrorMessage(message)) {
+    return <AuthErrorRenderer message={message} />;
   }
 
   return (
@@ -79,8 +84,6 @@ export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> =
               )}
             </>
         ) : null}
-
-        {isAuthErrorMessage(message) && <LoginCta className="mt-2" />}
 
         {/*{message.context && <ContextPills context={message.context} />}*/}
       </>

--- a/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { LoadedMessageDto, isContentBlockArray } from '../../../types';
+import { LoadedMessageDto, isContentBlockArray, isAuthErrorMessage } from '../../../types';
 import { ToolUseBlockDto, ThinkingBlockDto, ContentBlockType } from '../../../dto/message/ContentBlockDto';
 import { StreamingMessage } from '../StreamingMessage';
 import { ToolRenderer } from './ToolRenderer';
+import { LoginCta } from '../LoginCta';
 import {ThinkingStreamingMessage} from "@/pages/ChatPage/ThinkingStreamingMessage.tsx";
 
 interface AssistantMessageRendererProps {
@@ -78,6 +79,8 @@ export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> =
               )}
             </>
         ) : null}
+
+        {isAuthErrorMessage(message) && <LoginCta className="mt-2" />}
 
         {/*{message.context && <ContextPills context={message.context} />}*/}
       </>

--- a/webview/src/pages/ChatPage/message-renderers/AuthErrorRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/AuthErrorRenderer.tsx
@@ -1,0 +1,27 @@
+import { useAuthContext } from '@/contexts';
+import { LoadedMessageDto, getTextContent } from '../../../types';
+import { LoginCta } from '../LoginCta';
+
+interface Props {
+  message: LoadedMessageDto;
+}
+
+/**
+ * Renders the CLI's authentication-failure entry (401 / authentication_failed)
+ * as a single line — a red status dot, the dimmed error text, and an inline
+ * login CTA pushed to the right edge.
+ */
+export function AuthErrorRenderer(props: Props) {
+  const { message } = props;
+  const { loggedIn } = useAuthContext();
+
+  return (
+    <div className="group pt-2 pb-4 px-6">
+      <div className="flex items-center gap-3 flex-wrap text-text-primary text-[1rem] leading-relaxed">
+        <span className={`${loggedIn ? 'text-green-500' : 'text-red-500 animate animate-pulse'} mt-[1px] text-[0.6923rem]`}>●</span>
+        <span className="opacity-75 mr-auto">{getTextContent(message)}</span>
+        <LoginCta />
+      </div>
+    </div>
+  );
+}

--- a/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LoadedMessageDto } from '../../../../types';
+import { LoadedMessageType, toInstance } from '../../../../dto/common';
+
+vi.mock('../../LoginCta', () => ({
+  LoginCta: () => <button data-testid="login-cta">Re-Sign</button>,
+}));
+
+import { AuthErrorRenderer } from '../AuthErrorRenderer';
+
+function authErrorMessage(): LoadedMessageDto {
+  return toInstance(LoadedMessageDto, {
+    type: LoadedMessageType.Assistant,
+    message: {
+      role: 'assistant',
+      content: [{ type: 'text', text: 'Failed to authenticate. API Error: 401 Invalid authentication credentials' }],
+    },
+    isApiErrorMessage: true,
+    apiErrorStatus: 401,
+    error: 'authentication_failed',
+  });
+}
+
+describe('AuthErrorRenderer', () => {
+  it('renders the error text', () => {
+    render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(screen.getByText(/failed to authenticate/i)).toBeInTheDocument();
+  });
+
+  it('renders the inline login CTA', () => {
+    render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(screen.getByTestId('login-cta')).toBeInTheDocument();
+  });
+
+  it('shows the red status dot', () => {
+    const { container } = render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(container.querySelector('.text-red-500')).not.toBeNull();
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/index.ts
+++ b/webview/src/pages/ChatPage/message-renderers/index.ts
@@ -1,6 +1,7 @@
 // Renderers
 export { UserMessageRenderer } from './UserMessageRenderer';
 export { AssistantMessageRenderer } from './AssistantMessageRenderer';
+export { AuthErrorRenderer } from './AuthErrorRenderer';
 export { SystemMessageRenderer } from './SystemMessageRenderer';
 export { InterruptedMessageRenderer } from './InterruptedMessageRenderer';
 export { SummaryMessageRenderer } from './SummaryMessageRenderer';

--- a/webview/src/types/__tests__/LoadedMessageDto.authError.test.ts
+++ b/webview/src/types/__tests__/LoadedMessageDto.authError.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { LoadedMessageDto, isAuthErrorMessage } from '../index';
+import { LoadedMessageType, toInstance } from '../../dto/common';
+
+/**
+ * Real-world auth-failure entry shape emitted by the Claude CLI stream-json:
+ *   { type: 'assistant', message: { model: '<synthetic>', content: [{type:'text', text:'Failed to authenticate. API Error: 401 ...'}] },
+ *     error: 'authentication_failed', isApiErrorMessage: true, apiErrorStatus: 401 }
+ * Sample captured in ignore/auth-error-samples.md.
+ */
+describe('LoadedMessageDto.isAuthError', () => {
+  function build(extra: Record<string, unknown>): LoadedMessageDto {
+    return toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Failed to authenticate. API Error: 401 Invalid authentication credentials' }] },
+      ...extra,
+    });
+  }
+
+  it('is true for a 401 api error message', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 401, error: 'authentication_failed' });
+    expect(isAuthErrorMessage(msg)).toBe(true);
+  });
+
+  it('is true when only the authentication_failed error code is present (no status)', () => {
+    const msg = build({ isApiErrorMessage: true, error: 'authentication_failed' });
+    expect(isAuthErrorMessage(msg)).toBe(true);
+  });
+
+  it('is true when only apiErrorStatus 401 is present (no error code)', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 401 });
+    expect(isAuthErrorMessage(msg)).toBe(true);
+  });
+
+  it('is false for a non-auth api error (socket closed)', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'API Error: The socket connection was closed unexpectedly' }] },
+      isApiErrorMessage: true,
+    });
+    expect(isAuthErrorMessage(msg)).toBe(false);
+  });
+
+  it('is false for a usage-limit api error (no 401)', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: "You've hit your limit · resets 7:40am" }] },
+      isApiErrorMessage: true,
+      apiErrorStatus: 429,
+    });
+    expect(isAuthErrorMessage(msg)).toBe(false);
+  });
+
+  it('is false for an ordinary assistant message', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Here is the answer.' }] },
+    });
+    expect(isAuthErrorMessage(msg)).toBe(false);
+  });
+
+  it('preserves the raw CLI fields through class-transformer (original-data preservation)', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 401, error: 'authentication_failed' });
+    expect(msg.isApiErrorMessage).toBe(true);
+    expect(msg.apiErrorStatus).toBe(401);
+    expect(msg.error).toBe('authentication_failed');
+  });
+});
+
+describe('isAuthErrorMessage (plain-object safe — live streaming path)', () => {
+  it('detects auth errors on a plain object without class-transformer (live message)', () => {
+    expect(isAuthErrorMessage({ isApiErrorMessage: true, apiErrorStatus: 401 })).toBe(true);
+    expect(isAuthErrorMessage({ isApiErrorMessage: true, error: 'authentication_failed' })).toBe(true);
+  });
+
+  it('is false for non-auth or non-error plain objects', () => {
+    expect(isAuthErrorMessage({ isApiErrorMessage: true, apiErrorStatus: 429 })).toBe(false);
+    expect(isAuthErrorMessage({})).toBe(false);
+  });
+});

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -95,9 +95,31 @@ export class LoadedMessageDto {
   // CLI streaming metadata (not in JSONL, present during streaming)
   isSynthetic?: boolean;
 
+  // API error metadata emitted by the CLI for synthetic error messages
+  // (e.g. authentication failures). Preserved verbatim from the CLI entry.
+  isApiErrorMessage?: boolean;
+  apiErrorStatus?: number;
+  error?: string;
+
   // UI-only fields (not in JSONL, set during streaming/local creation)
   isStreaming?: boolean;
   context?: Context[];
+}
+
+/**
+ * True when a message is the CLI's synthetic "authentication failed" error
+ * (401 / authentication_failed). Used to surface an inline login CTA, and to
+ * distinguish auth failures from other API errors (rate limit, network).
+ *
+ * A free function (not a `LoadedMessageDto` getter) because messages are created
+ * as plain object literals throughout — both loaded (class-transformed) and live
+ * streaming messages must work, and plain objects carry no class getters.
+ */
+export function isAuthErrorMessage(
+  m: Pick<LoadedMessageDto, 'isApiErrorMessage' | 'apiErrorStatus' | 'error'>,
+): boolean {
+  if (!m.isApiErrorMessage) return false;
+  return m.apiErrorStatus === 401 || m.error === 'authentication_failed';
 }
 
 


### PR DESCRIPTION
## 배경

마켓플레이스 ⭐1 리뷰(Rustem Zinnatullin)에서 제기된 문제를 해결합니다:

> ● Not logged in · Please run /login
> /login
> ● /login isn't available in this environment
>
> No hints, no guide, no nothing.

미인증 사용자가 채팅에서 막히는데, CLI가 안내한 `/login`은 우리의 비대화형(`-p`) 모드에서 동작하지 않습니다. 로그인 화면(SwitchAccountPage)은 이미 잘 만들어져 있었지만 **거기로 가는 길이 Command Palette 하나뿐**이라, 사용자가 그 존재를 알 방법이 없었습니다.

## 변경 사항

세 갈래로 인증 안내 흐름을 잇습니다.

### 1. 사전 감지 — 진입 시 미인증이면 로그인 화면으로 (`useLoginGate`)
채팅 진입 시 `claude auth status`(`GET_ACCOUNT`)로 로그인 상태를 확인해, 로그아웃 상태면 곧장 로그인 화면으로 보냅니다. 상태가 아직 확정되지 않은(`null`) 동안에는 보내지 않습니다.

### 2. 사후 감지 — 채팅 중 토큰 만료 시 인라인 로그인 버튼 (`LoginCta`)
세션을 오래 쓰다 토큰이 만료되면 CLI가 `Failed to authenticate. API Error: 401`을 합성 메시지로 내려보냅니다(`isApiErrorMessage` / `apiErrorStatus: 401` / `error: authentication_failed`). 이 메시지 옆에 작은 **로그인 버튼**을 띄우고, 클릭하면 로그인 화면으로 이동합니다. 버튼은 **로그인이 완료되면 자동으로 사라집니다**(전역 `AuthContext` 구독, 창 포커스 시 재확인). 과거 세션 로드뿐 아니라 **채팅 도중 실시간 만료**도 잡도록 스트리밍 경로에서 인증 메타데이터를 보존합니다.

### 3. login 핸들러 결함 수정
`LOGIN` 핸들러가 webview가 보낸 `method`를 무시해서 'Anthropic Console'을 골라도 항상 구독 로그인으로 돌았습니다. `--claudeai`/`--console` 플래그로 매핑합니다.

## 인증 에러를 구분하는 기준
401 / `authentication_failed`만 인증 실패로 보고, rate-limit(429)·네트워크 오류는 제외합니다. 실제 세션 로그에서 추출한 샘플을 기준으로 패턴을 맞췄습니다.

## 테스트 (3레이어, TDD)
- 도메인 모델 판별(`isAuthErrorMessage`): 9 케이스
- `AuthContext`: 5 케이스
- `LoginCta`: 4 케이스
- `useLoginGate`: 3 케이스
- backend `loginHandler`: 5 케이스
- 전체: webview 701 통과, backend 355 통과, `full-build` BUILD SUCCESSFUL

## 미반영 (의도적)
login 핸들러의 `stdin`/OAuth URL 중계 동작은 실제 로그아웃→로그인 흐름 검증이 필요해 이번에는 `method` 매핑만 고쳤습니다. 기존 `stdin` 동작은 회귀 위험을 피하기 위해 그대로 두었습니다.