### PR TITLE
fix: clear remote-tunnel spinner as soon as the URL is ready

### DIFF
--- a/backend/src/core/__tests__/augmented-path.test.ts
+++ b/backend/src/core/__tests__/augmented-path.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { augmentedEnv, augmentedPath, buildAugmentedPath } from '../augmented-path';
+
+describe('augmented-path', () => {
+  it('buildAugmentedPath returns a PATH string', () => {
+    expect(typeof buildAugmentedPath()).toBe('string');
+  });
+
+  it('augmentedPath is cached (stable across calls)', () => {
+    expect(augmentedPath()).toBe(augmentedPath());
+  });
+
+  it('augmentedEnv sets PATH to the augmented path', () => {
+    expect(augmentedEnv().PATH).toBe(augmentedPath());
+  });
+
+  it('augmentedEnv preserves other process env vars', () => {
+    process.env.__AUG_TEST__ = 'xyz';
+    try {
+      expect(augmentedEnv().__AUG_TEST__).toBe('xyz');
+    } finally {
+      delete process.env.__AUG_TEST__;
+    }
+  });
+
+  it('augmentedEnv applies extra vars alongside PATH', () => {
+    const env = augmentedEnv({ FOO: 'bar' });
+    expect(env.FOO).toBe('bar');
+    expect(env.PATH).toBe(augmentedPath());
+  });
+
+  it('augmentedEnv lets extra override PATH when explicitly provided', () => {
+    expect(augmentedEnv({ PATH: '/custom/bin' }).PATH).toBe('/custom/bin');
+  });
+});

--- a/backend/src/core/__tests__/claude-bin-paths.test.ts
+++ b/backend/src/core/__tests__/claude-bin-paths.test.ts
@@ -34,6 +34,11 @@ describe('candidateBinDirs', () => {
     );
   });
 
