### PR TITLE
Honor CLAUDE_CONFIG_DIR for usage and chat via plugin settings (#123)

### DIFF
--- a/backend/src/core/__tests__/claude.test.ts
+++ b/backend/src/core/__tests__/claude.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // Mock readSettingsFile to avoid file system access
 vi.mock('../features/settings', () => ({
   readSettingsFile: vi.fn().mockResolvedValue({ cliPath: null }),
+  resolveClaudeConfigDirOverride: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock child_process so we can inspect the options passed to spawn/execFile
@@ -51,8 +52,26 @@ describe('Claude', () => {
   });
 
   describe('refresh()', () => {
+    const originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+
+    afterEach(async () => {
+      const settings = await import('../features/settings');
+      vi.mocked(settings.resolveClaudeConfigDirOverride).mockResolvedValue(null);
+      if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+      else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+    });
+
     it('should load settings without throwing', async () => {
       await expect(Claude.refresh()).resolves.not.toThrow();
+    });
+
+    it('applies the settings CLAUDE_CONFIG_DIR override onto process.env (#123)', async () => {
+      const settings = await import('../features/settings');
+      vi.mocked(settings.resolveClaudeConfigDirOverride).mockResolvedValueOnce('/custom/.claude-work');
+
+      await Claude.refresh('/some/project');
+
+      expect(process.env.CLAUDE_CONFIG_DIR).toBe('/custom/.claude-work');
     });
   });
 

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -130,6 +130,10 @@ export async function ensureClaudeProcess(
 
   console.error('[node-backend]', `Command: ${Claude.command} ${args.join(' ')}`);
 
+  // Load this project's CLAUDE_CONFIG_DIR (project > global) onto process.env before
+  // spawning, so the CLI resolves the right Claude data dir for THIS workingDir. (#123)
+  await Claude.applyConfigDir(workingDir);
+
   // Strip OAuth env inherited from parent (e.g. Claude Desktop spawning the IDE) so the
   // CLI falls through to its keychain-based auth, which can refresh expired tokens.
   // User-pinned keys in Claude settings are preserved by getStrippableAuthEnvKeys().

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -5,7 +5,7 @@ import {
   type SpawnOptions,
   type ExecFileOptions,
 } from 'child_process';
-import { readSettingsFile } from './features/settings';
+import { readSettingsFile, resolveClaudeConfigDirOverride } from './features/settings';
 import { augmentedPath } from './augmented-path';
 import { isWslUncPath, toWslPath } from './wsl-path';
 
@@ -25,16 +25,56 @@ function resolveWslCwd(cwd: SpawnOptions['cwd']): SpawnOptions['cwd'] {
 export class Claude {
   private static cliPath: string | null = null;
   private static initialized = false;
+  // The CLAUDE_CONFIG_DIR the backend inherited at startup (e.g. exported in the
+  // user's shell, or echoed temporarily). Captured once, before any plugin-settings
+  // override is applied, so we can restore it when the override is later cleared.
+  private static readonly inheritedConfigDir = process.env.CLAUDE_CONFIG_DIR;
 
   /** Load cliPath from settings. Call at server start or on settings change. */
-  static async refresh(): Promise<void> {
+  static async refresh(workingDir?: string): Promise<void> {
     const settings = await readSettingsFile();
     Claude.cliPath = (settings.cliPath as string) || null;
     Claude.initialized = true;
+    await Claude.applyConfigDir(workingDir);
+  }
+
+  /**
+   * Project the effective CLAUDE_CONFIG_DIR for the given working directory onto
+   * process.env, so getClaudeConfigDir(), the spawned `claude`, and the `ccb` usage
+   * child all resolve the SAME Claude data directory.
+   *
+   * Call this whenever an active context LOADS — a chat for a given workingDir, or the
+   * project picker with no workingDir — NOT merely when a setting is saved. process.env
+   * is a single shared slot on the backend, so projecting only at load time keeps a
+   * project-scoped value from leaking across the whole backend (issue #123 follow-up).
+   *
+   * The Claude CLI reads CLAUDE_CONFIG_DIR only from process.env (never from
+   * settings.json's `env`, which it consults too late), so we mirror our setting here.
+   * Priority: settings env (project > global) > inherited startup env > ~/.claude.
+   */
+  static async applyConfigDir(workingDir?: string): Promise<void> {
+    const override = await resolveClaudeConfigDirOverride(workingDir);
+    if (override) {
+      process.env.CLAUDE_CONFIG_DIR = override;
+    } else if (Claude.inheritedConfigDir !== undefined) {
+      process.env.CLAUDE_CONFIG_DIR = Claude.inheritedConfigDir;
+    } else {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    }
   }
 
   static get command(): string {
     return Claude.cliPath || 'claude';
+  }
+
+  /**
+   * The CLAUDE_CONFIG_DIR the backend inherited from its environment at startup,
+   * before any plugin-settings override was applied (undefined if none). The settings
+   * UI surfaces this so a value set only transiently (e.g. echoed/exported in a shell)
+   * can be offered for persistence. (#123)
+   */
+  static get inheritedClaudeConfigDir(): string | undefined {
+    return Claude.inheritedConfigDir;
   }
 
   static get env(): NodeJS.ProcessEnv {

--- a/backend/src/core/features/__tests__/settings.test.ts
+++ b/backend/src/core/features/__tests__/settings.test.ts
@@ -15,7 +15,13 @@ vi.mock('fs', () => ({
 // are not exported, we test them indirectly through saveSettingToFile and readSettingsFile.
 import { readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
-import { readSettingsFile, saveSettingToFile } from '../settings';
+import {
+  readSettingsFile,
+  saveSettingToFile,
+  readMergedSettings,
+  resolveClaudeConfigDirOverride,
+  saveEnvVarToScope,
+} from '../settings';
 
 const mockReadFile = vi.mocked(readFile);
 const mockWriteFile = vi.mocked(writeFile);
@@ -152,6 +158,34 @@ describe('settings', () => {
       expect(result.status).toBe('error');
       expect(result.error).toContain('hostMode must be one of');
     });
+
+    it('should accept an env object of string values', async () => {
+      const result = await saveSettingToFile('env', { CLAUDE_CONFIG_DIR: '/home/u/.claude-work' });
+      expect(result.status).toBe('ok');
+    });
+
+    it('should accept an empty env object', async () => {
+      const result = await saveSettingToFile('env', {});
+      expect(result.status).toBe('ok');
+    });
+
+    it('should reject env that is not an object', async () => {
+      const result = await saveSettingToFile('env', 'CLAUDE_CONFIG_DIR=/x');
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('env must be an object');
+    });
+
+    it('should reject env that is an array', async () => {
+      const result = await saveSettingToFile('env', ['/x']);
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('env must be an object');
+    });
+
+    it('should reject env with a non-string value', async () => {
+      const result = await saveSettingToFile('env', { CLAUDE_CONFIG_DIR: 123 });
+      expect(result.status).toBe('error');
+      expect(result.error).toContain('must be a string');
+    });
   });
 
   describe('readSettingsFile()', () => {
@@ -172,6 +206,7 @@ describe('settings', () => {
         logLevel: 'info',
         terminalApp: null,
         hostMode: 'editor-tab',
+        env: {},
       });
       expect(mockWriteFile).toHaveBeenCalled();
     });
@@ -241,7 +276,18 @@ export default {
         logLevel: 'info',
         terminalApp: null,
         hostMode: 'editor-tab',
+        env: {},
       });
+    });
+
+    it('should parse an env object from the settings file', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(
+        `export default { env: { CLAUDE_CONFIG_DIR: "/home/u/.claude-work" } };`,
+      );
+
+      const result = await readSettingsFile();
+      expect(result.env).toEqual({ CLAUDE_CONFIG_DIR: '/home/u/.claude-work' });
     });
 
     it('should handle trailing commas in JS object', async () => {
@@ -254,6 +300,95 @@ export default {
       const result = await readSettingsFile();
       expect(result.theme).toBe('dark');
       expect(result.fontSize).toBe(14);
+    });
+  });
+
+  describe('env merge and resolution', () => {
+    beforeEach(() => {
+      mockMkdir.mockResolvedValue(undefined);
+      mockWriteFile.mockResolvedValue(undefined);
+      mockExistsSync.mockReturnValue(true);
+    });
+
+    // global lives in ~/.claude-code-gui/settings.js, project in
+    // <proj>/.claude-code-gui/settings.json — route the mock by file extension.
+    function mockGlobalAndProjectEnv(globalEnv: unknown, projectEnv: unknown) {
+      mockReadFile.mockImplementation((async (p: string) => {
+        if (String(p).endsWith('.js')) {
+          return `export default { env: ${JSON.stringify(globalEnv)} };`;
+        }
+        return JSON.stringify({ env: projectEnv });
+      }) as unknown as typeof readFile);
+    }
+
+    it('deep-merges env: project keys override global, other global keys preserved', async () => {
+      mockGlobalAndProjectEnv(
+        { A: 'g', CLAUDE_CONFIG_DIR: '/global' },
+        { CLAUDE_CONFIG_DIR: '/project' },
+      );
+
+      const { settings } = await readMergedSettings('/proj');
+      expect(settings.env).toEqual({ A: 'g', CLAUDE_CONFIG_DIR: '/project' });
+    });
+
+    it('resolveClaudeConfigDirOverride prefers project over global', async () => {
+      mockGlobalAndProjectEnv(
+        { CLAUDE_CONFIG_DIR: '/global' },
+        { CLAUDE_CONFIG_DIR: '/project' },
+      );
+
+      const value = await resolveClaudeConfigDirOverride('/proj');
+      expect(value).toBe('/project');
+    });
+
+    it('resolveClaudeConfigDirOverride falls back to global when project has none', async () => {
+      mockGlobalAndProjectEnv({ CLAUDE_CONFIG_DIR: '/global' }, {});
+
+      const value = await resolveClaudeConfigDirOverride('/proj');
+      expect(value).toBe('/global');
+    });
+
+    it('resolveClaudeConfigDirOverride returns null when no override is set', async () => {
+      mockReadFile.mockImplementation((async () => `export default {};`) as unknown as typeof readFile);
+
+      const value = await resolveClaudeConfigDirOverride();
+      expect(value).toBeNull();
+    });
+  });
+
+  describe('saveEnvVarToScope', () => {
+    beforeEach(() => {
+      mockMkdir.mockResolvedValue(undefined);
+    });
+
+    it('writes an env var into global settings', async () => {
+      mockExistsSync.mockReturnValue(false);
+      let written = '';
+      mockWriteFile.mockImplementation((async (_p: string, content: string) => {
+        written = String(content);
+      }) as unknown as typeof writeFile);
+
+      const result = await saveEnvVarToScope('CLAUDE_CONFIG_DIR', '/home/u/.claude-work', 'global');
+
+      expect(result.status).toBe('ok');
+      expect(written).toContain('CLAUDE_CONFIG_DIR');
+      expect(written).toContain('/home/u/.claude-work');
+    });
+
+    it('removes an env var when value is null', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(
+        `export default { env: { CLAUDE_CONFIG_DIR: "/home/u/.claude-work" } };`,
+      );
+      let written = '';
+      mockWriteFile.mockImplementation((async (_p: string, content: string) => {
+        written = String(content);
+      }) as unknown as typeof writeFile);
+
+      const result = await saveEnvVarToScope('CLAUDE_CONFIG_DIR', null, 'global');
+
+      expect(result.status).toBe('ok');
+      expect(written).not.toContain('.claude-work');
     });
   });
 });

--- a/backend/src/core/features/settings.ts
+++ b/backend/src/core/features/settings.ts
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS: Record<string, unknown> = {
   logLevel: 'info',
   terminalApp: null,
   hostMode: 'editor-tab',
+  env: {},
 };
 
 const COMMENT_MAP: Record<string, string> = {
@@ -29,6 +30,7 @@ const COMMENT_MAP: Record<string, string> = {
   logLevel: '로그 레벨: "debug" | "info" | "warn" | "error"',
   terminalApp: '터미널 프로그램 (null이면 OS 기본 터미널)',
   hostMode: '채팅을 띄우는 자리: "editor-tab" | "tool-window"',
+  env: '자식 프로세스(claude, ccb)에 주입할 환경 변수. 예: { CLAUDE_CONFIG_DIR: "..." }',
 };
 
 function generateSettingsContent(settings: Record<string, unknown>): string {
@@ -142,8 +144,27 @@ function validateSetting(key: string, value: unknown): string | null {
         return 'hostMode must be one of "editor-tab", "tool-window"';
       }
       break;
+    case 'env': {
+      if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+        return 'env must be an object of string values';
+      }
+      for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        if (typeof v !== 'string') {
+          return `env.${k} must be a string`;
+        }
+      }
+      break;
+    }
   }
   return null;
+}
+
+/** Coerce an unknown settings value into a string-keyed env record (or {}). */
+function asEnvRecord(value: unknown): Record<string, string> {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, string>;
+  }
+  return {};
 }
 
 /**
@@ -172,10 +193,51 @@ export async function readMergedSettings(projectPath?: string): Promise<{ settin
   }
   const projectSettings = await readProjectSettings(projectPath);
   const overrides = Object.keys(projectSettings);
-  return {
-    settings: { ...globalSettings, ...projectSettings },
-    overrides,
-  };
+  const merged: Record<string, unknown> = { ...globalSettings, ...projectSettings };
+  // env is the one nested key we merge by sub-key (Claude's own order: global env,
+  // then project env overriding individual keys) rather than replacing wholesale —
+  // otherwise a project that sets one var would wipe the user's global vars.
+  merged.env = { ...asEnvRecord(globalSettings.env), ...asEnvRecord(projectSettings.env) };
+  return { settings: merged, overrides };
+}
+
+/**
+ * Resolve the effective CLAUDE_CONFIG_DIR override declared in the plugin settings
+ * `env` map (project takes priority over global). Returns null when unset, so callers
+ * can fall back to process.env / the default ~/.claude.
+ */
+export async function resolveClaudeConfigDirOverride(projectPath?: string): Promise<string | null> {
+  const { settings } = await readMergedSettings(projectPath);
+  const value = asEnvRecord(settings.env).CLAUDE_CONFIG_DIR;
+  return typeof value === 'string' && value.trim() !== '' ? value : null;
+}
+
+/**
+ * Set or remove a single variable inside the `env` map at the given scope, preserving
+ * the other variables. Passing value === null removes the variable.
+ */
+export async function saveEnvVarToScope(
+  name: string,
+  value: string | null,
+  scope: 'global' | 'project',
+  projectPath?: string,
+): Promise<SaveResult> {
+  if (scope === 'project' && !projectPath) {
+    return { status: 'error', error: 'projectPath required for project scope' };
+  }
+
+  const source = scope === 'project'
+    ? await readProjectSettings(projectPath as string)
+    : await readSettingsFile();
+  const currentEnv = { ...asEnvRecord(source.env) };
+
+  if (value === null) {
+    delete currentEnv[name];
+  } else {
+    currentEnv[name] = value;
+  }
+
+  return saveSettingToScope('env', currentEnv, scope, projectPath);
 }
 
 /**

--- a/backend/src/core/handlers/__tests__/getClaudeConfigDir.test.ts
+++ b/backend/src/core/handlers/__tests__/getClaudeConfigDir.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+
+vi.mock('../../features/settings', () => ({
+  readSettingsFile: vi.fn(),
+  readProjectSettings: vi.fn(),
+}));
+vi.mock('../../claude', () => ({
+  Claude: { inheritedClaudeConfigDir: undefined as string | undefined },
+}));
+
+import { getClaudeConfigDirHandler } from '../getClaudeConfigDir';
+import { readSettingsFile, readProjectSettings } from '../../features/settings';
+import { Claude } from '../../claude';
+import { MessageType } from '../../../shared';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+function createMockConnections() {
+  return {
+    sendTo: vi.fn(),
+    broadcastToAll: vi.fn(),
+  } as unknown as ConnectionManager;
+}
+
+const mockBridge = {} as Bridge;
+
+function setInherited(value: string | undefined) {
+  (Claude as unknown as { inheritedClaudeConfigDir: string | undefined }).inheritedClaudeConfigDir = value;
+}
+
+function lastAck(connections: ConnectionManager) {
+  const calls = (connections.sendTo as ReturnType<typeof vi.fn>).mock.calls;
+  return calls[calls.length - 1][2];
+}
+
+async function invoke(
+  connections: ConnectionManager,
+  payload: Record<string, unknown>,
+) {
+  const message: IPCMessage = {
+    type: MessageType.GET_CLAUDE_CONFIG_DIR,
+    payload,
+    timestamp: 0,
+    requestId: 'req',
+  };
+  await getClaudeConfigDirHandler('conn-1', message, connections, mockBridge);
+}
+
+describe('getClaudeConfigDirHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setInherited(undefined);
+  });
+
+  it('global scope: effective uses ONLY the global setting, ignoring project', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/global' } });
+    vi.mocked(readProjectSettings).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/project' } });
+
+    await invoke(connections, { workingDir: '/proj', scope: 'global' });
+
+    expect(lastAck(connections)).toMatchObject({
+      effective: '/global',
+      globalSetting: '/global',
+      projectSetting: '/project',
+    });
+  });
+
+  it('global scope with no global setting falls back to ~/.claude (NOT the project value)', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({});
+    vi.mocked(readProjectSettings).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/project' } });
+    setInherited(undefined);
+
+    await invoke(connections, { workingDir: '/proj', scope: 'global' });
+
+    expect(lastAck(connections)).toMatchObject({
+      effective: join(homedir(), '.claude'),
+      globalSetting: null,
+      projectSetting: '/project',
+    });
+  });
+
+  it('global scope with no setting falls back to the inherited startup env', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({});
+    setInherited('/inherited');
+
+    await invoke(connections, { scope: 'global' });
+
+    expect(lastAck(connections)).toMatchObject({
+      effective: '/inherited',
+      inherited: '/inherited',
+    });
+  });
+
+  it('project scope: project value overrides global', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/global' } });
+    vi.mocked(readProjectSettings).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/project' } });
+
+    await invoke(connections, { workingDir: '/proj', scope: 'project' });
+
+    expect(lastAck(connections)).toMatchObject({ effective: '/project' });
+  });
+
+  it('project scope with no project value falls back to the global setting', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({ env: { CLAUDE_CONFIG_DIR: '/global' } });
+    vi.mocked(readProjectSettings).mockResolvedValue({});
+
+    await invoke(connections, { workingDir: '/proj', scope: 'project' });
+
+    expect(lastAck(connections)).toMatchObject({ effective: '/global' });
+  });
+
+  it('does not read project settings when no workingDir is given', async () => {
+    const connections = createMockConnections();
+    vi.mocked(readSettingsFile).mockResolvedValue({});
+
+    await invoke(connections, { scope: 'global' });
+
+    expect(readProjectSettings).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/handlers/__tests__/saveClaudeConfigDir.test.ts
+++ b/backend/src/core/handlers/__tests__/saveClaudeConfigDir.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../features/settings', () => ({
+  saveEnvVarToScope: vi.fn(),
+  readMergedSettings: vi.fn(),
+}));
+vi.mock('../../claude', () => ({
+  Claude: { applyConfigDir: vi.fn() },
+}));
+
+import { saveClaudeConfigDirHandler } from '../saveClaudeConfigDir';
+import { saveEnvVarToScope, readMergedSettings } from '../../features/settings';
+import { Claude } from '../../claude';
+import { MessageType } from '../../../shared';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+function createMockConnections() {
+  return {
+    sendTo: vi.fn(),
+    broadcastToAll: vi.fn(),
+  } as unknown as ConnectionManager;
+}
+
+const mockBridge = {} as Bridge;
+
+describe('saveClaudeConfigDirHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: {}, overrides: [] });
+  });
+
+  it('saves the value to file, applies it to the current workingDir, and broadcasts', async () => {
+    const connections = createMockConnections();
+    vi.mocked(saveEnvVarToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_CLAUDE_CONFIG_DIR,
+      payload: { value: '/home/u/.claude-work', scope: 'project', workingDir: '/proj' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+    await saveClaudeConfigDirHandler('conn-1', message, connections, mockBridge);
+
+    expect(saveEnvVarToScope).toHaveBeenCalledWith('CLAUDE_CONFIG_DIR', '/home/u/.claude-work', 'project', '/proj');
+    expect(Claude.applyConfigDir).toHaveBeenCalledWith('/proj');
+    expect(connections.broadcastToAll).toHaveBeenCalledWith(MessageType.SETTINGS_CHANGED, expect.any(Object));
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', MessageType.ACK, expect.objectContaining({
+      requestId: 'req-1',
+      status: 'ok',
+    }));
+  });
+
+  it('treats a blank value as removal (passes null)', async () => {
+    const connections = createMockConnections();
+    vi.mocked(saveEnvVarToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_CLAUDE_CONFIG_DIR,
+      payload: { value: '   ', scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-2',
+    };
+    await saveClaudeConfigDirHandler('conn-1', message, connections, mockBridge);
+
+    expect(saveEnvVarToScope).toHaveBeenCalledWith('CLAUDE_CONFIG_DIR', null, 'global', undefined);
+  });
+
+  it('defaults scope to global when omitted', async () => {
+    const connections = createMockConnections();
+    vi.mocked(saveEnvVarToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_CLAUDE_CONFIG_DIR,
+      payload: { value: '/x' },
+      timestamp: 0,
+      requestId: 'req-3',
+    };
+    await saveClaudeConfigDirHandler('conn-1', message, connections, mockBridge);
+
+    expect(saveEnvVarToScope).toHaveBeenCalledWith('CLAUDE_CONFIG_DIR', '/x', 'global', undefined);
+  });
+
+  it('does not refresh or broadcast when the save fails', async () => {
+    const connections = createMockConnections();
+    vi.mocked(saveEnvVarToScope).mockResolvedValue({ status: 'error', error: 'disk full' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_CLAUDE_CONFIG_DIR,
+      payload: { value: '/x', scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-4',
+    };
+    await saveClaudeConfigDirHandler('conn-1', message, connections, mockBridge);
+
+    expect(Claude.applyConfigDir).not.toHaveBeenCalled();
+    expect(connections.broadcastToAll).not.toHaveBeenCalled();
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', MessageType.ACK, expect.objectContaining({
+      requestId: 'req-4',
+      status: 'error',
+      error: 'disk full',
+    }));
+  });
+});

--- a/backend/src/core/handlers/getAccount.ts
+++ b/backend/src/core/handlers/getAccount.ts
@@ -29,6 +29,12 @@ export async function getAccountHandler(
   connections: ConnectionManager,
   _bridge: Bridge,
 ): Promise<void> {
+  // Resolve this context's CLAUDE_CONFIG_DIR onto process.env so `auth status` reports
+  // the profile for the active workingDir (project > global), matching chat. Only when a
+  // workingDir is supplied — otherwise keep the already-active context. (#123)
+  const workingDir = (message.payload as { workingDir?: string })?.workingDir;
+  if (workingDir) await Claude.applyConfigDir(workingDir);
+
   const authStatus = await runClaudeAuthStatus();
 
   if (!authStatus) {

--- a/backend/src/core/handlers/getClaudeConfigDir.ts
+++ b/backend/src/core/handlers/getClaudeConfigDir.ts
@@ -1,0 +1,62 @@
+import { homedir } from 'os';
+import { join } from 'path';
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { readSettingsFile, readProjectSettings } from '../features/settings';
+import { Claude } from '../claude';
+import { MessageType } from '../../shared';
+
+/** Pull a non-empty CLAUDE_CONFIG_DIR string out of a settings object's `env` map. */
+function envConfigDir(settings: Record<string, unknown>): string | null {
+  const env = settings.env;
+  if (env && typeof env === 'object' && !Array.isArray(env)) {
+    const value = (env as Record<string, unknown>).CLAUDE_CONFIG_DIR;
+    if (typeof value === 'string' && value.trim() !== '') return value;
+  }
+  return null;
+}
+
+/**
+ * Report the Claude config directory state to the settings UI:
+ * - effective: the directory currently in use (process.env, after any override)
+ * - globalSetting / projectSetting: values declared in the plugin settings `env` map
+ * - inherited: the value the backend inherited from the environment at startup
+ *   (lets the UI offer to persist a transiently-set value). (#123)
+ */
+export async function getClaudeConfigDirHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const workingDir = message.payload?.workingDir as string | undefined;
+  const scope = (message.payload?.scope as 'global' | 'project' | undefined) === 'project'
+    ? 'project'
+    : 'global';
+  const global = await readSettingsFile();
+  const project = workingDir ? await readProjectSettings(workingDir) : {};
+
+  const globalSetting = envConfigDir(global);
+  const projectSetting = envConfigDir(project);
+  const inherited = Claude.inheritedClaudeConfigDir ?? null;
+  const fallback = inherited ?? join(homedir(), '.claude');
+
+  // `effective` reflects the SELECTED scope, computed from the files (never process.env,
+  // which holds whatever context loaded last):
+  // - global tab: only the global setting counts; project is ignored
+  // - project tab: project overrides global, then the shared fallbacks
+  // This is why the global tab shows ~/.claude even when a project sets a value. (#123)
+  const effective = scope === 'project'
+    ? (projectSetting ?? globalSetting ?? fallback)
+    : (globalSetting ?? fallback);
+
+  connections.sendTo(connectionId, MessageType.ACK, {
+    requestId: message.requestId,
+    status: 'ok',
+    effective,
+    globalSetting,
+    projectSetting,
+    inherited,
+  });
+}

