### PR TITLE
fix: resolve WSL claude/node ENOENT via interactive-login PATH capture (#57)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -160,12 +160,19 @@ class NodeProcessManager(
                     // PATH. NOTE: not verifiable on our dev host — see issue #57 (S4b).
                     val linuxBackend = WslPathResolver.toWslPath(backendFile.absolutePath)
                         ?: backendFile.absolutePath
+                    // Capture the distro's interactive-login PATH (sources ~/.bashrc, so nvm/fnm/nix
+                    // bin dirs are present) and inject it into the backend env. The backend launches
+                    // with `bash -lc` (login only) which never reads ~/.bashrc, so without this the
+                    // `node`/`claude` it spawns fail with ENOENT when installed on those paths (#57).
+                    // Null = capture failed; fall back to the login-shell PATH (no PATH export).
+                    val wslShellPath = ShellPathResolver.resolveWsl(wslDistro)
                     val wslEnv = buildMap {
                         put("JETBRAINS_MODE", "true")
                         put("PORT", requestedPort.toString())
                         webviewDir?.let { wv ->
                             WslPathResolver.toWslPath(wv.absolutePath)?.let { put("WEBVIEW_DIR", it) }
                         }
+                        wslShellPath?.let { put("PATH", it) }
                     }
                     val cmd = WslPathResolver.buildWslNodeCommand(wslDistro, wslCwd, wslEnv, linuxBackend)
                     logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${cmd.joinToString(" ")}")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
@@ -47,13 +47,38 @@ object ShellPathResolver {
 
         cache[shell]?.let { return it.ifEmpty { null } }
 
-        val resolved = runShell(shell)
+        val resolved = capturePath(shell) { marker -> listOf(shell, "-lic", buildShellCommand(marker)) }
         cache[shell] = resolved ?: ""
         return resolved
     }
 
-    /** Launch the shell and capture its PATH. Returns null on any failure. */
-    private fun runShell(shell: String): String? {
+    /**
+     * Resolve the real shell PATH *inside* a WSL [distro], the WSL counterpart of [resolve].
+     *
+     * A WSL backend is launched by `WslPathResolver.buildWslNodeCommand` with `bash -lc` (login
+     * only), which never sources `~/.bashrc` — so nvm/fnm/nix bin dirs that live there are absent
+     * and `spawn claude`/`node` fails with ENOENT (issue #57). This captures the PATH the same way
+     * native does (`bash -lic`, interactive login) so the caller can inject it back into the
+     * backend's env. Cached per distro. Returns null on any failure (caller falls back to the
+     * login-shell PATH). Only meaningful on Windows, where WSL exists.
+     */
+    @Synchronized
+    fun resolveWsl(distro: String): String? {
+        val key = "wsl:$distro"
+        cache[key]?.let { return it.ifEmpty { null } }
+
+        val resolved = capturePath(key) { marker ->
+            WslPathResolver.buildWslPathCaptureCommand(distro, buildShellCommand(marker))
+        }
+        cache[key] = resolved ?: ""
+        return resolved
+    }
+
+    /**
+     * Launch a process built by [commandFor] (given a fresh marker) and slice the marker-wrapped
+     * PATH out of its stdout. [label] is only for logging. Returns null on any failure.
+     */
+    private fun capturePath(label: String, commandFor: (String) -> List<String>): String? {
         val marker = UUID.randomUUID().toString().replace("-", "")
         return try {
             // Capture stdout ONLY. An interactive shell can write warnings to stderr
@@ -61,26 +86,26 @@ object ShellPathResolver {
             // stdout risks polluting the marker-sandwiched PATH. DISCARD routes stderr
             // to the OS null sink, so it can neither corrupt the slice nor fill a pipe
             // buffer and block the shell.
-            val pb = ProcessBuilder(shell, "-lic", buildShellCommand(marker))
+            val pb = ProcessBuilder(commandFor(marker))
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
             val proc = pb.start()
             val output = proc.inputStream.bufferedReader().use { it.readText() }
             val finished = proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
             if (!finished) {
                 proc.destroyForcibly()
-                logger.info("resolveShellPath: $shell timed out after ${TIMEOUT_SECONDS}s")
+                logger.info("resolveShellPath: $label timed out after ${TIMEOUT_SECONDS}s")
                 return null
             }
             val path = extractBetweenMarkers(output, marker)
             if (looksLikePath(path)) {
-                logger.info("resolveShellPath: $shell -> ${path!!.split(":").size} entries")
+                logger.info("resolveShellPath: $label -> ${path!!.split(":").size} entries")
                 path
             } else {
-                logger.info("resolveShellPath: $shell returned empty/invalid PATH")
+                logger.info("resolveShellPath: $label returned empty/invalid PATH")
                 null
             }
         } catch (e: Exception) {
-            logger.info("resolveShellPath: $shell failed: ${e.message}")
+            logger.info("resolveShellPath: $label failed: ${e.message}")
             null
         }
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
@@ -145,6 +145,28 @@ object WslPathResolver {
         }
     }
 
+    /**
+     * Build the command that captures the WSL distro's real shell PATH from the Windows host,
+     * via an **interactive login shell** (`bash -lic`) so the user's full PATH is sourced.
+     *
+     * Why interactive (`-i`) and not just login (`-l`): version managers like nvm/fnm and the
+     * nix profile add their bin directories in `~/.bashrc`, which a *non*-interactive login
+     * shell never reads. [buildWslNodeCommand] launches the backend with `bash -lc` (login only),
+     * so on its own it misses those PATH entries — exactly the `spawn claude ENOENT` reported on
+     * issue #57. This builder mirrors what native `ShellPathResolver` does with `$SHELL -lic`,
+     * giving WSL the same PATH-capture guarantee. The captured PATH is then injected back into
+     * [buildWslNodeCommand]'s env, so the backend (and the `claude`/`node` it spawns) sees it.
+     *
+     * [innerShellCommand] should print the PATH wrapped in markers (see
+     * `ShellPathResolver.buildShellCommand`) so the caller can slice it out of shell startup noise.
+     * Capturing in a *separate* process keeps that noise off the backend's own stdout.
+     *
+     * Produces, e.g.:
+     * `wsl.exe -d NixOS -- bash -lic "printf 'M'; command printenv PATH; printf 'M'"`
+     */
+    fun buildWslPathCaptureCommand(distro: String, innerShellCommand: String): List<String> =
+        listOf("wsl.exe", "-d", distro, "--", "bash", "-lic", innerShellCommand)
+
     /** POSIX-safe single-quote: wrap in `'…'`, replace each `'` inside with `'\''`. */
     private fun shellQuote(s: String): String = "'" + s.replace("'", "'\\''") + "'"
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolverTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolverTest.kt
@@ -199,4 +199,35 @@ class WslPathResolverTest {
             )
         }
     }
+
+    @Nested
+    inner class BuildWslPathCaptureCommand {
+        @Test
+        fun `wraps the inner shell command in a login shell inside the distro`() {
+            val inner = "printf 'M'; command printenv PATH; printf 'M'"
+            val cmd = WslPathResolver.buildWslPathCaptureCommand("NixOS", inner)
+            assertEquals(
+                listOf("wsl.exe", "-d", "NixOS", "--", "bash", "-lic", inner),
+                cmd,
+            )
+        }
+
+        @Test
+        fun `uses an interactive login shell so bashrc-managed PATH is sourced`() {
+            // -lic (interactive), NOT -lc: nvm/fnm/nix add their bin dirs in .bashrc,
+            // which a non-interactive login shell never reads. This is the whole point
+            // of capturing the WSL PATH the same way native ShellPathResolver does.
+            val cmd = WslPathResolver.buildWslPathCaptureCommand("Ubuntu", "x")
+            assertTrue(cmd.contains("-lic"))
+            assertFalse(cmd.contains("-lc"))
+        }
+
+        @Test
+        fun `passes the distro through -d`() {
+            val cmd = WslPathResolver.buildWslPathCaptureCommand("Debian", "x")
+            assertEquals("wsl.exe", cmd[0])
+            assertEquals("-d", cmd[1])
+            assertEquals("Debian", cmd[2])
+        }
+    }
 }


