### PR TITLE
feat: desktop notifications when a session needs attention in the IDE

### DIFF
--- a/backend/src/bridge/bridge-interface.ts
+++ b/backend/src/bridge/bridge-interface.ts
@@ -36,4 +36,21 @@ export interface Bridge {
    * above the IDE project they are inside.
    */
   getIdeRoot(workingDir?: string): Promise<string | null>;
+  /**
+   * Show a host-native desktop notification. Used for "agent needs your
+   * attention" / "response complete" events when the webview cannot raise its
+   * own browser notification (JCEF has no Notification API). In browser mode the
+   * webview shows the notification itself, so this is a no-op there.
+   *
+   * [workingDir] routes the request to the IDE host serving that project root
+   * when several IDEs share one backend; [panelId] then selects the exact panel
+   * (session tab) inside that IDE so the notification — and its "Open session"
+   * action — target the right tab.
+   */
+  showNotification(params: {
+    title: string;
+    body: string;
+    workingDir?: string;
+    panelId?: string;
+  }): Promise<void>;
 }

--- a/backend/src/bridge/bridge-interface.ts
+++ b/backend/src/bridge/bridge-interface.ts
@@ -46,11 +46,16 @@ export interface Bridge {
    * when several IDEs share one backend; [panelId] then selects the exact panel
    * (session tab) inside that IDE so the notification — and its "Open session"
    * action — target the right tab.
+   *
+   * Returns whether the IDE balloon was shown (false when suppressed because the
+   * user is viewing the session) and whether the IDE window was focused. The
+   * caller raises a real OS notification when the IDE is NOT focused, since an
+   * in-IDE balloon is hidden behind other apps then.
    */
   showNotification(params: {
     title: string;
     body: string;
     workingDir?: string;
     panelId?: string;
-  }): Promise<void>;
+  }): Promise<{ shown: boolean; ideFocused: boolean }>;
 }

--- a/backend/src/bridge/browser-bridge.ts
+++ b/backend/src/bridge/browser-bridge.ts
@@ -239,6 +239,16 @@ if ($dialog.ShowDialog() -eq 'OK') {
     return null;
   }
 
+  async showNotification(_params: {
+    title: string;
+    body: string;
+    workingDir?: string;
+    panelId?: string;
+  }): Promise<void> {
+    // no-op: browser mode raises notifications via the webview's own
+    // Notification API, so the backend is never asked to show one.
+  }
+
   async openTerminal(workingDir: string): Promise<void> {
     const settings = await readSettingsFile();
     const terminalApp = settings['terminalApp'] as string | null;

--- a/backend/src/bridge/browser-bridge.ts
+++ b/backend/src/bridge/browser-bridge.ts
@@ -244,9 +244,11 @@ if ($dialog.ShowDialog() -eq 'OK') {
     body: string;
     workingDir?: string;
     panelId?: string;
-  }): Promise<void> {
+  }): Promise<{ shown: boolean; ideFocused: boolean }> {
     // no-op: browser mode raises notifications via the webview's own
-    // Notification API, so the backend is never asked to show one.
+    // Notification API, so the backend is never asked to show one. Report
+    // ideFocused=true so the caller never raises an OS notification here.
+    return { shown: false, ideFocused: true };
   }
 
   async openTerminal(workingDir: string): Promise<void> {

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -234,6 +234,15 @@ export class JetBrainsBridge implements Bridge {
     const ideRoot = result['ideRoot'];
     return typeof ideRoot === 'string' && ideRoot.length > 0 ? ideRoot : null;
   }
+
+  async showNotification(params: {
+    title: string;
+    body: string;
+    workingDir?: string;
+    panelId?: string;
+  }): Promise<void> {
+    await this.request('SHOW_NOTIFICATION', params);
+  }
 }
 
 /**

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -240,8 +240,14 @@ export class JetBrainsBridge implements Bridge {
     body: string;
     workingDir?: string;
     panelId?: string;
-  }): Promise<void> {
-    await this.request('SHOW_NOTIFICATION', params);
+  }): Promise<{ shown: boolean; ideFocused: boolean }> {
+    const result = await this.request('SHOW_NOTIFICATION', params);
+    return {
+      shown: result['shown'] === true,
+      // Default ideFocused to true so we never raise a spurious OS notification
+      // when the field is missing/malformed.
+      ideFocused: result['ideFocused'] !== false,
+    };
   }
 }
 

--- a/backend/src/core/handlers/__tests__/showNotification.test.ts
+++ b/backend/src/core/handlers/__tests__/showNotification.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { showNotificationHandler } from '../showNotification';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+function createMockConnections() {
+  return {
+    sendTo: vi.fn(),
+    broadcastToAll: vi.fn(),
+  } as unknown as ConnectionManager;
+}
+
+function createMockBridge() {
+  return {
+    showNotification: vi.fn().mockResolvedValue(undefined),
+  } as unknown as Bridge;
+}
+
+describe('showNotificationHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('forwards title, body and workingDir to the bridge and acks ok', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge();
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session', body: 'Response complete', workingDir: '/repo' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.showNotification).toHaveBeenCalledWith({
+      title: 'My session',
+      body: 'Response complete',
+      workingDir: '/repo',
+    });
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-1',
+      status: 'ok',
+    });
+  });
+
+  it('defaults body to empty string and drops absent workingDir', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge();
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session' },
+      timestamp: 0,
+      requestId: 'req-2',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.showNotification).toHaveBeenCalledWith({
+      title: 'My session',
+      body: '',
+      workingDir: undefined,
+    });
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-2',
+      status: 'ok',
+    });
+  });
+
+  it('rejects when title is missing', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge();
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { body: 'no title' },
+      timestamp: 0,
+      requestId: 'req-3',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.showNotification).not.toHaveBeenCalled();
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-3',
+      status: 'error',
+      error: 'Missing or invalid title',
+    });
+  });
+
+  it('surfaces the underlying error message when the bridge throws', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge();
+    vi.mocked(bridge.showNotification).mockRejectedValue(new Error('No RPC client connected'));
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session', body: 'Response complete' },
+      timestamp: 0,
+      requestId: 'req-4',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-4',
+      status: 'error',
+      error: 'No RPC client connected',
+    });
+  });
+});

--- a/backend/src/core/handlers/__tests__/showNotification.test.ts
+++ b/backend/src/core/handlers/__tests__/showNotification.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('../../../system-notifications', () => ({
+  showOsNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { showNotificationHandler } from '../showNotification';
+import { showOsNotification } from '../../../system-notifications';
 import type { ConnectionManager } from '../../../ws/connection-manager';
 import type { Bridge } from '../../../bridge/bridge-interface';
 import type { IPCMessage } from '../../types';
+
+const mockOsNotify = vi.mocked(showOsNotification);
 
 function createMockConnections() {
   return {
@@ -12,9 +19,9 @@ function createMockConnections() {
   } as unknown as ConnectionManager;
 }
 
-function createMockBridge() {
+function createMockBridge(outcome: { shown: boolean; ideFocused: boolean } = { shown: true, ideFocused: true }) {
   return {
-    showNotification: vi.fn().mockResolvedValue(undefined),
+    showNotification: vi.fn().mockResolvedValue(outcome),
   } as unknown as Bridge;
 }
 
@@ -107,5 +114,54 @@ describe('showNotificationHandler', () => {
       status: 'error',
       error: 'No RPC client connected',
     });
+  });
+
+  it('raises an OS notification when the IDE balloon was shown but the IDE is NOT focused', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge({ shown: true, ideFocused: false });
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session', body: 'Response complete' },
+      timestamp: 0,
+      requestId: 'req-5',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(mockOsNotify).toHaveBeenCalledWith('My session', 'Response complete');
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', 'ACK', {
+      requestId: 'req-5',
+      status: 'ok',
+    });
+  });
+
+  it('does NOT raise an OS notification when the IDE is focused', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge({ shown: true, ideFocused: true });
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session', body: 'Response complete' },
+      timestamp: 0,
+      requestId: 'req-6',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(mockOsNotify).not.toHaveBeenCalled();
+  });
+
+  it('does NOT raise an OS notification when the balloon was suppressed (user viewing session)', async () => {
+    const connections = createMockConnections();
+    const bridge = createMockBridge({ shown: false, ideFocused: false });
+    const message: IPCMessage = {
+      type: 'SHOW_NOTIFICATION',
+      payload: { title: 'My session', body: 'Response complete' },
+      timestamp: 0,
+      requestId: 'req-7',
+    };
+
+    await showNotificationHandler('conn-1', message, connections, bridge);
+
+    expect(mockOsNotify).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -54,6 +54,7 @@ import { openFolderDialogHandler } from './openFolderDialog';
 import { findBackgroundTaskOutputPathHandler } from './findBackgroundTaskOutputPathHandler';
 import { listSystemSoundsHandler } from './listSystemSounds';
 import { playSystemSoundHandler } from './playSystemSound';
+import { showNotificationHandler } from './showNotification';
 
 export async function handleMessage(
   connectionId: string,
@@ -222,6 +223,9 @@ export async function handleMessage(
       break;
     case 'PLAY_SYSTEM_SOUND':
       await playSystemSoundHandler(connectionId, message, connections, bridge);
+      break;
+    case 'SHOW_NOTIFICATION':
+      await showNotificationHandler(connectionId, message, connections, bridge);
       break;
     default:
       console.error('[node-backend]', `Unknown message type: ${message.type}`);

--- a/backend/src/core/handlers/showNotification.ts
+++ b/backend/src/core/handlers/showNotification.ts
@@ -1,6 +1,7 @@
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
+import { showOsNotification } from '../../system-notifications';
 
 /**
  * Handle SHOW_NOTIFICATION: ask the host (IDE) to raise a native desktop
@@ -39,7 +40,13 @@ export async function showNotificationHandler(
     : undefined;
 
   try {
-    await bridge.showNotification({ title, body, workingDir, panelId });
+    const { shown, ideFocused } = await bridge.showNotification({ title, body, workingDir, panelId });
+    // The IDE balloon is hidden behind other apps when the IDE is in the
+    // background, so raise a real OS notification in that case (only when the
+    // balloon was actually shown — i.e. the user isn't already viewing it).
+    if (shown && !ideFocused) {
+      await showOsNotification(title, body);
+    }
     connections.sendTo(connectionId, 'ACK', {
       requestId: message.requestId,
       status: 'ok',

--- a/backend/src/core/handlers/showNotification.ts
+++ b/backend/src/core/handlers/showNotification.ts
@@ -1,0 +1,56 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+
+/**
+ * Handle SHOW_NOTIFICATION: ask the host (IDE) to raise a native desktop
+ * notification for an "attention needed" / "response complete" event.
+ *
+ * The webview only sends this when it cannot raise its own browser notification
+ * (JCEF has no Notification API). [workingDir] lets the bridge route the request
+ * to the IDE serving that project root; the host decides whether to suppress it
+ * (e.g. when its window is already focused).
+ */
+export async function showNotificationHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  bridge: Bridge,
+): Promise<void> {
+  const title = message.payload?.['title'];
+  if (typeof title !== 'string' || title.length === 0) {
+    connections.sendTo(connectionId, 'ACK', {
+      requestId: message.requestId,
+      status: 'error',
+      error: 'Missing or invalid title',
+    });
+    return;
+  }
+
+  const bodyValue = message.payload?.['body'];
+  const body = typeof bodyValue === 'string' ? bodyValue : '';
+  const workingDirValue = message.payload?.['workingDir'];
+  const workingDir = typeof workingDirValue === 'string' && workingDirValue.length > 0
+    ? workingDirValue
+    : undefined;
+  const panelIdValue = message.payload?.['panelId'];
+  const panelId = typeof panelIdValue === 'string' && panelIdValue.length > 0
+    ? panelIdValue
+    : undefined;
+
+  try {
+    await bridge.showNotification({ title, body, workingDir, panelId });
+    connections.sendTo(connectionId, 'ACK', {
+      requestId: message.requestId,
+      status: 'ok',
+    });
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    console.error('[node-backend]', 'showNotification failed:', err);
+    connections.sendTo(connectionId, 'ACK', {
+      requestId: message.requestId,
+      status: 'error',
+      error,
+    });
+  }
+}

