### PR TITLE
fix: load sessions when Claude Code data dir is moved via CLAUDE_CONFIG_DIR

### DIFF
--- a/backend/src/core/features/__tests__/claudeConfigDir.test.ts
+++ b/backend/src/core/features/__tests__/claudeConfigDir.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import { getClaudeConfigDir } from '../claudeConfigDir';
+
+describe('getClaudeConfigDir', () => {
+  const original = process.env.CLAUDE_CONFIG_DIR;
+
+  afterEach(() => {
+    if (original === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = original;
+  });
+
+  it('defaults to ~/.claude when CLAUDE_CONFIG_DIR is unset', () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    expect(getClaudeConfigDir()).toBe(join(homedir(), '.claude'));
+  });
+
+  it('returns CLAUDE_CONFIG_DIR when set to a custom location', () => {
+    process.env.CLAUDE_CONFIG_DIR = join('D:', 'Claude');
+    expect(getClaudeConfigDir()).toBe(join('D:', 'Claude'));
+  });
+});

--- a/backend/src/core/features/__tests__/getProjectSessionsPath.test.ts
+++ b/backend/src/core/features/__tests__/getProjectSessionsPath.test.ts
@@ -1,7 +1,34 @@
-import { describe, it, expect } from 'vitest';
-import { normalizeProjectPath } from '../getProjectSessionsPath';
+import { describe, it, expect, afterEach } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import { getProjectSessionsPath, normalizeProjectPath } from '../getProjectSessionsPath';
 
 describe('getProjectSessionsPath', () => {
+  describe('data directory resolution', () => {
+    const original = process.env.CLAUDE_CONFIG_DIR;
+
+    afterEach(() => {
+      if (original === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = original;
+    });
+
+    it('resolves under ~/.claude/projects by default', async () => {
+      delete process.env.CLAUDE_CONFIG_DIR;
+      const result = await getProjectSessionsPath('/home/user/project');
+      expect(result).toBe(
+        join(homedir(), '.claude', 'projects', '-home-user-project'),
+      );
+    });
+
+    it('honors a custom CLAUDE_CONFIG_DIR (issue #117)', async () => {
+      process.env.CLAUDE_CONFIG_DIR = join('D:', 'Claude');
+      const result = await getProjectSessionsPath('/home/user/project');
+      expect(result).toBe(
+        join('D:', 'Claude', 'projects', '-home-user-project'),
+      );
+    });
+  });
+
   describe('normalizeProjectPath()', () => {
     it('should replace forward slashes with hyphens', () => {
       expect(normalizeProjectPath('/home/user/project')).toBe('-home-user-project');

--- a/backend/src/core/features/claude-settings.ts
+++ b/backend/src/core/features/claude-settings.ts
@@ -1,10 +1,10 @@
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync, watch } from 'fs';
 import { join, dirname } from 'path';
-import { homedir } from 'os';
+import { getClaudeConfigDir } from './claudeConfigDir';
 
-const CLAUDE_SETTINGS_FILE = join(homedir(), '.claude', 'settings.json');
-const CLAUDE_SETTINGS_LOCAL_FILE = join(homedir(), '.claude', 'settings.local.json');
+const claudeSettingsFile = () => join(getClaudeConfigDir(), 'settings.json');
+const claudeSettingsLocalFile = () => join(getClaudeConfigDir(), 'settings.local.json');
 
 function deepMergeSettings(
   base: Record<string, unknown>,
@@ -53,8 +53,8 @@ async function readJsonFileSafe(filePath: string): Promise<Record<string, unknow
  */
 export async function readClaudeSettings(): Promise<Record<string, unknown>> {
   try {
-    const base = await readJsonFileSafe(CLAUDE_SETTINGS_FILE);
-    const local = await readJsonFileSafe(CLAUDE_SETTINGS_LOCAL_FILE);
+    const base = await readJsonFileSafe(claudeSettingsFile());
+    const local = await readJsonFileSafe(claudeSettingsLocalFile());
     return { ...base, ...local };
   } catch (err) {
     console.error('[node-backend]', 'Failed to read Claude settings:', err);
@@ -99,20 +99,20 @@ export async function saveClaudeSetting(
   value: unknown,
 ): Promise<{ status: 'ok' | 'error'; error?: string }> {
   try {
-    await mkdir(join(homedir(), '.claude'), { recursive: true });
+    await mkdir(getClaudeConfigDir(), { recursive: true });
 
     if (value === null || value === undefined) {
-      await removeKeyFromJsonFile(CLAUDE_SETTINGS_FILE, key);
-      await removeKeyFromJsonFile(CLAUDE_SETTINGS_LOCAL_FILE, key);
+      await removeKeyFromJsonFile(claudeSettingsFile(), key);
+      await removeKeyFromJsonFile(claudeSettingsLocalFile(), key);
       return { status: 'ok' };
     }
 
     // Write to the file where the key currently lives (local takes priority)
-    const localSettings = await readJsonFileSafe(CLAUDE_SETTINGS_LOCAL_FILE);
+    const localSettings = await readJsonFileSafe(claudeSettingsLocalFile());
     if (key in localSettings) {
-      await writeKeyToJsonFile(CLAUDE_SETTINGS_LOCAL_FILE, key, value);
+      await writeKeyToJsonFile(claudeSettingsLocalFile(), key, value);
     } else {
-      await writeKeyToJsonFile(CLAUDE_SETTINGS_FILE, key, value);
+      await writeKeyToJsonFile(claudeSettingsFile(), key, value);
     }
     return { status: 'ok' };
   } catch (err) {
@@ -273,7 +273,7 @@ export function watchClaudeSettingsFile(onFileChange: (settings: Record<string, 
   }
 
   try {
-    const settingsDir = join(homedir(), '.claude');
+    const settingsDir = getClaudeConfigDir();
 
     watcherInstance = watch(settingsDir, async (eventType, filename) => {
       // Only watch settings.json file
@@ -297,7 +297,7 @@ export function watchClaudeSettingsFile(onFileChange: (settings: Record<string, 
       }, DEBOUNCE_MS);
     });
 
-    console.log('[node-backend]', `Watching ${CLAUDE_SETTINGS_FILE} for changes`);
+    console.log('[node-backend]', `Watching ${claudeSettingsFile()} for changes`);
   } catch (err) {
     console.error('[node-backend]', 'Failed to start Claude settings file watcher:', err);
   }

--- a/backend/src/core/features/claudeConfigDir.ts
+++ b/backend/src/core/features/claudeConfigDir.ts
@@ -1,0 +1,14 @@
+import { homedir } from 'os';
+import { join } from 'path';
+
+/**
+ * Resolve the Claude Code CLI data directory.
+ *
+ * Mirrors the CLI's own resolution: `process.env.CLAUDE_CONFIG_DIR ?? ~/.claude`.
+ * When a user points the CLI at a non-default location (e.g. `D:\Claude` on
+ * Windows via the CLAUDE_CONFIG_DIR env var), every consumer that reads sessions,
+ * projects, or global settings must follow it here too. See issue #117.
+ */
+export function getClaudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+}

--- a/backend/src/core/features/getProjectSessionsPath.ts
+++ b/backend/src/core/features/getProjectSessionsPath.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { homedir } from 'os';
+import { getClaudeConfigDir } from './claudeConfigDir';
 
 /** OS 중립적 경로 정규화: 비영문자/비숫자를 모두 '-'로 치환 */
 export function normalizeProjectPath(workingDir: string): string {
@@ -7,5 +7,5 @@ export function normalizeProjectPath(workingDir: string): string {
 }
 
 export async function getProjectSessionsPath(workingDir: string): Promise<string> {
-  return join(homedir(), '.claude', 'projects', normalizeProjectPath(workingDir));
+  return join(getClaudeConfigDir(), 'projects', normalizeProjectPath(workingDir));
 }

--- a/backend/src/core/features/getProjectsList.ts
+++ b/backend/src/core/features/getProjectsList.ts
@@ -1,8 +1,8 @@
 import { createReadStream } from 'fs';
 import { readFile, readdir } from 'fs/promises';
 import { join } from 'path';
-import { homedir } from 'os';
 import { createInterface } from 'readline';
+import { getClaudeConfigDir } from './claudeConfigDir';
 
 interface ProjectEntry {
   name: string;       // 폴더 이름 (프로젝트 이름)
@@ -113,7 +113,7 @@ async function buildEntriesFromJsonl(folderPath: string): Promise<ProjectEntry[]
 
 export async function getProjectsList(): Promise<ProjectEntry[]> {
   try {
-    const projectsDir = join(homedir(), '.claude', 'projects');
+    const projectsDir = join(getClaudeConfigDir(), 'projects');
     const entries = await readdir(projectsDir, { withFileTypes: true });
 
     const projects: ProjectEntry[] = [];

--- a/backend/src/core/features/settings-watcher.ts
+++ b/backend/src/core/features/settings-watcher.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { readMergedSettings } from './settings';
 import { readMergedClaudeSettings } from './claude-settings';
+import { getClaudeConfigDir } from './claudeConfigDir';
 
 const DEBOUNCE_MS = 300;
 
@@ -31,7 +32,7 @@ export class SettingsFileWatcher {
    * Call this once on server startup.
    */
   startGlobalWatchers(): void {
-    const claudeDir = join(homedir(), '.claude');
+    const claudeDir = getClaudeConfigDir();
     const appDir = join(homedir(), '.claude-code-gui');
 
     this.watchDir(claudeDir, 'settings.json', async () => {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -218,6 +218,14 @@ class NodeProcessManager(
                         // Hand the backend the user's real shell PATH so anything it spawns
                         // (claude, npx, git) is found even when the IDE started from GUI (#59).
                         put("PATH", effectivePath())
+                        // Same gap for CLAUDE_CONFIG_DIR: when a user exports it from their
+                        // interactive rc to point the CLI at a non-default data dir, a
+                        // GUI-launched IDE never sourced that rc, so the backend would read
+                        // sessions/settings from ~/.claude and find nothing (#117). Capture it
+                        // from the shell and override only when the shell actually set it.
+                        ShellPathResolver.resolveEnvVar("CLAUDE_CONFIG_DIR")?.let {
+                            put("CLAUDE_CONFIG_DIR", it)
+                        }
                         if (webviewDir != null) {
                             put("WEBVIEW_DIR", webviewDir.absolutePath)
                         }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolver.kt
@@ -6,22 +6,25 @@ import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 /**
- * Captures the user's real shell PATH by launching their login + interactive shell.
+ * Captures environment variables from the user's real login + interactive shell.
  *
  * ## Why
  * A GUI-launched IDE (Dock, app icon, Spotlight) starts in a bare environment that
  * never sourced the user's interactive shell config (`.zshrc`/`.bashrc`). Version
- * managers like nvm/fnm/mise add their bin dirs there, so the IDE's inherited PATH
- * is missing them — and any `node`/`claude` spawned from the IDE can't be found (#59).
+ * managers like nvm/fnm/mise add their bin dirs to PATH there, so the IDE's inherited
+ * PATH is missing them — and any `node`/`claude` spawned from the IDE can't be found
+ * (#59). The same gap hides `CLAUDE_CONFIG_DIR` when a user exports it from their
+ * interactive rc to point the Claude CLI at a non-default data dir (#117).
  *
- * Asking the shell itself for its PATH is the only robust fix: it works for every
- * version manager at once, instead of hard-coding each one's install layout.
+ * Asking the shell itself is the only robust fix: it works for every version manager
+ * and every exported variable at once, instead of hard-coding install layouts.
  *
  * ## How
- * Runs `$SHELL -lic "printf '<UUID>'; command printenv PATH; printf '<UUID>'"`:
+ * Runs `$SHELL -lic "...; command printenv <VAR>; ..."` once, capturing every variable
+ * in [CAPTURED_VARS] in a single shell launch:
  * - `-lic` = login + interactive, so both `.zprofile`/`.zlogin` AND `.zshrc` are read.
- * - The PATH is sandwiched between two random-UUID markers so we can slice it out of
- *   any startup noise (prompts, banners, `.zshrc` echo) the shell prints.
+ * - Each value is sandwiched between a per-variable random-UUID marker pair so we can
+ *   slice it out of any startup noise (prompts, banners, `.zshrc` echo) the shell prints.
  * - `command printenv` bypasses user aliases/functions.
  *
  * This mirrors the approach the official Claude Code VS Code extension uses
@@ -33,54 +36,71 @@ object ShellPathResolver {
 
     private const val TIMEOUT_SECONDS = 10L
 
-    // Cached PATH per shell binary. Empty string = resolved-but-failed (don't retry).
-    private val cache = HashMap<String, String>()
+    // Variables captured from the user's shell in one launch. PATH carries
+    // version-manager bin dirs (#59); CLAUDE_CONFIG_DIR points the CLI at a custom
+    // data directory (#117).
+    private val CAPTURED_VARS = listOf("PATH", "CLAUDE_CONFIG_DIR")
+
+    // Cached per shell binary: varName -> captured value. An empty map means
+    // resolved-but-failed (don't retry).
+    private val cache = HashMap<String, Map<String, String>>()
 
     /**
-     * Resolve the user's shell PATH, or null when unavailable (Windows, no $SHELL,
-     * shell failure, or invalid output). Cached per shell binary.
+     * Capture [CAPTURED_VARS] from the user's shell. Returns an empty map when
+     * unavailable (Windows, no $SHELL, or shell failure). Cached per shell binary.
      */
     @Synchronized
-    fun resolve(): String? {
-        if (SystemInfo.isWindows) return null
-        val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: return null
+    private fun captured(): Map<String, String> {
+        if (SystemInfo.isWindows) return emptyMap()
+        val shell = System.getenv("SHELL")?.takeIf { it.isNotBlank() } ?: return emptyMap()
 
-        cache[shell]?.let { return it.ifEmpty { null } }
+        cache[shell]?.let { return it }
 
-        val resolved = runShell(shell)
-        cache[shell] = resolved ?: ""
+        val resolved = runShell(shell, CAPTURED_VARS) ?: emptyMap()
+        cache[shell] = resolved
         return resolved
     }
 
-    /** Launch the shell and capture its PATH. Returns null on any failure. */
-    private fun runShell(shell: String): String? {
+    /**
+     * Resolve the user's shell PATH, or null when unavailable or invalid (Windows,
+     * no $SHELL, shell failure, single-entry noise).
+     */
+    fun resolve(): String? = captured()["PATH"]?.takeIf { looksLikePath(it) }
+
+    /**
+     * Resolve a single captured env var (e.g. `CLAUDE_CONFIG_DIR`) from the user's
+     * shell, or null when it is unset/blank or capture was unavailable.
+     */
+    fun resolveEnvVar(name: String): String? = captured()[name]?.takeIf { it.isNotBlank() }
+
+    /** Launch the shell once and capture [vars]. Returns null on any failure. */
+    private fun runShell(shell: String, vars: List<String>): Map<String, String>? {
         val marker = UUID.randomUUID().toString().replace("-", "")
         return try {
             // Capture stdout ONLY. An interactive shell can write warnings to stderr
             // (e.g. zsh's `can't change option: zle` without a tty); merging them into
-            // stdout risks polluting the marker-sandwiched PATH. DISCARD routes stderr
+            // stdout risks polluting the marker-sandwiched values. DISCARD routes stderr
             // to the OS null sink, so it can neither corrupt the slice nor fill a pipe
             // buffer and block the shell.
-            val pb = ProcessBuilder(shell, "-lic", buildShellCommand(marker))
+            val pb = ProcessBuilder(shell, "-lic", buildShellCommand(marker, vars))
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
             val proc = pb.start()
             val output = proc.inputStream.bufferedReader().use { it.readText() }
             val finished = proc.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
             if (!finished) {
                 proc.destroyForcibly()
-                logger.info("resolveShellPath: $shell timed out after ${TIMEOUT_SECONDS}s")
+                logger.info("resolveShellEnv: $shell timed out after ${TIMEOUT_SECONDS}s")
                 return null
             }
-            val path = extractBetweenMarkers(output, marker)
-            if (looksLikePath(path)) {
-                logger.info("resolveShellPath: $shell -> ${path!!.split(":").size} entries")
-                path
-            } else {
-                logger.info("resolveShellPath: $shell returned empty/invalid PATH")
-                null
+            val result = HashMap<String, String>()
+            for (name in vars) {
+                val value = extractBetweenMarkers(output, markerFor(marker, name)) ?: continue
+                if (value.isNotEmpty()) result[name] = value
             }
+            logger.info("resolveShellEnv: $shell -> captured ${result.keys}")
+            result
         } catch (e: Exception) {
-            logger.info("resolveShellPath: $shell failed: ${e.message}")
+            logger.info("resolveShellEnv: $shell failed: ${e.message}")
             null
         }
     }
@@ -91,9 +111,22 @@ object ShellPathResolver {
 
     // ─── Pure helpers (unit-tested) ─────────────────────────────────
 
-    /** The shell command that prints the marker-wrapped PATH. */
-    fun buildShellCommand(marker: String): String =
-        "printf '$marker'; command printenv PATH; printf '$marker'"
+    /**
+     * The shell command that prints each variable in [vars] wrapped in its own
+     * per-variable marker pair (see [markerFor]).
+     */
+    fun buildShellCommand(marker: String, vars: List<String>): String =
+        vars.joinToString("; ") { name ->
+            val m = markerFor(marker, name)
+            "printf '$m'; command printenv $name; printf '$m'"
+        }
+
+    /**
+     * A marker unique to [varName], so concurrently-captured values never collide:
+     * the variable name is sandwiched inside the base [marker]. Variable names are
+     * shell identifiers (alphanumeric + `_`), so the result is regex/printf-safe.
+     */
+    fun markerFor(marker: String, varName: String): String = "$marker$varName$marker"
 
     /**
      * Slice the text between the first pair of [marker] occurrences and trim it.

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolverTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/ShellPathResolverTest.kt
@@ -76,15 +76,65 @@ class ShellPathResolverTest {
     }
 
     @Nested
+    inner class MarkerFor {
+        @Test
+        fun `should sandwich the variable name between the base marker`() {
+            assertEquals("MARKPATHMARK", ShellPathResolver.markerFor("MARK", "PATH"))
+            assertEquals(
+                "MARKCLAUDE_CONFIG_DIRMARK",
+                ShellPathResolver.markerFor("MARK", "CLAUDE_CONFIG_DIR"),
+            )
+        }
+
+        @Test
+        fun `should produce distinct markers per variable so values never collide`() {
+            val a = ShellPathResolver.markerFor("M", "PATH")
+            val b = ShellPathResolver.markerFor("M", "CLAUDE_CONFIG_DIR")
+            assertNotEquals(a, b)
+            assertFalse(a.contains(b) || b.contains(a))
+        }
+    }
+
+    @Nested
     inner class BuildShellCommand {
         @Test
-        fun `should wrap printenv PATH with the marker on both sides`() {
-            val cmd = ShellPathResolver.buildShellCommand("MARK")
-            // command printenv bypasses aliases/functions; markers sandwich the value.
-            assertTrue(cmd.contains("printf 'MARK'"), "command was: $cmd")
+        fun `should wrap each variable in its own per-variable marker pair`() {
+            val cmd = ShellPathResolver.buildShellCommand("MARK", listOf("PATH", "CLAUDE_CONFIG_DIR"))
+            // command printenv bypasses aliases/functions; per-variable markers sandwich each value.
             assertTrue(cmd.contains("command printenv PATH"), "command was: $cmd")
-            // marker must appear exactly twice so the extractor can find a pair
-            assertEquals(2, Regex("MARK").findAll(cmd).count())
+            assertTrue(cmd.contains("command printenv CLAUDE_CONFIG_DIR"), "command was: $cmd")
+            // each variable's marker must appear exactly twice so the extractor can find a pair
+            assertEquals(2, Regex("MARKPATHMARK").findAll(cmd).count())
+            assertEquals(2, Regex("MARKCLAUDE_CONFIG_DIRMARK").findAll(cmd).count())
+        }
+
+        @Test
+        fun `should extract each value from a combined output using its own marker`() {
+            val cmd = ShellPathResolver.buildShellCommand("M", listOf("PATH", "CLAUDE_CONFIG_DIR"))
+            assertTrue(cmd.isNotBlank())
+            // Simulate the shell having printed both values back, in order.
+            val output = "noise" +
+                "MPATHM/usr/bin:/binMPATHM" +
+                "MCLAUDE_CONFIG_DIRM/data/claudeMCLAUDE_CONFIG_DIRM" +
+                "tail"
+            assertEquals(
+                "/usr/bin:/bin",
+                ShellPathResolver.extractBetweenMarkers(output, ShellPathResolver.markerFor("M", "PATH")),
+            )
+            assertEquals(
+                "/data/claude",
+                ShellPathResolver.extractBetweenMarkers(output, ShellPathResolver.markerFor("M", "CLAUDE_CONFIG_DIR")),
+            )
+        }
+
+        @Test
+        fun `should yield an empty string for an unset variable (markers present, value blank)`() {
+            // `command printenv` prints nothing for an unset var, so the markers wrap "".
+            val output = "MCLAUDE_CONFIG_DIRMMCLAUDE_CONFIG_DIRM"
+            assertEquals(
+                "",
+                ShellPathResolver.extractBetweenMarkers(output, ShellPathResolver.markerFor("M", "CLAUDE_CONFIG_DIR")),
+            )
         }
     }
 


### PR DESCRIPTION
## Problem

Closes #117.

The plugin showed an empty session list whenever the Claude Code CLI's data
directory was moved off the default (`~/.claude`) via the `CLAUDE_CONFIG_DIR`
env var (e.g. `D:\Claude` on Windows). The backend hard-coded `~/.claude`
through `os.homedir()`, so it read from a directory the CLI never wrote to.

## Fix

Two gaps, matching how PATH is already handled:

1. **Backend** — Add `getClaudeConfigDir()` that mirrors the CLI's own
   resolution (`process.env.CLAUDE_CONFIG_DIR ?? ~/.claude`) and route every
   consumer of the global data dir through it: session read/write paths
   (`getProjectSessionsPath`, reused by `getSessionsList` /
   `loadSessionMessages` / `deleteSession` / `renameSession`), the project
   list, global Claude settings read/write, and the settings watcher.

2. **Plugin (Kotlin)** — A GUI-launched IDE never sources the user's
   interactive shell rc, so a `CLAUDE_CONFIG_DIR` exported from
   `.zshrc`/`.bashrc` was invisible to the backend — the same gap that hides
   version-manager PATH entries (#59). Generalize `ShellPathResolver` to
   capture `PATH` and `CLAUDE_CONFIG_DIR` in a single `$SHELL -lic` launch
   (per-variable markers), and inject `CLAUDE_CONFIG_DIR` into the backend env
   only when the shell actually set it. WSL already inherits it via `bash -lic`.

## Verification

- Backend tests: 402 pass (incl. new `claudeConfigDir` + `getProjectSessionsPath` cases)
- Kotlin tests: `BUILD SUCCESSFUL` (incl. new `ShellPathResolver` marker/multi-var cases)
- Manual E2E (isolated processes):
  - Shell capture: an `export CLAUDE_CONFIG_DIR` placed only in an interactive
    `.zshrc` is extracted correctly via the exact command `ShellPathResolver` builds.
  - Backend read: with a custom `CLAUDE_CONFIG_DIR`, real-fs `getProjectsList` /
    `getProjectSessionsPath` resolve to and read from that directory.