### PR DESCRIPTION
## Problem

Issue #57 was reopened by a comment from @maicol07: on v0.18.1 a WSL project fails with `Service error: SPAWN_ERROR - spawn claude ENOENT`. This is distinct from the original PowerShell-vs-bash issue — the Node backend running inside the WSL distro cannot find `claude` on its PATH.

## Root cause

native and WSL resolved the user's shell PATH asymmetrically:

| Path | Shell | Reads `~/.bashrc`? |
|------|-------|--------------------|
| native | `$SHELL -lic` | yes (interactive) |
| WSL | `bash -lc` | no (login only) |

nvm/fnm/nix add their `bin` dirs in `~/.bashrc`, which a non-interactive login shell never sources — so `node`/`claude` installed that way are absent from the WSL backend's PATH. native already captured PATH with `$SHELL -lic`; WSL had no such capture step.

## Change

Unify "capture the user's real shell PATH and inject it into the backend" across native and WSL.

- `WslPathResolver.buildWslPathCaptureCommand(distro, inner)` — pure builder for `wsl.exe -d <distro> -- bash -lic <inner>` (interactive).
- `ShellPathResolver` — generalise capture into `capturePath()`; add `resolveWsl(distro)`, cached per distro.
- `NodeProcessManager` — inject the captured PATH into the WSL backend env (`export PATH='<captured>'` before `exec node`) so node/claude resolve from it; fall back to the login PATH on capture failure.

## Verification

- `./scripts/build.sh build` → BUILD SUCCESSFUL (compile + all Kotlin unit tests, incl. 3 new builder tests).
- ⚠️ WSL runtime behaviour is **not verifiable on macOS** — needs Windows + WSL2 measurement before this can be claimed fixed.

## Not in scope (follow-ups)

- WSL2 localhost port reachability (backend binds `127.0.0.1`).
- node absolute-path fallback when PATH capture fails.
- wsl.exe zombie / idle-shutdown lifecycle.
- friendly "not installed in WSL" diagnostic.