+  it('includes the cloudflared auto-install location (~/.claude-code-gui/bin)', () => {
+    const dirs = candidateBinDirs({ HOME: home }, 'darwin');
+    expect(dirs).toContain(join(home, '.claude-code-gui', 'bin'));
+  });
+
   it('does not include unix-only dirs on Windows', () => {
     const dirs = candidateBinDirs({ HOME: home }, 'win32');
     expect(dirs).not.toContain('/usr/local/bin');

--- a/backend/src/core/augmented-path.ts
+++ b/backend/src/core/augmented-path.ts
@@ -1,0 +1,68 @@
+import { existsSync } from 'fs';
+import { join, delimiter, resolve } from 'path';
+import { execFileSync } from 'child_process';
+import { candidateBinDirs } from './claude-bin-paths';
+
+/**
+ * Build an augmented PATH that includes well-known bin directories where the
+ * CLIs the backend spawns (`claude`, `cloudflared`, ...) are likely installed.
+ *
+ * An IDE launched from the GUI hands its child Node.js process a minimal PATH
+ * that often omits nvm / volta / homebrew paths. Without this, a tool the user
+ * has clearly installed (e.g. `brew install cloudflared`) is invisible to the
+ * backend's `which` lookups. See issues #59 / #76.
+ */
+export function buildAugmentedPath(): string {
+  const basePath = process.env.PATH ?? '';
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+  if (!home) return basePath;
+
+  const extraDirs: string[] = candidateBinDirs();
+
+  // Add nvm current version bin if NVM_DIR is set
+  const nvmDir = process.env.NVM_DIR ?? join(home, '.nvm');
+  try {
+    // Validate nvmDir is a real path (prevent injection via NVM_DIR)
+    const resolvedNvmDir = resolve(nvmDir);
+    const nvmScript = join(resolvedNvmDir, 'nvm.sh');
+    if (!existsSync(nvmScript)) throw new Error('nvm.sh not found');
+
+    // Escape single quotes in path for safe bash embedding: ' -> '\''
+    const escapedNvmScript = nvmScript.replace(/'/g, "'\\''");
+    const nvmDefaultBin = execFileSync(
+      'bash',
+      ['-c', `source '${escapedNvmScript}' --no-use 2>/dev/null && nvm which current 2>/dev/null`],
+      { encoding: 'utf-8', timeout: 3000 },
+    ).trim();
+    if (nvmDefaultBin) {
+      const nvmBinDir = nvmDefaultBin.substring(0, nvmDefaultBin.lastIndexOf('/'));
+      if (nvmBinDir) extraDirs.push(nvmBinDir);
+    }
+  } catch {
+    // nvm not available - skip
+  }
+
+  const priorityDirs = extraDirs.filter((d) => existsSync(d));
+  if (priorityDirs.length === 0) return basePath;
+  const prioritySet = new Set(priorityDirs);
+  const remaining = basePath.split(delimiter).filter((d) => !prioritySet.has(d)).join(delimiter);
+  return `${priorityDirs.join(delimiter)}${delimiter}${remaining}`;
+}
+
+// Computed once at module load — the set of well-known dirs doesn't change
+// during a backend session, and the nvm probe spawns bash (worth caching).
+let cachedPath: string | null = null;
+
+/** The augmented PATH, computed lazily and cached for the process lifetime. */
+export function augmentedPath(): string {
+  if (cachedPath === null) cachedPath = buildAugmentedPath();
+  return cachedPath;
+}
+
+/**
+ * `process.env` with PATH replaced by the augmented PATH. Pass `extra` to
+ * override or add further variables (applied after PATH).
+ */
+export function augmentedEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return { ...process.env, PATH: augmentedPath(), ...extra };
+}

--- a/backend/src/core/claude-bin-paths.ts
+++ b/backend/src/core/claude-bin-paths.ts
@@ -27,6 +27,7 @@ export function candidateBinDirs(
     join(home, '.npm-global', 'bin'),                // npm global (custom prefix)
     join(home, '.volta', 'bin'),                     // volta
     join(home, '.fnm', 'aliases', 'default', 'bin'), // fnm
+    join(home, '.claude-code-gui', 'bin'),           // cloudflared auto-install location
   ];
 
   if (platform === 'win32') {

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -1,18 +1,14 @@
 import {
   spawn as cpSpawn,
   execFile as cpExecFile,
-  execFileSync,
   type ChildProcess,
   type SpawnOptions,
   type ExecFileOptions,
 } from 'child_process';
-import { existsSync } from 'fs';
-import { join, delimiter, resolve } from 'path';
 import { readSettingsFile } from './features/settings';
-import { candidateBinDirs } from './claude-bin-paths';
+import { augmentedPath } from './augmented-path';
 
 export class Claude {
-  private static augmentedPath: string = Claude.buildAugmentedPath();
   private static cliPath: string | null = null;
   private static initialized = false;
 
@@ -30,7 +26,7 @@ export class Claude {
   static get env(): NodeJS.ProcessEnv {
     return {
       ...process.env,
-      PATH: Claude.augmentedPath,
+      PATH: augmentedPath(),
     };
   }
 
@@ -76,45 +72,4 @@ export class Claude {
     });
   }
 
-  /**
-   * Build an augmented PATH that includes well-known bin directories where
-   * `claude` CLI is likely installed.  IDE-spawned Node.js processes often
-   * inherit a minimal PATH that doesn't include nvm / volta / homebrew paths.
-   */
-  private static buildAugmentedPath(): string {
-    const basePath = process.env.PATH ?? '';
-    const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
-    if (!home) return basePath;
-
-    const extraDirs: string[] = candidateBinDirs();
-
-    // Add nvm current version bin if NVM_DIR is set
-    const nvmDir = process.env.NVM_DIR ?? join(home, '.nvm');
-    try {
-      // Validate nvmDir is a real path (prevent injection via NVM_DIR)
-      const resolvedNvmDir = resolve(nvmDir);
-      const nvmScript = join(resolvedNvmDir, 'nvm.sh');
-      if (!existsSync(nvmScript)) throw new Error('nvm.sh not found');
-
-      // Escape single quotes in path for safe bash embedding: ' -> '\''
-      const escapedNvmScript = nvmScript.replace(/'/g, "'\\''");
-      const nvmDefaultBin = execFileSync(
-        'bash',
-        ['-c', `source '${escapedNvmScript}' --no-use 2>/dev/null && nvm which current 2>/dev/null`],
-        { encoding: 'utf-8', timeout: 3000 },
-      ).trim();
-      if (nvmDefaultBin) {
-        const nvmBinDir = nvmDefaultBin.substring(0, nvmDefaultBin.lastIndexOf('/'));
-        if (nvmBinDir) extraDirs.push(nvmBinDir);
-      }
-    } catch {
-      // nvm not available - skip
-    }
-
-    const priorityDirs = extraDirs.filter(d => existsSync(d));
-    if (priorityDirs.length === 0) return basePath;
-    const prioritySet = new Set(priorityDirs);
-    const remaining = basePath.split(delimiter).filter(d => !prioritySet.has(d)).join(delimiter);
-    return `${priorityDirs.join(delimiter)}${delimiter}${remaining}`;
-  }
 }

--- a/backend/src/core/features/tunnel-manager.ts
+++ b/backend/src/core/features/tunnel-manager.ts
@@ -1,9 +1,10 @@
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, execFileSync, type ChildProcess } from 'child_process';
 import { existsSync, mkdirSync, chmodSync, openSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { resolve } from 'path';
 import { exec as execCallback } from 'child_process';
 import { promisify } from 'util';
-import { arch, platform, tmpdir } from 'os';
+import { arch, platform, tmpdir, homedir } from 'os';
+import { augmentedEnv } from '../augmented-path';
 
 const execAsync = promisify(execCallback);
 
@@ -12,13 +13,30 @@ export interface TunnelStatus {
   url: string | null;
 }
 
+export type TunnelErrorCode =
+  | 'cloudflared-missing' // cloudflared not found and could not be installed
+  | 'tunnel-timeout'      // URL never appeared within the timeout window
+  | 'tunnel-exited'       // cloudflared exited before producing a URL
+  | 'unknown';
+
+/** Error carrying a machine-readable code so the UI can show actionable guidance. */
+export class TunnelError extends Error {
+  constructor(public readonly code: TunnelErrorCode, message: string) {
+    super(message);
+    this.name = 'TunnelError';
+  }
+}
+
 let tunnelProcess: ChildProcess | null = null;
 let tunnelUrl: string | null = null;
 const TUNNEL_LOG_FILE = resolve(tmpdir(), 'cloudflared-tunnel.log');
 const TUNNEL_PID_FILE = resolve(tmpdir(), 'cloudflared-tunnel.pid');
 
 function getLocalBinPath(): string {
-  return resolve(process.cwd(), '.local', 'bin', getLocalBinName());
+  // A stable, writable, per-user location (NOT process.cwd(), which for an
+  // IDE-spawned backend is unpredictable and may be read-only). This dir is
+  // also registered in candidateBinDirs so an installed binary is found later.
+  return resolve(homedir(), '.claude-code-gui', 'bin', getLocalBinName());
 }
 
 function getDownloadUrl(): string | null {
@@ -47,24 +65,27 @@ async function installCloudflared(): Promise<string> {
   const localBin = getLocalBinPath();
   const localBinDir = resolve(localBin, '..');
   const os = platform();
+  // Run every probe/install with the augmented PATH so brew/winget/cloudflared
+  // are visible even when the IDE handed us a minimal PATH.
+  const env = augmentedEnv();
 
   // Try package manager first
   if (os === 'darwin') {
     try {
-      await execAsync('which brew');
+      await execAsync('which brew', { env });
       console.error('[node-backend]', 'Installing cloudflared via Homebrew...');
-      await execAsync('brew install cloudflared');
-      const { stdout } = await execAsync('which cloudflared');
+      await execAsync('brew install cloudflared', { env });
+      const { stdout } = await execAsync('which cloudflared', { env });
       return stdout.trim();
     } catch {
       // brew not available or install failed, fall through
     }
   } else if (os === 'win32') {
     try {
-      await execAsync('where winget');
+      await execAsync('where winget', { env });
       console.error('[node-backend]', 'Installing cloudflared via winget...');
-      await execAsync('winget install --id Cloudflare.cloudflared --accept-source-agreements --accept-package-agreements');
-      const { stdout } = await execAsync('where cloudflared');
+      await execAsync('winget install --id Cloudflare.cloudflared --accept-source-agreements --accept-package-agreements', { env });
+      const { stdout } = await execAsync('where cloudflared', { env });
       return stdout.trim().split('\n')[0];
     } catch {
       // winget not available or install failed, fall through
@@ -81,12 +102,12 @@ async function installCloudflared(): Promise<string> {
   mkdirSync(localBinDir, { recursive: true });
 
   if (url.endsWith('.tgz')) {
-    await execAsync(`curl -fsSL "${url}" | tar -xz -C "${localBinDir}"`);
+    await execAsync(`curl -fsSL "${url}" | tar -xz -C "${localBinDir}"`, { env });
   } else if (os === 'win32') {
     // Windows: use PowerShell for download
-    await execAsync(`powershell -Command "Invoke-WebRequest -Uri '${url}' -OutFile '${localBin}'"`, { timeout: 60_000 });
+    await execAsync(`powershell -Command "Invoke-WebRequest -Uri '${url}' -OutFile '${localBin}'"`, { timeout: 60_000, env });
   } else {
-    await execAsync(`curl -fsSL -o "${localBin}" "${url}"`);
+    await execAsync(`curl -fsSL -o "${localBin}" "${url}"`, { env });
   }
 
   if (os !== 'win32') {
@@ -156,10 +177,10 @@ export function restoreTunnelState(): void {
 }
 
 async function findOrInstallCloudflared(): Promise<string> {
-  // 1. Try system PATH
+  // 1. Try system PATH (augmented so IDE-spawned backends still find it)
   const whichCmd = platform() === 'win32' ? 'where cloudflared' : 'which cloudflared';
   try {
-    const { stdout } = await execAsync(whichCmd);
+    const { stdout } = await execAsync(whichCmd, { env: augmentedEnv() });
     const binPath = stdout.trim().split('\n')[0];
     if (binPath) return binPath;
   } catch {
@@ -191,7 +212,7 @@ export function startTunnel(port: number): Promise<string> {
     try {
       binaryPath = await findOrInstallCloudflared();
     } catch (err) {
-      rejectPromise(new Error(`Failed to locate or install cloudflared: ${String(err)}`));
+      rejectPromise(new TunnelError('cloudflared-missing', `Failed to locate or install cloudflared: ${String(err)}`));
       return;
     }
 
@@ -202,6 +223,8 @@ export function startTunnel(port: number): Promise<string> {
     const proc = spawn(binaryPath, args, {
       stdio: ['ignore', logFd, logFd],
       detached: true,
+      windowsHide: true, // don't pop a console window on Windows
+      env: augmentedEnv(),
     });
 
     tunnelProcess = proc;
@@ -212,7 +235,7 @@ export function startTunnel(port: number): Promise<string> {
     const timeoutId = setTimeout(() => {
       if (!resolved) {
         resolved = true;
-        rejectPromise(new Error('Timed out waiting for cloudflared tunnel URL (15s)'));
+        rejectPromise(new TunnelError('tunnel-timeout', 'Timed out waiting for cloudflared tunnel URL (15s)'));
         stopTunnel();
       }
     }, 15_000);
@@ -244,7 +267,7 @@ export function startTunnel(port: number): Promise<string> {
       if (!resolved) {
         resolved = true;
         clearTimeout(timeoutId);
-        rejectPromise(err);
+        rejectPromise(new TunnelError('unknown', `cloudflared process error: ${err.message}`));
       }
       tunnelProcess = null;
       tunnelUrl = null;
@@ -255,7 +278,7 @@ export function startTunnel(port: number): Promise<string> {
       if (!resolved) {
         resolved = true;
         clearTimeout(timeoutId);
-        rejectPromise(new Error(`cloudflared exited unexpectedly (code=${code})`));
+        rejectPromise(new TunnelError('tunnel-exited', `cloudflared exited unexpectedly (code=${code})`));
       }
       tunnelProcess = null;
       tunnelUrl = null;
@@ -263,29 +286,56 @@ export function startTunnel(port: number): Promise<string> {
   });
 }
 
-export function stopTunnel(): void {
-  if (tunnelProcess) {
+/** Terminate the cloudflared process by PID, using the right mechanism per OS. */
+function killTunnelPid(pid: number): void {
+  if (process.platform === 'win32') {
+    // Windows ignores SIGTERM; taskkill /T also reaps the detached child tree.
     try {
-      tunnelProcess.kill('SIGTERM');
-    } catch (err) {
-      console.error('[node-backend]', 'Failed to kill cloudflared process:', err);
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)]);
+    } catch {
+      // already gone
     }
-    tunnelProcess = null;
   } else {
-    // Restored state: no ChildProcess reference, use PID file
     try {
-      if (existsSync(TUNNEL_PID_FILE)) {
-        const pid = parseInt(readFileSync(TUNNEL_PID_FILE, 'utf-8').trim(), 10);
-        if (!isNaN(pid) && isProcessAlive(pid)) {
-          process.kill(pid, 'SIGTERM');
-        }
-      }
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // already gone
+    }
+  }
+}
+
+export function stopTunnel(): void {
+  // Prefer the live ChildProcess pid; fall back to the PID file for a tunnel
+  // restored from a previous backend session (no ChildProcess reference).
+  let pid = tunnelProcess?.pid ?? null;
+  if (pid === null && existsSync(TUNNEL_PID_FILE)) {
+    try {
+      const parsed = parseInt(readFileSync(TUNNEL_PID_FILE, 'utf-8').trim(), 10);
+      if (!isNaN(parsed) && isProcessAlive(parsed)) pid = parsed;
     } catch {
       // ignore
     }
   }
+  if (pid !== null) killTunnelPid(pid);
+
+  tunnelProcess = null;
   tunnelUrl = null;
   removePidFile();
+}
+
+/**
+ * Best-effort check whether cloudflared can be located without installing it.
+ * Lets the UI warn the user before they toggle the tunnel on. Never throws.
+ */
+export async function isCloudflaredAvailable(): Promise<boolean> {
+  const whichCmd = platform() === 'win32' ? 'where cloudflared' : 'which cloudflared';
+  try {
+    const { stdout } = await execAsync(whichCmd, { env: augmentedEnv() });
+    if (stdout.trim()) return true;
+  } catch {
+    // not in PATH
+  }
+  return existsSync(getLocalBinPath());
 }
 
 /**

--- a/backend/src/core/features/tunnel-manager.ts
+++ b/backend/src/core/features/tunnel-manager.ts
@@ -61,7 +61,7 @@ function getLocalBinName(): string {
   return platform() === 'win32' ? 'cloudflared.exe' : 'cloudflared';
 }
 
-async function installCloudflared(): Promise<string> {
+export async function installCloudflared(): Promise<string> {
   const localBin = getLocalBinPath();
   const localBinDir = resolve(localBin, '..');
   const os = platform();
@@ -176,8 +176,13 @@ export function restoreTunnelState(): void {
   }
 }
 
-async function findOrInstallCloudflared(): Promise<string> {
-  // 1. Try system PATH (augmented so IDE-spawned backends still find it)
+/**
+ * Locate cloudflared WITHOUT installing it — installation is now an explicit,
+ * user-consented action (see installCloudflaredHandler). Returns null if not
+ * found. The PATH lookup is augmented so an IDE-spawned backend still sees a
+ * brew/winget install.
+ */
+async function findCloudflared(): Promise<string | null> {
   const whichCmd = platform() === 'win32' ? 'where cloudflared' : 'which cloudflared';
   try {
     const { stdout } = await execAsync(whichCmd, { env: augmentedEnv() });
@@ -186,15 +191,8 @@ async function findOrInstallCloudflared(): Promise<string> {
   } catch {
     // not in PATH
   }
-
-  // 2. Try project-local binary
   const localBin = getLocalBinPath();
-  if (existsSync(localBin)) {
-    return localBin;
-  }
-
-  // 3. Auto-install
-  return installCloudflared();
+  return existsSync(localBin) ? localBin : null;
 }
 
 export function startTunnel(port: number): Promise<string> {
@@ -208,11 +206,11 @@ export function startTunnel(port: number): Promise<string> {
       return;
     }
 
-    let binaryPath: string;
-    try {
-      binaryPath = await findOrInstallCloudflared();
-    } catch (err) {
-      rejectPromise(new TunnelError('cloudflared-missing', `Failed to locate or install cloudflared: ${String(err)}`));
+    const binaryPath = await findCloudflared();
+    if (!binaryPath) {
+      // Do NOT auto-install here — the UI asks for consent and calls
+      // INSTALL_CLOUDFLARED explicitly before retrying.
+      rejectPromise(new TunnelError('cloudflared-missing', 'cloudflared is not installed'));
       return;
     }
 
@@ -324,18 +322,11 @@ export function stopTunnel(): void {
 }
 
 /**
- * Best-effort check whether cloudflared can be located without installing it.
- * Lets the UI warn the user before they toggle the tunnel on. Never throws.
+ * Whether cloudflared can be located without installing it. Lets the UI warn
+ * the user (and ask for install consent) before they toggle the tunnel on.
  */
 export async function isCloudflaredAvailable(): Promise<boolean> {
-  const whichCmd = platform() === 'win32' ? 'where cloudflared' : 'which cloudflared';
-  try {
-    const { stdout } = await execAsync(whichCmd, { env: augmentedEnv() });
-    if (stdout.trim()) return true;
-  } catch {
-    // not in PATH
-  }
-  return existsSync(getLocalBinPath());
+  return (await findCloudflared()) !== null;
 }
 
 /**

--- a/backend/src/core/features/tunnel-manager.ts
+++ b/backend/src/core/features/tunnel-manager.ts
@@ -4,8 +4,6 @@ import { resolve } from 'path';
 import { exec as execCallback } from 'child_process';
 import { promisify } from 'util';
 import { arch, platform, tmpdir } from 'os';
-import http from 'http';
-import https from 'https';
 
 const execAsync = promisify(execCallback);
 
@@ -157,33 +155,6 @@ export function restoreTunnelState(): void {
   }
 }
 
-/**
- * Poll the tunnel URL until it returns HTTP 200, indicating
- * the Cloudflare edge has fully registered the tunnel.
- */
-async function waitForTunnelReady(url: string, timeoutMs = 30_000, intervalMs = 1_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const ok = await new Promise<boolean>((resolve) => {
-      const req = https.get(url, { timeout: 5_000 }, (res) => {
-        resolve(res.statusCode === 200);
-        res.resume();
-      });
-      req.on('error', () => resolve(false));
-      req.on('timeout', () => {
-        req.destroy();
-        resolve(false);
-      });
-    });
-
-    if (ok) return;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-
-  console.error('[node-backend]', `Tunnel URL did not become ready within ${timeoutMs / 1000}s, proceeding anyway`);
-}
-
 async function findOrInstallCloudflared(): Promise<string> {
   // 1. Try system PATH
   const whichCmd = platform() === 'win32' ? 'where cloudflared' : 'which cloudflared';
@@ -258,9 +229,10 @@ export function startTunnel(port: number): Promise<string> {
           const foundUrl = match[0];
           tunnelUrl = foundUrl;
           if (proc.pid) savePidFile(proc.pid);
-          waitForTunnelReady(foundUrl)
-            .then(() => resolvePromise(foundUrl))
-            .catch(() => resolvePromise(foundUrl));
+          // Resolve as soon as the URL is available. cloudflared prints the URL
+          // once the edge routing is essentially ready, so there's no value in
+          // an extra HTTP-200 warm-up poll — it only delayed the spinner.
+          resolvePromise(foundUrl);
         }
       } catch {
         // file not ready yet

--- a/backend/src/core/handlers/getTunnelPrereqs.ts
+++ b/backend/src/core/handlers/getTunnelPrereqs.ts
@@ -1,0 +1,23 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { isCloudflaredAvailable } from '../features/tunnel-manager';
+
+/**
+ * Report whether the tunnel's prerequisites are met (currently: cloudflared is
+ * locatable without installing). The UI calls this when the tunnel modal opens
+ * so it can warn the user before they toggle the tunnel on.
+ */
+export async function getTunnelPrereqsHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const cloudflaredAvailable = await isCloudflaredAvailable();
+  connections.sendTo(connectionId, 'ACK', {
+    requestId: message.requestId,
+    status: 'ok',
+    cloudflaredAvailable,
+  });
+}

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -44,6 +44,7 @@ import { tunnelStartHandler } from './tunnelStart';
 import { tunnelStopHandler } from './tunnelStop';
 import { getTunnelStatusHandler } from './getTunnelStatus';
 import { getTunnelPrereqsHandler } from './getTunnelPrereqs';
+import { installCloudflaredHandler } from './installCloudflared';
 import { sleepGuardEnableHandler } from './sleepGuardEnable';
 import { sleepGuardDisableHandler } from './sleepGuardDisable';
 import { listProjectFilesHandler } from './listProjectFiles';
@@ -190,6 +191,9 @@ export async function handleMessage(
       break;
     case 'GET_TUNNEL_PREREQS':
       await getTunnelPrereqsHandler(connectionId, message, connections, bridge);
+      break;
+    case 'INSTALL_CLOUDFLARED':
+      await installCloudflaredHandler(connectionId, message, connections, bridge);
       break;
     case 'SLEEP_GUARD_ENABLE':
       await sleepGuardEnableHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -43,6 +43,7 @@ import { getIdeRootHandler } from './getIdeRoot';
 import { tunnelStartHandler } from './tunnelStart';
 import { tunnelStopHandler } from './tunnelStop';
 import { getTunnelStatusHandler } from './getTunnelStatus';
+import { getTunnelPrereqsHandler } from './getTunnelPrereqs';
 import { sleepGuardEnableHandler } from './sleepGuardEnable';
 import { sleepGuardDisableHandler } from './sleepGuardDisable';
 import { listProjectFilesHandler } from './listProjectFiles';
@@ -186,6 +187,9 @@ export async function handleMessage(
       break;
     case 'GET_TUNNEL_STATUS':
       await getTunnelStatusHandler(connectionId, message, connections, bridge);
+      break;
+    case 'GET_TUNNEL_PREREQS':
+      await getTunnelPrereqsHandler(connectionId, message, connections, bridge);
       break;
     case 'SLEEP_GUARD_ENABLE':
       await sleepGuardEnableHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/installCloudflared.ts
+++ b/backend/src/core/handlers/installCloudflared.ts
@@ -1,0 +1,30 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { installCloudflared } from '../features/tunnel-manager';
+
+/**
+ * Explicitly install cloudflared after the user consented in the UI. ACK
+ * immediately (installation can take minutes — well past the request timeout)
+ * and report the outcome via a CLOUDFLARED_INSTALL_STATUS broadcast so the UI
+ * can proceed to start the tunnel, or show an error.
+ */
+export async function installCloudflaredHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  connections.sendTo(connectionId, 'ACK', {
+    requestId: message.requestId,
+    status: 'ok',
+  });
+
+  try {
+    await installCloudflared();
+    connections.broadcastToAll('CLOUDFLARED_INSTALL_STATUS', { status: 'installed' });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    connections.broadcastToAll('CLOUDFLARED_INSTALL_STATUS', { status: 'failed', error });
+  }
+}

--- a/backend/src/core/handlers/tunnelStart.ts
+++ b/backend/src/core/handlers/tunnelStart.ts
@@ -1,7 +1,7 @@
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
-import { startTunnel, getTunnelStatus } from '../features/tunnel-manager';
+import { startTunnel, getTunnelStatus, TunnelError } from '../features/tunnel-manager';
 import { serverPort } from '../../config/environment';
 
 export async function tunnelStartHandler(
@@ -32,6 +32,7 @@ export async function tunnelStartHandler(
       const status = getTunnelStatus();
       if (status.url !== null) return;
       const error = err instanceof Error ? err.message : String(err);
-      connections.broadcastToAll('TUNNEL_STATUS', { enabled: false, url: null, error });
+      const errorCode = err instanceof TunnelError ? err.code : 'unknown';
+      connections.broadcastToAll('TUNNEL_STATUS', { enabled: false, url: null, error, errorCode });
     });
 }

--- a/webview/src/components/TunnelModal/index.tsx
+++ b/webview/src/components/TunnelModal/index.tsx
@@ -3,6 +3,7 @@ import { XMarkIcon, ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@h
 import { QRCodeSVG } from 'qrcode.react';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { Portal } from '@/components/Portal';
+import { TunnelStatusNotice } from '@/components/TunnelStatusNotice';
 import { useTunnelStatus } from '@/hooks';
 
 interface Props {
@@ -15,11 +16,14 @@ export function TunnelModal(props: Props) {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    cloudflaredAvailable,
     preventSleep,
     sleepLoading,
     error,
+    errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    retryTunnel,
   } = useTunnelStatus();
 
   const [copied, setCopied] = useState(false);
@@ -92,11 +96,14 @@ export function TunnelModal(props: Props) {
 
         {/* Body */}
         <div className="px-4 py-4 space-y-4">
-          {error && (
-            <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-bg rounded">
-              {error}
-            </div>
-          )}
+          <TunnelStatusNotice
+            cloudflaredAvailable={cloudflaredAvailable}
+            tunnelEnabled={tunnelEnabled}
+            tunnelLoading={tunnelLoading}
+            error={error}
+            errorCode={errorCode}
+            onRetry={retryTunnel}
+          />
 
           {/* Tunnel toggle */}
           <div className="flex items-center justify-between">
@@ -119,7 +126,7 @@ export function TunnelModal(props: Props) {
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                <span>Connecting... ({elapsedSec}s)</span>
+                <span>{cloudflaredAvailable === false ? 'Installing cloudflared…' : 'Connecting…'} ({elapsedSec}s)</span>
               </div>
               <p className="text-xs text-text-disabled">Typically ~1 min (install: ~3 min)</p>
             </div>

--- a/webview/src/components/TunnelModal/index.tsx
+++ b/webview/src/components/TunnelModal/index.tsx
@@ -17,12 +17,16 @@ export function TunnelModal(props: Props) {
     tunnelUrl,
     tunnelLoading,
     cloudflaredAvailable,
+    awaitingInstallConsent,
+    installing,
     preventSleep,
     sleepLoading,
     error,
     errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    confirmInstallAndStart,
+    cancelInstall,
     retryTunnel,
   } = useTunnelStatus();
 
@@ -52,7 +56,7 @@ export function TunnelModal(props: Props) {
   }, [onClose]);
 
   useEffect(() => {
-    if (tunnelLoading) {
+    if (tunnelLoading || installing) {
       setElapsedSec(0);
       elapsedRef.current = setInterval(() => setElapsedSec((s) => s + 1), 1000);
     } else {
@@ -64,7 +68,7 @@ export function TunnelModal(props: Props) {
     return () => {
       if (elapsedRef.current) clearInterval(elapsedRef.current);
     };
-  }, [tunnelLoading]);
+  }, [tunnelLoading, installing]);
 
   const handleCopy = () => {
     if (!fullTunnelUrl) return;
@@ -100,9 +104,13 @@ export function TunnelModal(props: Props) {
             cloudflaredAvailable={cloudflaredAvailable}
             tunnelEnabled={tunnelEnabled}
             tunnelLoading={tunnelLoading}
+            installing={installing}
+            awaitingInstallConsent={awaitingInstallConsent}
             error={error}
             errorCode={errorCode}
             onRetry={retryTunnel}
+            onConfirmInstall={confirmInstallAndStart}
+            onCancelInstall={cancelInstall}
           />
 
           {/* Tunnel toggle */}
@@ -114,19 +122,19 @@ export function TunnelModal(props: Props) {
             <ToggleSwitch
               checked={tunnelEnabled}
               onChange={handleTunnelToggle}
-              disabled={tunnelLoading}
+              disabled={tunnelLoading || installing}
             />
           </div>
 
           {/* Loading indicator */}
-          {tunnelLoading && (
+          {(tunnelLoading || installing) && (
             <div className="flex flex-col items-center gap-2 py-2">
               <div className="flex items-center gap-2 text-sm text-text-secondary">
                 <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                <span>{cloudflaredAvailable === false ? 'Installing cloudflared…' : 'Connecting…'} ({elapsedSec}s)</span>
+                <span>{installing ? 'Installing cloudflared…' : 'Connecting…'} ({elapsedSec}s)</span>
               </div>
               <p className="text-xs text-text-disabled">Typically ~1 min (install: ~3 min)</p>
             </div>

--- a/webview/src/components/TunnelStatusNotice/index.tsx
+++ b/webview/src/components/TunnelStatusNotice/index.tsx
@@ -1,0 +1,88 @@
+import { useState } from 'react';
+import {
+  ClipboardDocumentIcon,
+  ClipboardDocumentCheckIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline';
+import { tunnelErrorGuidance, type TunnelErrorCode } from '@/hooks';
+import { getAdapter } from '@/adapters';
+
+interface Props {
+  cloudflaredAvailable: boolean | null;
+  tunnelEnabled: boolean;
+  tunnelLoading: boolean;
+  error: string | null;
+  errorCode: TunnelErrorCode | null;
+  onRetry: () => void;
+}
+
+/**
+ * Shared notice shown above the tunnel toggle in both the chat modal and the
+ * settings page: an actionable error panel when a start attempt failed, or an
+ * upfront warning when cloudflared isn't installed yet.
+ */
+export function TunnelStatusNotice(props: Props) {
+  const { cloudflaredAvailable, tunnelEnabled, tunnelLoading, error, errorCode, onRetry } = props;
+  const [copied, setCopied] = useState(false);
+
+  if (error) {
+    const guidance = tunnelErrorGuidance(errorCode, error);
+
+    const handleCopy = () => {
+      if (!guidance.manualInstallCommand) return;
+      navigator.clipboard.writeText(guidance.manualInstallCommand).then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      });
+    };
+
+    return (
+      <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-bg rounded space-y-2">
+        <div className="font-medium">{guidance.title}</div>
+        <div className="text-xs opacity-90">{guidance.detail}</div>
+
+        {guidance.manualInstallCommand && (
+          <div className="flex items-center gap-2">
+            <code className="flex-1 font-mono text-xs bg-surface-raised px-2 py-1 rounded truncate">
+              {guidance.manualInstallCommand}
+            </code>
+            <button onClick={handleCopy} className="flex-shrink-0" title="Copy command">
+              {copied
+                ? <ClipboardDocumentCheckIcon className="w-4 h-4 text-state-success-fg" />
+                : <ClipboardDocumentIcon className="w-4 h-4 cursor-pointer" />
+              }
+            </button>
+          </div>
+        )}
+
+        <div className="flex items-center gap-3 pt-1">
+          <button onClick={onRetry} className="text-xs font-medium underline cursor-pointer">
+            Try again
+          </button>
+          {guidance.helpUrl && (
+            <button
+              onClick={() => getAdapter().openUrl(guidance.helpUrl as string)}
+              className="text-xs underline opacity-90 cursor-pointer"
+            >
+              Install guide
+            </button>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  if (cloudflaredAvailable === false && !tunnelEnabled && !tunnelLoading) {
+    return (
+      <div className="py-2 px-3 text-xs text-state-warning-fg bg-state-warning-bg rounded flex items-start gap-2">
+        <ExclamationTriangleIcon className="w-4 h-4 flex-shrink-0 mt-0.5" />
+        <span>
+          cloudflared isn’t installed yet. Turning the tunnel on will download it
+          automatically (about 3 minutes the first time).
+        </span>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/webview/src/components/TunnelStatusNotice/index.tsx
+++ b/webview/src/components/TunnelStatusNotice/index.tsx
@@ -11,18 +11,33 @@ interface Props {
   cloudflaredAvailable: boolean | null;
   tunnelEnabled: boolean;
   tunnelLoading: boolean;
+  installing: boolean;
+  awaitingInstallConsent: boolean;
   error: string | null;
   errorCode: TunnelErrorCode | null;
   onRetry: () => void;
+  onConfirmInstall: () => void;
+  onCancelInstall: () => void;
 }
 
 /**
  * Shared notice shown above the tunnel toggle in both the chat modal and the
- * settings page: an actionable error panel when a start attempt failed, or an
- * upfront warning when cloudflared isn't installed yet.
+ * settings page: an actionable error panel, an install-consent prompt when
+ * cloudflared is missing, or an upfront warning that it isn't installed yet.
  */
 export function TunnelStatusNotice(props: Props) {
-  const { cloudflaredAvailable, tunnelEnabled, tunnelLoading, error, errorCode, onRetry } = props;
+  const {
+    cloudflaredAvailable,
+    tunnelEnabled,
+    tunnelLoading,
+    installing,
+    awaitingInstallConsent,
+    error,
+    errorCode,
+    onRetry,
+    onConfirmInstall,
+    onCancelInstall,
+  } = props;
   const [copied, setCopied] = useState(false);
 
   if (error) {
@@ -72,13 +87,35 @@ export function TunnelStatusNotice(props: Props) {
     );
   }
 
-  if (cloudflaredAvailable === false && !tunnelEnabled && !tunnelLoading) {
+  if (awaitingInstallConsent) {
+    return (
+      <div className="py-2 px-3 text-xs text-state-warning-fg bg-state-warning-bg rounded space-y-2">
+        <div className="flex items-start gap-2">
+          <ExclamationTriangleIcon className="w-4 h-4 flex-shrink-0 mt-0.5" />
+          <span>
+            cloudflared isn’t installed. Install it now and enable the tunnel? This downloads
+            cloudflared (about 3 minutes the first time).
+          </span>
+        </div>
+        <div className="flex items-center gap-3 pt-1 pl-6">
+          <button onClick={onConfirmInstall} className="text-xs font-medium underline cursor-pointer">
+            Install &amp; enable
+          </button>
+          <button onClick={onCancelInstall} className="text-xs underline opacity-80 cursor-pointer">
+            Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (cloudflaredAvailable === false && !tunnelEnabled && !tunnelLoading && !installing) {
     return (
       <div className="py-2 px-3 text-xs text-state-warning-fg bg-state-warning-bg rounded flex items-start gap-2">
         <ExclamationTriangleIcon className="w-4 h-4 flex-shrink-0 mt-0.5" />
         <span>
-          cloudflared isn’t installed yet. Turning the tunnel on will download it
-          automatically (about 3 minutes the first time).
+          cloudflared isn’t installed yet. Turning the tunnel on will ask to download it
+          (about 3 minutes the first time).
         </span>
       </div>
     );

--- a/webview/src/hooks/__tests__/tunnelError.test.ts
+++ b/webview/src/hooks/__tests__/tunnelError.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { tunnelErrorGuidance } from '../tunnelError';
+
+describe('tunnelErrorGuidance', () => {
+  it('cloudflared-missing → offers a manual install command and help link', () => {
+    const g = tunnelErrorGuidance('cloudflared-missing');
+    expect(g.manualInstallCommand).toBeTruthy();
+    expect(g.helpUrl).toBeTruthy();
+    expect(g.title).toMatch(/cloudflared/i);
+  });
+
+  it('tunnel-timeout → network-oriented guidance, no install command', () => {
+    const g = tunnelErrorGuidance('tunnel-timeout');
+    expect(g.manualInstallCommand).toBeUndefined();
+    expect(g.detail).toMatch(/network|firewall|region/i);
+  });
+
+  it('tunnel-exited → suggests retrying, no install command', () => {
+    const g = tunnelErrorGuidance('tunnel-exited');
+    expect(g.manualInstallCommand).toBeUndefined();
+    expect(g.detail).toMatch(/again/i);
+  });
+
+  it('unknown code → falls back to the raw backend message', () => {
+    const g = tunnelErrorGuidance('unknown', 'raw backend message');
+    expect(g.detail).toBe('raw backend message');
+  });
+
+  it('null code with no fallback → still returns a generic title and detail', () => {
+    const g = tunnelErrorGuidance(null);
+    expect(g.title).toBeTruthy();
+    expect(g.detail).toBeTruthy();
+  });
+});

--- a/webview/src/hooks/index.ts
+++ b/webview/src/hooks/index.ts
@@ -12,4 +12,5 @@ export { useLoginGate } from './useLoginGate';
 export type { LoadedMessage } from './useChatStream';
 export type { AttachedContext } from './useContext';
 export { useTunnelStatus } from './useTunnelStatus';
+export * from './tunnelError';
 export * from './useEditorContext';

--- a/webview/src/hooks/tunnelError.ts
+++ b/webview/src/hooks/tunnelError.ts
@@ -1,0 +1,54 @@
+// Mirrors TunnelErrorCode in the backend (backend/src/core/features/tunnel-manager.ts).
+// The two packages don't share types, so keep these in sync.
+export type TunnelErrorCode =
+  | 'cloudflared-missing'
+  | 'tunnel-timeout'
+  | 'tunnel-exited'
+  | 'unknown';
+
+export interface TunnelErrorGuidance {
+  title: string;
+  detail: string;
+  /** Shown as a copyable command when the user likely needs to install manually. */
+  manualInstallCommand?: string;
+  helpUrl?: string;
+}
+
+const CLOUDFLARED_DOWNLOADS_URL =
+  'https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/';
+
+/**
+ * Map a tunnel error code to user-facing, actionable guidance. `fallback` is the
+ * raw backend message, used only when the code is unknown.
+ */
+export function tunnelErrorGuidance(
+  code: TunnelErrorCode | null | undefined,
+  fallback?: string,
+): TunnelErrorGuidance {
+  switch (code) {
+    case 'cloudflared-missing':
+      return {
+        title: 'Couldn’t install cloudflared',
+        detail:
+          'The tunnel needs cloudflared, and it couldn’t be installed automatically. Install it manually, then try again.',
+        manualInstallCommand: 'brew install cloudflared',
+        helpUrl: CLOUDFLARED_DOWNLOADS_URL,
+      };
+    case 'tunnel-timeout':
+      return {
+        title: 'Tunnel connection timed out',
+        detail:
+          'Couldn’t reach the Cloudflare tunnel server in time. Check your network or firewall — some regions restrict access to Cloudflare.',
+      };
+    case 'tunnel-exited':
+      return {
+        title: 'cloudflared stopped unexpectedly',
+        detail: 'The tunnel process exited before it was ready. Please try again.',
+      };
+    default:
+      return {
+        title: 'Couldn’t start the tunnel',
+        detail: fallback || 'An unexpected error occurred. Please try again.',
+      };
+  }
+}

--- a/webview/src/hooks/useTunnelStatus.ts
+++ b/webview/src/hooks/useTunnelStatus.ts
@@ -8,12 +8,18 @@ interface TunnelStatus {
   tunnelLoading: boolean;
   /** null until the prerequisite probe returns; false means cloudflared is missing. */
   cloudflaredAvailable: boolean | null;
+  /** true when the user toggled on but cloudflared must be installed first. */
+  awaitingInstallConsent: boolean;
+  /** true while cloudflared is being installed after the user consented. */
+  installing: boolean;
   preventSleep: boolean;
   sleepLoading: boolean;
   error: string | null;
   errorCode: TunnelErrorCode | null;
   handleTunnelToggle: (checked: boolean) => Promise<void>;
   handleSleepToggle: (checked: boolean) => Promise<void>;
+  confirmInstallAndStart: () => Promise<void>;
+  cancelInstall: () => void;
   retryTunnel: () => Promise<void>;
 }
 
@@ -24,10 +30,27 @@ export function useTunnelStatus(): TunnelStatus {
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
   const [tunnelLoading, setTunnelLoading] = useState(false);
   const [cloudflaredAvailable, setCloudflaredAvailable] = useState<boolean | null>(null);
+  const [awaitingInstallConsent, setAwaitingInstallConsent] = useState(false);
+  const [installing, setInstalling] = useState(false);
   const [preventSleep, setPreventSleep] = useState(false);
   const [sleepLoading, setSleepLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<TunnelErrorCode | null>(null);
+
+  // Start the tunnel unconditionally (caller has ensured cloudflared exists).
+  const startTunnelNow = useCallback(async () => {
+    setTunnelLoading(true);
+    try {
+      const res = await send('TUNNEL_START', { port: Number(window.location.port) || 80 });
+      if (res.status === 'error') {
+        setError(res.error as string);
+        setErrorCode('unknown');
+        setTunnelLoading(false);
+      }
+    } catch {
+      setTunnelLoading(false);
+    }
+  }, [send]);
 
   // Fetch initial status
   useEffect(() => {
@@ -41,7 +64,7 @@ export function useTunnelStatus(): TunnelStatus {
     }).catch(() => {});
   }, [send]);
 
-  // Probe prerequisites (cloudflared availability) so the UI can warn upfront
+  // Probe prerequisites (cloudflared availability) so the UI can warn/ask upfront
   useEffect(() => {
     send('GET_TUNNEL_PREREQS', {}).then((res) => {
       const p = res.payload ?? res;
@@ -61,36 +84,61 @@ export function useTunnelStatus(): TunnelStatus {
         setErrorCode((p.errorCode as TunnelErrorCode) ?? 'unknown');
       }
     });
+    const unsubInstall = subscribe('CLOUDFLARED_INSTALL_STATUS', (msg) => {
+      const p = msg.payload as Record<string, unknown>;
+      setInstalling(false);
+      if (p.status === 'installed') {
+        setCloudflaredAvailable(true);
+        startTunnelNow();
+      } else {
+        setError((p.error as string) ?? 'Installation failed');
+        setErrorCode('cloudflared-missing');
+      }
+    });
     const unsubSleep = subscribe('SLEEP_GUARD_STATUS', (msg) => {
       const p = msg.payload as Record<string, unknown>;
       setPreventSleep(p.enabled as boolean);
       setSleepLoading(false);
     });
-    return () => { unsubTunnel(); unsubSleep(); };
-  }, [subscribe]);
+    return () => { unsubTunnel(); unsubInstall(); unsubSleep(); };
+  }, [subscribe, startTunnelNow]);
 
   const handleTunnelToggle = useCallback(async (checked: boolean) => {
     setError(null);
     setErrorCode(null);
     if (checked) {
-      setTunnelLoading(true);
-      try {
-        const res = await send('TUNNEL_START', { port: Number(window.location.port) || 80 });
-        if (res.status === 'error') {
-          setError(res.error as string);
-          setErrorCode('unknown');
-          setTunnelLoading(false);
-        }
-      } catch {
-        setTunnelLoading(false);
+      // Missing cloudflared → ask for install consent instead of starting.
+      if (cloudflaredAvailable === false) {
+        setAwaitingInstallConsent(true);
+        return;
       }
+      await startTunnelNow();
     } else {
+      setAwaitingInstallConsent(false);
       if (preventSleep) {
         await send('SLEEP_GUARD_DISABLE', {}).catch(() => {});
       }
       await send('TUNNEL_STOP', {}).catch(() => {});
     }
-  }, [send, preventSleep]);
+  }, [cloudflaredAvailable, startTunnelNow, preventSleep, send]);
+
+  const confirmInstallAndStart = useCallback(async () => {
+    setAwaitingInstallConsent(false);
+    setError(null);
+    setErrorCode(null);
+    setInstalling(true);
+    // Outcome arrives via the CLOUDFLARED_INSTALL_STATUS broadcast, which then
+    // starts the tunnel on success.
+    await send('INSTALL_CLOUDFLARED', {}).catch(() => {
+      setInstalling(false);
+      setError('Installation failed');
+      setErrorCode('cloudflared-missing');
+    });
+  }, [send]);
+
+  const cancelInstall = useCallback(() => {
+    setAwaitingInstallConsent(false);
+  }, []);
 
   const handleSleepToggle = useCallback(async (checked: boolean) => {
     setError(null);
@@ -117,12 +165,16 @@ export function useTunnelStatus(): TunnelStatus {
     tunnelUrl,
     tunnelLoading,
     cloudflaredAvailable,
+    awaitingInstallConsent,
+    installing,
     preventSleep,
     sleepLoading,
     error,
     errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    confirmInstallAndStart,
+    cancelInstall,
     retryTunnel,
   };
 }

--- a/webview/src/hooks/useTunnelStatus.ts
+++ b/webview/src/hooks/useTunnelStatus.ts
@@ -1,15 +1,20 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useBridge } from './useBridge';
+import type { TunnelErrorCode } from './tunnelError';
 
 interface TunnelStatus {
   tunnelEnabled: boolean;
   tunnelUrl: string | null;
   tunnelLoading: boolean;
+  /** null until the prerequisite probe returns; false means cloudflared is missing. */
+  cloudflaredAvailable: boolean | null;
   preventSleep: boolean;
   sleepLoading: boolean;
   error: string | null;
+  errorCode: TunnelErrorCode | null;
   handleTunnelToggle: (checked: boolean) => Promise<void>;
   handleSleepToggle: (checked: boolean) => Promise<void>;
+  retryTunnel: () => Promise<void>;
 }
 
 export function useTunnelStatus(): TunnelStatus {
@@ -18,9 +23,11 @@ export function useTunnelStatus(): TunnelStatus {
   const [tunnelEnabled, setTunnelEnabled] = useState(false);
   const [tunnelUrl, setTunnelUrl] = useState<string | null>(null);
   const [tunnelLoading, setTunnelLoading] = useState(false);
+  const [cloudflaredAvailable, setCloudflaredAvailable] = useState<boolean | null>(null);
   const [preventSleep, setPreventSleep] = useState(false);
   const [sleepLoading, setSleepLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<TunnelErrorCode | null>(null);
 
   // Fetch initial status
   useEffect(() => {
@@ -34,6 +41,14 @@ export function useTunnelStatus(): TunnelStatus {
     }).catch(() => {});
   }, [send]);
 
+  // Probe prerequisites (cloudflared availability) so the UI can warn upfront
+  useEffect(() => {
+    send('GET_TUNNEL_PREREQS', {}).then((res) => {
+      const p = res.payload ?? res;
+      if (p.status === 'ok') setCloudflaredAvailable(Boolean(p.cloudflaredAvailable));
+    }).catch(() => {});
+  }, [send]);
+
   // Subscribe to broadcast updates
   useEffect(() => {
     const unsubTunnel = subscribe('TUNNEL_STATUS', (msg) => {
@@ -43,6 +58,7 @@ export function useTunnelStatus(): TunnelStatus {
       setTunnelLoading(false);
       if (p.error) {
         setError(p.error as string);
+        setErrorCode((p.errorCode as TunnelErrorCode) ?? 'unknown');
       }
     });
     const unsubSleep = subscribe('SLEEP_GUARD_STATUS', (msg) => {
@@ -55,12 +71,14 @@ export function useTunnelStatus(): TunnelStatus {
 
   const handleTunnelToggle = useCallback(async (checked: boolean) => {
     setError(null);
+    setErrorCode(null);
     if (checked) {
       setTunnelLoading(true);
       try {
         const res = await send('TUNNEL_START', { port: Number(window.location.port) || 80 });
         if (res.status === 'error') {
           setError(res.error as string);
+          setErrorCode('unknown');
           setTunnelLoading(false);
         }
       } catch {
@@ -92,14 +110,19 @@ export function useTunnelStatus(): TunnelStatus {
     }
   }, [send]);
 
+  const retryTunnel = useCallback(() => handleTunnelToggle(true), [handleTunnelToggle]);
+
   return {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    cloudflaredAvailable,
     preventSleep,
     sleepLoading,
     error,
+    errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    retryTunnel,
   };
 }

--- a/webview/src/pages/SettingsPage/Tunnel/index.tsx
+++ b/webview/src/pages/SettingsPage/Tunnel/index.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
+import { TunnelStatusNotice } from '@/components/TunnelStatusNotice';
 import { ROUTE_META, Route } from '@/router/routes';
 import { SettingSection, SettingRow } from '../common';
 import { useTunnelStatus } from '@/hooks';
@@ -11,11 +12,14 @@ export function TunnelSettings() {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    cloudflaredAvailable,
     preventSleep,
     sleepLoading,
     error,
+    errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    retryTunnel,
   } = useTunnelStatus();
 
   const [copied, setCopied] = useState(false);
@@ -52,11 +56,14 @@ export function TunnelSettings() {
       <h2 className="text-xl font-semibold text-text-primary mb-6">{meta.label}</h2>
 
       <SettingSection title="Connection">
-        {error && (
-          <div className="py-2 px-3 text-sm text-state-error-fg bg-state-error-bg rounded">
-            {error}
-          </div>
-        )}
+        <TunnelStatusNotice
+          cloudflaredAvailable={cloudflaredAvailable}
+          tunnelEnabled={tunnelEnabled}
+          tunnelLoading={tunnelLoading}
+          error={error}
+          errorCode={errorCode}
+          onRetry={retryTunnel}
+        />
         <SettingRow
           label="Remote Tunnel (Unofficial)"
           description="Expose your local server via cloudflared for remote access. No account required. If cloudflared is not installed, it will be downloaded automatically."
@@ -75,7 +82,7 @@ export function TunnelSettings() {
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
-              <span>Establishing tunnel connection... ({elapsedSec}s)</span>
+              <span>{cloudflaredAvailable === false ? 'Installing cloudflared…' : 'Establishing tunnel connection…'} ({elapsedSec}s)</span>
             </div>
             <p className="text-xs text-text-disabled">This typically takes ~1 min (If installation is required, it takes about 3 mins.)</p>
           </div>

--- a/webview/src/pages/SettingsPage/Tunnel/index.tsx
+++ b/webview/src/pages/SettingsPage/Tunnel/index.tsx
@@ -13,12 +13,16 @@ export function TunnelSettings() {
     tunnelUrl,
     tunnelLoading,
     cloudflaredAvailable,
+    awaitingInstallConsent,
+    installing,
     preventSleep,
     sleepLoading,
     error,
     errorCode,
     handleTunnelToggle,
     handleSleepToggle,
+    confirmInstallAndStart,
+    cancelInstall,
     retryTunnel,
   } = useTunnelStatus();
 
@@ -29,7 +33,7 @@ export function TunnelSettings() {
   const meta = ROUTE_META[Route.SETTINGS_TUNNEL];
 
   useEffect(() => {
-    if (tunnelLoading) {
+    if (tunnelLoading || installing) {
       setElapsedSec(0);
       elapsedRef.current = setInterval(() => setElapsedSec((s) => s + 1), 1000);
     } else {
@@ -41,7 +45,7 @@ export function TunnelSettings() {
     return () => {
       if (elapsedRef.current) clearInterval(elapsedRef.current);
     };
-  }, [tunnelLoading]);
+  }, [tunnelLoading, installing]);
 
   const handleCopy = () => {
     if (!tunnelUrl) return;
@@ -60,29 +64,33 @@ export function TunnelSettings() {
           cloudflaredAvailable={cloudflaredAvailable}
           tunnelEnabled={tunnelEnabled}
           tunnelLoading={tunnelLoading}
+          installing={installing}
+          awaitingInstallConsent={awaitingInstallConsent}
           error={error}
           errorCode={errorCode}
           onRetry={retryTunnel}
+          onConfirmInstall={confirmInstallAndStart}
+          onCancelInstall={cancelInstall}
         />
         <SettingRow
           label="Remote Tunnel (Unofficial)"
-          description="Expose your local server via cloudflared for remote access. No account required. If cloudflared is not installed, it will be downloaded automatically."
+          description="Expose your local server via cloudflared for remote access. No account required. If cloudflared isn’t installed, you’ll be asked to install it first."
         >
           <ToggleSwitch
             checked={tunnelEnabled}
             onChange={handleTunnelToggle}
-            disabled={tunnelLoading}
+            disabled={tunnelLoading || installing}
           />
         </SettingRow>
 
-        {tunnelLoading && (
+        {(tunnelLoading || installing) && (
           <div className="py-4 border-b border-border-default flex flex-col items-center gap-2">
             <div className="flex items-center gap-2 text-sm text-text-secondary">
               <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
                 <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                 <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
               </svg>
-              <span>{cloudflaredAvailable === false ? 'Installing cloudflared…' : 'Establishing tunnel connection…'} ({elapsedSec}s)</span>
+              <span>{installing ? 'Installing cloudflared…' : 'Establishing tunnel connection…'} ({elapsedSec}s)</span>
             </div>
             <p className="text-xs text-text-disabled">This typically takes ~1 min (If installation is required, it takes about 3 mins.)</p>
           </div>


### PR DESCRIPTION
## Problem

The Remote Tunnel feature (the "remote control" a Marketplace reviewer reported as not working) had an asymmetric UX bug: the view that **toggled the tunnel on** kept spinning for 30–60s, while the **other view** (Settings ↔ chat header) showed the QR code within seconds.

## Root cause

The tunnel URL is extracted from the cloudflared log within a few seconds, but `startTunnel` did not resolve there — it waited for `waitForTunnelReady`, which polled the tunnel URL for an HTTP 200 for up to 30s. That resolve is what fires the `TUNNEL_STATUS` broadcast, and the toggling view only clears its spinner when it receives that broadcast. The other view never set a spinner; it picks up the already-running state via `GET_TUNNEL_STATUS` on mount, so it looked instant.

The warm-up poll was best-effort (it proceeded anyway on timeout), measured the backend's own HTTP path rather than the phone's, and checked HTTP `/` rather than the WebSocket that actually matters.

## Fix

Resolve as soon as the tunnel URL is available and broadcast immediately. Remove `waitForTunnelReady` and the now-unused `http`/`https` imports.

## Verification (measured)

Reproduced with the same `cloudflared tunnel --protocol http2 --url http://localhost:PORT` the manager uses, driving a real `TUNNEL_START` over `/ws`:

| Item | Result |
|------|--------|
| `TUNNEL_STATUS` broadcast latency | ~30s+ → **4.0s** |
| Tunnel URL reachable right after it's printed (no warm-up) | HTTP 200 immediately; WebSocket `OPEN` + `BRIDGE_READY` |
| Backend typecheck (`tsc --noEmit`) | clean |
| Backend tests | 355 passed |