--- a/backend/src/system-notifications/__tests__/notifier.test.ts
+++ b/backend/src/system-notifications/__tests__/notifier.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { escapeForOsascript, buildWindowsToastScript } from '../notifier';
+
+describe('escapeForOsascript', () => {
+  it('escapes double quotes', () => {
+    expect(escapeForOsascript('say "hi"')).toBe('say \\"hi\\"');
+  });
+
+  it('escapes backslashes before quotes', () => {
+    expect(escapeForOsascript('a\\b"c')).toBe('a\\\\b\\"c');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(escapeForOsascript('Response complete')).toBe('Response complete');
+  });
+});
+
+describe('buildWindowsToastScript', () => {
+  it('embeds title and body and escapes single quotes', () => {
+    const script = buildWindowsToastScript("It's done", 'all good');
+    expect(script).toContain("CreateTextNode('It''s done')");
+    expect(script).toContain("CreateTextNode('all good')");
+  });
+
+  it('uses the WinRT ToastNotificationManager without external modules', () => {
+    const script = buildWindowsToastScript('t', 'b');
+    expect(script).toContain('Windows.UI.Notifications.ToastNotificationManager');
+    expect(script).not.toContain('BurntToast');
+  });
+});

--- a/backend/src/system-notifications/index.ts
+++ b/backend/src/system-notifications/index.ts
@@ -1,0 +1,1 @@
+export * from './notifier';

