### PR TITLE
feat: show current model in composer with quick-switch shortcuts

### DIFF
--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -4,6 +4,8 @@ import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { getAdapter } from '@/adapters';
+import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
+import { ROTATE_MODEL_EVENT } from '@/pages/ChatPage/ChatInput/ModelTag';
 import { PanelSection } from '@/types/commandPalette';
 import type { SlashCommandInfo } from '@/types/slashCommand';
 import { CommandPaletteServices } from './types';
@@ -151,6 +153,24 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
       match: (e: KeyboardEvent) => (e.metaKey || e.ctrlKey) && e.key === ',',
       execute: async () => {
         await getAdapter().openSettings();
+      },
+    });
+
+    keyboardReg.register({
+      id: 'open-model-menu',
+      match: (e: KeyboardEvent) =>
+        (e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'M' || e.key === 'm'),
+      execute: async () => {
+        window.dispatchEvent(new CustomEvent(SWITCH_MODEL_EVENT));
+      },
+    });
+
+    keyboardReg.register({
+      id: 'rotate-model',
+      match: (e: KeyboardEvent) =>
+        (e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === '.' || e.key === '>'),
+      execute: async () => {
+        window.dispatchEvent(new CustomEvent(ROTATE_MODEL_EVENT));
       },
     });
 

--- a/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
@@ -1,0 +1,84 @@
+import { useEffect } from 'react';
+import { Tag } from '@/pages/ChatPage/ChatInput/Tag';
+import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+import { useSessionContext } from '@/contexts/SessionContext';
+import { useBridge } from '@/hooks/useBridge';
+import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
+import { DEFAULT_MODEL_ALIAS } from '@/types/models';
+import { LoadedMessageType } from '@/types';
+import type { ModelInfo } from '@/types/slashCommand';
+
+/** Fired by the ⌘/Ctrl+Shift+. shortcut to rotate to the next model. */
+export const ROTATE_MODEL_EVENT = 'rotate-model';
+
+/**
+ * Resolve the label to show for a model. The CLI's displayName hides the
+ * real model behind generic labels ("Default (recommended)", "Sonnet"),
+ * but the description's first "·"-separated segment carries the actual
+ * model, e.g. "Opus 4.8 with 1M context · Best for everyday tasks".
+ * Keep only the model name + version ("Opus 4.8"), dropping trailing
+ * qualifiers; fall back to the full segment, then to displayName.
+ */
+function resolveModelLabel(info: ModelInfo): string {
+  const firstSegment = info.description?.split('·')[0]?.trim();
+  if (!firstSegment) return info.displayName;
+  const nameVersion = firstSegment.match(/^.+?\s[\d.]+/);
+  return nameVersion ? nameVersion[0].trim() : firstSegment;
+}
+
+/**
+ * Always-on indicator of the current session model in the composer's
+ * bottom bar. Clicking (or ⌘/Ctrl+Shift+M) opens the existing
+ * `ModelSwitchOverlay`; ⌘/Ctrl+Shift+. rotates to the next model.
+ *
+ * The label is the real model name resolved from the CLI model info
+ * (see `resolveModelLabel`). If the current model can't be resolved
+ * (models not loaded yet), the tag renders nothing.
+ */
+export function ModelTag() {
+  const { sessionModel, setSessionModel, appendMessage } = useChatStreamContext();
+  const { controlResponse } = useCliConfig();
+  const { currentSessionId } = useSessionContext();
+  const { send } = useBridge();
+
+  const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
+
+  useEffect(() => {
+    const handleRotate = () => {
+      if (models.length === 0) return;
+      const current = sessionModel ?? DEFAULT_MODEL_ALIAS;
+      const idx = models.findIndex((m) => m.value === current);
+      const next = models[(idx + 1) % models.length];
+
+      setSessionModel(next.value);
+      appendMessage({
+        type: LoadedMessageType.Notification,
+        uuid: crypto.randomUUID(),
+        timestamp: new Date().toISOString(),
+        summary: `Set model to ${resolveModelLabel(next)}`,
+      });
+      if (currentSessionId) void send('SET_MODEL', { model: next.value });
+    };
+
+    window.addEventListener(ROTATE_MODEL_EVENT, handleRotate);
+    return () => window.removeEventListener(ROTATE_MODEL_EVENT, handleRotate);
+  }, [models, sessionModel, setSessionModel, appendMessage, currentSessionId, send]);
+
+  const current = sessionModel ?? DEFAULT_MODEL_ALIAS;
+  const info = models.find((m) => m.value === current);
+  if (!info?.displayName) return null;
+
+  const handleClick = () => {
+    window.dispatchEvent(new CustomEvent(SWITCH_MODEL_EVENT));
+  };
+
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+  const rotateHint = isMac ? '⌘⇧.' : 'Ctrl+Shift+.';
+
+  return (
+    <Tag title={`Switch model (${rotateHint})`} onClick={handleClick}>
+      <span>{resolveModelLabel(info)}</span>
+    </Tag>
+  );
+}