--- a/backend/src/core/handlers/getProjects.ts
+++ b/backend/src/core/handlers/getProjects.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { getProjectsList } from '../features/getProjectsList';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 export async function getProjectsHandler(
@@ -10,6 +11,10 @@ export async function getProjectsHandler(
   connections: ConnectionManager,
   _bridge: Bridge,
 ): Promise<void> {
+  // The project picker has no active project, so resolve the GLOBAL CLAUDE_CONFIG_DIR
+  // onto process.env. Otherwise a project-scoped override left in process.env would
+  // make the list read from the wrong profile's projects dir (showing "No projects"). (#123)
+  await Claude.applyConfigDir();
   const projects = await getProjectsList();
   connections.sendTo(connectionId, MessageType.PROJECTS_LIST, { projects });
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });

--- a/backend/src/core/handlers/getUsage.ts
+++ b/backend/src/core/handlers/getUsage.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 interface UsageBucket {
@@ -142,6 +143,7 @@ export async function getUsageHandler(
   _bridge: Bridge,
 ): Promise<void> {
   const force = (message.payload as { force?: boolean })?.force === true;
+  const workingDir = (message.payload as { workingDir?: string })?.workingDir;
 
   if (!force && Date.now() - cachedAt < CACHE_TTL_MS && (cachedUsage !== null || lastErrorInfo !== null)) {
     if (cachedUsage !== null) {
@@ -192,6 +194,11 @@ export async function getUsageHandler(
     }
 
     const runPromise = (async () => {
+      // Resolve this context's CLAUDE_CONFIG_DIR onto process.env before invoking ccb,
+      // so the usage child reads credentials from the same profile as chat. Only when a
+      // workingDir is supplied — otherwise keep whatever context is already active so we
+      // don't clobber it back to global. (#123)
+      if (workingDir) await Claude.applyConfigDir(workingDir);
       const usage = await runCcbUsage();
       cachedUsage = usage;
       cachedAt = Date.now();

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { MessageType } from '../../shared';
+import { Claude } from '../claude';
 import { sendMessageHandler } from './sendMessage';
 import { stopGenerationHandler } from './stopGeneration';
 import { stopSessionHandler } from './stopSession';
@@ -71,6 +72,14 @@ export async function handleMessage(
   bridge: Bridge,
 ): Promise<void> {
   console.error('[node-backend]', `Received: ${message.type}`);
+
+  // Project the active context's CLAUDE_CONFIG_DIR onto process.env up front, so every
+  // handler that reads Claude data (sessions, projects) or spawns a child (claude/ccb)
+  // resolves the right profile for this workingDir. Messages without a workingDir leave
+  // the current context untouched — the project picker (getProjects) sets global itself,
+  // and usage/account intentionally keep whatever context is already active. (#123)
+  const ctxWorkingDir = (message.payload as { workingDir?: string } | undefined)?.workingDir;
+  if (ctxWorkingDir) await Claude.applyConfigDir(ctxWorkingDir);
 
   switch (message.type) {
     case MessageType.SEND_MESSAGE:

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -14,6 +14,8 @@ import { deleteSessionHandler } from './deleteSession';
 import { renameSessionHandler } from './renameSession';
 import { getSettingsHandler } from './getSettings';
 import { saveSettingsHandler } from './saveSettings';
+import { getClaudeConfigDirHandler } from './getClaudeConfigDir';
+import { saveClaudeConfigDirHandler } from './saveClaudeConfigDir';
 import { getTelemetryConsentHandler } from './getTelemetryConsent';
 import { setTelemetryConsentHandler } from './setTelemetryConsent';
 import { getProjectsHandler } from './getProjects';
@@ -106,6 +108,12 @@ export async function handleMessage(
       break;
     case MessageType.SAVE_SETTINGS:
       await saveSettingsHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.GET_CLAUDE_CONFIG_DIR:
+      await getClaudeConfigDirHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.SAVE_CLAUDE_CONFIG_DIR:
+      await saveClaudeConfigDirHandler(connectionId, message, connections, bridge);
       break;
     case MessageType.GET_TELEMETRY_CONSENT:
       await getTelemetryConsentHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/saveClaudeConfigDir.ts
+++ b/backend/src/core/handlers/saveClaudeConfigDir.ts
@@ -1,0 +1,42 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { saveEnvVarToScope, readMergedSettings } from '../features/settings';
+import { Claude } from '../claude';
+import { MessageType } from '../../shared';
+
+/**
+ * Persist CLAUDE_CONFIG_DIR into the plugin settings `env` map at the requested scope,
+ * then apply it to the CURRENT context (this settings screen's workingDir) so the change
+ * takes effect immediately. An empty/blank value removes the override.
+ *
+ * This does not leak across the backend: process.env is a single shared slot, but every
+ * other context re-resolves on its own load — the project picker resets to global, and a
+ * chat applies its own workingDir. So a project-scoped save only sticks for that project.
+ * (#123)
+ */
+export async function saveClaudeConfigDirHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const raw = message.payload?.value;
+  // Treat empty/blank as removal so the user can clear the override from the UI.
+  const value = typeof raw === 'string' && raw.trim() !== '' ? raw : null;
+  const scope = (message.payload?.scope as 'global' | 'project') || 'global';
+  const workingDir = message.payload?.workingDir as string | undefined;
+
+  const result = await saveEnvVarToScope('CLAUDE_CONFIG_DIR', value, scope, workingDir);
+
+  if (result.status === 'ok') {
+    await Claude.applyConfigDir(workingDir);
+    const { settings, overrides } = await readMergedSettings(workingDir);
+    connections.broadcastToAll(MessageType.SETTINGS_CHANGED, { settings, overrides });
+  }
+
+  connections.sendTo(connectionId, MessageType.ACK, {
+    requestId: message.requestId,
+    ...result,
+  });
+}

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -59,6 +59,10 @@ export enum MessageType {
   GET_CLAUDE_SETTINGS = 'GET_CLAUDE_SETTINGS',
   /** Persist a single Claude Code setting at a given scope. */
   SAVE_CLAUDE_SETTINGS = 'SAVE_CLAUDE_SETTINGS',
+  /** Read the effective CLAUDE_CONFIG_DIR: active value, per-scope plugin settings, and the value inherited from the environment at startup. inbound webview→backend */
+  GET_CLAUDE_CONFIG_DIR = 'GET_CLAUDE_CONFIG_DIR',
+  /** Persist CLAUDE_CONFIG_DIR into the plugin settings `env` map at a scope (global/project) and re-apply it. inbound webview→backend */
+  SAVE_CLAUDE_CONFIG_DIR = 'SAVE_CLAUDE_CONFIG_DIR',
   /** Set the active model for the session/CLI. */
   SET_MODEL = 'SET_MODEL',
   /** Read the CLI control configuration (slash commands, etc.). */

--- a/webview/src/contexts/__tests__/AuthContext.test.tsx
+++ b/webview/src/contexts/__tests__/AuthContext.test.tsx
@@ -11,6 +11,10 @@ vi.mock('../BridgeContext', () => ({
   useBridgeContext: () => ({ isConnected: connected, send: mockSend, subscribe: vi.fn(), lastError: null }),
 }));
 
+vi.mock('@/contexts/WorkingDirContext', () => ({
+  useWorkingDir: () => ({ workingDirectory: null }),
+}));
+
 import { AuthProvider, useAuthContext } from '../AuthContext';
 
 const wrapper = ({ children }: { children: ReactNode }) => {

--- a/webview/src/hooks/queries/__tests__/useAccountQuery.test.tsx
+++ b/webview/src/hooks/queries/__tests__/useAccountQuery.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/contexts/BridgeContext', () => ({
   useBridgeContext: () => ({ isConnected: connected, send: mockSend, subscribe: vi.fn(), lastError: null }),
 }));
 
+vi.mock('@/contexts/WorkingDirContext', () => ({
+  useWorkingDir: () => ({ workingDirectory: null }),
+}));
+
 import { useAccountQuery, type AccountQueryResult } from '../useAccountQuery';
 
 function Consumer() {

--- a/webview/src/hooks/queries/useAccountQuery.ts
+++ b/webview/src/hooks/queries/useAccountQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { useBridgeContext } from '@/contexts/BridgeContext';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import { MessageType } from '@/shared';
 
 /**
@@ -44,12 +45,17 @@ interface RawAccountResponse {
  */
 export function useAccountQuery(): UseQueryResult<AccountQueryResult, Error> {
   const { isConnected, send } = useBridgeContext();
+  const { workingDirectory } = useWorkingDir();
 
+  // Key by workingDir and pass it along, so `auth status` reports the profile for the
+  // active project (the backend resolves CLAUDE_CONFIG_DIR per project). (#123)
   return useQuery<AccountQueryResult, Error>({
-    queryKey: [MessageType.GET_ACCOUNT],
+    queryKey: [MessageType.GET_ACCOUNT, workingDirectory],
     enabled: isConnected,
     queryFn: async () => {
-      const result = (await send(MessageType.GET_ACCOUNT, {})) as RawAccountResponse;
+      const result = (await send(MessageType.GET_ACCOUNT, {
+        workingDir: workingDirectory ?? undefined,
+      })) as RawAccountResponse;
       if (result?.status === 'ok' && result.account) {
         return { loggedIn: result.account.loggedIn === true, account: result.account };
       }

--- a/webview/src/hooks/queries/useUsageQuery.ts
+++ b/webview/src/hooks/queries/useUsageQuery.ts
@@ -1,5 +1,6 @@
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import { useBridgeContext } from '@/contexts/BridgeContext';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import type { UsageResponse, UsageErrorKind } from '@/types/usage';
 import { MessageType } from '@/shared';
 
@@ -48,11 +49,19 @@ export function normalizeUsage(result: RawUsageResponse): UsageQueryResult {
  */
 export function useUsageQuery(): UseQueryResult<UsageQueryResult, Error> {
   const { isConnected, send } = useBridgeContext();
+  const { workingDirectory } = useWorkingDir();
 
+  // Key by workingDir so each project's usage is cached separately and the request
+  // carries its workingDir — the backend resolves CLAUDE_CONFIG_DIR per project. (#123)
   return useQuery<UsageQueryResult, Error>({
-    queryKey: [MessageType.GET_USAGE],
+    queryKey: [MessageType.GET_USAGE, workingDirectory],
     enabled: isConnected,
     queryFn: async () =>
-      normalizeUsage((await send(MessageType.GET_USAGE, { force: false })) as RawUsageResponse),
+      normalizeUsage(
+        (await send(MessageType.GET_USAGE, {
+          force: false,
+          workingDir: workingDirectory ?? undefined,
+        })) as RawUsageResponse,
+      ),
   });
 }

--- a/webview/src/pages/SettingsPage/CLAUDE.md
+++ b/webview/src/pages/SettingsPage/CLAUDE.md
@@ -1,0 +1,77 @@
+# 설정 페이지 작성 원칙
+
+`SettingsPage` 하위에 설정 항목을 추가/수정하는 모든 에이전트는 아래 원칙을 따른다.
+**특별한 경우이거나 사용자의 별도 지시가 있는 경우에만** 예외를 둔다.
+
+## 1. 사전 확인 — 레퍼런스를 먼저 본다
+
+설정을 추가하기 **전에**, 같은 설정이 커서(Cursor)의 Claude Code 공식 확장에 이미 있는지 확인한다.
+
+- 레퍼런스 위치: `~/.vscode/extensions/anthropic.claude-code-*` (또는 `~/.cursor/extensions/...`).
+  설정 키는 `package.json` 의 `contributes.configuration`(예: `claudeCode.*`), UI 텍스트/동작은
+  `webview/index.js`(minified)에서 확인. ([[cursor-claude-code-extension-bundle-reverse-engineering]] 참고)
+- **대칭되는 기능이 있으면, 동작 방식·제목/설명 텍스트·값 타입을 가능한 한 그대로 가져온다.**
+  레퍼런스와 100% 동일하게 만드는 것이 베스트이자 목표(goal)다. 자의적으로 다르게 만들지 않는다.
+- 대칭 기능이 없을 때만 아래 원칙들로 넘어간다.
+
+## 2. 레퍼런스에 없으면 — 간단·명료하게
+
+레퍼런스에 대칭이 없는 새 설정은 가급적 **가장 간단한 형태**로 만든다.
+
+- 설명 텍스트도 최대한 짧게. **모바일에서 봐도 한 문장으로 끊기는 수준**으로 — 간단하되 명료하게.
+- 예: `CLAUDE_CONFIG_DIR` → 라벨 `CLAUDE_CONFIG_DIR`,
+  설명 `Home directory for Claude's config. Same as the CLAUDE_CONFIG_DIR environment variable.`
+- 장황한 다문장 설명(동작 범위 나열, 부연 등)을 피한다.
+
+## 3. 새 설정은 General 에 추가한다
+
+별도 지시가 없으면 새 설정 항목은 [General](./General/index.tsx) 섹션에 넣는다.
+도메인이 명백히 다른 섹션(CLI, Appearance, Privacy 등)에 속할 때만 그쪽에 둔다 — 그것도
+"애매하면 General" 을 기본값으로 삼는다.
+
+## 4. 작명은 사용자의 워딩을 그대로 쓴다
+
+라벨·키 이름을 자의적으로 변형하지 않는다. 사용자가 사용한 단어의 텍스트를 **그대로** 쓴다.
+
+- 사용자가 `CLAUDE_CONFIG_DIR` 이라 부르면 라벨도 `CLAUDE_CONFIG_DIR`. ~~`Config Directory`~~ 로 멋대로 바꾸지 않는다.
+- 환경변수·플래그·CLI 옵션 등 고유 식별자는 원형 그대로 노출한다.
+
+## 5. 항목 하나 때문에 섹션을 새로 만들지 않는다
+
+`SettingSection`(제목 + 박스)은 **여러 관련 항목을 묶을 때만** 만든다.
+인풋 하나를 추가하면서 `섹션 + 제목 + 설명 + 인풋` 한 세트를 통째로 만드는 것은
+UI 오남용 안티패턴이다. 기존 섹션 안에 `SettingRow` 하나로 추가한다.
+
+- 모범: [HostModeRow](./General/HostModeRow.tsx), [ClaudeConfigDirRow](./General/ClaudeConfigDirRow.tsx)
+  — 둘 다 General 섹션 안의 단일 `SettingRow`.
+- 안티패턴: 항목 하나마다 `<SettingSection title="...">` 를 새로 두르는 것.
+
+## 6. 저장 버튼을 두지 않는다 — 입력이 곧 저장이다
+
+특수한 경우를 제외하면 Save 버튼을 등장시키지 않는다. **입력 = 저장**이어야 한다.
+
+- `Select` / `ToggleSwitch`: `onChange` 에서 즉시 저장.
+- 자유 입력(`input`): `onBlur` 에서 저장 (포커스가 떠날 때). 값이 바뀌지 않았으면 저장을 건너뛴다.
+- ~~별도 `Save` 버튼~~, ~~"Save to global / Save to project" 같은 보조 버튼~~ 은 두지 않는다.
+
+## 컴포넌트 패턴
+
+- 한 설정 항목은 별도 파일의 컴포넌트로 분리하고(예: `XxxRow.tsx`), 섹션 `index.tsx` 에서 조합한다.
+- 공통 레이아웃은 [common](./common) 의 `SettingSection` / `SettingRow` 를 사용한다.
+- 전역/지역(global/project) scope 는 `ScopeTabs` 가 `useSettings` 와 `useClaudeSettings`
+  양쪽 scope 를 동기화하므로, 항목에서는 둘 중 하나의 `scope` 를 읽어 현재 탭에 맞춰 저장한다.
+- 스타일은 Tailwind 클래스로만 한다. 인라인 `style={{}}` 금지.
+- Props 선언, named export, 100줄 초과 시 폴더 분리 등은 프로젝트 루트 컨벤션을 따른다.
+
+## blur 저장 예시 (ClaudeConfigDirRow)
+
+```tsx
+<SettingRow label="CLAUDE_CONFIG_DIR" description="...">
+  <input
+    value={draft}
+    onChange={(e) => setDraft(e.target.value)}
+    onBlur={() => void commit()}   // 입력 = 저장, 별도 버튼 없음
+    placeholder="Default (~/.claude)"
+  />
+</SettingRow>
+```

--- a/webview/src/pages/SettingsPage/General/ClaudeConfigDirRow.tsx
+++ b/webview/src/pages/SettingsPage/General/ClaudeConfigDirRow.tsx
@@ -1,0 +1,90 @@
+import { useState, useEffect, useCallback } from 'react';
+import { SettingRow } from '../common';
+import { useBridge } from '@/hooks/useBridge';
+import { useSettings } from '@/contexts/SettingsContext';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
+import { MessageType } from '@/shared';
+
+interface ConfigDirInfo {
+  effective: string;
+  globalSetting: string | null;
+  projectSetting: string | null;
+  inherited: string | null;
+}
+
+/**
+ * Edits CLAUDE_CONFIG_DIR — the folder Claude reads its settings and credentials
+ * from. Stored in the plugin settings `env` map (global/project per the active scope
+ * tab) and re-applied to the backend immediately so chat, the usage widget (ccb), and
+ * session history all resolve the same directory. (#123)
+ *
+ * Rendered as a single row inside the General section: blur-to-save, no Save button,
+ * no dedicated section — per SettingsPage/CLAUDE.md.
+ */
+export function ClaudeConfigDirRow() {
+  const { send } = useBridge();
+  const { scope } = useSettings();
+  const { workingDirectory } = useWorkingDir();
+  const [info, setInfo] = useState<ConfigDirInfo | null>(null);
+  const [draft, setDraft] = useState('');
+
+  const load = useCallback(async () => {
+    const res = await send<ConfigDirInfo>(MessageType.GET_CLAUDE_CONFIG_DIR, {
+      workingDir: workingDirectory ?? undefined,
+      scope,
+    });
+    if (res) setInfo(res);
+  }, [send, workingDirectory, scope]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const stored = (scope === 'project' ? info?.projectSetting : info?.globalSetting) ?? '';
+  // Keep the field in sync with the stored value when scope/info changes.
+  useEffect(() => {
+    setDraft(stored);
+  }, [stored]);
+
+  const projectScopeUnavailable = scope === 'project' && !workingDirectory;
+
+  const commit = useCallback(async () => {
+    const next = draft.trim();
+    if (next === stored) return; // nothing changed
+    await send(MessageType.SAVE_CLAUDE_CONFIG_DIR, {
+      value: next || null,
+      scope,
+      workingDir: workingDirectory ?? undefined,
+    });
+    await load();
+  }, [draft, stored, send, scope, workingDirectory, load]);
+
+  return (
+    <SettingRow
+      label="CLAUDE_CONFIG_DIR"
+      description="Home directory for Claude's config. Same as the CLAUDE_CONFIG_DIR environment variable."
+    >
+      <div className="flex flex-col items-end gap-1">
+        <input
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => void commit()}
+          placeholder="Default (~/.claude)"
+          disabled={projectScopeUnavailable}
+          aria-label="CLAUDE_CONFIG_DIR"
+          className="w-64 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary disabled:opacity-50"
+        />
+        {projectScopeUnavailable ? (
+          <span className="text-xs text-text-tertiary">Open a project to set a project value.</span>
+        ) : (
+          info && (
+            <span className="text-xs text-text-tertiary truncate max-w-64" title={info.effective}>
+              Active: {info.effective}
+            </span>
+          )
+        )}
+      </div>
+    </SettingRow>
+  );
+}

--- a/webview/src/pages/SettingsPage/General/__tests__/ClaudeConfigDirRow.test.tsx
+++ b/webview/src/pages/SettingsPage/General/__tests__/ClaudeConfigDirRow.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const sendMock = vi.fn();
+let mockScope: 'global' | 'project' = 'global';
+let mockWorkingDir: string | null = '/proj';
+
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ send: sendMock }),
+}));
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({ scope: mockScope }),
+}));
+vi.mock('@/contexts/WorkingDirContext', () => ({
+  useWorkingDir: () => ({ workingDirectory: mockWorkingDir }),
+}));
+
+import { ClaudeConfigDirRow } from '../ClaudeConfigDirRow';
+import { MessageType } from '@/shared';
+
+interface Info {
+  effective: string;
+  globalSetting: string | null;
+  projectSetting: string | null;
+  inherited: string | null;
+}
+
+function mockInfo(info: Info) {
+  sendMock.mockImplementation((type: string) => {
+    if (type === MessageType.GET_CLAUDE_CONFIG_DIR) return Promise.resolve(info);
+    return Promise.resolve({ status: 'ok' });
+  });
+}
+
+beforeEach(() => {
+  sendMock.mockReset();
+  mockScope = 'global';
+  mockWorkingDir = '/proj';
+});
+
+describe('ClaudeConfigDirRow', () => {
+  it('labels the field with the variable name verbatim', async () => {
+    mockInfo({ effective: '/home/u/.claude', globalSetting: null, projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    expect(await screen.findByText('CLAUDE_CONFIG_DIR')).toBeInTheDocument();
+  });
+
+  it('shows the active directory', async () => {
+    mockInfo({ effective: '/home/u/.claude-work', globalSetting: '/home/u/.claude-work', projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    expect(await screen.findByText(/Active: \/home\/u\/\.claude-work/)).toBeInTheDocument();
+  });
+
+  it('has no Save button (saves on blur)', async () => {
+    mockInfo({ effective: '/home/u/.claude', globalSetting: null, projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    await screen.findByText(/Active:/);
+    expect(screen.queryByRole('button', { name: /save/i })).not.toBeInTheDocument();
+  });
+
+  it('saves the edited value to the active scope on blur', async () => {
+    mockInfo({ effective: '/home/u/.claude', globalSetting: null, projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    await screen.findByText(/Active:/);
+
+    const input = screen.getByLabelText('CLAUDE_CONFIG_DIR') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '/new/.claude-work' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(MessageType.SAVE_CLAUDE_CONFIG_DIR, {
+        value: '/new/.claude-work',
+        scope: 'global',
+        workingDir: '/proj',
+      });
+    });
+  });
+
+  it('does not save on blur when the value is unchanged', async () => {
+    mockInfo({ effective: '/g', globalSetting: '/g', projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    await screen.findByText(/Active:/);
+
+    const input = screen.getByLabelText('CLAUDE_CONFIG_DIR') as HTMLInputElement;
+    fireEvent.blur(input);
+
+    expect(sendMock).not.toHaveBeenCalledWith(MessageType.SAVE_CLAUDE_CONFIG_DIR, expect.anything());
+  });
+
+  it('clearing the field saves null (back to default)', async () => {
+    mockInfo({ effective: '/g', globalSetting: '/g', projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    await screen.findByText(/Active:/);
+
+    const input = screen.getByLabelText('CLAUDE_CONFIG_DIR') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '' } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(sendMock).toHaveBeenCalledWith(MessageType.SAVE_CLAUDE_CONFIG_DIR, {
+        value: null,
+        scope: 'global',
+        workingDir: '/proj',
+      });
+    });
+  });
+
+  it('disables editing for project scope when no project is open', async () => {
+    mockScope = 'project';
+    mockWorkingDir = null;
+    mockInfo({ effective: '/home/u/.claude', globalSetting: null, projectSetting: null, inherited: null });
+    render(<ClaudeConfigDirRow />);
+    await screen.findByText(/Open a project/i);
+    expect(screen.getByLabelText('CLAUDE_CONFIG_DIR')).toBeDisabled();
+  });
+});

--- a/webview/src/pages/SettingsPage/General/index.tsx
+++ b/webview/src/pages/SettingsPage/General/index.tsx
@@ -2,6 +2,7 @@ import { SettingSection, SettingRow } from '../common';
 import { Select, type SelectOption } from '@/components/Select';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { HostModeRow } from './HostModeRow';
+import { ClaudeConfigDirRow } from './ClaudeConfigDirRow';
 import { APP_NAME } from '@/config/app';
 import { ROUTE_META, Route } from '@/router/routes';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
@@ -87,6 +88,8 @@ export function GeneralSettings() {
         </SettingRow>
 
         <HostModeRow />
+
+        <ClaudeConfigDirRow />
       </SettingSection>
     </div>
   );

--- a/webview/src/pages/SettingsPage/Usage/useUsageData.ts
+++ b/webview/src/pages/SettingsPage/Usage/useUsageData.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import type { UsageResponse, UsageErrorKind } from '@/types/usage';
 import { MessageType } from '@/shared';
 import { useUsageQuery, normalizeUsage, type RawUsageResponse } from '@/hooks/queries/useUsageQuery';
@@ -19,6 +20,7 @@ export function useUsageData(): UseUsageDataReturn {
   const { send } = useBridgeContext();
   const queryClient = useQueryClient();
   const { messages } = useChatStreamContext();
+  const { workingDirectory } = useWorkingDir();
   const usageQuery = useUsageQuery();
 
   // Re-fetch on conversation changes (new message, session switch, clear). The
@@ -33,9 +35,13 @@ export function useUsageData(): UseUsageDataReturn {
   // Explicit refresh bypasses the backend's usage cache (force: true). Write the
   // result straight into the shared cache so all consumers update at once.
   const refresh = useCallback(async () => {
-    const result = (await send(MessageType.GET_USAGE, { force: true })) as RawUsageResponse;
-    queryClient.setQueryData([MessageType.GET_USAGE], normalizeUsage(result));
-  }, [send, queryClient]);
+    const result = (await send(MessageType.GET_USAGE, {
+      force: true,
+      workingDir: workingDirectory ?? undefined,
+    })) as RawUsageResponse;
+    // Write into THIS project's cache entry (keyed by workingDir), matching useUsageQuery.
+    queryClient.setQueryData([MessageType.GET_USAGE, workingDirectory], normalizeUsage(result));
+  }, [send, queryClient, workingDirectory]);
 
   const result = usageQuery.data;
   return {

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -59,6 +59,10 @@ export enum MessageType {
   GET_CLAUDE_SETTINGS = 'GET_CLAUDE_SETTINGS',
   /** Persist a single Claude Code setting at a given scope. */
   SAVE_CLAUDE_SETTINGS = 'SAVE_CLAUDE_SETTINGS',
+  /** Read the effective CLAUDE_CONFIG_DIR: active value, per-scope plugin settings, and the value inherited from the environment at startup. inbound webview→backend */
+  GET_CLAUDE_CONFIG_DIR = 'GET_CLAUDE_CONFIG_DIR',
+  /** Persist CLAUDE_CONFIG_DIR into the plugin settings `env` map at a scope (global/project) and re-apply it. inbound webview→backend */
+  SAVE_CLAUDE_CONFIG_DIR = 'SAVE_CLAUDE_CONFIG_DIR',
   /** Set the active model for the session/CLI. */
   SET_MODEL = 'SET_MODEL',
   /** Read the CLI control configuration (slash commands, etc.). */


### PR DESCRIPTION
## Summary

Fixes #123. The usage widget (ccb) and session reads ignored `cliPath` / `CLAUDE_CONFIG_DIR` and always read the default `~/.claude` — so a non-default Claude profile worked in chat but failed in the usage widget with "credentials not found".

Adds a **`CLAUDE_CONFIG_DIR`** field under **Settings → General** (global / project scope), stored in the plugin settings `env` map.

## How it works

- `CLAUDE_CONFIG_DIR` is a **bootstrap variable** the CLI reads only from `process.env` (never from `settings.json`'s `env`, which it consults too late), so it gets dedicated handling.
- The backend projects the resolved value (project > global) onto `process.env` **when an active context loads** — chat spawn (its workingDir), the project picker (global), usage, account — and on save (current context). Applying only at load time keeps a project-scoped value from leaking across the whole backend.
- The settings screen computes `Active` per the selected scope from the files (global tab = global only; project tab = project > global), never by reading back `process.env`.

## Changes

- **backend**: `settings.ts` (`env` key + deep-merge + `saveEnvVarToScope` + `resolveClaudeConfigDirOverride`); `claude.ts` `applyConfigDir(workingDir)`; load-time application in chat spawn / getProjects / getUsage / getAccount; new `GET/SAVE_CLAUDE_CONFIG_DIR` handlers; `MessageType` (mirrored both sides).
- **webview**: `ClaudeConfigDirRow` in General (blur-to-save, no Save button).
- **docs**: `SettingsPage/CLAUDE.md` authoring conventions.

## Tests

backend 440 passing, webview 930 passing, type-check clean both sides.

## Notes / limitations

- On **macOS** OAuth tokens live in the keychain (`~/.claude/.credentials.json` absent), so `ccb` ignores `CLAUDE_CONFIG_DIR` and usage can't be reproduced locally there. On **Windows/Linux** ccb reads `<CLAUDE_CONFIG_DIR>/.credentials.json` — the reporter's case — so the fix takes effect there. Verified on macOS via `claude` (a non-existent dir sends auth to the login screen, proving the value reaches the child).
- Users who set `CLAUDE_CONFIG_DIR` only inside a `cliPath` wrapper should set it in this field instead — the backend can't see a value hidden inside the wrapper process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
