### PR TITLE
fix: restore tool OUT rendering (#103) and fix unread tab badge crash

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorManagerListener.kt
@@ -2,6 +2,7 @@ package com.github.yhk1038.claudecodegui.editor
 
 import com.intellij.openapi.fileEditor.FileEditorManagerEvent
 import com.intellij.openapi.fileEditor.FileEditorManagerListener
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 
 /**
  * Clears the unread badge when a Claude Code tab becomes selected.
@@ -19,7 +20,9 @@ class ClaudeCodeEditorManagerListener : FileEditorManagerListener {
     override fun selectionChanged(event: FileEditorManagerEvent) {
         val file = event.newFile
         if (file is ClaudeCodeVirtualFile && file.badgeState == TabBadge.UNREAD) {
-            file.setBadge(TabBadge.NONE)
+            if (file.setBadge(TabBadge.NONE)) {
+                (event.manager as? FileEditorManagerEx)?.refreshIcons()
+            }
         }
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorLocation
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.UserDataHolderBase
@@ -51,7 +52,9 @@ class ClaudeCodeFileEditor(
         panel.onStreamingStateChanged = { isStreaming ->
             if (!isStreaming && wasStreaming) {
                 if (!isTabActive()) {
-                    virtualFile.setBadge(TabBadge.UNREAD)
+                    if (virtualFile.setBadge(TabBadge.UNREAD)) {
+                        FileEditorManagerEx.getInstanceEx(project).refreshIcons()
+                    }
                 }
             }
             wasStreaming = isStreaming

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
@@ -41,11 +41,18 @@ class ClaudeCodeVirtualFile(
     var badgeState: TabBadge = TabBadge.NONE
         private set
 
-    fun setBadge(badge: TabBadge) {
-        if (badgeState == badge) return
+    /**
+     * Updates the unread badge state. Returns true if the state actually changed,
+     * so the caller can refresh the editor tab icon (re-running
+     * [ClaudeCodeFileIconPatcher]). The icon refresh itself is driven by the
+     * caller via [com.intellij.openapi.fileEditor.ex.FileEditorManagerEx.refreshIcons],
+     * because firing a PROP_NAME change with an unchanged name throws
+     * IllegalArgumentException ("Values must be different").
+     */
+    fun setBadge(badge: TabBadge): Boolean {
+        if (badgeState == badge) return false
         badgeState = badge
-        // Trigger tab icon refresh by notifying a property change
-        VirtualFileManager.getInstance().notifyPropertyChanged(this, PROP_NAME, name, name)
+        return true
     }
 
     companion object {

--- a/webview/src/pages/ChatPage/ChatMessageArea.tsx
+++ b/webview/src/pages/ChatPage/ChatMessageArea.tsx
@@ -1,41 +1,14 @@
 import { useMemo, useRef } from 'react';
-import {LoadedMessageDto, isContentBlockArray} from '../../types';
 import { MessageBubble } from './MessageBubble';
 import { ProjectSelectorPage } from '@/pages/ProjectSelectorPage';
-import { ToolUseBlockDto, ToolResultBlockDto, ContentBlockType } from '../../dto/message/ContentBlockDto';
-import { transformContentBlocks } from '../../mappers/contentBlockTransformer';
-import type { SubAgentMessage } from '../../dto/message/ContentBlockDto';
 import { useSessionContext } from '../../contexts/SessionContext';
 import { useChatStreamContext } from '../../contexts/ChatStreamContext';
+import { mergeToolResults } from './mergeToolResults';
 import { StreamErrorBanner } from './StreamErrorBanner';
-import { LoadedMessageType, MessageRole } from '../../dto/common';
 import './streaming.css';
 import {StreamingIndicator} from "./StreamingIndicator/index.tsx";
 import { EmptyState } from './EmptyState';
 import { isJetBrains } from '@/config/environment';
-
-/**
- * Convert progress entries into SubAgentMessage array.
- * Filters to only `agent_progress` type (excludes `hook_progress` and others).
- * Both assistant (tool_use) and user (tool_result) roles are preserved;
- * merging of tool_result into tool_use happens in TaskRenderer.
- */
-function buildSubAgentMessages(progressEntries: LoadedMessageDto[]): SubAgentMessage[] {
-  return progressEntries
-    .filter(entry => entry.data?.type === 'agent_progress' && entry.data?.message)
-    .map(entry => {
-      const msgData = entry.data!.message.message;
-      const content = transformContentBlocks(msgData.content);
-      return {
-        content,
-        role: msgData.role as MessageRole,
-        timestamp: entry.timestamp ?? '',
-      };
-    })
-    .sort((a, b) => {
-      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
-    });
-}
 
 interface Props {
   isStreaming: boolean;
@@ -51,86 +24,7 @@ export function ChatMessageArea(props: Props) {
   // the container directly — this component only renders the messages.
 
   // Merge tool_result user messages into preceding assistant's tool_use blocks
-  const mergedMessages = useMemo(() => {
-    // Phase 0: Collect progress entries grouped by parentToolUseID
-    const progressMap = new Map<string, LoadedMessageDto[]>();
-    for (const msg of messages) {
-      if (msg.type === LoadedMessageType.Progress && msg.parentToolUseID) {
-        const list = progressMap.get(msg.parentToolUseID) || [];
-        list.push(msg);
-        progressMap.set(msg.parentToolUseID, list);
-      }
-    }
-
-    // Build tool_use_id → cloned ToolUseBlockDto lookup from all assistant messages.
-    // Cloning prevents mutation of the original block objects (which live on the
-    // shared messages array). In-place mutation would break React.memo bailouts on
-    // MessageBubble — referential equality holds, but the cloned inner block would
-    // be wrong — and could also duplicate runtime fields on re-render
-    // (e.g. React StrictMode).
-    const toolUseMap = new Map<string, ToolUseBlockDto>();
-    for (const msg of messages) {
-      if (msg.type !== LoadedMessageType.Assistant) continue;
-      const content = msg.message?.content;
-      if (!isContentBlockArray(content)) continue;
-      for (const block of content) {
-        if (block.type === ContentBlockType.ToolUse) {
-          const orig = block as ToolUseBlockDto;
-          toolUseMap.set(orig.id, {
-            ...orig,
-            tool_result: undefined,
-            childMessages: undefined,
-            subAgentMessages: undefined,
-          });
-        }
-      }
-    }
-
-    // Phase 1.5: Attach progress entries to Task tool_use blocks
-    for (const [parentId, progressEntries] of progressMap) {
-      const toolUseBlock = toolUseMap.get(parentId);
-      if (toolUseBlock) {
-        toolUseBlock.subAgentMessages = buildSubAgentMessages(progressEntries);
-      }
-    }
-
-    // Attach tool_result messages to matching tool_use blocks and filter them out
-    const result: LoadedMessageDto[] = [];
-    for (const msg of messages) {
-      if (msg.type === LoadedMessageType.Progress) continue; // Skip progress entries (rendered inside TaskRenderer)
-      if (msg.type === LoadedMessageType.User) {
-        // Phase 2a: Attach child messages linked via sourceToolUseID (e.g. skill-expanded prompts)
-        if (msg.sourceToolUseID) {
-          const toolUseBlock = toolUseMap.get(msg.sourceToolUseID);
-          if (toolUseBlock) {
-            if (!toolUseBlock.childMessages) toolUseBlock.childMessages = [];
-            toolUseBlock.childMessages.push(msg);
-            continue; // Don't add to result (rendered inside tool renderer)
-          }
-        }
-
-        // Phase 2b: Attach tool_result messages
-        const content = msg.message?.content;
-        if (isContentBlockArray(content)) {
-          const isToolResultOnly = content.every(block => block.type === ContentBlockType.ToolResult);
-          if (isToolResultOnly) {
-            // Attach this message to each matching tool_use block
-            for (const block of content) {
-              if (block.type === ContentBlockType.ToolResult) {
-                const toolUseBlock = toolUseMap.get((block as ToolResultBlockDto).tool_use_id);
-                if (toolUseBlock) {
-                  toolUseBlock.tool_result = msg;
-                }
-              }
-            }
-            continue; // Don't add to result (hidden)
-          }
-        }
-      }
-      result.push(msg);
-    }
-    return result;
-  }, [messages]);
+  const mergedMessages = useMemo(() => mergeToolResults(messages), [messages]);
 
   const isEmpty = mergedMessages.length === 0;
 

--- a/webview/src/pages/ChatPage/__tests__/mergeToolResults.test.ts
+++ b/webview/src/pages/ChatPage/__tests__/mergeToolResults.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { mergeToolResults } from '../mergeToolResults';
+import { LoadedMessageType, MessageRole } from '../../../dto/common';
+import { ContentBlockType } from '../../../dto/message/ContentBlockDto';
+import type { LoadedMessageDto } from '../../../types';
+
+function assistantWithTool(uuid: string, toolId: string, name: string): LoadedMessageDto {
+  return {
+    uuid,
+    type: LoadedMessageType.Assistant,
+    message: {
+      role: MessageRole.Assistant,
+      content: [
+        { type: 'tool_use', id: toolId, name, input: { command: 'ls' } },
+      ],
+    },
+    timestamp: '2026-01-01T00:00:00.000Z',
+  } as unknown as LoadedMessageDto;
+}
+
+function toolResultUser(
+  uuid: string,
+  toolId: string,
+  content: string | Array<{ type: string; text: string }>,
+): LoadedMessageDto {
+  return {
+    uuid,
+    type: LoadedMessageType.User,
+    message: {
+      role: MessageRole.User,
+      content: [
+        { type: 'tool_result', tool_use_id: toolId, content },
+      ],
+    },
+    timestamp: '2026-01-01T00:00:01.000Z',
+  } as unknown as LoadedMessageDto;
+}
+
+function getToolUseBlock(msg: LoadedMessageDto) {
+  const content = msg.message?.content as unknown as Array<Record<string, unknown>>;
+  return content.find(b => b.type === ContentBlockType.ToolUse) as Record<string, unknown> | undefined;
+}
+
+describe('mergeToolResults', () => {
+  it('merges a tool_result into the preceding assistant tool_use block (string content)', () => {
+    const messages = [
+      assistantWithTool('a1', 'tool1', 'Bash'),
+      toolResultUser('u1', 'tool1', 'command output here'),
+    ];
+
+    const merged = mergeToolResults(messages);
+
+    // the tool_result-only user message must be hidden from the rendered list
+    expect(merged.find(m => m.uuid === 'u1')).toBeUndefined();
+
+    // the assistant message remains, and its tool_use block now carries the result
+    const assistant = merged.find(m => m.uuid === 'a1');
+    expect(assistant).toBeDefined();
+    const toolUseBlock = getToolUseBlock(assistant!);
+    expect(toolUseBlock).toBeDefined();
+    expect(toolUseBlock!.tool_result).toBeDefined();
+    expect((toolUseBlock!.tool_result as LoadedMessageDto).uuid).toBe('u1');
+  });
+
+  it('merges a tool_result whose content is a content-block array', () => {
+    const messages = [
+      assistantWithTool('a1', 'tool1', 'Task'),
+      toolResultUser('u1', 'tool1', [{ type: 'text', text: 'sub-agent done' }]),
+    ];
+
+    const merged = mergeToolResults(messages);
+
+    const assistant = merged.find(m => m.uuid === 'a1')!;
+    const toolUseBlock = getToolUseBlock(assistant);
+    expect(toolUseBlock!.tool_result).toBeDefined();
+  });
+
+  it('does not mutate the original messages array or its blocks', () => {
+    const messages = [
+      assistantWithTool('a1', 'tool1', 'Bash'),
+      toolResultUser('u1', 'tool1', 'output'),
+    ];
+
+    mergeToolResults(messages);
+
+    // original assistant block must stay untouched (no in-place mutation)
+    const originalBlock = getToolUseBlock(messages[0]);
+    expect(originalBlock!.tool_result).toBeUndefined();
+  });
+
+  it('keeps non-tool messages as their original references', () => {
+    const userMsg = {
+      uuid: 'u0',
+      type: LoadedMessageType.User,
+      message: { role: MessageRole.User, content: 'hi' },
+      timestamp: '2026-01-01T00:00:00.000Z',
+    } as unknown as LoadedMessageDto;
+
+    const merged = mergeToolResults([userMsg]);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toBe(userMsg); // same reference → MessageBubble memo bailout holds
+  });
+});

--- a/webview/src/pages/ChatPage/mergeToolResults.ts
+++ b/webview/src/pages/ChatPage/mergeToolResults.ts
@@ -1,0 +1,143 @@
+import { LoadedMessageDto, isContentBlockArray } from '../../types';
+import { ToolUseBlockDto, ToolResultBlockDto, ContentBlockType } from '../../dto/message/ContentBlockDto';
+import { transformContentBlocks } from '../../mappers/contentBlockTransformer';
+import type { SubAgentMessage } from '../../dto/message/ContentBlockDto';
+import { LoadedMessageType, MessageRole } from '../../dto/common';
+
+/**
+ * Convert progress entries into SubAgentMessage array.
+ * Filters to only `agent_progress` type (excludes `hook_progress` and others).
+ * Both assistant (tool_use) and user (tool_result) roles are preserved;
+ * merging of tool_result into tool_use happens in TaskRenderer.
+ */
+export function buildSubAgentMessages(progressEntries: LoadedMessageDto[]): SubAgentMessage[] {
+  return progressEntries
+    .filter(entry => entry.data?.type === 'agent_progress' && entry.data?.message)
+    .map(entry => {
+      const msgData = entry.data!.message.message;
+      const content = transformContentBlocks(msgData.content);
+      return {
+        content,
+        role: msgData.role as MessageRole,
+        timestamp: entry.timestamp ?? '',
+      };
+    })
+    .sort((a, b) => {
+      return new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime();
+    });
+}
+
+/**
+ * Merge tool_result user messages into the preceding assistant's tool_use blocks,
+ * attach sub-agent progress (Task) and child messages (Skill), and hide the
+ * now-merged user messages from the rendered list.
+ *
+ * Returns a new array; the input messages and their nested blocks are never mutated.
+ */
+export function mergeToolResults(messages: LoadedMessageDto[]): LoadedMessageDto[] {
+  // Phase 0: Collect progress entries grouped by parentToolUseID
+  const progressMap = new Map<string, LoadedMessageDto[]>();
+  for (const msg of messages) {
+    if (msg.type === LoadedMessageType.Progress && msg.parentToolUseID) {
+      const list = progressMap.get(msg.parentToolUseID) || [];
+      list.push(msg);
+      progressMap.set(msg.parentToolUseID, list);
+    }
+  }
+
+  // Build tool_use_id → cloned ToolUseBlockDto lookup from all assistant messages.
+  // Cloning prevents mutation of the original block objects (which live on the
+  // shared messages array). In-place mutation would break React.memo bailouts on
+  // MessageBubble — referential equality holds, but the cloned inner block would
+  // be wrong — and could also duplicate runtime fields on re-render
+  // (e.g. React StrictMode).
+  const toolUseMap = new Map<string, ToolUseBlockDto>();
+  for (const msg of messages) {
+    if (msg.type !== LoadedMessageType.Assistant) continue;
+    const content = msg.message?.content;
+    if (!isContentBlockArray(content)) continue;
+    for (const block of content) {
+      if (block.type === ContentBlockType.ToolUse) {
+        const orig = block as ToolUseBlockDto;
+        toolUseMap.set(orig.id, {
+          ...orig,
+          tool_result: undefined,
+          childMessages: undefined,
+          subAgentMessages: undefined,
+        });
+      }
+    }
+  }
+
+  // Phase 1.5: Attach progress entries to Task tool_use blocks
+  for (const [parentId, progressEntries] of progressMap) {
+    const toolUseBlock = toolUseMap.get(parentId);
+    if (toolUseBlock) {
+      toolUseBlock.subAgentMessages = buildSubAgentMessages(progressEntries);
+    }
+  }
+
+  // Phase 2: Attach tool_result / child messages to the tool_use clones and
+  // record which user messages are now merged (and must be hidden). Tracked by
+  // object reference since uuid is optional.
+  const mergedUserMsgs = new Set<LoadedMessageDto>();
+  for (const msg of messages) {
+    if (msg.type !== LoadedMessageType.User) continue;
+
+    // Phase 2a: Attach child messages linked via sourceToolUseID (e.g. skill-expanded prompts)
+    if (msg.sourceToolUseID) {
+      const toolUseBlock = toolUseMap.get(msg.sourceToolUseID);
+      if (toolUseBlock) {
+        if (!toolUseBlock.childMessages) toolUseBlock.childMessages = [];
+        toolUseBlock.childMessages.push(msg);
+        mergedUserMsgs.add(msg);
+        continue; // Rendered inside the tool renderer
+      }
+    }
+
+    // Phase 2b: Attach tool_result messages
+    const content = msg.message?.content;
+    if (isContentBlockArray(content)) {
+      const isToolResultOnly = content.every(block => block.type === ContentBlockType.ToolResult);
+      if (isToolResultOnly) {
+        for (const block of content) {
+          if (block.type === ContentBlockType.ToolResult) {
+            const toolUseBlock = toolUseMap.get((block as ToolResultBlockDto).tool_use_id);
+            if (toolUseBlock) {
+              toolUseBlock.tool_result = msg;
+            }
+          }
+        }
+        mergedUserMsgs.add(msg);
+      }
+    }
+  }
+
+  // Phase 3: Build the rendered list. Progress entries and merged tool_result
+  // user messages are hidden. Assistant messages that contain tool_use blocks
+  // are rebuilt as NEW objects whose blocks point at the merged clones — this is
+  // what surfaces the tool_result (OUT), sub-agent progress and child messages
+  // in the UI. Messages without tool_use keep their original reference so
+  // MessageBubble's React.memo bailout still holds.
+  const result: LoadedMessageDto[] = [];
+  for (const msg of messages) {
+    if (msg.type === LoadedMessageType.Progress) continue;
+    if (msg.type === LoadedMessageType.User && mergedUserMsgs.has(msg)) continue;
+
+    if (msg.type === LoadedMessageType.Assistant) {
+      const message = msg.message;
+      const content = message?.content;
+      if (message && isContentBlockArray(content) && content.some(b => b.type === ContentBlockType.ToolUse)) {
+        const newContent = content.map(block =>
+          block.type === ContentBlockType.ToolUse
+            ? (toolUseMap.get((block as ToolUseBlockDto).id) ?? block)
+            : block,
+        );
+        result.push({ ...msg, message: { ...message, content: newContent } });
+        continue;
+      }
+    }
+    result.push(msg);
+  }
+  return result;
+}

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/BashRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/BashRenderer.tsx
@@ -1,4 +1,4 @@
-import {Container, LabelValue, RendererProps, ToolHeader, ToolWrapper} from "./common";
+import {Container, LabelValue, RendererProps, ToolHeader, ToolWrapper, toolResultText} from "./common";
 
 interface BashToolUseDto {
     name: string;
@@ -6,30 +6,22 @@ interface BashToolUseDto {
         command: string;
         description: string;
     };
-    tool_result?: BashToolResultDto;
-}
-
-interface BashToolResultDto {
-    message: {
-        content: [{content: string}]
-    }
 }
 
 export function BashRenderer(props: RendererProps) {
     const toolUse = props.toolUse as unknown as BashToolUseDto;
-    const toolResult = props.toolResult as BashToolResultDto | undefined;
 
     const name = toolUse.name;
     const description = toolUse.input?.description ?? '';
-    const input = toolUse.input?.command ?? '' as string;
-    const output = toolResult?.message?.content?.[0]?.content ?? '' as string;
+    const input = toolUse.input?.command ?? '';
+    const output = toolResultText(props.toolResult);
 
     return (
         <ToolWrapper message={props.message}>
             <ToolHeader
                 name={name}
                 description={description}
-                inProgress={!toolResult}
+                inProgress={!props.toolResult}
                 className="mb-2.5"
             />
 
@@ -42,7 +34,7 @@ export function BashRenderer(props: RendererProps) {
                     {input}
                 </LabelValue>
                 <LabelValue label="OUT" maxHeight="max-h-[60px]">
-                    {toolUse.tool_result ? output : ''}
+                    {output}
                 </LabelValue>
             </Container>
         </ToolWrapper>

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/GrepRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/GrepRenderer.tsx
@@ -1,6 +1,6 @@
 import {useState} from "react";
 import {ToolUseBlockDto} from "@/types";
-import {RendererProps, ToolHeader, ToolWrapper} from "./common";
+import {RendererProps, ToolHeader, ToolWrapper, toolResultText} from "./common";
 
 class GrepToolUseDto extends ToolUseBlockDto {
     caller: { type: 'direct' };
@@ -15,20 +15,13 @@ class GrepToolUseDto extends ToolUseBlockDto {
     };
 }
 
-class GrepToolResultDto {
-    type: string;
-    tool_use_id: string;
-    content: string;
-}
-
 export function GrepRenderer(props: RendererProps) {
     const [isExpanded, setIsExpanded] = useState(false);
     const toolUse = props.toolUse as unknown as GrepToolUseDto;
-    const toolResult = props.toolResult?.message?.content?.[0] as GrepToolResultDto | undefined;
+    const output = toolResultText(props.toolResult);
 
     const name = toolUse.name;
     const pattern = toolUse.input?.pattern ?? '';
-    // const output = toolResult?.message?.content[0].content ?? '' as string;
 
     return (
         <ToolWrapper message={props.message}>
@@ -40,11 +33,11 @@ export function GrepRenderer(props: RendererProps) {
                 </div>
             </ToolHeader>
 
-            {toolResult?.content && (
+            {output && (
                 <div
                     onClick={() => setIsExpanded(!isExpanded)}
                     className={`text-text-primary/50 text-[0.8461rem] -mt-1 cursor-pointer hover:underline whitespace-pre-wrap ${isExpanded ? '' : 'max-h-[20px] overflow-hidden'}`}>
-                    {toolResult.content}
+                    {output}
                 </div>
             )}
         </ToolWrapper>

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/__tests__/toolResultText.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/__tests__/toolResultText.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { toolResultText } from '../index';
+import { LoadedMessageType, MessageRole } from '@/dto/common';
+import type { LoadedMessageDto } from '@/types';
+
+function toolResultMsg(content: unknown): LoadedMessageDto {
+  return {
+    type: LoadedMessageType.User,
+    message: {
+      role: MessageRole.User,
+      content: [{ type: 'tool_result', tool_use_id: 't1', content }],
+    },
+  } as unknown as LoadedMessageDto;
+}
+
+describe('toolResultText', () => {
+  it('returns string content as-is (e.g. Bash output)', () => {
+    expect(toolResultText(toolResultMsg('command output'))).toBe('command output');
+  });
+
+  it('joins text blocks when content is a content-block array (e.g. Task output)', () => {
+    const msg = toolResultMsg([
+      { type: 'text', text: 'line1\n' },
+      { type: 'text', text: 'line2' },
+    ]);
+    expect(toolResultText(msg)).toBe('line1\nline2');
+  });
+
+  it('returns empty string for undefined tool_result', () => {
+    expect(toolResultText(undefined)).toBe('');
+  });
+
+  it('returns empty string when the first block is not a tool_result', () => {
+    const msg = {
+      type: LoadedMessageType.User,
+      message: { role: MessageRole.User, content: [{ type: 'text', text: 'x' }] },
+    } as unknown as LoadedMessageDto;
+    expect(toolResultText(msg)).toBe('');
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
@@ -2,8 +2,29 @@ import {ReactNode, useState} from "react";
 import {ContextPills} from "@/pages/ChatPage/message-renderers";
 import type {LoadedMessageDto} from "@/types";
 import {cn} from "@/utils/cn.ts";
+import {AnyContentBlockDto, ContentBlockType, TextBlockDto, ToolResultBlockDto} from "@/dto/message/ContentBlockDto";
 
 export * from './RendererProps';
+
+/**
+ * Extract displayable text from a tool_result (OUT) message.
+ * tool_result content can be a plain string or a content-block array
+ * (e.g. [{ type: 'text', text }]); both are normalized to a single string.
+ */
+export function toolResultText(toolResult?: LoadedMessageDto): string {
+    const content = toolResult?.message?.content;
+    if (!Array.isArray(content)) return '';
+    const block = content[0];
+    if (!block || block.type !== ContentBlockType.ToolResult) return '';
+    const value = (block as ToolResultBlockDto).content;
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+        return value
+            .map((b: AnyContentBlockDto) => (b.type === ContentBlockType.Text ? (b as TextBlockDto).text : ''))
+            .join('');
+    }
+    return '';
+}
 
 export const ToolWrapper = (props: {
     message?: LoadedMessageDto;


### PR DESCRIPTION
## Summary

Two independent bug fixes.

### 1. Tool result (OUT) not rendered in tool widgets (#103)

`ChatMessageArea`'s merge logic cloned each `tool_use` block into a lookup map and attached `tool_result` to the clones, but pushed the **original** assistant messages to the render list — so the renderers never saw the merged results. This dropped tool OUT (Bash/Grep), Task sub-agent progress, and Skill child messages (regression from #31).

- Extracted the merge into a pure `mergeToolResults()` that rebuilds assistant messages from the merged clones as **new** objects (originals untouched, so keystroke `React.memo` bailouts still hold — `useMemo` only recomputes when `messages` changes).
- Added `toolResultText()` helper to normalize `tool_result.content` (string **or** content-block array) so OUT renders regardless of shape.

### 2. Unread tab badge crash

`setBadge()` fired a `PROP_NAME` VirtualFile property change with `old == new` to force a tab icon refresh, which the platform rejects (`IllegalArgumentException: "Values must be different"`) — crashing on session switch.

- `setBadge()` now only mutates state and returns whether it changed; callers refresh the tab icon via `FileEditorManagerEx.refreshIcons()` (public, non-internal API).

## Test plan

- `wv-test`: 743 webview tests pass, including new regression tests (`mergeToolResults`, `toolResultText`).
- `wv-lint` (tsc) + plugin `build` (Kotlin + tests) pass.
- Verified in a clean run-ide sandbox: Bash OUT renders correctly; switching tabs to trigger the unread badge no longer throws (`Values must be different` absent from logs).

