### PR TITLE
fix: Claude in WSL projects + Windows login screen stuck (#57, #99)

### DIFF
--- a/backend/src/core/__tests__/claude.test.ts
+++ b/backend/src/core/__tests__/claude.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 
 // We can't easily test Claude class directly because buildAugmentedPath runs
 // at class load time. Instead we test the observable behavior.
@@ -9,6 +9,24 @@ vi.mock('../features/settings', () => ({
   readSettingsFile: vi.fn().mockResolvedValue({ cliPath: null }),
 }));
 
+// Mock child_process so we can inspect the options passed to spawn/execFile
+// without launching a real process.
+vi.mock('child_process', () => ({
+  spawn: vi.fn(() => ({ on: vi.fn() })),
+  execFile: vi.fn(
+    (
+      _cmd: string,
+      _args: string[],
+      _opts: unknown,
+      cb?: (err: unknown, stdout: string, stderr: string) => void,
+    ) => {
+      cb?.(null, '{}', '');
+      return { on: vi.fn() };
+    },
+  ),
+}));
+
+import { spawn as cpSpawn, execFile as cpExecFile } from 'child_process';
 import { Claude } from '../claude';
 
 describe('Claude', () => {
@@ -35,6 +53,52 @@ describe('Claude', () => {
   describe('refresh()', () => {
     it('should load settings without throwing', async () => {
       await expect(Claude.refresh()).resolves.not.toThrow();
+    });
+  });
+
+  // Regression for issue #99: on Windows the `claude` launcher is a .cmd/.ps1
+  // wrapper that execFile cannot run without a shell, so `claude auth status`
+  // (GET_ACCOUNT) failed with ENOENT and the user was stuck on the login screen
+  // even while already authenticated. spawn() already ran through a shell on
+  // win32; exec() must do the same so the two stay symmetric.
+  describe('shell handling across platforms', () => {
+    const originalPlatform = process.platform;
+
+    const setPlatform = (value: NodeJS.Platform) => {
+      Object.defineProperty(process, 'platform', { value, configurable: true });
+    };
+
+    afterEach(() => {
+      setPlatform(originalPlatform);
+      vi.clearAllMocks();
+    });
+
+    it('exec() runs through a shell on win32 (#99)', async () => {
+      setPlatform('win32');
+      await Claude.exec(['auth', 'status']);
+      const opts = vi.mocked(cpExecFile).mock.calls[0]?.[2] as { shell?: boolean };
+      expect(opts.shell).toBe(true);
+    });
+
+    it('exec() does not force a shell on non-win32', async () => {
+      setPlatform('darwin');
+      await Claude.exec(['auth', 'status']);
+      const opts = vi.mocked(cpExecFile).mock.calls[0]?.[2] as { shell?: boolean };
+      expect(opts.shell).toBeFalsy();
+    });
+
+    it('exec() honors an explicit shell override', async () => {
+      setPlatform('win32');
+      await Claude.exec(['auth', 'status'], { shell: false });
+      const opts = vi.mocked(cpExecFile).mock.calls[0]?.[2] as { shell?: boolean };
+      expect(opts.shell).toBe(false);
+    });
+
+    it('spawn() runs through a shell on win32', () => {
+      setPlatform('win32');
+      Claude.spawn(['auth', 'login', '--claudeai']);
+      const opts = vi.mocked(cpSpawn).mock.calls[0]?.[2] as { shell?: boolean };
+      expect(opts.shell).toBe(true);
     });
   });
 });

--- a/backend/src/core/__tests__/wsl-path.test.ts
+++ b/backend/src/core/__tests__/wsl-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isWslUncPath } from '../wsl-path';
+import { isWslUncPath, parseUncPath, toWslPath } from '../wsl-path';
 
 describe('isWslUncPath', () => {
   it('recognizes the modern wsl.localhost prefix', () => {
@@ -28,5 +28,72 @@ describe('isWslUncPath', () => {
     expect(isWslUncPath(null)).toBe(false);
     expect(isWslUncPath(undefined)).toBe(false);
     expect(isWslUncPath('')).toBe(false);
+  });
+});
+
+describe('parseUncPath', () => {
+  it('extracts distro and linux path from the modern prefix', () => {
+    expect(parseUncPath('\\\\wsl.localhost\\Ubuntu\\home\\user\\proj')).toEqual({
+      distro: 'Ubuntu',
+      linuxPath: '/home/user/proj',
+    });
+  });
+
+  it('extracts distro and linux path from the legacy prefix', () => {
+    expect(parseUncPath('\\\\wsl$\\NixOS\\home\\maicol07')).toEqual({
+      distro: 'NixOS',
+      linuxPath: '/home/maicol07',
+    });
+  });
+
+  it('accepts already forward-slashed input', () => {
+    expect(parseUncPath('//wsl.localhost/Ubuntu/home/yhk/test-proj')).toEqual({
+      distro: 'Ubuntu',
+      linuxPath: '/home/yhk/test-proj',
+    });
+  });
+
+  it('preserves distro casing while matching host case-insensitively', () => {
+    expect(parseUncPath('\\\\WSL.LOCALHOST\\Ubuntu-22.04\\srv\\app')).toEqual({
+      distro: 'Ubuntu-22.04',
+      linuxPath: '/srv/app',
+    });
+  });
+
+  it('returns distro root when there is no inner path', () => {
+    expect(parseUncPath('\\\\wsl.localhost\\Ubuntu')).toEqual({
+      distro: 'Ubuntu',
+      linuxPath: '/',
+    });
+  });
+
+  it('returns null for non-wsl paths', () => {
+    expect(parseUncPath('C:\\Users\\foo')).toBeNull();
+    expect(parseUncPath('/home/user')).toBeNull();
+    expect(parseUncPath(null)).toBeNull();
+  });
+});
+
+describe('toWslPath', () => {
+  it('converts a wsl unc path to the inner linux path', () => {
+    expect(toWslPath('\\\\wsl.localhost\\Ubuntu\\home\\yhk\\test-proj')).toBe('/home/yhk/test-proj');
+    expect(toWslPath('//wsl.localhost/Ubuntu/home/yhk/test-proj')).toBe('/home/yhk/test-proj');
+    expect(toWslPath('\\\\wsl$\\NixOS\\home\\maicol07')).toBe('/home/maicol07');
+  });
+
+  it('converts a drive path to a /mnt path', () => {
+    expect(toWslPath('C:\\Users\\foo\\bar')).toBe('/mnt/c/Users/foo/bar');
+    expect(toWslPath('D:\\work')).toBe('/mnt/d/work');
+    expect(toWslPath('C:\\')).toBe('/mnt/c');
+  });
+
+  it('leaves an existing linux path unchanged', () => {
+    expect(toWslPath('/home/user/proj')).toBe('/home/user/proj');
+  });
+
+  it('passes null and blank through unchanged', () => {
+    expect(toWslPath(null)).toBeNull();
+    expect(toWslPath(undefined)).toBeUndefined();
+    expect(toWslPath('')).toBe('');
   });
 });

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -46,6 +46,13 @@ export class Claude {
       cpExecFile(Claude.command, args, {
         timeout: 10000,
         ...options,
+        // On Windows the `claude` launcher is a .cmd/.ps1 wrapper that execFile
+        // cannot run without a shell (it fails with ENOENT). spawn() already
+        // runs through a shell on win32; keep exec() symmetric so `auth status`
+        // and `--version` resolve the wrapper. Without this, GET_ACCOUNT always
+        // reported "not logged in" and users were stuck on the login screen
+        // even while authenticated (#99).
+        shell: options?.shell ?? (process.platform === 'win32'),
         env: {
           ...Claude.env,
           ...options?.env,

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -7,6 +7,20 @@ import {
 } from 'child_process';
 import { readSettingsFile } from './features/settings';
 import { augmentedPath } from './augmented-path';
+import { isWslUncPath, toWslPath } from './wsl-path';
+
+/**
+ * In a WSL backend (running inside the distro, platform === 'linux') the IDE hands us the
+ * project root as a Windows UNC path (`//wsl.localhost/Ubuntu/home/...`). That path does not
+ * exist inside the distro, so spawning the CLI with it as cwd fails with `spawn ... ENOENT`
+ * — the *cwd*, not the binary, is missing. Convert it to the inner Linux path. Issue #57.
+ */
+function resolveWslCwd(cwd: SpawnOptions['cwd']): SpawnOptions['cwd'] {
+  if (process.platform === 'linux' && typeof cwd === 'string' && isWslUncPath(cwd)) {
+    return toWslPath(cwd) ?? cwd;
+  }
+  return cwd;
+}
 
 export class Claude {
   private static cliPath: string | null = null;
@@ -33,6 +47,7 @@ export class Claude {
   static spawn(args: string[], options?: SpawnOptions): ChildProcess {
     return cpSpawn(Claude.command, args, {
       ...options,
+      cwd: resolveWslCwd(options?.cwd),
       shell: options?.shell ?? (process.platform === 'win32'),
       env: {
         ...Claude.env,
@@ -46,6 +61,7 @@ export class Claude {
       cpExecFile(Claude.command, args, {
         timeout: 10000,
         ...options,
+        cwd: resolveWslCwd(options?.cwd),
         // On Windows the `claude` launcher is a .cmd/.ps1 wrapper that execFile
         // cannot run without a shell (it fails with ENOENT). spawn() already
         // runs through a shell on win32; keep exec() symmetric so `auth status`

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -27,6 +27,7 @@ import { getVersionHandler } from './getVersion';
 import { getAccountHandler } from './getAccount';
 import { reclaimSessionHandler } from './reclaimSession';
 import { loginHandler } from './login';
+import { submitLoginCodeHandler } from './submitLoginCode';
 import { openUrlHandler } from './openUrl';
 import { getAvailableTerminalsHandler } from './getAvailableTerminals';
 import { getDetectedCliPathHandler } from './getDetectedCliPath';
@@ -140,6 +141,9 @@ export async function handleMessage(
       break;
     case 'LOGIN':
       await loginHandler(connectionId, message, connections, bridge);
+      break;
+    case 'SUBMIT_LOGIN_CODE':
+      submitLoginCodeHandler(connectionId, message, connections, bridge);
       break;
     case 'OPEN_URL':
       await openUrlHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/login.ts
+++ b/backend/src/core/handlers/login.ts
@@ -1,13 +1,19 @@
+import type { ChildProcess } from 'child_process';
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { Claude } from '../claude';
 
+// In-flight `claude auth login` processes, keyed by the webview connection that
+// started them. Kept so a later SUBMIT_LOGIN_CODE message can write the pasted
+// OAuth code to the right process's stdin. Issue #57.
+const activeLoginChildren = new Map<string, ChildProcess>();
+
 export function loginHandler(
   connectionId: string,
   message: IPCMessage,
   connections: ConnectionManager,
-  _bridge: Bridge,
+  bridge: Bridge,
 ): Promise<void> {
   return new Promise((resolve) => {
     // Map the webview-selected login method to the CLI flag. The default
@@ -17,11 +23,59 @@ export function loginHandler(
     const method = message.payload?.method as string | undefined;
     const methodFlag = method === 'console' ? '--console' : '--claudeai';
 
+    // stdin stays open ('pipe') so we can feed back the OAuth code the user pastes
+    // after signing in (see submitLoginCode).
     const child = Claude.spawn(['auth', 'login', methodFlag], {
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
+    activeLoginChildren.set(connectionId, child);
+
+    let buf = '';
+    let urlOpened = false;
+    let codeRequested = false;
+    const scan = (chunk: Buffer): void => {
+      buf += chunk.toString();
+
+      // (1) claude tries to open the browser itself, but where it can't find an
+      // opener it silently prints "visit: <url>" and waits — e.g. WSL with
+      // appendWindowsPath=false (no xdg-open/cmd/explorer on PATH; claude ignores
+      // $BROWSER), where the user got an endless spinner and no browser. Capture the
+      // OAuth URL and open it through the IDE (BrowserUtil.browse on the Windows
+      // side). Issue #57.
+      if (!urlOpened) {
+        const match = buf.match(/https:\/\/[^\s]*\/oauth\/authorize[^\s]*/);
+        if (match) {
+          urlOpened = true;
+          console.error('[login] opening OAuth URL via IDE:', match[0]);
+          bridge.openUrl(match[0]).catch((err) => {
+            console.error('[login] bridge.openUrl failed:', err);
+          });
+        }
+      }
+
+      // (2) When the flow can't auto-complete via a local callback, the CLI prints
+      // the post-sign-in code prompt ("Paste code here ...") and waits on stdin. This
+      // prompt does NOT appear for every user/flow, so we tell the webview to reveal
+      // an OPTIONAL code-input field only once we actually observe it. Issue #57.
+      if (!codeRequested && /paste code/i.test(buf)) {
+        codeRequested = true;
+        console.error('[login] CLI is prompting for an OAuth code; asking webview to show input');
+        connections.sendTo(connectionId, 'LOGIN_CODE_REQUIRED', {
+          requestId: message.requestId,
+        });
+      }
+    };
+    child.stdout?.on('data', scan);
+    child.stderr?.on('data', scan);
+
+    const cleanup = (): void => {
+      if (activeLoginChildren.get(connectionId) === child) {
+        activeLoginChildren.delete(connectionId);
+      }
+    };
 
     child.on('close', (code) => {
+      cleanup();
       connections.sendTo(connectionId, 'ACK', {
         requestId: message.requestId,
         status: code === 0 ? 'ok' : 'error',
@@ -31,6 +85,7 @@ export function loginHandler(
     });
 
     child.on('error', (err) => {
+      cleanup();
       connections.sendTo(connectionId, 'ACK', {
         requestId: message.requestId,
         status: 'error',
@@ -39,4 +94,16 @@ export function loginHandler(
       resolve();
     });
   });
+}
+
+/**
+ * Feed the OAuth code the user pasted in the webview to the in-flight
+ * `claude auth login` process for [connectionId]. Returns false when there is no
+ * such process or its stdin is no longer writable. Issue #57.
+ */
+export function submitLoginCode(connectionId: string, code: string): boolean {
+  const child = activeLoginChildren.get(connectionId);
+  if (!child?.stdin?.writable) return false;
+  child.stdin.write(code.trim() + '\n');
+  return true;
 }

--- a/backend/src/core/handlers/submitLoginCode.ts
+++ b/backend/src/core/handlers/submitLoginCode.ts
@@ -1,0 +1,26 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { submitLoginCode } from './login';
+
+/**
+ * Write the OAuth code the user pasted in the webview to the in-flight
+ * `claude auth login` process. The final login result still arrives via the
+ * original LOGIN request's ACK (emitted when the CLI process closes). Issue #57.
+ */
+export function submitLoginCodeHandler(
+  connectionId: string,
+  message: IPCMessage,
+  _connections: ConnectionManager,
+  _bridge: Bridge,
+): void {
+  const code = message.payload?.code as string | undefined;
+  if (!code) {
+    console.error('[submitLoginCode] missing code in payload');
+    return;
+  }
+  const ok = submitLoginCode(connectionId, code);
+  if (!ok) {
+    console.error('[submitLoginCode] no active login process (or stdin closed) for', connectionId);
+  }
+}

--- a/backend/src/core/wsl-path.ts
+++ b/backend/src/core/wsl-path.ts
@@ -12,3 +12,78 @@ export function isWslUncPath(p: string | undefined | null): boolean {
   const n = p.replace(/\\/g, '/').toLowerCase();
   return n.startsWith('//wsl.localhost/') || n.startsWith('//wsl$/');
 }
+
+/** A WSL location parsed out of a Windows UNC path: which distro, and where inside it. */
+export interface WslLocation {
+  distro: string;
+  linuxPath: string;
+}
+
+/**
+ * Parse a WSL UNC path into its distro and inner Linux path. Mirror of the Kotlin
+ * `WslPathResolver.parseUncPath` so both ends agree on the conversion.
+ *
+ * `\\wsl.localhost\Ubuntu\home\user\proj` -> { distro: "Ubuntu", linuxPath: "/home/user/proj" }
+ * `\\wsl$\NixOS\home\maicol07`            -> { distro: "NixOS", linuxPath: "/home/maicol07" }
+ * `\\wsl.localhost\Ubuntu`                -> { distro: "Ubuntu", linuxPath: "/" }
+ *
+ * Returns null when [uncPath] is not a WSL UNC path. The distro keeps its original
+ * casing (ids are case-sensitive to `wsl -d`); only the host prefix is matched
+ * case-insensitively.
+ */
+export function parseUncPath(uncPath: string | undefined | null): WslLocation | null {
+  if (!isWslUncPath(uncPath)) return null;
+  const normalized = (uncPath as string).replace(/\\/g, '/');
+
+  // Drop the leading "//<host>/", preserving the original casing of the distro id.
+  const afterSlashes = normalized.substring(2); // strip leading "//"
+  const firstSlash = afterSlashes.indexOf('/');
+  if (firstSlash < 0) return null;
+  const rest = afterSlashes.substring(firstSlash + 1); // "Ubuntu/home/user/proj"
+
+  const segments = rest.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return null;
+
+  const distro = segments[0];
+  const linuxSegments = segments.slice(1);
+  const linuxPath = linuxSegments.length === 0 ? '/' : '/' + linuxSegments.join('/');
+  return { distro, linuxPath };
+}
+
+/**
+ * Convert a Windows-side path to the path WSL sees. Mirror of the Kotlin
+ * `WslPathResolver.toWslPath`.
+ *
+ * - Already a Linux path (`/home/...`)      -> returned unchanged.
+ * - WSL UNC (`\\wsl.localhost\Ubuntu\home`) -> the Linux path inside the distro (`/home`).
+ * - Drive path (`C:\Users\foo`)             -> `/mnt/c/Users/foo`.
+ * - Anything else                           -> back-slashes turned into forward-slashes.
+ *
+ * Returns the input unchanged for null/undefined/blank.
+ */
+export function toWslPath(windowsPath: string | undefined | null): string | null | undefined {
+  if (windowsPath == null) return windowsPath;
+  if (windowsPath.trim() === '') return windowsPath;
+
+  // WSL UNC path -> the path inside the distro. Checked BEFORE the leading-slash
+  // short-circuit below: a forward-slashed UNC (`//wsl.localhost/...`) — the exact
+  // form the IDE hands the backend — also starts with '/', so a naive linux-path
+  // check would wrongly return it unchanged and the cwd fix would be a no-op (#57).
+  const loc = parseUncPath(windowsPath);
+  if (loc) return loc.linuxPath;
+
+  // Already a Linux absolute path — nothing to convert.
+  if (windowsPath.startsWith('/')) return windowsPath;
+
+  // Drive-letter path: "C:\Users\foo" or "C:Users\foo" -> "/mnt/c/Users/foo".
+  if (windowsPath.length >= 2 && windowsPath[1] === ':') {
+    const drive = windowsPath[0].toLowerCase();
+    const rest = windowsPath.substring(2).replace(/\\/g, '/');
+    const withLeadingSlash = rest.startsWith('/') ? rest : '/' + rest;
+    const full = `/mnt/${drive}${withLeadingSlash}`.replace(/\/+$/, '');
+    return full || `/mnt/${drive}`;
+  }
+
+  // Fallback: normalize separators.
+  return windowsPath.replace(/\\/g, '/');
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
@@ -80,11 +80,13 @@ object WslPathResolver {
         if (windowsPath == null) return null
         if (windowsPath.isBlank()) return windowsPath
 
+        // WSL UNC path -> the path inside the distro. Checked BEFORE the leading-slash
+        // short-circuit: a forward-slashed UNC (`//wsl.localhost/...`) also starts with
+        // '/', so a naive linux-path check would wrongly return it unchanged. See #57.
+        parseUncPath(windowsPath)?.let { return it.linuxPath }
+
         // Already a Linux absolute path — nothing to convert.
         if (windowsPath.startsWith("/")) return windowsPath
-
-        // WSL UNC path -> the path inside the distro.
-        parseUncPath(windowsPath)?.let { return it.linuxPath }
 
         // Drive-letter path: "C:\Users\foo" or "C:Users\foo" -> "/mnt/c/Users/foo".
         if (windowsPath.length >= 2 && windowsPath[1] == ':') {
@@ -100,12 +102,20 @@ object WslPathResolver {
 
     /**
      * Build the command to run `node <script>` inside a WSL distro from the Windows host,
-     * via a **login shell** so the user's PATH (`~/.profile`, `~/.bash_profile`, `/etc/profile`)
-     * is sourced — required for distros like NixOS where `node` is on the nix profile PATH
-     * and not visible to a non-login shell. Issue #57: see the maicol07 reproducer (NixOS).
+     * via a **login + interactive shell** (`bash -lic`) so the user's full PATH is sourced.
      *
-     * Produces, e.g.:
-     * `wsl.exe -d NixOS --cd /home/u/proj -- bash -lc "export PORT='0'; export … ; exec 'node' '/mnt/c/.../backend.mjs'"`
+     * A login shell alone (`-lc`) sources `~/.profile` / `~/.bash_profile` / `/etc/profile`,
+     * which covers nix-profile distros like NixOS. But it does NOT source `~/.bashrc`, where
+     * nvm/fnm/n write their PATH init — and Ubuntu's stock `.bashrc` returns at the very top
+     * for non-interactive shells (`case $- in *i*) ;; *) return;; esac`). So `-lc` misses an
+     * nvm-managed `node`/`claude` entirely: the backend dies with exit 127 (node not found)
+     * or, where node is on the profile PATH but claude is not, the CLI later fails with
+     * `spawn claude ENOENT`. Adding `-i` makes bash source `.bashrc`, matching how the native
+     * host captures PATH (ShellPathResolver also uses `-lic`). Issue #57 / maicol07 reproducer.
+     *
+     * `exec` then replaces bash with node, so node — and anything it spawns (claude) —
+     * inherits that interactive-shell PATH. Produces, e.g.:
+     * `wsl.exe -d Ubuntu --cd /home/u/proj -- bash -lic "export PORT='0'; export … ; exec 'node' '/mnt/c/.../backend.mjs'"`
      *
      * - The leading `wsl.exe` is resolved on the Windows PATH (System32).
      * - Everything after `--` runs inside the distro, so `bash`/`node` are the distro's.
@@ -114,7 +124,7 @@ object WslPathResolver {
      *   from the IDE reach `node` directly.
      * - [scriptLinuxPath] must already be a WSL-visible path (use [toWslPath] on the
      *   Windows extraction path). [nodeExec] defaults to `node` (resolved on the distro's
-     *   login-shell PATH).
+     *   login + interactive shell PATH).
      * - All values are single-quoted with `'` → `'\''` escaping so spaces or quotes in
      *   paths/env values can't break out of the snippet.
      *
@@ -141,7 +151,7 @@ object WslPathResolver {
                 add("--cd"); add(linuxCwd)
             }
             add("--")
-            add("bash"); add("-lc"); add(snippet)
+            add("bash"); add("-lic"); add(snippet)
         }
     }
 

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolverTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolverTest.kt
@@ -106,6 +106,13 @@ class WslPathResolverTest {
         }
 
         @Test
+        fun `converts forward-slashed wsl unc path`() {
+            // The IDE hands the backend a forward-slashed UNC; it also starts with '/',
+            // so it must be matched as UNC before the linux-path short-circuit. See #57.
+            assertEquals("/home/yhk/test-proj", WslPathResolver.toWslPath("//wsl.localhost/Ubuntu/home/yhk/test-proj"))
+        }
+
+        @Test
         fun `leaves linux path unchanged`() {
             assertEquals("/home/user/proj", WslPathResolver.toWslPath("/home/user/proj"))
         }
@@ -135,7 +142,7 @@ class WslPathResolverTest {
             assertEquals(
                 listOf(
                     "wsl.exe", "-d", "Ubuntu", "--cd", "/home/u/proj", "--",
-                    "bash", "-lc",
+                    "bash", "-lic",
                     "export PORT='0'; export JETBRAINS_MODE='true'; exec 'node' '/mnt/c/Temp/backend.mjs'",
                 ),
                 cmd,
@@ -153,7 +160,7 @@ class WslPathResolverTest {
             assertEquals(
                 listOf(
                     "wsl.exe", "-d", "NixOS", "--",
-                    "bash", "-lc", "exec 'node' '/mnt/c/b.mjs'",
+                    "bash", "-lic", "exec 'node' '/mnt/c/b.mjs'",
                 ),
                 cmd,
             )
@@ -173,7 +180,7 @@ class WslPathResolverTest {
             assertEquals(
                 listOf(
                     "wsl.exe", "-d", "Ubuntu", "--cd", "/p", "--",
-                    "bash", "-lc",
+                    "bash", "-lic",
                     "exec '/home/u/.nvm/node' '/s.mjs' '--flag' 'x'",
                 ),
                 cmd,
@@ -192,7 +199,7 @@ class WslPathResolverTest {
             assertEquals(
                 listOf(
                     "wsl.exe", "-d", "Ubuntu", "--cd", "/p", "--",
-                    "bash", "-lc",
+                    "bash", "-lic",
                     "export MSG='it'\\''s'; exec 'node' '/path with spaces/it'\\''s.mjs'",
                 ),
                 cmd,

--- a/webview/src/pages/SwitchAccountPage/LoginCodeInput/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/LoginCodeInput/index.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react';
+
+interface Props {
+  onSubmit: (code: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * Optional OAuth code-entry field. Some login flows (notably WSL projects, where
+ * the CLI can't auto-complete via a local callback) print a code after browser
+ * sign-in and wait for it to be pasted back. The backend signals LOGIN_CODE_REQUIRED
+ * only when that prompt actually appears, so this is shown conditionally. Issue #57.
+ */
+export function LoginCodeInput(props: Props) {
+  const { onSubmit, disabled = false, className = '' } = props;
+  const [code, setCode] = useState('');
+
+  const submit = (): void => {
+    const trimmed = code.trim();
+    if (trimmed) onSubmit(trimmed);
+  };
+
+  return (
+    <div className={`mt-6 p-4 rounded-lg bg-surface-overlay border border-border-default ${className}`}>
+      <p className="text-sm text-text-primary font-semibold">Paste the code from your browser</p>
+      <p className="text-xs text-text-tertiary mt-1">
+        After signing in, your browser shows a code. Paste it here to finish logging in.
+      </p>
+      <input
+        type="text"
+        value={code}
+        onChange={(e) => setCode(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Enter') submit(); }}
+        placeholder="Paste code here"
+        autoFocus
+        className="w-full mt-3 px-3 py-2 rounded-md bg-surface-base border border-border-default text-sm text-text-primary focus:outline-none focus:border-accent-claude"
+      />
+      <button
+        onClick={submit}
+        disabled={disabled || code.trim() === ''}
+        className="w-full mt-3 py-2.5 rounded-lg bg-accent-claude hover:bg-accent-claude-hover disabled:opacity-60 disabled:cursor-not-allowed text-text-primary font-semibold text-sm transition-colors"
+      >
+        Submit code
+      </button>
+    </div>
+  );
+}

--- a/webview/src/pages/SwitchAccountPage/__tests__/index.test.tsx
+++ b/webview/src/pages/SwitchAccountPage/__tests__/index.test.tsx
@@ -2,15 +2,17 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { Route } from '@/router/routes';
 
-const { mockNavigate, mockRequest, mockRefetch } = vi.hoisted(() => ({
+const { mockNavigate, mockRequest, mockRefetch, mockSubscribe, mockSendRaw } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
   mockRequest: vi.fn(),
   mockRefetch: vi.fn(),
+  mockSubscribe: vi.fn((_type: string, _handler: (m: unknown) => void) => () => {}),
+  mockSendRaw: vi.fn(),
 }));
 
 vi.mock('@/router', () => ({ useRouter: () => ({ navigate: mockNavigate }) }));
 vi.mock('@/api/bridge/Bridge', () => ({
-  getBridge: () => ({ request: mockRequest }),
+  getBridge: () => ({ request: mockRequest, subscribe: mockSubscribe, sendRaw: mockSendRaw }),
   LOGIN_REQUEST_TIMEOUT_MS: 300000,
 }));
 vi.mock('@/contexts', () => ({
@@ -30,6 +32,10 @@ describe('SwitchAccountPage', () => {
     mockNavigate.mockReset();
     mockRequest.mockReset();
     mockRefetch.mockReset();
+    mockSendRaw.mockReset();
+    mockSubscribe.mockReset();
+    // Default: subscribe is a no-op returning an unsubscribe fn.
+    mockSubscribe.mockReturnValue(() => {});
   });
 
   // Regression for issue #99 (cause B): after a login completes, the chat login
@@ -60,5 +66,42 @@ describe('SwitchAccountPage', () => {
     await waitFor(() => screen.getByText('Login failed'));
     expect(mockNavigate).not.toHaveBeenCalled();
     expect(mockRefetch).not.toHaveBeenCalled();
+  });
+
+  // Issue #57: flows that can't auto-complete (e.g. WSL projects) print a code
+  // after browser sign-in. The optional code input must stay hidden until the
+  // backend emits LOGIN_CODE_REQUIRED, then submitting it sends SUBMIT_LOGIN_CODE.
+  it('shows the optional code input only when the CLI requests a code, then submits it (#57)', async () => {
+    // Capture the LOGIN_CODE_REQUIRED handler so we can fire it mid-login.
+    let codeHandler: ((m: unknown) => void) | undefined;
+    mockSubscribe.mockImplementation((type: string, handler: (m: unknown) => void) => {
+      if (type === 'LOGIN_CODE_REQUIRED') codeHandler = handler;
+      return () => {};
+    });
+    // Keep LOGIN pending so the input can appear mid-flow.
+    let resolveLogin: (v: { status: string }) => void = () => {};
+    mockRequest.mockReturnValue(new Promise((res) => { resolveLogin = res; }));
+    mockRefetch.mockResolvedValue(undefined);
+
+    render(<SwitchAccountPage />);
+    fireEvent.click(screen.getByText('Claude.ai Subscription'));
+
+    // Hidden until the backend asks for a code.
+    expect(screen.queryByPlaceholderText('Paste code here')).toBeNull();
+
+    await waitFor(() => expect(codeHandler).toBeDefined());
+    codeHandler?.({ type: 'LOGIN_CODE_REQUIRED' });
+
+    const input = await screen.findByPlaceholderText('Paste code here');
+    fireEvent.change(input, { target: { value: '  my-code  ' } });
+    fireEvent.click(screen.getByText('Submit code'));
+
+    expect(mockSendRaw).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'SUBMIT_LOGIN_CODE', payload: { code: 'my-code' } }),
+    );
+
+    // Completing the login navigates as usual.
+    resolveLogin({ status: 'ok' });
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(Route.NEW_SESSION));
   });
 });

--- a/webview/src/pages/SwitchAccountPage/__tests__/index.test.tsx
+++ b/webview/src/pages/SwitchAccountPage/__tests__/index.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Route } from '@/router/routes';
+
+const { mockNavigate, mockRequest, mockRefetch } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockRequest: vi.fn(),
+  mockRefetch: vi.fn(),
+}));
+
+vi.mock('@/router', () => ({ useRouter: () => ({ navigate: mockNavigate }) }));
+vi.mock('@/api/bridge/Bridge', () => ({
+  getBridge: () => ({ request: mockRequest }),
+  LOGIN_REQUEST_TIMEOUT_MS: 300000,
+}));
+vi.mock('@/contexts', () => ({
+  useAuthContext: () => ({ loggedIn: null, refetch: mockRefetch }),
+}));
+vi.mock('@/contexts/SessionContext', () => ({
+  useSessionContext: () => ({ workingDirectory: '/tmp' }),
+}));
+vi.mock('@/adapters', () => ({
+  getAdapter: () => ({ openUrl: vi.fn(), openTerminal: vi.fn() }),
+}));
+
+import { SwitchAccountPage } from '../index';
+
+describe('SwitchAccountPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset();
+    mockRequest.mockReset();
+    mockRefetch.mockReset();
+  });
+
+  // Regression for issue #99 (cause B): after a login completes, the chat login
+  // gate reads AuthContext.loggedIn. If we navigate before re-querying auth
+  // status, loggedIn is still the stale `false` and the gate bounces the user
+  // straight back to the login screen. refetch() must run (and resolve) before
+  // navigate() so the gate sees the fresh logged-in state.
+  it('refetches auth state before navigating to chat after a successful login (#99)', async () => {
+    mockRequest.mockResolvedValue({ status: 'ok' });
+    mockRefetch.mockResolvedValue(undefined);
+
+    render(<SwitchAccountPage />);
+    fireEvent.click(screen.getByText('Claude.ai Subscription'));
+
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith(Route.NEW_SESSION));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+    expect(mockRefetch.mock.invocationCallOrder[0]).toBeLessThan(
+      mockNavigate.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('does not navigate or refetch when login fails', async () => {
+    mockRequest.mockResolvedValue({ status: 'error', error: 'Login failed' });
+
+    render(<SwitchAccountPage />);
+    fireEvent.click(screen.getByText('Claude.ai Subscription'));
+
+    await waitFor(() => screen.getByText('Login failed'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(mockRefetch).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/pages/SwitchAccountPage/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/index.tsx
@@ -6,6 +6,7 @@ import { getBridge, LOGIN_REQUEST_TIMEOUT_MS } from '@/api/bridge/Bridge';
 import { getAdapter } from '@/adapters';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useAuthContext } from '@/contexts';
+import { LoginCodeInput } from './LoginCodeInput';
 
 interface Props {
   className?: string;
@@ -22,12 +23,21 @@ export function SwitchAccountPage(props: Props) {
   const { refetch } = useAuthContext();
   const [loadingMethod, setLoadingMethod] = useState<LoginMethod | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [codeRequired, setCodeRequired] = useState(false);
 
   const handleLogin = async (method: LoginMethod) => {
     if (loadingMethod !== null) return;
 
     setLoadingMethod(method);
     setError(null);
+    setCodeRequired(false);
+
+    // Some flows (e.g. WSL projects) can't auto-complete via a local callback: the
+    // CLI prints a code after browser sign-in and waits for it. The backend emits
+    // LOGIN_CODE_REQUIRED only when that prompt appears, so the input is optional. (#57)
+    const unsubscribe = getBridge().subscribe('LOGIN_CODE_REQUIRED', () => {
+      setCodeRequired(true);
+    });
 
     try {
       const result = await getBridge().request<{ requestId: string; status: string; error?: string }>(
@@ -49,8 +59,18 @@ export function SwitchAccountPage(props: Props) {
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed. Please try again.');
     } finally {
+      unsubscribe();
+      setCodeRequired(false);
       setLoadingMethod(null);
     }
+  };
+
+  const handleSubmitCode = (code: string): void => {
+    getBridge().sendRaw({
+      type: 'SUBMIT_LOGIN_CODE',
+      payload: { code },
+      timestamp: Date.now(),
+    });
   };
 
   const handleOpenProviderDocs = async () => {
@@ -103,6 +123,10 @@ export function SwitchAccountPage(props: Props) {
             <p className="text-xs text-state-error-fg mt-3 px-3 py-2 bg-state-error-bg border border-state-error-border rounded-lg">
               {error}
             </p>
+          )}
+
+          {codeRequired && (
+            <LoginCodeInput onSubmit={handleSubmitCode} />
           )}
 
           <button

--- a/webview/src/pages/SwitchAccountPage/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/index.tsx
@@ -5,6 +5,7 @@ import { Route, ROUTE_META, Label } from '@/router/routes';
 import { getBridge, LOGIN_REQUEST_TIMEOUT_MS } from '@/api/bridge/Bridge';
 import { getAdapter } from '@/adapters';
 import { useSessionContext } from '@/contexts/SessionContext';
+import { useAuthContext } from '@/contexts';
 
 interface Props {
   className?: string;
@@ -18,6 +19,7 @@ export function SwitchAccountPage(props: Props) {
   const meta = ROUTE_META[Route.SWITCH_ACCOUNT];
 
   const { workingDirectory } = useSessionContext();
+  const { refetch } = useAuthContext();
   const [loadingMethod, setLoadingMethod] = useState<LoginMethod | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,6 +37,11 @@ export function SwitchAccountPage(props: Props) {
       );
 
       if (result?.status === 'ok') {
+        // Re-query auth status before navigating so the chat login gate
+        // (useLoginGate) sees the fresh logged-in state. Without this, navigate
+        // happens while AuthContext.loggedIn is still the stale `false`, and the
+        // gate bounces the user right back to this login screen (#99).
+        await refetch();
         navigate(Route.NEW_SESSION);
       } else {
         setError(result?.error ?? 'Login failed. Please try again.');


### PR DESCRIPTION
This branch started as **#99** (Windows login screen stuck) and, since it touches
the same claude exec/login code path, **#57** (Claude unusable in WSL projects) was
integrated on top. Both ship together here.

---

# #57 — Claude unusable in WSL projects

A JetBrains project opened from WSL runs the backend *inside* the distro and hands
it a Windows UNC path (`//wsl.localhost/...`). Several layers broke `claude` there:

1. **node not found (exit 127).** The backend was spawned with `bash -lc`, which
   does not source `~/.bashrc`, so an nvm/fnm-managed node was invisible. Now
   `bash -lic` (interactive login shell), matching how the native host captures
   PATH; node — and anything it spawns — inherit it.
2. **`spawn claude ENOENT`.** claude was spawned with the UNC working directory,
   which does not exist inside the distro — the *cwd* was missing, not the binary.
   UNC/drive paths are now converted to the inner Linux path before spawn (and a
   forward-slashed UNC is matched as UNC *before* the linux-path short-circuit,
   which a unit test pinned down).
3. **Login browser never opened (endless spinner).** With interop
   `appendWindowsPath=false`, claude can't find a browser opener and ignores
   `$BROWSER`, so it just printed the OAuth URL and waited. `loginHandler` now
   extracts that URL and opens it through the IDE (`BrowserUtil.browse`), and
   detects the post-sign-in "paste code" prompt.
4. **OAuth code entry.** An optional code-input field appears only when the CLI
   prompts for it (some flows auto-complete and never prompt); the pasted code is
   written to the login process stdin via `SUBMIT_LOGIN_CODE`.

### Verification (Windows 11 + WSL Ubuntu, real sandbox)
- Backend boots inside WSL via `-lic`; claude spawns with `cwd=/home/yhk/test-proj`
  and receives the **Bash** tool (not PowerShell) — exactly the #57 ask
  ("Claude in WSL projects run bash instead of powershell").
- Full GUI login end-to-end: button → browser opens → optional code field appears →
  paste code → `~/.claude/.credentials.json` created → chat.
- Tests: `wsl-path` 16 (parse/convert incl. forward-slash UNC), `SwitchAccountPage`
  optional code-input, login handler — all green; type-check clean.

Fixes #57

---

# #99 — Windows login screen stuck

On Windows, an already-authenticated user was trapped on the login screen, and
even after completing the browser OAuth flow the view never advanced to chat
(#99). This turned out to be **two distinct bugs** where the first masked the
second — fixing the backend revealed the webview race.

## Cause A — backend (`Claude.exec` shell asymmetry)

The `claude` launcher on Windows is a `.cmd`/`.ps1` wrapper. `Claude.exec` called
`execFile` **without a shell**, so the wrapper failed with `ENOENT` and
`claude auth status` (the `GET_ACCOUNT` handler) always returned
*"Claude Code credentials not found"*. `Claude.spawn` already ran through a shell
on win32 — which is exactly why `auth login` (spawn) worked while `auth status`
(exec) did not.

**Fix:** `exec` now defaults `shell` to `true` on win32 (overridable), matching
`spawn`. The `claude --version` lookup (same path) is fixed as a side effect.

## Cause B — webview (post-login navigation race)

With Cause A fixed, `auth status` succeeds, but a second bug surfaces: after a
successful `LOGIN`, `SwitchAccountPage` navigated to the chat route **immediately**,
while `AuthContext.loggedIn` was still the stale `false` from the pre-login check.
The chat login gate (`useLoginGate`) then saw `loggedIn === false` and bounced the
user right back to the login screen.

**Fix:** `AuthContext` already exposes an awaitable `refetch` intended for exactly
this. `SwitchAccountPage` now awaits it before navigating, so the gate sees the
fresh logged-in state.

Both are required: A lets `auth status` succeed on Windows at all; B makes the
post-login transition actually land on chat.

## Verification (Windows 11, real sandbox)

- **Cause A — backend before/after via run-ide** (same machine, same CLI, backend
  swapped):
  - before: `GET_ACCOUNT → ACK status:"error"` ("credentials not found")
  - after:  `GET_ACCOUNT → ACK status:"ok", account:{ loggedIn:true, ... }`
- **Cause B confirmed live**: with the backend fix in place, a full
  logout → login flow showed the backend doing everything right
  (`LOGIN → ok`, then `GET_ACCOUNT → ok, loggedIn:true`), yet the webview stayed
  on the login screen — pinpointing the navigate-before-refetch race.
- **Tests**: backend — 4 regression tests for exec/spawn shell defaults + explicit
  override; webview — 2 tests for refetch-before-navigate on success and
  no-navigate on failure.

Fixes #99
