### PR TITLE
fix: hide scroll-to-bottom button when near the bottom

### DIFF
--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -21,7 +21,7 @@ import { useNotificationSound } from '@/notifications';
 import {isMobile} from "@/config/environment.ts";
 import { useSettings } from '@/contexts/SettingsContext';
 import { SettingKey } from '@/types/settings';
-import { clampAutoScrollThreshold, nextAutoFollow, AUTO_SCROLL_THRESHOLD_DEFAULT, AUTO_SCROLL_BOTTOM_EPS } from '@/utils/autoScroll';
+import { clampAutoScrollThreshold, nextAutoFollow, shouldShowScrollToBottom, AUTO_SCROLL_THRESHOLD_DEFAULT, AUTO_SCROLL_BOTTOM_EPS } from '@/utils/autoScroll';
 
 export function ChatPage() {
   // Redirect logged-out users to the login screen before they hit a failing chat.
@@ -46,7 +46,15 @@ export function ChatPage() {
   const autoFollowRef = useRef(true);
   const prevScrollTopRef = useRef(0);
   const lastScrollHeightRef = useRef(0);
-  const [autoFollow, setAutoFollow] = useState(true);
+  // Button visibility is a separate, position-aware decision from auto-follow
+  // (which tracks intent): the button hides whenever the view already shows the
+  // bottom — auto-follow active, no messages, or within the resume threshold.
+  const hasMessagesRef = useRef(false);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+
+  useEffect(() => {
+    hasMessagesRef.current = messages.length > 0;
+  }, [messages.length]);
 
   // Drive auto-follow from a requestAnimationFrame loop. A single loop both
   // decides the next auto-follow state and performs the scroll, so the two can
@@ -67,7 +75,8 @@ export function ChatPage() {
         const delta = el.scrollTop - prevScrollTopRef.current;
         const next = nextAutoFollow(autoFollowRef.current, delta, dist, autoScrollThreshold);
         autoFollowRef.current = next;
-        setAutoFollow(prev => (prev === next ? prev : next));
+        const show = shouldShowScrollToBottom(next, hasMessagesRef.current, dist, autoScrollThreshold);
+        setShowScrollButton(prev => (prev === show ? prev : show));
         const grew = el.scrollHeight !== lastScrollHeightRef.current;
         if (next && grew && dist > AUTO_SCROLL_BOTTOM_EPS) {
           el.scrollTo({ top: el.scrollHeight });
@@ -85,7 +94,7 @@ export function ChatPage() {
     const el = scrollContainerRef.current;
     if (!el) return;
     autoFollowRef.current = true;
-    setAutoFollow(true);
+    setShowScrollButton(false);
     el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
   }, []);
 
@@ -135,7 +144,7 @@ export function ChatPage() {
         const dist = el.scrollHeight - el.scrollTop - el.clientHeight;
         const atBottom = dist <= autoScrollThreshold;
         autoFollowRef.current = atBottom;
-        setAutoFollow(atBottom);
+        // Button visibility is reconciled by the rAF loop on the next frame.
       });
       localStorage.removeItem(key);
     }
@@ -204,7 +213,7 @@ export function ChatPage() {
 
       </div>
 
-      {!autoFollow && (
+      {showScrollButton && (
         <button
           onClick={scrollToBottom}
           className="fixed bottom-[7.5rem] left-1/2 -translate-x-1/2 z-20 flex items-center gap-1.5 px-3 py-1.5 bg-surface-raised border border-border-default rounded-full shadow-md text-xs text-text-primary hover:bg-surface-hover transition-colors"

--- a/webview/src/utils/__tests__/autoScroll.test.ts
+++ b/webview/src/utils/__tests__/autoScroll.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import {
   clampAutoScrollThreshold,
   nextAutoFollow,
+  shouldShowScrollToBottom,
   AUTO_SCROLL_THRESHOLD_DEFAULT,
   AUTO_SCROLL_THRESHOLD_MAX,
   AUTO_SCROLL_THRESHOLD_MIN,
@@ -83,5 +84,42 @@ describe('nextAutoFollow', () => {
   it('respects a custom release EPS argument', () => {
     expect(nextAutoFollow(true, -10, 500, RESUME, 20)).toBe(true);
     expect(nextAutoFollow(true, -25, 500, RESUME, 20)).toBe(false);
+  });
+});
+
+describe('shouldShowScrollToBottom', () => {
+  const THRESHOLD = 80;
+
+  // The button is meaningful ONLY when all three hide-conditions are false:
+  // auto-follow off AND there are messages AND the view is beyond the threshold.
+  it('shows when auto-follow is off, has messages, and far from the bottom', () => {
+    expect(shouldShowScrollToBottom(false, true, 500, THRESHOLD)).toBe(true);
+  });
+
+  // Hide-condition 1: auto-follow is active -> the view already tracks the bottom.
+  it('hides while auto-follow is active, even when far from the bottom', () => {
+    expect(shouldShowScrollToBottom(true, true, 500, THRESHOLD)).toBe(false);
+  });
+
+  // Hide-condition 2: no messages (an uninitialized session has nothing to scroll).
+  it('hides when there are no messages', () => {
+    expect(shouldShowScrollToBottom(false, false, 500, THRESHOLD)).toBe(false);
+  });
+
+  // Hide-condition 3: already within the threshold of the bottom.
+  it('hides when within the threshold of the bottom', () => {
+    expect(shouldShowScrollToBottom(false, true, THRESHOLD, THRESHOLD)).toBe(false);
+    expect(shouldShowScrollToBottom(false, true, THRESHOLD - 1, THRESHOLD)).toBe(false);
+    expect(shouldShowScrollToBottom(false, true, 0, THRESHOLD)).toBe(false);
+  });
+
+  // The exact bug: pinned near the bottom, a tiny upward nudge releases
+  // auto-follow, but the position is still within the threshold -> stay hidden.
+  it('stays hidden when auto-follow released but still within the threshold', () => {
+    expect(shouldShowScrollToBottom(false, true, 10, THRESHOLD)).toBe(false);
+  });
+
+  it('shows just past the threshold boundary', () => {
+    expect(shouldShowScrollToBottom(false, true, THRESHOLD + 1, THRESHOLD)).toBe(true);
   });
 });

--- a/webview/src/utils/autoScroll.ts
+++ b/webview/src/utils/autoScroll.ts
@@ -60,3 +60,29 @@ export function nextAutoFollow(
   if (scrollDelta > releaseEps && distanceFromBottom <= resumeThreshold) return true;
   return prev;
 }
+
+/**
+ * Decide whether the "Scroll to bottom" button should be visible.
+ *
+ * The button is only useful when the user is genuinely stranded above the
+ * stream, so it hides whenever ANY of these hold:
+ *  - auto-follow is active (the view already tracks the bottom)
+ *  - there are no messages (an uninitialized session has nothing to scroll)
+ *  - the view is already within `threshold` px of the bottom
+ *
+ * This must NOT be conflated with auto-follow alone: auto-follow tracks user
+ * *intent*, so a tiny upward nudge while pinned near the bottom releases it —
+ * but the button should stay hidden there because the user can already see the
+ * bottom. Visibility is therefore a separate, position-aware decision.
+ */
+export function shouldShowScrollToBottom(
+  autoFollow: boolean,
+  hasMessages: boolean,
+  distanceFromBottom: number,
+  threshold: number,
+): boolean {
+  if (autoFollow) return false;
+  if (!hasMessages) return false;
+  if (distanceFromBottom <= threshold) return false;
+  return true;
+}


### PR DESCRIPTION
## 문제

"Scroll to bottom" 버튼의 노출이 `autoFollow`(오토 스크롤 추종) 상태 하나에만 묶여 있었다. `autoFollow`는 위치가 아니라 사용자의 *의도*를 추적하므로(2px만 위로 올려도 release됨), 바닥에 거의 붙어 있는 상태에서 휠을 살짝만 올려도 버튼이 떠버렸다 — 정작 버튼이 필요 없는 위치인데도.

## 해결

버튼 노출을 `autoFollow`에서 분리해 **위치 기반 판정**으로 바꿨다. 다음 세 조건 중 하나라도 참이면 숨긴다:

1. 오토 스크롤 활성 (이미 바닥을 추종 중)
2. 메시지 없음 (초기화된 세션은 스크롤할 내용이 없음)
3. 바닥으로부터 임계값 범위 내 (이미 바닥이 보임)

즉 **노출 = 오토스크롤 꺼짐 AND 메시지 있음 AND 임계값 밖**.

## 변경

- `shouldShowScrollToBottom` 순수 함수 추가 (`utils/autoScroll.ts`)
- `ChatPage`에서 더 이상 읽히지 않는 `autoFollow` state를 `autoFollowRef`로 일원화하고, rAF 루프에서 위치·메시지 유무를 반영한 `showScrollButton` state로 버튼 노출 판정
- 단위 테스트 6개 추가 (세 숨김 조건 + "바닥 근처 release 시에도 숨김 유지" 핵심 케이스)

## 검증

- WebView 단위 테스트 735개 통과 (신규 6개 포함)
- TypeScript 타입 체크 통과
- dev server 브라우저 실증 완료