--- a/webview/src/pages/ChatPage/ChatInput/Tag.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/Tag.tsx
@@ -18,7 +18,7 @@ export function Tag(props: Props) {
                 text-[0.8461rem] font-medium transition-colors
                 ${disabled
                     ? 'text-text-tertiary cursor-default'
-                    : 'text-text-secondary cursor-pointer hover:bg-surface-base/[7%]'
+                    : 'text-text-secondary cursor-pointer hover:bg-surface-hover'
                 }
                 ${className}
             `}

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -16,6 +16,7 @@ import { LoadedMessageType } from '@/dto';
 import { useAttachments } from './hooks/useAttachments';
 import { AttachmentPreview } from './AttachmentPreview';
 import { ContextWindowTag } from './ContextWindowTag';
+import { ModelTag } from './ModelTag';
 import { DragOverlay } from './DragOverlay';
 import { AttachMenu } from './AttachMenu';
 import { ModelSwitchOverlay, SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
@@ -556,8 +557,10 @@ export function ChatInput() {
             <ContextWindowTag onClick={handleCompact} disabled={isStreaming} />
           </div>
 
-          {/* 우측: 액션 버튼들 + 첨부 드롭다운 메뉴 */}
-          <div className="relative">
+          {/* 우측: 모델 태그 + 액션 버튼들 + 첨부 드롭다운 메뉴 */}
+          <div className="flex items-center gap-2">
+            <ModelTag />
+            <div className="relative">
             <AttachMenu
               addImageAttachment={addImageAttachment}
               addFileAttachment={addFileAttachment}
@@ -579,6 +582,7 @@ export function ChatInput() {
               }}
               onStop={onStop}
             />
+            </div>
           </div>
         </div>
       </div>

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -23,6 +23,7 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
 
   const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
   const currentModel = sessionModel ?? DEFAULT_MODEL_ALIAS;
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -83,8 +84,11 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
       }}
     >
       {/* Header */}
-      <div className="pt-1 pb-1.5 px-3 text-[0.9230rem] text-text-tertiary">
-        Select a model
+      <div className="pt-1 pb-1.5 px-3 text-[0.9230rem] text-text-tertiary flex items-center justify-between">
+        <span>Select a model</span>
+        <kbd className="inline-flex items-center px-1.5 py-0.5 bg-surface-tooltip rounded text-text-secondary text-xs font-mono">
+          {isMac ? '⌘⇧M' : 'Ctrl+Shift+M'}
+        </kbd>
       </div>
 
       {/* Model list */}


### PR DESCRIPTION
## Summary

Adds an always-on indicator of the current model in the composer's bottom bar, addressing #102 (users couldn't tell which model was active).

- **ModelTag**: always shows the current session model, resolved to its real name (e.g. `Opus 4.8`) even when the CLI labels it `Default (recommended)` — parsed from the CLI model description.
- **Click / `⌘⇧M`**: opens the model picker (`ModelSwitchOverlay`).
- **`⌘⇧.`**: rotates to the next model.
- Picker header shows the open shortcut; tag tooltip shows the rotate shortcut. Shortcut symbols adapt to platform (macOS vs others).

## Out of scope (follow-up)

- effort / fast mode / thinking toggles in the dropdown (deferred).

Closes #102