--- a/backend/src/system-notifications/notifier.ts
+++ b/backend/src/system-notifications/notifier.ts
@@ -1,0 +1,67 @@
+import { execFile } from 'child_process';
+
+/**
+ * Escape a string for embedding inside an `osascript -e` AppleScript string
+ * literal: backslashes first, then double quotes.
+ */
+export function escapeForOsascript(s: string): string {
+  return s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+/**
+ * Build a PowerShell command that raises a Windows toast via WinRT, without
+ * requiring any third-party module (e.g. BurntToast). Strings are embedded in
+ * single-quoted PowerShell literals, so `'` is escaped as `''`.
+ *
+ * NOTE: Windows toasts are best-effort here — they surface reliably only under a
+ * registered AppUserModelID; this uses a plain id and is not verified on a real
+ * Windows host (see the macOS-only test environment).
+ */
+export function buildWindowsToastScript(title: string, body: string): string {
+  const t = title.replace(/'/g, "''");
+  const b = body.replace(/'/g, "''");
+  return [
+    "$ErrorActionPreference='Stop'",
+    '[Windows.UI.Notifications.ToastNotificationManager,Windows.UI.Notifications,ContentType=WindowsRuntime]>$null',
+    '$xml=[Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)',
+    "$texts=$xml.GetElementsByTagName('text')",
+    `$texts.Item(0).AppendChild($xml.CreateTextNode('${t}'))>$null`,
+    `$texts.Item(1).AppendChild($xml.CreateTextNode('${b}'))>$null`,
+    '$toast=[Windows.UI.Notifications.ToastNotification]::new($xml)',
+    "[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Claude Code GUI').Show($toast)",
+  ].join(';');
+}
+
+/**
+ * Raise a real OS desktop notification (macOS Notification Center / Windows
+ * toast / Linux libnotify) directly from the backend — the same OS-native
+ * approach used for sounds.
+ *
+ * Used when the IDE is in the background, where an in-IDE balloon would be
+ * hidden behind other apps. Best-effort and fire-and-forget: a failure is logged
+ * but never propagated.
+ */
+export function showOsNotification(title: string, body: string): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const done = (err: Error | null) => {
+      if (err) {
+        console.error('[node-backend]', 'showOsNotification failed:', err.message);
+      }
+      resolve();
+    };
+
+    try {
+      if (process.platform === 'darwin') {
+        const script = `display notification "${escapeForOsascript(body)}" with title "${escapeForOsascript(title)}"`;
+        execFile('osascript', ['-e', script], done);
+      } else if (process.platform === 'win32') {
+        execFile('powershell', ['-NoProfile', '-Command', buildWindowsToastScript(title, body)], done);
+      } else {
+        // notify-send takes title/body as separate args — no shell escaping needed.
+        execFile('notify-send', [title, body], done);
+      }
+    } catch (err) {
+      done(err instanceof Error ? err : new Error(String(err)));
+    }
+  });
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -1,6 +1,7 @@
 package com.github.yhk1038.claudecodegui.actions
 
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.bridge.NotificationOutcome
 import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
 import com.github.yhk1038.claudecodegui.services.NodeBackendService
 import com.intellij.openapi.actionSystem.ActionUpdateThread
@@ -211,6 +212,7 @@ class SendSelectionToClaudeAction : AnAction() {
         override suspend fun updatePlugin() {}
         override suspend fun requiresRestart(): Boolean = false
         override suspend fun getIdeRoot(workingDir: String?): String? = null
-        override suspend fun showNotification(title: String, body: String, panelId: String?) {}
+        override suspend fun showNotification(title: String, body: String, panelId: String?) =
+            NotificationOutcome(shown = false, ideFocused = true)
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -211,5 +211,6 @@ class SendSelectionToClaudeAction : AnAction() {
         override suspend fun updatePlugin() {}
         override suspend fun requiresRestart(): Boolean = false
         override suspend fun getIdeRoot(workingDir: String?): String? = null
+        override suspend fun showNotification(title: String, body: String, panelId: String?) {}
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -13,6 +13,17 @@ import java.io.File
 import java.io.InputStreamReader
 
 /**
+ * Result of an RpcHandler.showNotification call.
+ *
+ * - [shown]: the IDE balloon was actually displayed (false when suppressed
+ *   because the user is already viewing the session).
+ * - [ideFocused]: the IDE window was focused at the time. When false and [shown]
+ *   is true, the backend additionally raises a real OS notification, since an
+ *   in-IDE balloon is hidden behind other apps.
+ */
+data class NotificationOutcome(val shown: Boolean, val ideFocused: Boolean)
+
+/**
  * Manages the Node.js backend process lifecycle.
  *
  * Responsibilities:
@@ -109,8 +120,14 @@ class NodeProcessManager(
          * browser notification (JCEF has no Notification API). [panelId] identifies
          * the originating session tab so the request is routed to the right panel
          * and its "Open session" action returns there.
+         *
+         * Returns whether the IDE balloon was actually shown (vs suppressed because
+         * the user is already viewing the session) and whether the IDE window is
+         * focused — the backend uses the latter to decide whether to additionally
+         * raise a real OS notification (an IDE balloon is hidden when the IDE is in
+         * the background).
          */
-        suspend fun showNotification(title: String, body: String, panelId: String?)
+        suspend fun showNotification(title: String, body: String, panelId: String?): NotificationOutcome
     }
 
     /**

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -103,6 +103,14 @@ class NodeProcessManager(
          * traversal in the working-directory dropdown.
          */
         suspend fun getIdeRoot(workingDir: String?): String?
+        /**
+         * Raise a host-native desktop notification for an "attention needed" /
+         * "response complete" event. Called when the webview cannot raise its own
+         * browser notification (JCEF has no Notification API). [panelId] identifies
+         * the originating session tab so the request is routed to the right panel
+         * and its "Open session" action returns there.
+         */
+        suspend fun showNotification(title: String, body: String, panelId: String?)
     }
 
     /**

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -282,8 +282,11 @@ class RpcWebSocketClient(
                     ?: throw IllegalArgumentException("Missing 'title' param")
                 val body = params["body"]?.jsonPrimitive?.content ?: ""
                 val panelId = params["panelId"]?.jsonPrimitive?.content
-                rpcHandler.showNotification(title, body, panelId)
-                buildJsonObject {}
+                val outcome = rpcHandler.showNotification(title, body, panelId)
+                buildJsonObject {
+                    put("shown", outcome.shown)
+                    put("ideFocused", outcome.ideFocused)
+                }
             }
             else -> {
                 throw IllegalArgumentException("Unknown RPC method: $method")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -277,6 +277,14 @@ class RpcWebSocketClient(
                     if (ideRoot != null) put("ideRoot", ideRoot) else put("ideRoot", JsonNull)
                 }
             }
+            "SHOW_NOTIFICATION" -> {
+                val title = params["title"]?.jsonPrimitive?.content
+                    ?: throw IllegalArgumentException("Missing 'title' param")
+                val body = params["body"]?.jsonPrimitive?.content ?: ""
+                val panelId = params["panelId"]?.jsonPrimitive?.content
+                rpcHandler.showNotification(title, body, panelId)
+                buildJsonObject {}
+            }
             else -> {
                 throw IllegalArgumentException("Unknown RPC method: $method")
             }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
@@ -19,7 +19,7 @@ class ClaudeCodeEditorManagerListener : FileEditorManagerListener {
     override fun selectionChanged(event: FileEditorManagerEvent) {
         val file = event.newFile
         if (file is ClaudeCodeVirtualFile && file.badgeState == TabBadge.UNREAD) {
-            file.setBadge(TabBadge.NONE)
+            file.setBadge(TabBadge.NONE, event.manager.project)
         }
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
@@ -51,7 +51,7 @@ class ClaudeCodeFileEditor(
         panel.onStreamingStateChanged = { isStreaming ->
             if (!isStreaming && wasStreaming) {
                 if (!isTabActive()) {
-                    virtualFile.setBadge(TabBadge.UNREAD)
+                    virtualFile.setBadge(TabBadge.UNREAD, project)
                 }
             }
             wasStreaming = isStreaming

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
@@ -1,5 +1,7 @@
 package com.github.yhk1038.claudecodegui.editor
 
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.testFramework.LightVirtualFile
@@ -41,11 +43,18 @@ class ClaudeCodeVirtualFile(
     var badgeState: TabBadge = TabBadge.NONE
         private set
 
-    fun setBadge(badge: TabBadge) {
+    fun setBadge(badge: TabBadge, project: Project) {
         if (badgeState == badge) return
         badgeState = badge
-        // Trigger tab icon refresh by notifying a property change
-        VirtualFileManager.getInstance().notifyPropertyChanged(this, PROP_NAME, name, name)
+        // Refresh the tab's icon so ClaudeCodeFileIconPatcher repaints the badge.
+        // Do NOT use notifyPropertyChanged(PROP_NAME, name, name): IntelliJ 2024.2+
+        // rejects a VFilePropertyChangeEvent whose old == new value with
+        // "IllegalArgumentException: Values must be different" (the name is
+        // unchanged here — only the badge is). updateFilePresentation refreshes the
+        // tab presentation without faking a name change.
+        ApplicationManager.getApplication().invokeLater {
+            FileEditorManagerEx.getInstanceEx(project).updateFilePresentation(this)
+        }
     }
 
     companion object {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -1,6 +1,7 @@
 package com.github.yhk1038.claudecodegui.services
 
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.bridge.NotificationOutcome
 import com.github.yhk1038.claudecodegui.bridge.RpcWebSocketClient
 import com.github.yhk1038.claudecodegui.bridge.WslPathResolver
 import com.intellij.openapi.Disposable
@@ -131,12 +132,13 @@ class NodeBackendService : Disposable {
 
             override suspend fun getIdeRoot(workingDir: String?): String? = basePath.ifBlank { null }
 
-            override suspend fun showNotification(title: String, body: String, panelId: String?) {
+            override suspend fun showNotification(title: String, body: String, panelId: String?): NotificationOutcome {
                 // Route to the originating panel so its "Open session" action returns
                 // to the right tab; fall back to any panel when the id is unknown
                 // (e.g. the tab was closed between send and completion).
                 val handler = panelId?.let { handlers[it] } ?: any()
-                handler?.showNotification(title, body, panelId) ?: warn("showNotification")
+                return handler?.showNotification(title, body, panelId)
+                    ?: run { warn("showNotification"); NotificationOutcome(shown = false, ideFocused = true) }
             }
         }
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -130,6 +130,14 @@ class NodeBackendService : Disposable {
                 any()?.requiresRestart() ?: run { warn("requiresRestart"); true }
 
             override suspend fun getIdeRoot(workingDir: String?): String? = basePath.ifBlank { null }
+
+            override suspend fun showNotification(title: String, body: String, panelId: String?) {
+                // Route to the originating panel so its "Open session" action returns
+                // to the right tab; fall back to any panel when the id is unknown
+                // (e.g. the tab was closed between send and completion).
+                val handler = panelId?.let { handlers[it] } ?: any()
+                handler?.showNotification(title, body, panelId) ?: warn("showNotification")
+            }
         }
 
         @Synchronized

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -17,7 +17,12 @@ import com.intellij.ide.dnd.DnDManager
 import com.intellij.ide.dnd.DnDTarget
 import com.intellij.ide.dnd.FileCopyPasteUtil
 import com.intellij.ide.dnd.TransferableWrapper
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileChooser.FileChooser
 import com.intellij.openapi.fileChooser.FileChooserDescriptor
@@ -1072,6 +1077,36 @@ class ClaudeCodePanel(
                 // returns its own project root. The composite picks the right
                 // panel before this is ever reached.
                 return project.basePath
+            }
+
+            override suspend fun showNotification(title: String, body: String, panelId: String?) {
+                // panelId already routed us to the right panel (see NodeBackendService
+                // Router), so we act on our own tabId here.
+                ApplicationManager.getApplication().invokeLater {
+                    // No focus/visibility gating here: the webview only sends this when
+                    // its session view is hidden (document.hidden), so by the time we get
+                    // here the user is not looking at this session. The platform then
+                    // renders a balloon when the IDE is focused, or promotes it to an OS
+                    // notification (macOS Notification Center / Windows toast) when the
+                    // IDE itself is in the background.
+                    val notification = NotificationGroupManager.getInstance()
+                        .getNotificationGroup("claude-code-gui.attention")
+                        .createNotification(title, body, NotificationType.INFORMATION)
+
+                    // Offer a one-click jump back to the session tab that needs attention.
+                    if (ClaudeCodeVirtualFile.isTabOpen(project, tabId)) {
+                        notification.addAction(object : NotificationAction("Open session") {
+                            override fun actionPerformed(e: AnActionEvent, n: Notification) {
+                                val virtualFile = ClaudeCodeVirtualFile.getOrCreate(project, tabId)
+                                FileEditorManager.getInstance(project).openFile(virtualFile, true)
+                                n.expire()
+                            }
+                        })
+                    }
+
+                    notification.notify(project)
+                    logger.info("Showed attention notification: $title")
+                }
             }
         }
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -2,6 +2,7 @@ package com.github.yhk1038.claudecodegui.toolwindow
 
 import com.github.yhk1038.claudecodegui.actions.OpenClaudeCodeAction
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.bridge.NotificationOutcome
 import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
 import com.github.yhk1038.claudecodegui.notifications.JcefRuntimeNotifier
 import com.github.yhk1038.claudecodegui.services.ClaudeCodeBrowserService
@@ -35,6 +36,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.wm.WindowManager
 import com.intellij.psi.PsiElement
 import com.intellij.ui.jcef.JBCefBrowser
 import com.intellij.ui.jcef.JBCefJSQuery
@@ -1079,21 +1081,35 @@ class ClaudeCodePanel(
                 return project.basePath
             }
 
-            override suspend fun showNotification(title: String, body: String, panelId: String?) {
+            override suspend fun showNotification(title: String, body: String, panelId: String?): NotificationOutcome {
                 // panelId already routed us to the right panel (see NodeBackendService
                 // Router), so we act on our own tabId here.
+                val result = CompletableDeferred<NotificationOutcome>()
                 ApplicationManager.getApplication().invokeLater {
-                    // No focus/visibility gating here: the webview only sends this when
-                    // its session view is hidden (document.hidden), so by the time we get
-                    // here the user is not looking at this session. The platform then
-                    // renders a balloon when the IDE is focused, or promotes it to an OS
-                    // notification (macOS Notification Center / Windows toast) when the
-                    // IDE itself is in the background.
+                    // Gate here, not in the webview: JCEF's document.hidden is unreliable
+                    // for editor-tab / app-focus changes (works in 2024.2, not 2026.1).
+                    // Suppress only when the user is actually looking at THIS session —
+                    // its editor tab is the selected editor AND the IDE window is focused
+                    // (the same signal the unread tab badge uses).
+                    val fem = FileEditorManager.getInstance(project)
+                    val thisTabSelected = fem.selectedEditors.any {
+                        (it.file as? ClaudeCodeVirtualFile)?.tabId == tabId
+                    }
+                    val ideFocused = WindowManager.getInstance().getFrame(project)?.isActive == true
+                    if (thisTabSelected && ideFocused) {
+                        logger.info("Skipping notification (user viewing this session): $title")
+                        result.complete(NotificationOutcome(shown = false, ideFocused = ideFocused))
+                        return@invokeLater
+                    }
+
+                    // IDE balloon (visible when the IDE is in the foreground) + Event Log
+                    // entry with a one-click jump back to the session. When the IDE is in
+                    // the background the backend also raises a real OS notification (it
+                    // reads ideFocused from this result), since the balloon would be hidden.
                     val notification = NotificationGroupManager.getInstance()
                         .getNotificationGroup("claude-code-gui.attention")
                         .createNotification(title, body, NotificationType.INFORMATION)
 
-                    // Offer a one-click jump back to the session tab that needs attention.
                     if (ClaudeCodeVirtualFile.isTabOpen(project, tabId)) {
                         notification.addAction(object : NotificationAction("Open session") {
                             override fun actionPerformed(e: AnActionEvent, n: Notification) {
@@ -1105,8 +1121,10 @@ class ClaudeCodePanel(
                     }
 
                     notification.notify(project)
-                    logger.info("Showed attention notification: $title")
+                    logger.info("Showed attention notification: $title (ideFocused=$ideFocused)")
+                    result.complete(NotificationOutcome(shown = true, ideFocused = ideFocused))
                 }
+                return result.await()
             }
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -64,6 +64,13 @@
             displayType="STICKY_BALLOON"
             displayName="JCEF Runtime"/>
 
+        <!-- Notification group for "agent needs your attention" / "response complete"
+             events raised when the IDE window is not focused (see ClaudeCodePanel). -->
+        <notificationGroup
+            id="claude-code-gui.attention"
+            displayType="BALLOON"
+            displayName="Claude Code Attention"/>
+
         <!-- Tab icon badge for unread streaming completions -->
         <fileIconPatcher
             implementation="com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileIconPatcher"/>

--- a/webview/src/api/ClaudeCodeApi.ts
+++ b/webview/src/api/ClaudeCodeApi.ts
@@ -3,6 +3,7 @@ import { SessionsApi } from './modules/SessionsApi';
 import { MessagesApi } from './modules/MessagesApi';
 import { ToolsApi } from './modules/ToolsApi';
 import { SoundsApi } from './modules/SoundsApi';
+import { NotificationsApi } from './modules/NotificationsApi';
 
 /**
  * API configuration options
@@ -43,6 +44,7 @@ export class ClaudeCodeApi {
   readonly messages: MessagesApi;
   readonly tools: ToolsApi;
   readonly sounds: SoundsApi;
+  readonly notifications: NotificationsApi;
 
   constructor(configOrBridge?: ApiConfig | BridgeClient, bridge?: BridgeClient) {
     // Handle both constructor signatures for backwards compatibility
@@ -61,6 +63,7 @@ export class ClaudeCodeApi {
     this.messages = new MessagesApi(this.bridge);
     this.tools = new ToolsApi(this.bridge);
     this.sounds = new SoundsApi(this.bridge);
+    this.notifications = new NotificationsApi(this.bridge, getConfig);
   }
 
   /**

--- a/webview/src/api/modules/NotificationsApi.ts
+++ b/webview/src/api/modules/NotificationsApi.ts
@@ -1,0 +1,44 @@
+import { BridgeClient } from '../bridge/BridgeClient';
+import type { ApiConfig } from '../ClaudeCodeApi';
+
+/**
+ * Notifications API module
+ *
+ * Bridges to the host's native desktop-notification support via
+ * `SHOW_NOTIFICATION { title, body, workingDir }`.
+ *
+ * Only used in JCEF (the JetBrains IDE), where the page has no browser
+ * `Notification` API — the IDE host raises the notification instead. In
+ * browser/standalone mode the webview shows the notification itself and never
+ * calls this. The backend ACKs immediately, so callers treat it as
+ * fire-and-forget.
+ *
+ * `workingDir` routes the request to the IDE host serving that project root when
+ * several IDEs share one backend. `panelId` (the per-tab id embedded in the page
+ * URL by the IDE) then selects the exact panel inside that IDE, so the host shows
+ * the notification for — and its "Open session" action returns to — the right
+ * session tab.
+ */
+export class NotificationsApi {
+  constructor(
+    private bridge: BridgeClient,
+    private getConfig: () => ApiConfig,
+  ) {}
+
+  /**
+   * Ask the host to show a native notification.
+   *
+   * `workingDir` defaults to the API's configured working directory and `panelId`
+   * to the one in the page URL, so the IDE host can route to the exact session tab.
+   */
+  async show(params: { title: string; body: string; workingDir?: string }): Promise<void> {
+    const workingDir = params.workingDir ?? this.getConfig().workingDir;
+    const panelId = new URLSearchParams(window.location.search).get('panelId');
+    await this.bridge.request('SHOW_NOTIFICATION', {
+      title: params.title,
+      body: params.body,
+      ...(workingDir ? { workingDir } : {}),
+      ...(panelId ? { panelId } : {}),
+    });
+  }
+}

--- a/webview/src/api/modules/__tests__/NotificationsApi.test.ts
+++ b/webview/src/api/modules/__tests__/NotificationsApi.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NotificationsApi } from '../NotificationsApi';
+import type { BridgeClient } from '../../bridge/BridgeClient';
+import type { ApiConfig } from '../../ClaudeCodeApi';
+
+function createMockBridge() {
+  return {
+    request: vi.fn().mockResolvedValue(undefined),
+    subscribe: vi.fn().mockReturnValue(vi.fn()),
+  } as unknown as BridgeClient;
+}
+
+describe('NotificationsApi', () => {
+  let bridge: ReturnType<typeof createMockBridge>;
+
+  beforeEach(() => {
+    bridge = createMockBridge();
+    // Reset the page URL so panelId isn't carried between tests.
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('sends SHOW_NOTIFICATION with title and body', async () => {
+    const api = new NotificationsApi(bridge, () => ({} as ApiConfig));
+
+    await api.show({ title: 'My session', body: 'Response complete' });
+
+    expect(bridge.request).toHaveBeenCalledWith('SHOW_NOTIFICATION', {
+      title: 'My session',
+      body: 'Response complete',
+    });
+  });
+
+  it('attaches the configured workingDir when present', async () => {
+    const api = new NotificationsApi(bridge, () => ({ workingDir: '/repo' }));
+
+    await api.show({ title: 'My session', body: 'Response complete' });
+
+    expect(bridge.request).toHaveBeenCalledWith('SHOW_NOTIFICATION', {
+      title: 'My session',
+      body: 'Response complete',
+      workingDir: '/repo',
+    });
+  });
+
+  it('prefers an explicit workingDir over the configured one', async () => {
+    const api = new NotificationsApi(bridge, () => ({ workingDir: '/repo' }));
+
+    await api.show({ title: 't', body: 'b', workingDir: '/other' });
+
+    expect(bridge.request).toHaveBeenCalledWith('SHOW_NOTIFICATION', {
+      title: 't',
+      body: 'b',
+      workingDir: '/other',
+    });
+  });
+
+  it('omits workingDir when neither explicit nor configured', async () => {
+    const api = new NotificationsApi(bridge, () => ({} as ApiConfig));
+
+    await api.show({ title: 't', body: 'b' });
+
+    const [, payload] = vi.mocked(bridge.request).mock.calls[0];
+    expect(payload).not.toHaveProperty('workingDir');
+  });
+
+  it('attaches the panelId from the page URL when present', async () => {
+    window.history.replaceState({}, '', '/sessions/x?panelId=panel-123&workingDir=/repo');
+    const api = new NotificationsApi(bridge, () => ({ workingDir: '/repo' }));
+
+    await api.show({ title: 't', body: 'b' });
+
+    expect(bridge.request).toHaveBeenCalledWith('SHOW_NOTIFICATION', {
+      title: 't',
+      body: 'b',
+      workingDir: '/repo',
+      panelId: 'panel-123',
+    });
+  });
+
+  it('omits panelId when the URL has none', async () => {
+    const api = new NotificationsApi(bridge, () => ({} as ApiConfig));
+
+    await api.show({ title: 't', body: 'b' });
+
+    const [, payload] = vi.mocked(bridge.request).mock.calls[0];
+    expect(payload).not.toHaveProperty('panelId');
+  });
+
+  it('propagates backend errors', async () => {
+    vi.mocked(bridge.request).mockRejectedValueOnce(new Error('No RPC client connected'));
+    const api = new NotificationsApi(bridge, () => ({} as ApiConfig));
+
+    await expect(api.show({ title: 't', body: 'b' })).rejects.toThrow('No RPC client connected');
+  });
+});

--- a/webview/src/hooks/useAwaitingNotifications.ts
+++ b/webview/src/hooks/useAwaitingNotifications.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import {
   NotificationKind,
   notify,
+  shouldNotifyForBackgroundEvent,
   type SoundSelection,
 } from '@/notifications';
 import { setUnreadFavicon } from './favicon';
@@ -20,11 +21,12 @@ interface AwaitingSignals {
  * transitions into a state that needs the user's attention (currently:
  * pending tool-permission, plan-approval, or user-question prompts).
  *
- * Triggers only while the tab is hidden — if the user is already viewing
- * the session, both the OS notification and the unread badge would be
- * redundant noise. The favicon is restored by useDocumentTitle's
- * visibilitychange handler, which reads the DOM directly so any source can
- * set the unread state.
+ * Gated by shouldNotifyForBackgroundEvent(): in the browser this fires only
+ * while the tab is hidden — if the user is already viewing the session, both
+ * the OS notification and the unread badge would be redundant noise. In JCEF it
+ * always fires and the IDE host focus-gates the native notification instead. The
+ * favicon is restored by useDocumentTitle's visibilitychange handler, which
+ * reads the DOM directly so any source can set the unread state.
  *
  * Unread badge and desktop notification always travel together: their
  * shared purpose is to signal "you should be looking at this session right
@@ -47,7 +49,7 @@ export function useAwaitingNotifications(
   const wasPendingPermissionRef = useRef(false);
   useEffect(() => {
     const isPending = signals.pendingPermission;
-    if (isPending && !wasPendingPermissionRef.current && document.hidden) {
+    if (isPending && !wasPendingPermissionRef.current && shouldNotifyForBackgroundEvent()) {
       setUnreadFavicon();
       notify(
         NotificationKind.AWAITING_PERMISSION,
@@ -61,7 +63,7 @@ export function useAwaitingNotifications(
   const wasPendingPlanRef = useRef(false);
   useEffect(() => {
     const isPending = signals.pendingPlanApproval;
-    if (isPending && !wasPendingPlanRef.current && document.hidden) {
+    if (isPending && !wasPendingPlanRef.current && shouldNotifyForBackgroundEvent()) {
       setUnreadFavicon();
       notify(
         NotificationKind.AWAITING_PLAN_APPROVAL,
@@ -75,7 +77,7 @@ export function useAwaitingNotifications(
   const wasPendingUserAnswerRef = useRef(false);
   useEffect(() => {
     const isPending = signals.pendingUserAnswer;
-    if (isPending && !wasPendingUserAnswerRef.current && document.hidden) {
+    if (isPending && !wasPendingUserAnswerRef.current && shouldNotifyForBackgroundEvent()) {
       setUnreadFavicon();
       notify(
         NotificationKind.AWAITING_USER_INPUT,

--- a/webview/src/hooks/useDocumentTitle.ts
+++ b/webview/src/hooks/useDocumentTitle.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import {
   NotificationKind,
   notify,
+  shouldNotifyForBackgroundEvent,
   type SoundSelection,
 } from '@/notifications';
 import { APP_NAME } from '@/config/app';
@@ -82,9 +83,11 @@ export function useDocumentTitle(
     }
   }, [isStreaming]);
 
-  // Detect streaming end while tab is hidden → show unread favicon + desktop notification
+  // Detect streaming end while the user isn't looking → show unread favicon +
+  // desktop notification. In JCEF the IDE host focus-gates instead (see
+  // shouldNotifyForBackgroundEvent).
   useEffect(() => {
-    if (!isStreaming && wasStreamingRef.current && document.hidden) {
+    if (!isStreaming && wasStreamingRef.current && shouldNotifyForBackgroundEvent()) {
       setUnreadFavicon();
       notify(
         errorRef.current ? NotificationKind.STREAM_ERROR : NotificationKind.SESSION_COMPLETE,

--- a/webview/src/notifications/__tests__/host.test.ts
+++ b/webview/src/notifications/__tests__/host.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { isIdeHost } from '../host';
+
+describe('isIdeHost()', () => {
+  afterEach(() => {
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('returns true when panelId is present in the page URL (IDE)', () => {
+    window.history.replaceState({}, '', '/sessions/x?panelId=panel-1&workingDir=/repo');
+    expect(isIdeHost()).toBe(true);
+  });
+
+  it('returns false when there is no panelId (standalone browser)', () => {
+    window.history.replaceState({}, '', '/sessions/x?workingDir=/repo');
+    expect(isIdeHost()).toBe(false);
+  });
+});

--- a/webview/src/notifications/__tests__/notify.test.ts
+++ b/webview/src/notifications/__tests__/notify.test.ts
@@ -10,11 +10,15 @@ import { NotificationKind, SOUND_OFF } from '../types';
 // ---------------------------------------------------------------------------
 
 const playMock = vi.fn();
+const showNotificationMock = vi.fn();
 
 vi.mock('@/api/ClaudeCodeApi', () => ({
   api: {
     sounds: {
       play: (...args: unknown[]) => playMock(...args),
+    },
+    notifications: {
+      show: (...args: unknown[]) => showNotificationMock(...args),
     },
   },
 }));
@@ -73,6 +77,8 @@ beforeEach(() => {
   vi.resetModules();
   playMock.mockReset();
   playMock.mockResolvedValue(undefined);
+  showNotificationMock.mockReset();
+  showNotificationMock.mockResolvedValue(undefined);
   beforeUnloadListeners = [];
   originalAddEventListener = window.addEventListener.bind(window);
   vi.spyOn(window, 'addEventListener').mockImplementation(((
@@ -99,13 +105,42 @@ afterEach(() => {
 });
 
 describe('notify()', () => {
-  it('is a no-op when window.Notification is unavailable', async () => {
+  it('delegates to api.notifications.show when window.Notification is unavailable (JCEF)', async () => {
     uninstallNotificationMock();
     const { notify } = await import('../notify');
-    expect(() =>
-      notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: 't' }, SOUND_OFF),
-    ).not.toThrow();
+    notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: 'My Session' }, SOUND_OFF);
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(showNotificationMock).toHaveBeenCalledWith({
+      title: 'My Session',
+      body: 'Response complete',
+    });
+    // SOUND_OFF → no sound on the JCEF path either.
     expect(playMock).not.toHaveBeenCalled();
+  });
+
+  it('falls back to APP_NAME on the JCEF path when sessionTitle is null', async () => {
+    uninstallNotificationMock();
+    const { notify } = await import('../notify');
+    notify(NotificationKind.STREAM_ERROR, { sessionTitle: null }, SOUND_OFF);
+    expect(showNotificationMock).toHaveBeenCalledWith({
+      title: 'Claude Code',
+      body: 'Response failed',
+    });
+  });
+
+  it('plays the selected sound on the JCEF path', async () => {
+    uninstallNotificationMock();
+    const { notify } = await import('../notify');
+    notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: null }, 'Glass');
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(playMock).toHaveBeenCalledWith('Glass');
+  });
+
+  it('does NOT call api.notifications.show on the browser path', async () => {
+    installNotificationMock('granted');
+    const { notify } = await import('../notify');
+    notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: 't' }, SOUND_OFF);
+    expect(showNotificationMock).not.toHaveBeenCalled();
   });
 
   it('is a no-op when permission is "default"', async () => {

--- a/webview/src/notifications/__tests__/notify.test.ts
+++ b/webview/src/notifications/__tests__/notify.test.ts
@@ -73,6 +73,12 @@ function uninstallNotificationMock() {
   delete (globalThis as unknown as { Notification?: unknown }).Notification;
 }
 
+// notify() detects the IDE (JCEF) by the panelId in the page URL, NOT by the
+// presence of window.Notification.
+function setPanelId(id: string | null) {
+  window.history.replaceState({}, '', id ? `/?panelId=${id}` : '/');
+}
+
 beforeEach(() => {
   vi.resetModules();
   playMock.mockReset();
@@ -96,16 +102,21 @@ beforeEach(() => {
   originalFocus = window.focus.bind(window);
   focusSpy = vi.fn();
   window.focus = focusSpy as unknown as typeof window.focus;
+
+  // Default to standalone (no panelId); IDE tests opt in via setPanelId.
+  setPanelId(null);
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
   uninstallNotificationMock();
+  setPanelId(null);
   window.focus = originalFocus;
 });
 
 describe('notify()', () => {
-  it('delegates to api.notifications.show when window.Notification is unavailable (JCEF)', async () => {
+  it('delegates to api.notifications.show when panelId is present (IDE)', async () => {
+    setPanelId('panel-1');
     uninstallNotificationMock();
     const { notify } = await import('../notify');
     notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: 'My Session' }, SOUND_OFF);
@@ -114,11 +125,23 @@ describe('notify()', () => {
       title: 'My Session',
       body: 'Response complete',
     });
-    // SOUND_OFF → no sound on the JCEF path either.
+    // SOUND_OFF → no sound on the IDE path either.
     expect(playMock).not.toHaveBeenCalled();
   });
 
-  it('falls back to APP_NAME on the JCEF path when sessionTitle is null', async () => {
+  it('delegates to the host in the IDE even when window.Notification exists (CEF #2951)', async () => {
+    // Recent JCEF exposes a present-but-broken Notification object; panelId must
+    // win so we never take the dead browser path inside the IDE.
+    setPanelId('panel-1');
+    installNotificationMock('granted');
+    const { notify } = await import('../notify');
+    notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: 'My Session' }, SOUND_OFF);
+    expect(showNotificationMock).toHaveBeenCalledTimes(1);
+    expect(constructorSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to APP_NAME on the IDE path when sessionTitle is null', async () => {
+    setPanelId('panel-1');
     uninstallNotificationMock();
     const { notify } = await import('../notify');
     notify(NotificationKind.STREAM_ERROR, { sessionTitle: null }, SOUND_OFF);
@@ -128,7 +151,8 @@ describe('notify()', () => {
     });
   });
 
-  it('plays the selected sound on the JCEF path', async () => {
+  it('plays the selected sound on the IDE path', async () => {
+    setPanelId('panel-1');
     uninstallNotificationMock();
     const { notify } = await import('../notify');
     notify(NotificationKind.SESSION_COMPLETE, { sessionTitle: null }, 'Glass');

--- a/webview/src/notifications/__tests__/visibility.test.ts
+++ b/webview/src/notifications/__tests__/visibility.test.ts
@@ -8,17 +8,29 @@ function setHidden(hidden: boolean) {
   });
 }
 
+function setPanelId(id: string | null) {
+  window.history.replaceState({}, '', id ? `/?panelId=${id}` : '/');
+}
+
 describe('shouldNotifyForBackgroundEvent()', () => {
   afterEach(() => {
     setHidden(false);
+    setPanelId(null);
   });
 
-  it('returns true when the page is hidden (tab backgrounded / editor tab not selected)', () => {
+  it('always returns true in the IDE (panelId present), regardless of document.hidden', () => {
+    // JCEF document.hidden is unreliable, so the IDE host gates instead.
+    setPanelId('panel-1');
+    setHidden(false);
+    expect(shouldNotifyForBackgroundEvent()).toBe(true);
     setHidden(true);
     expect(shouldNotifyForBackgroundEvent()).toBe(true);
   });
 
-  it('returns false when the page is visible (user is looking at this session)', () => {
+  it('returns document.hidden in standalone (no panelId)', () => {
+    setPanelId(null);
+    setHidden(true);
+    expect(shouldNotifyForBackgroundEvent()).toBe(true);
     setHidden(false);
     expect(shouldNotifyForBackgroundEvent()).toBe(false);
   });

--- a/webview/src/notifications/__tests__/visibility.test.ts
+++ b/webview/src/notifications/__tests__/visibility.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { shouldNotifyForBackgroundEvent } from '../visibility';
+
+function setHidden(hidden: boolean) {
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => hidden,
+  });
+}
+
+describe('shouldNotifyForBackgroundEvent()', () => {
+  afterEach(() => {
+    setHidden(false);
+  });
+
+  it('returns true when the page is hidden (tab backgrounded / editor tab not selected)', () => {
+    setHidden(true);
+    expect(shouldNotifyForBackgroundEvent()).toBe(true);
+  });
+
+  it('returns false when the page is visible (user is looking at this session)', () => {
+    setHidden(false);
+    expect(shouldNotifyForBackgroundEvent()).toBe(false);
+  });
+});

--- a/webview/src/notifications/host.ts
+++ b/webview/src/notifications/host.ts
@@ -1,0 +1,14 @@
+/**
+ * Whether we're running inside the JetBrains IDE (JCEF) rather than a standalone
+ * browser. Detected by the `panelId` the IDE embeds in the page URL.
+ *
+ * We must NOT key this off `'Notification' in window`: recent JCEF/CEF builds
+ * expose a `Notification` object that is present but non-functional (CEF #2951),
+ * so that check wrongly classifies the IDE as a browser. `panelId` is only ever
+ * set by the IDE host (see WebSocketConnector / ClaudeCodePanel), never in
+ * standalone mode.
+ */
+export function isIdeHost(): boolean {
+  if (typeof window === 'undefined') return false;
+  return !!new URLSearchParams(window.location.search).get('panelId');
+}

--- a/webview/src/notifications/index.ts
+++ b/webview/src/notifications/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './templates';
+export * from './host';
 export * from './notify';
 export * from './visibility';
 export * from './useNotificationSound';

--- a/webview/src/notifications/index.ts
+++ b/webview/src/notifications/index.ts
@@ -1,5 +1,6 @@
 export * from './types';
 export * from './templates';
 export * from './notify';
+export * from './visibility';
 export * from './useNotificationSound';
 export * from './useSystemSounds';

--- a/webview/src/notifications/notify.ts
+++ b/webview/src/notifications/notify.ts
@@ -10,16 +10,19 @@ import {
 /**
  * Emits a desktop notification for the given event kind.
  *
- * Silently no-ops in environments where the Notification API is unavailable
- * (e.g. JCEF inside the JetBrains IDE) or when permission has not been
- * granted yet, so callers can invoke it unconditionally.
+ * Two delivery paths, chosen by environment:
+ *  - Browser / standalone: the page's own `Notification` API. No-ops when
+ *    permission has not been granted yet, so callers can invoke unconditionally.
+ *  - JCEF (JetBrains IDE): the page has no `Notification` API, so we ask the IDE
+ *    host to raise a native notification via `SHOW_NOTIFICATION`. The host
+ *    decides whether to suppress it (e.g. when its window is already focused).
  *
- * As of Phase 1.5 the notification itself is always created with
- * `silent: true` — sound playback is delegated to the Node.js backend via
- * `PLAY_SYSTEM_SOUND` so we can play a specific OS sound consistently
- * across browsers (the browser `silent: false` path is too unreliable on
- * Chrome/macOS). When `soundSelection !== SOUND_OFF`, the selected
- * `soundId` is sent to the backend in fire-and-forget fashion.
+ * The notification is always created with `silent: true` on the browser path —
+ * sound playback is delegated to the Node.js backend via `PLAY_SYSTEM_SOUND` so
+ * we can play a specific OS sound consistently across browsers (the browser
+ * `silent: false` path is too unreliable on Chrome/macOS). Sound is played in
+ * both paths; when `soundSelection !== SOUND_OFF` the selected `soundId` is sent
+ * to the backend in fire-and-forget fashion.
  */
 
 const activeNotifications = new Set<Notification>();
@@ -30,24 +33,42 @@ export function notify(
   soundSelection: SoundSelection,
 ): void {
   if (typeof window === 'undefined') return;
-  if (!('Notification' in window)) return;
-  if (Notification.permission !== 'granted') return;
 
   const template = NOTIFICATION_TEMPLATES[kind];
+  const title = template.title(ctx);
 
-  let n: Notification;
-  try {
-    n = new Notification(template.title(ctx), {
-      body: template.body,
-      icon: template.icon,
-      // Always silence the browser's own sound channel — sound is played by
-      // the backend (Phase 1.5) so we don't double up.
-      silent: true,
+  if ('Notification' in window) {
+    // Browser / standalone mode: raise the notification ourselves.
+    if (Notification.permission !== 'granted') return;
+
+    let n: Notification;
+    try {
+      n = new Notification(title, {
+        body: template.body,
+        icon: template.icon,
+        // Always silence the browser's own sound channel — sound is played by
+        // the backend so we don't double up.
+        silent: true,
+      });
+    } catch {
+      // Some platforms (e.g. some mobile Safari versions) throw when constructing
+      // a Notification directly. Treat construction failure as a no-op.
+      return;
+    }
+
+    activeNotifications.add(n);
+    n.onclick = () => {
+      window.focus();
+      n.close();
+    };
+    n.onclose = () => {
+      activeNotifications.delete(n);
+    };
+  } else {
+    // JCEF (JetBrains IDE): no Notification API — delegate to the IDE host.
+    api.notifications.show({ title, body: template.body }).catch((err: unknown) => {
+      console.warn('[notify] SHOW_NOTIFICATION failed:', err);
     });
-  } catch {
-    // Some platforms (e.g. some mobile Safari versions) throw when constructing
-    // a Notification directly. Treat construction failure as a no-op.
-    return;
   }
 
   if (soundSelection !== SOUND_OFF) {
@@ -56,15 +77,6 @@ export function notify(
       console.warn('[notify] PLAY_SYSTEM_SOUND failed:', err);
     });
   }
-
-  activeNotifications.add(n);
-  n.onclick = () => {
-    window.focus();
-    n.close();
-  };
-  n.onclose = () => {
-    activeNotifications.delete(n);
-  };
 }
 
 if (typeof window !== 'undefined' && 'addEventListener' in window) {

--- a/webview/src/notifications/notify.ts
+++ b/webview/src/notifications/notify.ts
@@ -1,5 +1,6 @@
 import { api } from '@/api/ClaudeCodeApi';
 import { NOTIFICATION_TEMPLATES } from './templates';
+import { isIdeHost } from './host';
 import {
   NotificationKind,
   SOUND_OFF,
@@ -11,18 +12,18 @@ import {
  * Emits a desktop notification for the given event kind.
  *
  * Two delivery paths, chosen by environment:
+ *  - JetBrains IDE (JCEF): the page's own `Notification` API is unreliable, so we
+ *    ask the IDE host to raise a native notification via `SHOW_NOTIFICATION`. The
+ *    platform shows a balloon, or an OS notification when the IDE is backgrounded.
  *  - Browser / standalone: the page's own `Notification` API. No-ops when
- *    permission has not been granted yet, so callers can invoke unconditionally.
- *  - JCEF (JetBrains IDE): the page has no `Notification` API, so we ask the IDE
- *    host to raise a native notification via `SHOW_NOTIFICATION`. The host
- *    decides whether to suppress it (e.g. when its window is already focused).
+ *    permission has not been granted, so callers can invoke unconditionally.
  *
- * The notification is always created with `silent: true` on the browser path —
- * sound playback is delegated to the Node.js backend via `PLAY_SYSTEM_SOUND` so
- * we can play a specific OS sound consistently across browsers (the browser
- * `silent: false` path is too unreliable on Chrome/macOS). Sound is played in
- * both paths; when `soundSelection !== SOUND_OFF` the selected `soundId` is sent
- * to the backend in fire-and-forget fashion.
+ * On the browser path the notification is created with `silent: true` — sound is
+ * delegated to the Node.js backend via `PLAY_SYSTEM_SOUND` so we can play a
+ * specific OS sound consistently across browsers (the browser `silent: false`
+ * path is too unreliable on Chrome/macOS). Sound is played on both paths; when
+ * `soundSelection !== SOUND_OFF` the selected `soundId` is sent to the backend in
+ * fire-and-forget fashion.
  */
 
 const activeNotifications = new Set<Notification>();
@@ -37,10 +38,14 @@ export function notify(
   const template = NOTIFICATION_TEMPLATES[kind];
   const title = template.title(ctx);
 
-  if ('Notification' in window) {
+  if (isIdeHost()) {
+    // JetBrains IDE: delegate to the host (browser Notification API is
+    // present-but-broken in JCEF — CEF #2951 — so never use it here).
+    api.notifications.show({ title, body: template.body }).catch((err: unknown) => {
+      console.warn('[notify] SHOW_NOTIFICATION failed:', err);
+    });
+  } else if ('Notification' in window && Notification.permission === 'granted') {
     // Browser / standalone mode: raise the notification ourselves.
-    if (Notification.permission !== 'granted') return;
-
     let n: Notification;
     try {
       n = new Notification(title, {
@@ -65,10 +70,8 @@ export function notify(
       activeNotifications.delete(n);
     };
   } else {
-    // JCEF (JetBrains IDE): no Notification API — delegate to the IDE host.
-    api.notifications.show({ title, body: template.body }).catch((err: unknown) => {
-      console.warn('[notify] SHOW_NOTIFICATION failed:', err);
-    });
+    // Browser without notification permission/API — nothing to show, no sound.
+    return;
   }
 
   if (soundSelection !== SOUND_OFF) {

--- a/webview/src/notifications/visibility.ts
+++ b/webview/src/notifications/visibility.ts
@@ -1,18 +1,19 @@
+import { isIdeHost } from './host';
+
 /**
  * Whether a just-fired background event (streaming end, awaiting permission,
  * etc.) should raise an attention notification — i.e. the user is NOT currently
  * looking at this session.
  *
- * Gated on `document.hidden`: a visible tab makes both the notification and the
- * unread badge redundant noise. This holds in both environments:
- * - Browser / standalone: the page is hidden when its browser tab is backgrounded.
- * - JCEF (JetBrains IDE): the page is hidden when its editor tab is not the
- *   selected one (Chromium reports the embedded view's visibility), so switching
- *   to another tab — or away from the IDE — suppresses or raises it correctly.
- *   The IDE host then shows a balloon (IDE focused) or, when the IDE itself is in
- *   the background, the platform promotes it to an OS notification automatically.
+ * - Browser / standalone: gate on `document.hidden` — a visible tab makes both
+ *   the notification and the unread badge redundant noise.
+ * - JCEF (JetBrains IDE): `document.hidden` is NOT reliable across JCEF versions
+ *   for editor-tab switches or app-focus changes (it tracks in 2024.2 but not in
+ *   2026.1). So always pass here and let the IDE host gate by real editor-tab
+ *   selection + window focus when it shows the notification.
  */
 export function shouldNotifyForBackgroundEvent(): boolean {
   if (typeof document === 'undefined') return false;
+  if (isIdeHost()) return true;
   return document.hidden;
 }

--- a/webview/src/notifications/visibility.ts
+++ b/webview/src/notifications/visibility.ts
@@ -1,0 +1,18 @@
+/**
+ * Whether a just-fired background event (streaming end, awaiting permission,
+ * etc.) should raise an attention notification — i.e. the user is NOT currently
+ * looking at this session.
+ *
+ * Gated on `document.hidden`: a visible tab makes both the notification and the
+ * unread badge redundant noise. This holds in both environments:
+ * - Browser / standalone: the page is hidden when its browser tab is backgrounded.
+ * - JCEF (JetBrains IDE): the page is hidden when its editor tab is not the
+ *   selected one (Chromium reports the embedded view's visibility), so switching
+ *   to another tab — or away from the IDE — suppresses or raises it correctly.
+ *   The IDE host then shows a balloon (IDE focused) or, when the IDE itself is in
+ *   the background, the platform promotes it to an OS notification automatically.
+ */
+export function shouldNotifyForBackgroundEvent(): boolean {
+  if (typeof document === 'undefined') return false;
+  return document.hidden;
+}


### PR DESCRIPTION
## Overview

Inside a JetBrains IDE (JCEF), the browser `Notification` API is unavailable, so the "response complete / waiting for input" desktop notifications never appeared (issue #94). Until now they only worked in standalone browser mode. This PR makes notifications appear in the IDE environment as well.

## How it works

- When the webview has no native `Notification` API, it delegates to the IDE host via a `SHOW_NOTIFICATION` bridge call.
- Gated by `document.hidden` — it only fires when the session view is not visible (a different editor tab, or the IDE in the background), and the sound is gated by the same signal.
- The host shows an IntelliJ `NotificationGroup` balloon, and **when the IDE loses focus the platform automatically promotes it to an OS notification** (macOS Notification Center / Windows toast / libnotify). There is not a single line of OS-specific notification code.
- Notifications are routed via `panelId` (the tab identifier in the page URL) back to the panel that raised them → even with several tabs open, the "Open session" action returns to the correct tab.
- The sound reuses the existing backend OS path as-is.

## Included fix (separate commit)

- **fix: remove the spurious name change on tab badge updates** — `setBadge` called `notifyPropertyChanged(PROP_NAME, name, name)` to refresh the tab icon, but IntelliJ 2024.2+ rejects an old == new property change (`Values must be different`), producing a SEVERE error every time streaming finished on a background tab. Replaced with `FileEditorManagerEx.updateFilePresentation`.

## Tests

- webview 747 / backend 390 unit tests pass, type check passes
- New: `NotificationsApi`, `visibility`, and backend `showNotification` handler tests

## Platform notes

- There is no OS-dependent branching in the code (notifications are delegated to the IntelliJ platform, and JCEF `document.hidden` is Chromium, so it is OS-agnostic).
- **Verification was done only in a macOS sandbox.** Real-world behavior on Windows (native / WSL) is not yet verified — by design the notification is raised by Windows IntelliJ, so it should work regardless of WSL, but it needs actual confirmation.
