### PR TITLE
fix: time-box backend startup so the panel can't hang on "Starting backend..." (#97)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -5,6 +5,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.EnvironmentUtil
 import com.github.yhk1038.claudecodegui.settings.SettingsManager
+import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
@@ -50,6 +51,14 @@ class NodeProcessManager(
     private val wslDistro: String? = null,
     /** Linux working directory inside [wslDistro] (the project root's `/home/...` path). */
     private val wslCwd: String? = null,
+    /**
+     * Invoked as [start] advances through its blocking sub-steps (node discovery,
+     * shell-PATH capture, resource extraction, waiting for the PORT line) so the panel
+     * placeholder can show real progress instead of a single frozen "Starting backend..."
+     * line. Called off the EDT; the listener is responsible for marshalling to the UI
+     * thread. See issue #97.
+     */
+    private val onProgress: ((LoadingPhase) -> Unit)? = null,
 ) : Disposable {
 
     private val logger = Logger.getInstance(NodeProcessManager::class.java)
@@ -115,6 +124,7 @@ class NodeProcessManager(
         // synchronously from tool-window content creation, so a blocking call here
         // would freeze the IDE UI. Run the whole thing on Dispatchers.IO.
         scope.launch(Dispatchers.IO) {
+            onProgress?.invoke(LoadingPhase.LOCATING_NODE)
             // A WSL backend runs node inside the distro (resolved on the distro's PATH),
             // so skip Windows-side node discovery for WSL project roots.
             val nodePath = if (wslDistro != null) null else findNodeExecutable()
@@ -135,6 +145,7 @@ class NodeProcessManager(
                 return@launch
             }
 
+            onProgress?.invoke(LoadingPhase.PREPARING_BACKEND)
             val backendFile = findBackendFile()
             if (backendFile == null) {
                 logger.error("Backend entry file (backend.mjs) not found.")
@@ -196,6 +207,7 @@ class NodeProcessManager(
                 val proc = pb.start()
                 process = proc
                 lifecycle = Lifecycle.RUNNING
+                onProgress?.invoke(LoadingPhase.WAITING_FOR_PORT)
 
                 // Read stdout: first line is PORT, rest are logged
                 stdoutJob = scope.launch(Dispatchers.IO) {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -71,6 +71,26 @@ class NodeProcessManager(
     private var stdoutJob: Job? = null
     private var stderrJob: Job? = null
 
+    // Bounded ring buffer of the most recent backend stderr lines. Lets a startup
+    // failure or port timeout surface the backend's own output in the error panel
+    // instead of an opaque "did not become ready" message — the watchdog half of the
+    // issue #97 fix. Written from the stderr reader, read from a timeout handler on a
+    // different thread, so all access is synchronized on the deque.
+    private val recentStderrLines = ArrayDeque<String>()
+
+    private fun rememberStderr(line: String) {
+        synchronized(recentStderrLines) {
+            recentStderrLines.addLast(line)
+            while (recentStderrLines.size > MAX_STDERR_LINES) recentStderrLines.removeFirst()
+        }
+    }
+
+    /** The most recent backend stderr lines (up to [MAX_STDERR_LINES]), or null if none. */
+    fun recentStderr(): String? {
+        val lines = synchronized(recentStderrLines) { recentStderrLines.toList() }
+        return lines.takeIf { it.isNotEmpty() }?.joinToString("\n")
+    }
+
     /**
      * Lifecycle of the managed process. [start] runs asynchronously, so for a window
      * after start() returns the OS process does not yet exist and [isAlive] is false.
@@ -305,6 +325,7 @@ class NodeProcessManager(
         while (true) {
             val line = reader.readLine() ?: break
             if (line.isNotBlank()) {
+                rememberStderr(line)
                 System.err.println("[Node.js] $line")
                 logger.info("[Node.js] $line")
             }
@@ -832,4 +853,9 @@ class NodeProcessManager(
      */
     val isAlive: Boolean
         get() = process?.isAlive == true
+
+    companion object {
+        // How many recent stderr lines to retain for startup-failure diagnostics (#97).
+        private const val MAX_STDERR_LINES = 30
+    }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -230,6 +230,9 @@ class NodeBackendService : Disposable {
 
         suspend fun awaitPort(): Int = portDeferred.await()
 
+        /** Recent backend stderr, for surfacing a startup-failure cause (#97). */
+        fun recentDiagnostics(): String? = nodeProcessManager?.recentStderr()
+
         /** Kill the process — used by restart() for a clean slate. */
         fun stop() {
             rpcClient?.dispose(); rpcClient = null
@@ -270,6 +273,13 @@ class NodeBackendService : Disposable {
     suspend fun awaitPort(projectBasePath: String): Int =
         (backends[projectBasePath]
             ?: error("No backend registered for project root: $projectBasePath")).awaitPort()
+
+    /**
+     * Most recent backend stderr for [projectBasePath], or null when none. Used to
+     * attach a concrete cause to a start failure/timeout error panel. See issue #97.
+     */
+    fun recentBackendDiagnostics(projectBasePath: String): String? =
+        backends[projectBasePath]?.recentDiagnostics()
 
     /** Restart the backend for [projectBasePath] (retry path). */
     @Synchronized

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -3,6 +3,7 @@ package com.github.yhk1038.claudecodegui.services
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
 import com.github.yhk1038.claudecodegui.bridge.RpcWebSocketClient
 import com.github.yhk1038.claudecodegui.bridge.WslPathResolver
+import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
@@ -67,6 +68,22 @@ class NodeBackendService : Disposable {
 
         // panelId -> handler. The Claude Code editor tabs open under this root.
         val handlers = ConcurrentHashMap<String, NodeProcessManager.RpcHandler>()
+
+        // panelId -> loading-progress listener. Panels register here so they can
+        // reflect the backend's start sub-phases in their placeholder label (#97).
+        private val progressListeners = ConcurrentHashMap<String, (LoadingPhase) -> Unit>()
+
+        fun addProgressListener(panelId: String, listener: (LoadingPhase) -> Unit) {
+            progressListeners[panelId] = listener
+        }
+
+        fun removeProgressListener(panelId: String) {
+            progressListeners.remove(panelId)
+        }
+
+        private fun emitProgress(phase: LoadingPhase) {
+            progressListeners.values.forEach { it(phase) }
+        }
 
         /**
          * RPC requests from this backend always concern this one project root, so
@@ -142,6 +159,14 @@ class NodeBackendService : Disposable {
             nodeProcessManager?.let { if (!it.isDead) return }
             nodeProcessManager?.let { stop() } // clean up a dead manager/socket
 
+            // Wake any awaiter still parked on the previous (now superseded) deferred so
+            // it fails fast instead of hanging on a port that will never arrive — the new
+            // deferred below is a different object the old awaiter can't observe. Matters
+            // on the retry path (restart() → start()), where a panel may already be in
+            // awaitPort(). See issue #97.
+            if (!portDeferred.isCompleted) {
+                portDeferred.cancel(CancellationException("Backend restarting"))
+            }
             portDeferred = CompletableDeferred()
             // A WSL project root (UNC basePath) runs its backend inside the distro so
             // node/claude execute as Linux natives (issue #57); a native root runs locally.
@@ -154,6 +179,7 @@ class NodeBackendService : Disposable {
                 instanceTag = instanceTag,
                 wslDistro = wsl?.distro,
                 wslCwd = wsl?.linuxPath,
+                onProgress = ::emitProgress,
             )
             nodeProcessManager = manager
             manager.start()
@@ -229,6 +255,17 @@ class NodeBackendService : Disposable {
         inst.start() // no-op if already running
     }
 
+    /**
+     * Register a loading-progress [listener] for [panelId] so the panel can mirror the
+     * backend's start sub-phases in its placeholder. Register BEFORE [ensureStarted] so
+     * the first phase emitted by start() is not missed. See issue #97.
+     */
+    @Synchronized
+    fun addProgressListener(projectBasePath: String, panelId: String, listener: (LoadingPhase) -> Unit) {
+        backends.getOrPut(projectBasePath) { BackendInstance(projectBasePath) }
+            .addProgressListener(panelId, listener)
+    }
+
     /** Await the port of the backend serving [projectBasePath]. */
     suspend fun awaitPort(projectBasePath: String): Int =
         (backends[projectBasePath]
@@ -255,6 +292,7 @@ class NodeBackendService : Disposable {
     fun releasePanel(projectBasePath: String, panelId: String) {
         val inst = backends[projectBasePath] ?: return
         inst.handlers.remove(panelId)
+        inst.removeProgressListener(panelId)
         logger.info("Panel released: $projectBasePath::$panelId (remaining handlers: ${inst.handlers.size})")
     }
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -270,8 +270,9 @@ class ClaudeCodePanel(
                     }
                     if (port == null) {
                         logger.warn("Node.js backend did not become ready within ${BACKEND_START_TIMEOUT_MS}ms")
+                        val diag = backendService.recentBackendDiagnostics(project.basePath ?: "")
                         javax.swing.SwingUtilities.invokeLater {
-                            showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.")
+                            showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.", diag)
                         }
                         return@launch
                     }
@@ -282,8 +283,9 @@ class ClaudeCodePanel(
                     throw e
                 } catch (e: Exception) {
                     logger.error("Failed to start Node.js backend", e)
+                    val diag = backendService.recentBackendDiagnostics(project.basePath ?: "")
                     javax.swing.SwingUtilities.invokeLater {
-                        showBackendError(e.message ?: "Unknown error")
+                        showBackendError(e.message ?: "Unknown error", diag)
                     }
                 }
             }
@@ -900,20 +902,31 @@ class ClaudeCodePanel(
     }
 
     /**
-     * Show error when the Node.js backend fails to start.
+     * Show error when the Node.js backend fails to start. When [diagnostics] (the
+     * backend's recent stderr) is available it is appended so the user/maintainer sees
+     * the concrete cause instead of an opaque message — the watchdog half of #97.
      */
-    private fun showBackendError(errorMessage: String) {
+    private fun showBackendError(errorMessage: String, diagnostics: String? = null) {
         remove(loadingLabel)
 
         errorPanel = JPanel(BorderLayout(0, 12)).apply {
             border = javax.swing.BorderFactory.createEmptyBorder(40, 40, 40, 40)
 
+            val diagnosticsHtml = diagnostics
+                ?.let { escapeHtml(it).replace("\n", "<br>") }
+                ?.let {
+                    "<br><br><b>Recent backend output:</b><br>" +
+                    "<div style='text-align:left;'>$it</div>"
+                }
+                ?: ""
+
             val messageLabel = javax.swing.JLabel(
                 "<html><div style='text-align:center;'>" +
                 "<b>Node.js backend failed to start</b><br><br>" +
-                "Error: $errorMessage<br><br>" +
+                "Error: ${escapeHtml(errorMessage)}<br><br>" +
                 "Ensure Node.js is installed and available on PATH.<br>" +
                 "The backend file (backend.mjs) must be built before running." +
+                diagnosticsHtml +
                 "</div></html>"
             ).apply {
                 horizontalAlignment = javax.swing.SwingConstants.CENTER
@@ -950,8 +963,9 @@ class ClaudeCodePanel(
                 }
                 if (port == null) {
                     logger.warn("Retry: Node.js backend did not become ready within ${BACKEND_START_TIMEOUT_MS}ms")
+                    val diag = backendService.recentBackendDiagnostics(project.basePath ?: "")
                     javax.swing.SwingUtilities.invokeLater {
-                        showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.")
+                        showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.", diag)
                     }
                     return@launch
                 }
@@ -961,8 +975,9 @@ class ClaudeCodePanel(
                 throw e
             } catch (e: Exception) {
                 logger.error("Retry: Failed to start Node.js backend", e)
+                val diag = backendService.recentBackendDiagnostics(project.basePath ?: "")
                 javax.swing.SwingUtilities.invokeLater {
-                    showBackendError(e.message ?: "Unknown error")
+                    showBackendError(e.message ?: "Unknown error", diag)
                 }
             }
         }
@@ -1222,6 +1237,11 @@ class ClaudeCodePanel(
          * `wsl.exe` start, while still bounding the formerly-unbounded wait. See issue #97.
          */
         private const val BACKEND_START_TIMEOUT_MS = 30_000L
+
+        /** Escape the minimal set of HTML metacharacters so backend stderr can be safely
+         * embedded in the Swing HTML error label without breaking its markup. */
+        private fun escapeHtml(s: String): String =
+            s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
     }
 
     override fun dispose() {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonObject
@@ -240,6 +241,18 @@ class ClaudeCodePanel(
             acquired.nativeDropBridgeInstalled = true
         }
 
+        // Mirror the backend's start sub-phases in the placeholder label so a slow
+        // start (heavy .zshrc shell-PATH capture, first-run extraction) reads as
+        // progress, not a frozen screen. Registered BEFORE ensureStarted so the first
+        // emitted phase is not missed. See issue #97.
+        backendService.addProgressListener(project.basePath ?: "", panelId) { phase ->
+            ApplicationManager.getApplication().invokeLater {
+                if (!isPanelDisposed && holder?.isLoaded != true) {
+                    loadingLabel.text = phase.message
+                }
+            }
+        }
+
         // Register RPC handler for this panel.
         backendService.ensureStarted(project.basePath ?: "", panelId, createRpcHandler())
 
@@ -247,7 +260,21 @@ class ClaudeCodePanel(
         if (!acquired.isLoaded) {
             scope.launch {
                 try {
-                    val port = backendService.awaitPort(project.basePath ?: "")
+                    // Bound the wait: without a timeout a backend that never prints its
+                    // PORT line (and never exits) leaves the panel stuck on the
+                    // placeholder forever. withTimeoutOrNull returns null on timeout —
+                    // and, being non-throwing, never trips the CancellationException
+                    // re-throw below (TimeoutCancellationException is a subclass). #97.
+                    val port = withTimeoutOrNull(BACKEND_START_TIMEOUT_MS) {
+                        backendService.awaitPort(project.basePath ?: "")
+                    }
+                    if (port == null) {
+                        logger.warn("Node.js backend did not become ready within ${BACKEND_START_TIMEOUT_MS}ms")
+                        javax.swing.SwingUtilities.invokeLater {
+                            showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.")
+                        }
+                        return@launch
+                    }
                     loadWebView(port)
                 } catch (e: CancellationException) {
                     // Panel/tab closed before the backend port was ready — a normal
@@ -918,7 +945,16 @@ class ClaudeCodePanel(
         backendService.restart(project.basePath ?: "")
         scope.launch {
             try {
-                val port = backendService.awaitPort(project.basePath ?: "")
+                val port = withTimeoutOrNull(BACKEND_START_TIMEOUT_MS) {
+                    backendService.awaitPort(project.basePath ?: "")
+                }
+                if (port == null) {
+                    logger.warn("Retry: Node.js backend did not become ready within ${BACKEND_START_TIMEOUT_MS}ms")
+                    javax.swing.SwingUtilities.invokeLater {
+                        showBackendError("Backend did not become ready within ${BACKEND_START_TIMEOUT_MS / 1000} seconds.")
+                    }
+                    return@launch
+                }
                 loadWebView(port)
             } catch (e: CancellationException) {
                 // Panel/tab closed mid-retry — a normal shutdown, not a failure.
@@ -1177,6 +1213,16 @@ class ClaudeCodePanel(
     }
 
     // ─── Lifecycle ──────────────────────────────────────────────────
+
+    companion object {
+        /**
+         * Upper bound on how long the panel waits for the backend to report its port
+         * before surfacing a retryable error. Generous enough to absorb a slow shell-PATH
+         * capture (up to a 10s timeout), first-run resource extraction, and a cold WSL
+         * `wsl.exe` start, while still bounding the formerly-unbounded wait. See issue #97.
+         */
+        private const val BACKEND_START_TIMEOUT_MS = 30_000L
+    }
 
     override fun dispose() {
         isPanelDisposed = true

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhase.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhase.kt
@@ -8,4 +8,10 @@ package com.github.yhk1038.claudecodegui.toolwindow.realization
 enum class LoadingPhase(val message: String) {
     INDEXING_WAIT("Waiting for project indexing..."),
     BACKEND_START("Starting backend..."),
+    // Fine-grained backend-start sub-phases, emitted from NodeProcessManager.start()
+    // so the placeholder reflects real progress instead of a single frozen line while
+    // node discovery / shell-PATH capture / resource extraction run (issue #97).
+    LOCATING_NODE("Locating Node.js..."),
+    PREPARING_BACKEND("Preparing backend files..."),
+    WAITING_FOR_PORT("Waiting for backend to be ready..."),
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
@@ -49,4 +49,13 @@ class NodeProcessManagerLifecycleTest {
         assertEquals(LoadingPhase.LOCATING_NODE, firstPhase)
         mgr.dispose()
     }
+
+    @Test
+    fun `recentStderr is null before any backend output`() {
+        // The watchdog diagnostics buffer starts empty; recentStderr() must report
+        // null (not an empty string) so callers can branch on "no diagnostics". #97.
+        val mgr = NodeProcessManager(CoroutineScope(Dispatchers.Default))
+        assertNull(mgr.recentStderr(), "no stderr should be collected before start")
+        mgr.dispose()
+    }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
@@ -1,9 +1,12 @@
 package com.github.yhk1038.claudecodegui.bridge
 
+import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class NodeProcessManagerLifecycleTest {
 
@@ -23,5 +26,27 @@ class NodeProcessManagerLifecycleTest {
         mgr.dispose()
         assertTrue(mgr.isDead, "after dispose the manager is dead")
         assertFalse(mgr.isAlive)
+    }
+
+    @Test
+    fun `start emits LOCATING_NODE as its first progress phase`() {
+        // start() emits LOCATING_NODE before any blocking discovery work, so it fires
+        // regardless of whether node is actually installed — this is the signal the panel
+        // uses to replace the frozen "Starting backend..." line. See issue #97.
+        val latch = CountDownLatch(1)
+        var firstPhase: LoadingPhase? = null
+        val mgr = NodeProcessManager(
+            CoroutineScope(Dispatchers.Default),
+            onProgress = { phase ->
+                if (firstPhase == null) {
+                    firstPhase = phase
+                    latch.countDown()
+                }
+            },
+        )
+        mgr.start()
+        assertTrue(latch.await(5, TimeUnit.SECONDS), "start() must emit a progress phase")
+        assertEquals(LoadingPhase.LOCATING_NODE, firstPhase)
+        mgr.dispose()
     }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhaseTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/realization/LoadingPhaseTest.kt
@@ -14,4 +14,19 @@ class LoadingPhaseTest {
     fun `BACKEND_START carries expected message`() {
         assertEquals("Starting backend...", LoadingPhase.BACKEND_START.message)
     }
+
+    @Test
+    fun `LOCATING_NODE carries expected message`() {
+        assertEquals("Locating Node.js...", LoadingPhase.LOCATING_NODE.message)
+    }
+
+    @Test
+    fun `PREPARING_BACKEND carries expected message`() {
+        assertEquals("Preparing backend files...", LoadingPhase.PREPARING_BACKEND.message)
+    }
+
+    @Test
+    fun `WAITING_FOR_PORT carries expected message`() {
+        assertEquals("Waiting for backend to be ready...", LoadingPhase.WAITING_FOR_PORT.message)
+    }
 }


### PR DESCRIPTION
## 배경 (#97)

이슈 #97에는 두 증상이 있었다:
1. 백엔드 시작 화면("Starting backend...")이 오래/무한정 멈춤
2. 그 상태에서 탭을 닫으면 가짜 "Failed to start" 예외

증상 ②는 이미 `20e267c`로 해결됐다(탭 닫기 취소를 실패로 로깅하지 않게). 하지만 보고자가 처음 마주친 **증상 ①(시작 화면이 멈추는 것) 자체는 미해결**이라 이슈가 OPEN으로 남아 있었다. 이 PR이 ①을 다룬다.

## 근본 원인

포트 대기 사슬 어디에도 타임아웃이 없었다:

```
ClaudeCodePanel.awaitPort → NodeBackendService.portDeferred.await() → NodeProcessManager.port.await()
```

백엔드 프로세스가 `PORT:{n}` 줄을 끝내 출력하지 못하고 죽지도 않으면, `portDeferred`는 영영 완료되지 않아 패널이 placeholder에 무한정 멈춘다(프로세스가 *죽으면* exit 감지로 유한 실패가 되지만, 살아서 멈추면 복구 불가). 또한 시작이 느린 정상 경로(무거운 `.zshrc`로 인한 셸 PATH 캡처, 첫 실행 리소스 추출)에서도 화면이 "멈춘 것처럼" 보였다 — 단계 표시가 없었기 때문.

## 변경 사항

- **타임아웃 도입**: 두 `awaitPort` 호출부(초기 로드 + 재시도)를 `withTimeoutOrNull(30초)`로 감쌌다. 타임아웃 시 기존의 재시도 가능한 에러 패널을 띄운다. `withTimeoutOrNull`은 예외를 던지지 않으므로, 탭 닫기 수정에서 추가한 `CancellationException` re-throw를 건드리지 않는다(`TimeoutCancellationException`이 그 하위 타입이라 발생하는 함정 회피).
- **로딩 단계 세분화**: `NodeProcessManager.start()`의 실제 진행에 맞춰 `Locating Node.js` / `Preparing backend files` / `Waiting for backend to be ready` 단계를 emit하고 패널 라벨에 반영. 느린 시작이 "정지"가 아니라 "진행 중"으로 읽힌다.
- **재시작 시 옛 deferred 취소**: `restart()`가 새 `portDeferred`로 교체할 때 기존 deferred를 명시적으로 취소해, 옛 deferred를 기다리던 awaiter가 영영 오지 않을 포트를 기다리지 않고 즉시 빠져나온다.

## 타임아웃 위치 결정

타임아웃은 **소비자 계층(`ClaudeCodePanel` 호출부)**에 뒀다. `portDeferred`는 한 project root의 여러 패널이 공유하는 객체라, `withTimeoutOrNull`을 각 패널 코루틴에 두면 그 패널의 await만 끊고 공유 deferred는 보존된다. 타임아웃을 `NodeBackendService.awaitPort` 내부에 두고 deferred를 깨면 다른 패널까지 동반 실패하므로 부적절하다.

## 테스트

- `LoadingPhaseTest`: 새 3개 단계 메시지 검증
- `NodeProcessManagerLifecycleTest`: `start()`가 첫 단계로 `LOCATING_NODE`를 emit하는지 검증
- `./scripts/build.sh build` (compile + test + koverVerify) 통과

## 남은 후속 (이 PR 범위 밖)

- 셸 PATH 캡처 결과의 영속 캐싱(IDE 재시작마다 반복되는 ~10초 비용 제거)
- PORT 워치독으로 stderr 진단 첨부