### PR TITLE
fix: show ccb-missing usage notice regardless of shell locale (#114)

### DIFF
--- a/backend/src/core/features/telemetry.test.ts
+++ b/backend/src/core/features/telemetry.test.ts
@@ -31,7 +31,11 @@ function mockCommonDeps() {
   }));
 }
 
-async function loadTelemetry(profile: TestProfile, apiKey: string, fetchImpl?: () => Promise<unknown>) {
+async function loadTelemetry(
+  profile: TestProfile,
+  apiKey: string,
+  fetchImpl?: (input: string, init: { body: string }) => Promise<unknown>,
+) {
   vi.resetModules();
   vi.stubEnv('CCG_RYBBIT_API_KEY', apiKey);
   vi.doMock('./profile', () => ({
@@ -108,7 +112,7 @@ describe('telemetry consent gating', () => {
     trackEvent('e', { big: 'x'.repeat(5000) });
     await flushTelemetry();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    const body = JSON.parse((fetchMock.mock.calls[0][1] as { body: string }).body);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.properties.length).toBeLessThanOrEqual(4096);
   });
 

--- a/backend/src/core/handlers/__tests__/getUsage.test.ts
+++ b/backend/src/core/handlers/__tests__/getUsage.test.ts
@@ -126,11 +126,18 @@ describe('getUsageHandler', () => {
       }));
     });
 
-    it('should classify ENOENT (spawn failure) as ccb_missing', async () => {
+    // exit code 127 = the shell could not find the command. This is the standard,
+    // locale-independent signal for "ccb is not installed". The shell's "command not
+    // found" text is localized (e.g. Russian "команда не найдена") and cannot be matched
+    // by an English regex, but the exit code is always 127. (issue #114)
+    it('should classify exit code 127 as ccb_missing regardless of shell locale', async () => {
       const connections = createMockConnections();
       const message: IPCMessage = { type: 'GET_USAGE', payload: {}, timestamp: 0, requestId: 'req-1' };
-      const enoentErr = Object.assign(new Error('spawn ccb ENOENT'), { code: 'ENOENT' });
-      setupExecFileError(enoentErr);
+      const err = Object.assign(
+        new Error('Command failed: /bin/bash -l -i -c ccb oauth usage --json\nbash: no job control in this shell\nbash: ccb: команда не найдена'),
+        { code: 127 },
+      );
+      setupExecFileError(err);
 
       await getUsageHandler('conn-1', message, connections, mockBridge);
 
@@ -140,6 +147,21 @@ describe('getUsageHandler', () => {
         error_kind: 'ccb_missing',
         error: 'claude-code-battery CLI is not installed',
       }));
+    });
+
+    // ENOENT means the SHELL binary itself is missing, not ccb. execFile spawns the
+    // shell (not ccb directly), so a missing ccb surfaces as exit 127, never ENOENT.
+    // A broken-shell environment must not be mislabeled as "ccb not installed". (issue #114)
+    it('should NOT classify ENOENT (missing shell binary) as ccb_missing', async () => {
+      const connections = createMockConnections();
+      const message: IPCMessage = { type: 'GET_USAGE', payload: {}, timestamp: 0, requestId: 'req-1' };
+      const enoentErr = Object.assign(new Error('spawn /bin/bash ENOENT'), { code: 'ENOENT' });
+      setupExecFileError(enoentErr);
+
+      await getUsageHandler('conn-1', message, connections, mockBridge);
+
+      const call = (connections.sendTo as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+      expect(call?.[2].error_kind).not.toBe('ccb_missing');
     });
 
     it('should classify npm "could not determine executable" as ccb_missing', async () => {

--- a/backend/src/core/handlers/getUsage.ts
+++ b/backend/src/core/handlers/getUsage.ts
@@ -33,12 +33,32 @@ interface UsageErrorInfo {
   message: string;
 }
 
-function classifyError(raw: string): UsageErrorInfo {
+interface ExecFileError extends Error {
+  // child_process surfaces the process exit code as a number (e.g. 127) and spawn
+  // failures as a string errno (e.g. 'ENOENT').
+  code?: number | string;
+}
+
+function classifyError(raw: string, code?: number | string): UsageErrorInfo {
   if (/npm[^a-z].*(?:command not found|not recognized)|(?:command not found|not recognized).*npm/i.test(raw)) {
     return { kind: 'npm_missing', message: 'Node.js / npm not found in PATH' };
   }
 
-  if (/spawn .*ENOENT|ENOENT/i.test(raw) || /could not determine executable to run/i.test(raw) || /command not found.*ccb|ccb.*not found|ccb.*not recognized/i.test(raw)) {
+  // exit code 127 = the shell could not find the command we asked it to run (`ccb`).
+  // This is the standard, locale-independent signal for a missing command: the shell's
+  // "command not found" text is localized (e.g. Russian "команда не найдена") and cannot
+  // be matched by an English regex, but the exit code is always 127. We additionally
+  // require the `ccb` token so an unrelated failure inside the command is not misattributed.
+  // The English text patterns remain as a fallback for paths where the exit code is
+  // unavailable (e.g. npm's "could not determine executable to run"). (issue #114)
+  //
+  // Note: ENOENT is intentionally NOT treated as ccb_missing. execFile spawns the shell,
+  // not ccb directly, so a missing ccb always surfaces as exit 127 — an ENOENT here means
+  // the shell binary itself is absent, a different failure.
+  const ccbMissingByCode = code === 127 && /\bccb\b/.test(raw);
+  const ccbMissingByText = /could not determine executable to run/i.test(raw)
+    || /command not found.*ccb|ccb.*not found|ccb.*not recognized/i.test(raw);
+  if (ccbMissingByCode || ccbMissingByText) {
     return { kind: 'ccb_missing', message: 'claude-code-battery CLI is not installed' };
   }
 
@@ -190,7 +210,8 @@ export async function getUsageHandler(
       usage,
     });
   } catch (err) {
-    const info = classifyError(err instanceof Error ? err.message : String(err));
+    const code = err instanceof Error ? (err as ExecFileError).code : undefined;
+    const info = classifyError(err instanceof Error ? err.message : String(err), code);
     lastErrorInfo = info;
     cachedAt = Date.now();
     connections.sendTo(connectionId, 'ACK', {

--- a/webview/src/pages/SettingsPage/Usage/CcbNotInstalledNotice.tsx
+++ b/webview/src/pages/SettingsPage/Usage/CcbNotInstalledNotice.tsx
@@ -31,10 +31,14 @@ export function CcbNotInstalledNotice(props: Props) {
   return (
     <div className="mb-6 p-4 bg-surface-raised border border-border-default rounded-lg">
       <h3 className="text-sm font-semibold text-text-primary mb-2">
-        Usage feature requires claude-code-battery CLI
+        A required dependency
       </h3>
       <p className="text-sm text-text-secondary mb-3">
-        Install it globally via npm to enable real-time usage tracking:
+        Due to marketplace policy, this feature cannot be bundled in. It is published as a
+        separate library that you need to install yourself.
+      </p>
+      <p className="text-sm text-text-secondary mb-3">
+        Install it globally via npm:
       </p>
       <div className="flex items-center gap-2 mb-3 p-2 bg-surface-base border border-border-default rounded font-mono text-xs text-text-secondary">
         <code className="flex-1">{INSTALL_CMD}</code>
@@ -46,7 +50,7 @@ export function CcbNotInstalledNotice(props: Props) {
         </button>
       </div>
       <p className="text-xs text-text-tertiary mb-3">
-        After installing, restart the IDE if it was running before the install.
+        After installing, click Retry below — no IDE restart needed.
       </p>
       <button
         onClick={onRetry}

--- a/webview/src/pages/SettingsPage/Usage/__tests__/UsageSettings.test.tsx
+++ b/webview/src/pages/SettingsPage/Usage/__tests__/UsageSettings.test.tsx
@@ -37,7 +37,7 @@ describe('UsageSettings', () => {
 
     render(<UsageSettings />);
 
-    expect(screen.queryByText(/Usage feature requires/i)).toBeNull();
+    expect(screen.queryByText(/A required dependency/i)).toBeNull();
     expect(screen.queryByText(/Failed to fetch/i)).toBeNull();
   });
 
@@ -53,7 +53,7 @@ describe('UsageSettings', () => {
 
     render(<UsageSettings />);
 
-    expect(screen.getByText(/Usage feature requires claude-code-battery CLI/i)).toBeInTheDocument();
+    expect(screen.getByText(/A required dependency/i)).toBeInTheDocument();
     expect(screen.getByText(/npm install -g claude-code-battery/)).toBeInTheDocument();
   });
 
@@ -70,7 +70,7 @@ describe('UsageSettings', () => {
     render(<UsageSettings />);
 
     expect(screen.getByText(/Network error reaching Anthropic API/i)).toBeInTheDocument();
-    expect(screen.queryByText(/Usage feature requires/i)).toBeNull();
+    expect(screen.queryByText(/A required dependency/i)).toBeNull();
   });
 
   it('clears error/errorKind when usage-data-updated event fires (cross-instance sync)', () => {
@@ -85,7 +85,7 @@ describe('UsageSettings', () => {
       refresh,
     });
     const { rerender } = render(<UsageSettings />);
-    expect(screen.getByText(/Usage feature requires/i)).toBeInTheDocument();
+    expect(screen.getByText(/A required dependency/i)).toBeInTheDocument();
 
     // 다른 인스턴스가 데이터를 성공적으로 가져오고 error/errorKind를 클리어한 상태로 변경
     vi.mocked(useUsageData).mockReturnValue({
@@ -99,7 +99,7 @@ describe('UsageSettings', () => {
     rerender(<UsageSettings />);
 
     // 에러 UI가 사라지고 정상 데이터 화면이 나타남
-    expect(screen.queryByText(/Usage feature requires/i)).toBeNull();
+    expect(screen.queryByText(/A required dependency/i)).toBeNull();
     expect(screen.queryByText(/Failed to fetch/i)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Fixes #114 — on a non-English shell (the reporter's was Russian), the Usage screen showed a raw `Command failed: ... ccb oauth usage --json` error instead of the install guide.

The root cause: the usage error was classified as "ccb not installed" by matching the **English** `command not found` string, so localized messages (e.g. Russian `команда не найдена`) fell through to the raw `unknown` error and never reached the install-guide UI.

## What changed

- **Locale-independent classification** ([getUsage.ts](backend/src/core/handlers/getUsage.ts)): classify ccb-missing by the shell's **exit code 127** (locale-independent) plus a `ccb` token, keeping the English text patterns as a fallback. `ENOENT` is no longer treated as ccb-missing — execFile spawns the shell, not ccb, so a missing ccb always surfaces as exit 127; an ENOENT means the shell binary itself is absent.
- **Notice copy** ([CcbNotInstalledNotice.tsx](webview/src/pages/SettingsPage/Usage/CcbNotInstalledNotice.tsx)): reframed around *why* the dependency is separate (marketplace policy), shorter title, and a corrected hint. Retry sends `force=true` and the backend re-runs ccb in a fresh login shell, so a freshly installed ccb is picked up **without restarting the IDE** — the old "restart the IDE" line was removed.
- **be-lint gate** ([telemetry.test.ts](backend/src/core/features/telemetry.test.ts)): typed the fetch mock's `fetchImpl` so `mock.calls[0][1]` type-checks. This was a pre-existing failure on `main` (from #115) blocking the lint gate; fixed in a separate commit.

## Verification

- Backend: `be-test` 398 passed, `be-lint` clean
- Webview: `wv-test` 773 passed, `wv-lint` clean
- Probed real shell behavior: missing command → `err.code === 127` (locale-independent); missing shell → `ENOENT`
- **End-to-end (run-ide)**: with ccb removed the new notice renders (Settings + account modal); after restoring ccb, **Retry alone** restored usage data with no IDE restart.