### PR TITLE
test: fix failing AuthErrorRenderer unit test (missing auth context)

### DIFF
--- a/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
@@ -3,6 +3,13 @@ import { render, screen } from '@testing-library/react';
 import { LoadedMessageDto } from '../../../../types';
 import { LoadedMessageType, toInstance } from '../../../../dto/common';
 
+// AuthErrorRenderer reads loggedIn from the auth context; without a provider
+// it throws. Mock the context (as LoginCta's own test does) so the renderer can
+// be unit-tested in isolation. logged-out → the red status dot is shown.
+vi.mock('@/contexts', () => ({
+  useAuthContext: () => ({ loggedIn: false }),
+}));
+
 vi.mock('../../LoginCta', () => ({
   LoginCta: () => <button data-testid="login-cta">Re-Sign</button>,
 }));


### PR DESCRIPTION
## Problem

`AuthErrorRenderer.test.tsx` (3 tests) has been failing on `main` with:

```
useAuthContext must be used within an AuthProvider
```

`AuthErrorRenderer` reads `loggedIn` from `useAuthContext`, but the test renders it without an `AuthProvider`. This has been broken since the renderer was added in #91 — it's a test-only gap, not a product bug.

## Fix

Mock `@/contexts` (logged-out → red status dot) exactly as `LoginCta`'s own test already does. No product code changes.

## Verification

- `AuthErrorRenderer.test.tsx`: 3/3 pass
- Full webview suite: **706 passed (68 files)** — previously 703 passed / 3 failed