### PR TITLE
feat: /resume slash command to browse and resume past conversations (#28)

### DIFF
--- a/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
+++ b/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
@@ -257,4 +257,73 @@ describe('useCommandPalette', () => {
       expect(result.current.showSlashCommands).toBe(false);
     });
   });
+
+  // ──────────────────────────────────────────────────────
+  // searchOnly items — hidden by default, surfaced via search
+  // ──────────────────────────────────────────────────────
+
+  describe('searchOnly items', () => {
+    const sectionsWithSearchOnly: PanelSection[] = [
+      {
+        id: PanelSectionId.Context,
+        title: 'Context',
+        showDividerAbove: false,
+        items: [
+          {
+            id: 'normal',
+            label: 'Attach file',
+            type: PanelItemType.Action,
+            action: vi.fn(),
+          } as ActionItem,
+          {
+            id: 'resume',
+            label: 'Resume conversation',
+            type: PanelItemType.Action,
+            searchOnly: true,
+            action: vi.fn(),
+          } as ActionItem,
+        ],
+      },
+    ];
+
+    it('hides searchOnly items when filterQuery is empty', () => {
+      setupMockRegistry(sectionsWithSearchOnly);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.find(i => i.id === 'resume')).toBeUndefined();
+      expect(items.find(i => i.id === 'normal')).toBeDefined();
+    });
+
+    it('surfaces searchOnly items when filterQuery matches the label', () => {
+      setupMockRegistry(sectionsWithSearchOnly);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('res');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.find(i => i.id === 'resume')).toBeDefined();
+    });
+
+    it('still hides searchOnly items when filterQuery matches a different item', () => {
+      setupMockRegistry(sectionsWithSearchOnly);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('attach');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.find(i => i.id === 'resume')).toBeUndefined();
+      expect(items.find(i => i.id === 'normal')).toBeDefined();
+    });
+  });
 });

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -17,18 +17,21 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
   const [showSlashCommands, setShowSlashCommands] = useState(false);
 
   const filteredSections = useMemo(() => {
-    if (!filterQuery) return sections;
-
     const query = filterQuery.toLowerCase();
+    const hasQuery = query.length > 0;
+
     return sections
       .map((section, index) => {
-        const filteredItems = section.items.filter(item =>
-          item.label.toLowerCase().includes(query)
-        );
+        const filteredItems = section.items.filter(item => {
+          // searchOnly items stay hidden until the user types a matching query.
+          if (item.searchOnly && !hasQuery) return false;
+          if (hasQuery) return item.label.toLowerCase().includes(query);
+          return true;
+        });
         if (filteredItems.length === 0) return null;
         return {
           ...section,
-          showDividerAbove: index > 0,
+          showDividerAbove: hasQuery ? index > 0 : section.showDividerAbove,
           items: filteredItems,
         };
       })

--- a/webview/src/commandPalette/sections/context/items.ts
+++ b/webview/src/commandPalette/sections/context/items.ts
@@ -1,6 +1,12 @@
 import { IconType } from '@/types/commandPalette';
 import { StaticItem } from '../../types';
 
+/**
+ * Fired when the user runs `/resume`. The session dropdown opens (browse/resume
+ * past conversations) and the composer clears the `/resume` text. Issue #28.
+ */
+export const OPEN_SESSION_DROPDOWN_EVENT = 'command-palette:open-session-dropdown';
+
 export const contextItems = [
   new StaticItem('attach-file', 'Attach file...', {
     icon: IconType.File,
@@ -22,6 +28,15 @@ export const contextItems = [
       if (services.chatStream.isStreaming) services.chatStream.stop();
       services.chatStream.resetForSessionSwitch();
       services.session.resetToNewSession();
+    },
+  }),
+  // Search-only: surfaces when the user types `/resume`. Opens the session
+  // dropdown so past conversations can be browsed and resumed (issue #28).
+  new StaticItem('resume-conversation', 'Resume conversation', {
+    disabled: false,
+    searchOnly: true,
+    action: async () => {
+      window.dispatchEvent(new CustomEvent(OPEN_SESSION_DROPDOWN_EVENT));
     },
   }),
 ];

--- a/webview/src/commandPalette/types.ts
+++ b/webview/src/commandPalette/types.ts
@@ -51,6 +51,8 @@ export interface CommandPaletteCommand {
   readonly disabled: boolean;
   readonly keepOpen?: boolean;
   readonly order?: number;
+  /** Hidden from the panel by default; only surfaced when the filter query matches its label. */
+  readonly searchOnly?: boolean;
 
   execute(): Promise<void>;
   bindKeyboard?(e: KeyboardEvent): boolean;
@@ -134,6 +136,7 @@ export class StaticItem implements CommandPaletteCommand {
   readonly disabled: boolean;
   readonly keepOpen?: boolean;
   readonly order?: number;
+  readonly searchOnly?: boolean;
 
   private action?: () => Promise<void>;
   private serviceAction?: (services: CommandPaletteServices) => Promise<void>;
@@ -148,6 +151,7 @@ export class StaticItem implements CommandPaletteCommand {
       disabled?: boolean;
       keepOpen?: boolean;
       order?: number;
+      searchOnly?: boolean;
       action?: () => Promise<void>;
       serviceAction?: (services: CommandPaletteServices) => Promise<void>;
     },
@@ -157,6 +161,7 @@ export class StaticItem implements CommandPaletteCommand {
     this.disabled = options?.disabled ?? true;
     this.keepOpen = options?.keepOpen;
     this.order = options?.order;
+    this.searchOnly = options?.searchOnly;
     this.action = options?.action;
     this.serviceAction = options?.serviceAction;
   }

--- a/webview/src/components/SessionList/SearchInput.tsx
+++ b/webview/src/components/SessionList/SearchInput.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { SessionRefresher } from './SessionRefresher';
 import { useSessionListScale } from './scale';
 
@@ -9,11 +10,20 @@ interface Props {
 export function SearchInput(props: Props) {
   const { value, onChange } = props;
   const scale = useSessionListScale();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // The dropdown mounts SearchInput only while open, so focusing on mount puts
+  // the caret in the search box every time the dropdown opens (including via
+  // the `/resume` slash command). Issue #28.
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
 
   return (
     <div className={scale.searchPad}>
       <div className="relative">
         <input
+          ref={inputRef}
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}

--- a/webview/src/components/SessionList/SearchInput.tsx
+++ b/webview/src/components/SessionList/SearchInput.tsx
@@ -1,14 +1,15 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, KeyboardEvent } from 'react';
 import { SessionRefresher } from './SessionRefresher';
 import { useSessionListScale } from './scale';
 
 interface Props {
   value: string;
   onChange: (value: string) => void;
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 export function SearchInput(props: Props) {
-  const { value, onChange } = props;
+  const { value, onChange, onKeyDown } = props;
   const scale = useSessionListScale();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -27,6 +28,7 @@ export function SearchInput(props: Props) {
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           className={`w-full ${scale.searchInput} bg-surface-overlay text-text-secondary rounded outline-none placeholder:text-text-tertiary`}
           placeholder="Search sessions..."
         />

--- a/webview/src/components/SessionList/SessionItem.tsx
+++ b/webview/src/components/SessionList/SessionItem.tsx
@@ -6,18 +6,30 @@ import { useSessionListScale } from './scale';
 interface Props {
   session: SessionMetaDto;
   isSelected: boolean;
+  /** Keyboard-navigation highlight (distinct from isSelected = current session). */
+  isHighlighted?: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onRename: (title: string) => void;
 }
 
 export function SessionItem(props: Props) {
-  const { session, isSelected, onSelect, onDelete, onRename } = props;
+  const { session, isSelected, isHighlighted = false, onSelect, onDelete, onRename } = props;
   const scale = useSessionListScale();
   const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
   const [draft, setDraft] = useState(session.title);
   const inputRef = useRef<HTMLInputElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  // Keep the keyboard-highlighted row in view as the user arrows through.
+  // scrollIntoView is absent in jsdom (and some headless environments), so call
+  // it defensively.
+  useEffect(() => {
+    if (isHighlighted) {
+      buttonRef.current?.scrollIntoView?.({ block: 'nearest' });
+    }
+  }, [isHighlighted]);
   // Escape cancels editing by unmounting the input, which can fire a trailing
   // blur. This flag tells the blur handler to skip committing in that case.
   const skipCommitRef = useRef(false);
@@ -92,11 +104,12 @@ export function SessionItem(props: Props) {
 
   return (
     <button
+      ref={buttonRef}
       onClick={onSelect}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className={`w-full ${scale.itemPad} text-left ${scale.itemText} rounded transition-colors flex justify-between items-center gap-2 ${
-        isSelected
+        isSelected || isHighlighted
           ? 'text-text-primary bg-[var(--surface-selected)]'
           : 'text-text-secondary hover:text-text-primary hover:bg-[var(--surface-selected)]'
       }`}

--- a/webview/src/components/SessionList/index.tsx
+++ b/webview/src/components/SessionList/index.tsx
@@ -5,6 +5,8 @@ import { useSessionListScale } from './scale';
 interface Props {
   groupedSessions: GroupedSessions;
   currentSessionId: string | null;
+  /** Session highlighted via keyboard navigation (distinct from the current session). */
+  highlightedSessionId?: string | null;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
   onRenameSession: (sessionId: string, title: string) => void;
@@ -13,7 +15,7 @@ interface Props {
 }
 
 export function SessionList(props: Props) {
-  const { groupedSessions, currentSessionId, onSelectSession, onDeleteSession, onRenameSession, className = 'max-h-80' } = props;
+  const { groupedSessions, currentSessionId, highlightedSessionId = null, onSelectSession, onDeleteSession, onRenameSession, className = 'max-h-80' } = props;
   const scale = useSessionListScale();
 
   return (
@@ -32,6 +34,7 @@ export function SessionList(props: Props) {
                 key={session.id}
                 session={session}
                 isSelected={session.id === currentSessionId}
+                isHighlighted={session.id === highlightedSessionId}
                 onSelect={() => onSelectSession(session.id)}
                 onDelete={() => onDeleteSession(session.id)}
                 onRename={(title) => onRenameSession(session.id, title)}

--- a/webview/src/components/SessionList/useSessionList.ts
+++ b/webview/src/components/SessionList/useSessionList.ts
@@ -26,15 +26,17 @@ export function useSessionList(): UseSessionListResult {
   const { confirmDialog, confirm } = useConfirmDialog();
   const [searchQuery, setSearchQuery] = useState('');
 
-  // Filter sessions using regex (falls back to substring match on invalid regex)
+  // Filter sessions by title or session id (uuid), using regex with a
+  // substring-match fallback on invalid regex.
   const filteredSessions = useMemo(() => {
     if (!searchQuery.trim()) return sessions;
     try {
       const regex = new RegExp(searchQuery, 'i');
-      return sessions.filter(s => regex.test(s.title));
+      return sessions.filter(s => regex.test(s.title) || regex.test(s.id));
     } catch {
+      const query = searchQuery.toLowerCase();
       return sessions.filter(s =>
-        s.title.toLowerCase().includes(searchQuery.toLowerCase())
+        s.title.toLowerCase().includes(query) || s.id.toLowerCase().includes(query)
       );
     }
   }, [sessions, searchQuery]);

--- a/webview/src/components/SessionList/useSessionListKeyboard.ts
+++ b/webview/src/components/SessionList/useSessionListKeyboard.ts
@@ -1,0 +1,86 @@
+import { useState, useMemo, useEffect, KeyboardEvent } from 'react';
+import { GroupedSessions, GROUP_ORDER } from './utils';
+
+interface Params {
+  groupedSessions: GroupedSessions;
+  /** Re-highlight resets whenever this changes (typically the search query). */
+  searchQuery: string;
+  /** When false, the highlight clears and the refresh shortcut is disabled. */
+  isActive: boolean;
+  /** Resume/open the session at the given id (Enter on a highlighted row). */
+  onSelect: (sessionId: string) => void;
+  /** Reload the session list (Cmd/Ctrl+Shift+P). */
+  onRefresh: () => void;
+  /** Optional Escape handler (e.g. close a dropdown). Omitted for the always-on side panel. */
+  onEscape?: () => void;
+}
+
+interface Result {
+  /** Session highlighted by keyboard navigation, or null when none. */
+  highlightedSessionId: string | null;
+  /** Attach to the search input's onKeyDown. */
+  handleSearchKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+}
+
+/**
+ * Keyboard navigation shared by the session dropdown and the side panel:
+ * arrow-key highlight over the rows (in display order), Enter to select,
+ * optional Escape, and Cmd/Ctrl+Shift+P to refresh the list. Issue #28.
+ */
+export function useSessionListKeyboard(params: Params): Result {
+  const { groupedSessions, searchQuery, isActive, onSelect, onRefresh, onEscape } = params;
+
+  // Cursor over the displayed rows. -1 = no row highlighted.
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+
+  // Sessions in the exact order they render (group order, then within-group),
+  // so arrow-key navigation matches what the user sees.
+  const orderedSessions = useMemo(
+    () => GROUP_ORDER.flatMap((group) => groupedSessions[group]),
+    [groupedSessions],
+  );
+  const highlightedSessionId =
+    highlightedIndex >= 0 ? orderedSessions[highlightedIndex]?.id ?? null : null;
+
+  // Keep the cursor from pointing past the end as the list changes.
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [searchQuery]);
+  useEffect(() => {
+    if (!isActive) setHighlightedIndex(-1);
+  }, [isActive]);
+
+  // Cmd/Ctrl+Shift+P refreshes the list while active.
+  useEffect(() => {
+    if (!isActive) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'P' || e.key === 'p')) {
+        e.preventDefault();
+        onRefresh();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isActive, onRefresh]);
+
+  const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.min(i + 1, orderedSessions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.max(i - 1, -1));
+    } else if (e.key === 'Enter') {
+      const session = orderedSessions[highlightedIndex];
+      if (session) {
+        e.preventDefault();
+        onSelect(session.id);
+      }
+    } else if (e.key === 'Escape' && onEscape) {
+      e.preventDefault();
+      onEscape();
+    }
+  };
+
+  return { highlightedSessionId, handleSearchKeyDown };
+}

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -22,6 +22,7 @@ import { AttachMenu } from './AttachMenu';
 import { ModelSwitchOverlay, SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { EFFORT_CYCLE_EVENT } from '@/commandPalette/sections/model/EffortItem';
 import { THINKING_TOGGLE_EVENT } from '@/commandPalette/sections/model/ThinkingItem';
+import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useEffort } from '@/hooks/useEffort';
 import { useMention } from './hooks/useMention';
@@ -145,6 +146,14 @@ export function ChatInput() {
     window.addEventListener('command-palette:attach-files', handleAttachFromPalette);
     return () => window.removeEventListener('command-palette:attach-files', handleAttachFromPalette);
   }, []);
+
+  // 커맨드 팔레트 "Resume conversation" 항목 연동: 입력창의 `/resume` 텍스트를 비운다.
+  // (드롭다운 열기·포커스는 SessionDropdown이 같은 이벤트를 수신해 처리한다.)
+  useEffect(() => {
+    const handleResumeFromPalette = () => onChange('');
+    window.addEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleResumeFromPalette);
+    return () => window.removeEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleResumeFromPalette);
+  }, [onChange]);
 
   // 커맨드 팔레트 "Switch model..." 항목 연동
   useEffect(() => {

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/DropdownMenu.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/DropdownMenu.tsx
@@ -1,3 +1,4 @@
+import { KeyboardEvent } from 'react';
 import { GroupedSessions } from '@/components/SessionList/utils';
 import { SearchInput } from '@/components/SessionList/SearchInput';
 import { SessionList } from '@/components/SessionList';
@@ -5,9 +6,11 @@ import { SessionList } from '@/components/SessionList';
 interface Props {
   searchQuery: string;
   onSearchChange: (value: string) => void;
+  onSearchKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   groupedSessions: GroupedSessions;
   filteredSessionsCount: number;
   currentSessionId: string | null;
+  highlightedSessionId?: string | null;
   onSelectSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
   onRenameSession: (sessionId: string, title: string) => void;
@@ -17,9 +20,11 @@ export function DropdownMenu(props: Props) {
   const {
     searchQuery,
     onSearchChange,
+    onSearchKeyDown,
     groupedSessions,
     filteredSessionsCount,
     currentSessionId,
+    highlightedSessionId = null,
     onSelectSession,
     onDeleteSession,
     onRenameSession,
@@ -27,12 +32,13 @@ export function DropdownMenu(props: Props) {
 
   return (
     <div className="absolute left-0 top-full mt-1 w-[23rem] bg-surface-raised border border-border-default rounded-md shadow-xl overflow-hidden z-50">
-      <SearchInput value={searchQuery} onChange={onSearchChange} />
+      <SearchInput value={searchQuery} onChange={onSearchChange} onKeyDown={onSearchKeyDown} />
 
       {filteredSessionsCount > 0 ? (
         <SessionList
           groupedSessions={groupedSessions}
           currentSessionId={currentSessionId}
+          highlightedSessionId={highlightedSessionId}
           onSelectSession={onSelectSession}
           onDeleteSession={onDeleteSession}
           onRenameSession={onRenameSession}

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
@@ -3,6 +3,7 @@ import { DropdownToggle } from './DropdownToggle';
 import { DropdownMenu } from './DropdownMenu';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useSessionList } from '@/components/SessionList/useSessionList';
+import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 
 export function SessionDropdown() {
   const { currentSession, switchSession } = useSessionContext();
@@ -20,6 +21,17 @@ export function SessionDropdown() {
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const sessionTitle = currentSession?.title || 'Past Conversations';
+
+  // `/resume` slash command opens the dropdown so past conversations can be
+  // browsed and resumed. Issue #28.
+  useEffect(() => {
+    const handleOpenFromPalette = () => {
+      setSearchQuery('');
+      setIsOpen(true);
+    };
+    window.addEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleOpenFromPalette);
+    return () => window.removeEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleOpenFromPalette);
+  }, [setSearchQuery]);
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
@@ -8,7 +8,7 @@ import { useChatInputFocus } from '@/contexts/ChatInputFocusContext';
 import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 
 export function SessionDropdown() {
-  const { currentSession, switchSession } = useSessionContext();
+  const { currentSession, switchSession, loadSessions } = useSessionContext();
   const { focus: focusComposer } = useChatInputFocus();
   const {
     currentSessionId,
@@ -73,6 +73,20 @@ export function SessionDropdown() {
       return () => document.removeEventListener('mousedown', handleClickOutside);
     }
   }, [isOpen, setSearchQuery]);
+
+  // While the dropdown is open, Cmd/Ctrl+Shift+P refreshes the session list
+  // (same action as the refresh button in the search box).
+  useEffect(() => {
+    if (!isOpen) return;
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'P' || e.key === 'p')) {
+        e.preventDefault();
+        loadSessions();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [isOpen, loadSessions]);
 
   const handleSelectSession = (sessionId: string) => {
     switchSession(sessionId);

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
@@ -1,12 +1,15 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useMemo, KeyboardEvent } from 'react';
 import { DropdownToggle } from './DropdownToggle';
 import { DropdownMenu } from './DropdownMenu';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useSessionList } from '@/components/SessionList/useSessionList';
+import { GROUP_ORDER } from '@/components/SessionList/utils';
+import { useChatInputFocus } from '@/contexts/ChatInputFocusContext';
 import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 
 export function SessionDropdown() {
   const { currentSession, switchSession } = useSessionContext();
+  const { focus: focusComposer } = useChatInputFocus();
   const {
     currentSessionId,
     searchQuery,
@@ -18,15 +21,40 @@ export function SessionDropdown() {
     confirmDialog,
   } = useSessionList();
   const [isOpen, setIsOpen] = useState(false);
+  // Keyboard-navigation cursor over the displayed session rows. -1 = no row
+  // highlighted (caret rests in the search box).
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const sessionTitle = currentSession?.title || 'Past Conversations';
+
+  // Sessions in the exact order they render (group order, then within-group
+  // order) so arrow-key navigation matches what the user sees.
+  const orderedSessions = useMemo(
+    () => GROUP_ORDER.flatMap((group) => groupedSessions[group]),
+    [groupedSessions],
+  );
+  const highlightedSessionId =
+    highlightedIndex >= 0 ? orderedSessions[highlightedIndex]?.id ?? null : null;
+
+  const closeDropdown = () => {
+    setIsOpen(false);
+    setSearchQuery('');
+    setHighlightedIndex(-1);
+  };
+
+  // Reset the highlight whenever the filtered list changes so the cursor never
+  // points past the end of the list.
+  useEffect(() => {
+    setHighlightedIndex(-1);
+  }, [searchQuery]);
 
   // `/resume` slash command opens the dropdown so past conversations can be
   // browsed and resumed. Issue #28.
   useEffect(() => {
     const handleOpenFromPalette = () => {
       setSearchQuery('');
+      setHighlightedIndex(-1);
       setIsOpen(true);
     };
     window.addEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleOpenFromPalette);
@@ -36,8 +64,7 @@ export function SessionDropdown() {
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsOpen(false);
-        setSearchQuery('');
+        closeDropdown();
       }
     };
 
@@ -49,8 +76,27 @@ export function SessionDropdown() {
 
   const handleSelectSession = (sessionId: string) => {
     switchSession(sessionId);
-    setIsOpen(false);
-    setSearchQuery('');
+    closeDropdown();
+  };
+
+  const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.min(i + 1, orderedSessions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((i) => Math.max(i - 1, -1));
+    } else if (e.key === 'Enter') {
+      const session = orderedSessions[highlightedIndex];
+      if (session) {
+        e.preventDefault();
+        handleSelectSession(session.id);
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      closeDropdown();
+      focusComposer();
+    }
   };
 
   return (
@@ -65,9 +111,11 @@ export function SessionDropdown() {
         <DropdownMenu
           searchQuery={searchQuery}
           onSearchChange={setSearchQuery}
+          onSearchKeyDown={handleSearchKeyDown}
           groupedSessions={groupedSessions}
           filteredSessionsCount={filteredSessions.length}
           currentSessionId={currentSessionId}
+          highlightedSessionId={highlightedSessionId}
           onSelectSession={handleSelectSession}
           onDeleteSession={handleDeleteSession}
           onRenameSession={renameSession}

--- a/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SessionDropdown/index.tsx
@@ -1,9 +1,9 @@
-import { useState, useRef, useEffect, useMemo, KeyboardEvent } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { DropdownToggle } from './DropdownToggle';
 import { DropdownMenu } from './DropdownMenu';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useSessionList } from '@/components/SessionList/useSessionList';
-import { GROUP_ORDER } from '@/components/SessionList/utils';
+import { useSessionListKeyboard } from '@/components/SessionList/useSessionListKeyboard';
 import { useChatInputFocus } from '@/contexts/ChatInputFocusContext';
 import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 
@@ -21,40 +21,37 @@ export function SessionDropdown() {
     confirmDialog,
   } = useSessionList();
   const [isOpen, setIsOpen] = useState(false);
-  // Keyboard-navigation cursor over the displayed session rows. -1 = no row
-  // highlighted (caret rests in the search box).
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   const sessionTitle = currentSession?.title || 'Past Conversations';
 
-  // Sessions in the exact order they render (group order, then within-group
-  // order) so arrow-key navigation matches what the user sees.
-  const orderedSessions = useMemo(
-    () => GROUP_ORDER.flatMap((group) => groupedSessions[group]),
-    [groupedSessions],
-  );
-  const highlightedSessionId =
-    highlightedIndex >= 0 ? orderedSessions[highlightedIndex]?.id ?? null : null;
-
   const closeDropdown = () => {
     setIsOpen(false);
     setSearchQuery('');
-    setHighlightedIndex(-1);
   };
 
-  // Reset the highlight whenever the filtered list changes so the cursor never
-  // points past the end of the list.
-  useEffect(() => {
-    setHighlightedIndex(-1);
-  }, [searchQuery]);
+  const handleSelectSession = (sessionId: string) => {
+    switchSession(sessionId);
+    closeDropdown();
+  };
+
+  const { highlightedSessionId, handleSearchKeyDown } = useSessionListKeyboard({
+    groupedSessions,
+    searchQuery,
+    isActive: isOpen,
+    onSelect: handleSelectSession,
+    onRefresh: loadSessions,
+    onEscape: () => {
+      closeDropdown();
+      focusComposer();
+    },
+  });
 
   // `/resume` slash command opens the dropdown so past conversations can be
   // browsed and resumed. Issue #28.
   useEffect(() => {
     const handleOpenFromPalette = () => {
       setSearchQuery('');
-      setHighlightedIndex(-1);
       setIsOpen(true);
     };
     window.addEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleOpenFromPalette);
@@ -73,45 +70,6 @@ export function SessionDropdown() {
       return () => document.removeEventListener('mousedown', handleClickOutside);
     }
   }, [isOpen, setSearchQuery]);
-
-  // While the dropdown is open, Cmd/Ctrl+Shift+P refreshes the session list
-  // (same action as the refresh button in the search box).
-  useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e: globalThis.KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === 'P' || e.key === 'p')) {
-        e.preventDefault();
-        loadSessions();
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [isOpen, loadSessions]);
-
-  const handleSelectSession = (sessionId: string) => {
-    switchSession(sessionId);
-    closeDropdown();
-  };
-
-  const handleSearchKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      setHighlightedIndex((i) => Math.min(i + 1, orderedSessions.length - 1));
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      setHighlightedIndex((i) => Math.max(i - 1, -1));
-    } else if (e.key === 'Enter') {
-      const session = orderedSessions[highlightedIndex];
-      if (session) {
-        e.preventDefault();
-        handleSelectSession(session.id);
-      }
-    } else if (e.key === 'Escape') {
-      e.preventDefault();
-      closeDropdown();
-      focusComposer();
-    }
-  };
 
   return (
     <div className="relative min-w-0" ref={dropdownRef}>

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -169,6 +169,31 @@ describe('SessionHeader', () => {
     expect(screen.queryByPlaceholderText('Search sessions...')).not.toBeInTheDocument();
   });
 
+  it('드롭다운이 열린 상태에서 Cmd/Ctrl+Shift+P로 세션 목록을 새로고침', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />);
+    await user.click(screen.getByRole('button', { name: /First Chat/i }));
+
+    mockLoadSessions.mockClear();
+    fireEvent.keyDown(window, { key: 'P', ctrlKey: true, shiftKey: true });
+
+    expect(mockLoadSessions).toHaveBeenCalledTimes(1);
+  });
+
+  it('세션 아이디(uuid)로 검색하면 해당 세션이 표시됨', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />);
+    await user.click(screen.getByRole('button', { name: /First Chat/i }));
+
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+    await user.type(searchInput, 'session-3');
+
+    const dropdown = document.querySelector('.max-h-80');
+    expect(within(dropdown as HTMLElement).getByText('API Discussion')).toBeInTheDocument();
+    expect(within(dropdown as HTMLElement).queryByText('First Chat')).not.toBeInTheDocument();
+    expect(within(dropdown as HTMLElement).queryByText('Second Chat')).not.toBeInTheDocument();
+  });
+
   it('드롭다운 외부 클릭 시 드롭다운이 닫힘', async () => {
     const user = userEvent.setup();
     const { container } = render(<SessionHeader />);

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { render, screen, fireEvent, within, act } from '@testing-library/react';
+import { OPEN_SESSION_DROPDOWN_EVENT } from '@/commandPalette/sections/context/items';
 import userEvent from '@testing-library/user-event';
 import { SessionHeader } from '../SessionHeader/index';
 import { SessionMetaDto } from '../../../dto';
@@ -112,6 +113,22 @@ describe('SessionHeader', () => {
     // 다시 클릭 → 드롭다운 닫힘
     await user.click(toggleButton);
     expect(screen.queryByPlaceholderText('Search sessions...')).not.toBeInTheDocument();
+  });
+
+  it('/resume 이벤트(open-session-dropdown) 디스패치 시 드롭다운이 열리고 검색창에 포커스', async () => {
+    render(<SessionHeader />);
+
+    // 초기 상태: 드롭다운 닫힘
+    expect(screen.queryByPlaceholderText('Search sessions...')).not.toBeInTheDocument();
+
+    // `/resume` 슬래시 커맨드가 디스패치하는 이벤트
+    act(() => {
+      window.dispatchEvent(new CustomEvent(OPEN_SESSION_DROPDOWN_EVENT));
+    });
+
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+    expect(searchInput).toBeInTheDocument();
+    expect(searchInput).toHaveFocus();
   });
 
   it('드롭다운 외부 클릭 시 드롭다운이 닫힘', async () => {

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -131,6 +131,44 @@ describe('SessionHeader', () => {
     expect(searchInput).toHaveFocus();
   });
 
+  it('방향키(ArrowDown)로 세션을 이동하고 Enter로 진입', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />);
+    await user.click(screen.getByRole('button', { name: /First Chat/i }));
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+
+    // -1 → 0(First Chat) → 1(Second Chat)
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(mockSwitchSession).toHaveBeenCalledWith('session-2');
+  });
+
+  it('하이라이트된 세션이 없을 때 Enter는 아무 세션도 진입하지 않음', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />);
+    await user.click(screen.getByRole('button', { name: /First Chat/i }));
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+
+    // 방향키를 누르지 않은 상태(highlightedIndex = -1)
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(mockSwitchSession).not.toHaveBeenCalled();
+  });
+
+  it('Escape로 드롭다운이 닫힘', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />);
+    await user.click(screen.getByRole('button', { name: /First Chat/i }));
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+    expect(searchInput).toBeInTheDocument();
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' });
+
+    expect(screen.queryByPlaceholderText('Search sessions...')).not.toBeInTheDocument();
+  });
+
   it('드롭다운 외부 클릭 시 드롭다운이 닫힘', async () => {
     const user = userEvent.setup();
     const { container } = render(<SessionHeader />);

--- a/webview/src/pages/SessionPanelPage/__tests__/SessionPanelPage.test.tsx
+++ b/webview/src/pages/SessionPanelPage/__tests__/SessionPanelPage.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { SessionPanelPage } from '../index';
 
-const { mockOpenNewTab, mockOpenSession, mockUseSessionList } = vi.hoisted(() => {
+const { mockOpenNewTab, mockOpenSession, mockLoadSessions, mockUseSessionList } = vi.hoisted(() => {
   const session = {
     id: 's1',
     title: 'My Session',
@@ -14,6 +14,7 @@ const { mockOpenNewTab, mockOpenSession, mockUseSessionList } = vi.hoisted(() =>
   return {
     mockOpenNewTab: vi.fn(),
     mockOpenSession: vi.fn().mockResolvedValue(undefined),
+    mockLoadSessions: vi.fn(),
     mockUseSessionList: vi.fn(() => ({
       currentSessionId: null,
       searchQuery: '',
@@ -34,7 +35,7 @@ const { mockOpenNewTab, mockOpenSession, mockUseSessionList } = vi.hoisted(() =>
 });
 
 vi.mock('@/contexts/SessionContext', () => ({
-  useSessionContext: () => ({ openNewTab: mockOpenNewTab }),
+  useSessionContext: () => ({ openNewTab: mockOpenNewTab, loadSessions: mockLoadSessions }),
 }));
 
 vi.mock('@/adapters', () => ({
@@ -49,6 +50,7 @@ describe('SessionPanelPage', () => {
   beforeEach(() => {
     mockOpenNewTab.mockClear();
     mockOpenSession.mockClear();
+    mockLoadSessions.mockClear();
     mockUseSessionList.mockClear();
   });
 
@@ -61,6 +63,23 @@ describe('SessionPanelPage', () => {
     render(<SessionPanelPage />);
     fireEvent.click(screen.getByRole('button', { name: /My Session/i }));
     expect(mockOpenSession).toHaveBeenCalledWith('s1');
+  });
+
+  it('방향키로 세션을 하이라이트하고 Enter로 새 탭에서 연다', () => {
+    render(<SessionPanelPage />);
+    const searchInput = screen.getByPlaceholderText('Search sessions...');
+
+    // -1 → 0 (My Session)
+    fireEvent.keyDown(searchInput, { key: 'ArrowDown' });
+    fireEvent.keyDown(searchInput, { key: 'Enter' });
+
+    expect(mockOpenSession).toHaveBeenCalledWith('s1');
+  });
+
+  it('Cmd/Ctrl+Shift+P로 세션 목록을 새로고침한다', () => {
+    render(<SessionPanelPage />);
+    fireEvent.keyDown(window, { key: 'P', ctrlKey: true, shiftKey: true });
+    expect(mockLoadSessions).toHaveBeenCalledTimes(1);
   });
 
   it('opens a new session when "New session" is clicked', () => {

--- a/webview/src/pages/SessionPanelPage/index.tsx
+++ b/webview/src/pages/SessionPanelPage/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useSessionList } from '@/components/SessionList/useSessionList';
+import { useSessionListKeyboard } from '@/components/SessionList/useSessionListKeyboard';
 import { SessionList } from '@/components/SessionList';
 import { SearchInput } from '@/components/SessionList/SearchInput';
 import { SessionListScaleProvider, SessionListScale } from '@/components/SessionList/scale';
@@ -16,7 +17,7 @@ import { ScopeTabs, SessionScope } from './ScopeTabs';
  * 드롭다운과 달리 면적이 넉넉하므로 채팅영역과 동일한 일반 스케일(Regular)을 쓴다.
  */
 export function SessionPanelPage() {
-  const { openNewTab } = useSessionContext();
+  const { openNewTab, loadSessions } = useSessionContext();
   const {
     currentSessionId,
     searchQuery,
@@ -34,6 +35,17 @@ export function SessionPanelPage() {
       console.error('[SessionPanelPage] Failed to open session:', error);
     });
   };
+
+  // Arrow-key navigation + Enter to open + Cmd/Ctrl+Shift+P refresh, shared
+  // with the session dropdown. The side panel is always visible, so there is
+  // no Escape handler. Issue #28.
+  const { highlightedSessionId, handleSearchKeyDown } = useSessionListKeyboard({
+    groupedSessions,
+    searchQuery,
+    isActive: scope === SessionScope.Local,
+    onSelect: handleSelectSession,
+    onRefresh: loadSessions,
+  });
 
   return (
     <SessionListScaleProvider scale={SessionListScale.Regular}>
@@ -55,7 +67,7 @@ export function SessionPanelPage() {
         </div>
 
         <div className="flex-shrink-0">
-          <SearchInput value={searchQuery} onChange={setSearchQuery} />
+          <SearchInput value={searchQuery} onChange={setSearchQuery} onKeyDown={handleSearchKeyDown} />
         </div>
 
         {scope === SessionScope.Local ? (
@@ -64,6 +76,7 @@ export function SessionPanelPage() {
               className="flex-1 min-h-0"
               groupedSessions={groupedSessions}
               currentSessionId={currentSessionId}
+              highlightedSessionId={highlightedSessionId}
               onSelectSession={handleSelectSession}
               onDeleteSession={handleDeleteSession}
               onRenameSession={renameSession}

--- a/webview/src/types/commandPalette.ts
+++ b/webview/src/types/commandPalette.ts
@@ -40,6 +40,8 @@ export interface PanelItemBase {
   valueComponent?: () => React.ReactNode;
   disabled?: boolean;
   keepOpen?: boolean;
+  /** Hidden from the panel by default; only surfaced when the filter query matches its label. */
+  searchOnly?: boolean;
   textStyle?: {
     underline?: boolean;
     italic?: boolean;


### PR DESCRIPTION
Closes #28

## Background

A Marketplace review (Mikaël Léger, ⭐4) reported that past conversations could not be retrieved and that `/resume` did nothing. The backend already supported resuming sessions (`--resume`) and the session dropdown could browse them — but CLI users who typed `/resume` found no entry point, so the feature felt missing.

## What this adds

Typing `/resume` now surfaces a **Resume conversation** entry that opens the session dropdown, ready to browse and resume past conversations entirely from the keyboard.

- **Search-only palette items** — a new `searchOnly` flag: items hidden by default, surfaced only when the filter query matches. The "Resume conversation" entry lives in the Context section and appears when you type `/res…`.
- **`/resume` flow** — running it clears the composer text, opens the session dropdown, and focuses the search box.
- **Keyboard navigation** — ArrowUp/Down move a highlight over the rows (display order), Enter resumes the highlighted session, Escape closes and returns focus to the composer.
- **Extras** — `Cmd/Ctrl+Shift+P` refreshes the list while the dropdown is open; search now matches the session id (uuid) as well as the title.

## Scope

webview only — the backend resume mechanism was already in place and is untouched.

## Verification

- 762 webview tests pass (9 new: `searchOnly` filter, `/resume` event, keyboard nav, refresh shortcut, uuid search)
- Typecheck clean (`wv-lint`)
- Manually verified in the IDE

## Commits

- `e383fd4` search-only item + `/resume` opens session dropdown
- `caccd19` keyboard navigation for the session dropdown
- `80550e7` refresh shortcut and uuid search