### PR TITLE
feat(webview): Cursor-parity Effort slider, ultracode step & /effort fix (#121)

### DIFF
--- a/webview/src/commandPalette/commandToItem.ts
+++ b/webview/src/commandPalette/commandToItem.ts
@@ -18,6 +18,7 @@ export function commandToItem(cmd: CommandPaletteCommand): PanelItem {
     type: cmd.type,
     icon: cmd.icon,
     valueComponent: cmd.valueComponent,
+    labelSuffix: cmd.labelSuffix,
     keepOpen: cmd.keepOpen,
     searchOnly: cmd.searchOnly,
     keywords: cmd.keywords,

--- a/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
+++ b/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
@@ -258,6 +258,57 @@ describe('useCommandPalette', () => {
       expect(onChange).toHaveBeenCalledWith('');
       expect(result.current.showSlashCommands).toBe(false);
     });
+
+    it('keeps the panel open and the query intact for a keepOpen item (issue #121)', () => {
+      // Effort is a keepOpen item: pressing Enter should run its action and
+      // leave the panel open so repeated Enter cycles the value, instead of
+      // advancing once and closing (which read as "nothing happens").
+      const actionFn = vi.fn();
+      const sectionsWithKeepOpen: PanelSection[] = [
+        {
+          id: PanelSectionId.Model,
+          title: 'Model',
+          showDividerAbove: false,
+          items: [
+            {
+              id: 'effort',
+              label: 'Effort',
+              type: PanelItemType.Action,
+              keepOpen: true,
+              action: actionFn,
+            } as ActionItem,
+          ],
+        },
+      ];
+
+      setupMockRegistry(sectionsWithKeepOpen);
+
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.handleSlashButtonClick();
+      });
+
+      vi.clearAllMocks();
+
+      const enterEvent = {
+        key: 'Enter',
+        shiftKey: false,
+        nativeEvent: { isComposing: false },
+        preventDefault: vi.fn(),
+      } as unknown as import('react').KeyboardEvent<HTMLElement>;
+
+      act(() => {
+        result.current.handleSlashKeyDown(enterEvent, '/effort');
+      });
+
+      expect(actionFn).toHaveBeenCalledTimes(1);
+      // Panel stays open and the input is NOT cleared.
+      expect(onChange).not.toHaveBeenCalled();
+      expect(result.current.showSlashCommands).toBe(true);
+    });
   });
 
   // ──────────────────────────────────────────────────────

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -142,7 +142,17 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
       const hasItems = filteredSections.some(s => s.items.length > 0);
       if (hasItems) {
         e.preventDefault();
-        executeAndClear();
+        const selectedItem = filteredSections[selectedSectionIndex]?.items[selectedItemIndex];
+        if (selectedItem?.keepOpen) {
+          // keepOpen items (e.g. Effort) act in place: run the action but keep
+          // the panel open and the typed "/query" intact, so pressing Enter
+          // repeatedly cycles the value — matching the click behavior. Without
+          // this, Enter would advance one step then close the panel, which
+          // read as "nothing happens" (issue #121).
+          executeSelectedItem();
+        } else {
+          executeAndClear();
+        }
         return true;
       }
       // No matching command — close panel, let normal submit handle it
@@ -178,7 +188,7 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
     }
 
     return false;
-  }, [showSlashCommands, filteredSections, selectedSectionIndex, selectedItemIndex, executeAndClear, closePanel, moveSelection, onChange]);
+  }, [showSlashCommands, filteredSections, selectedSectionIndex, selectedItemIndex, executeSelectedItem, executeAndClear, closePanel, moveSelection, onChange]);
 
   const detectSlashCommand = useCallback((newValue: string) => {
     // Show panel only while typing the command name itself. As soon as

--- a/webview/src/commandPalette/sections/model/EffortItem.tsx
+++ b/webview/src/commandPalette/sections/model/EffortItem.tsx
@@ -1,33 +1,30 @@
 import { StaticItem } from '../../types';
 import { useEffort } from '@/hooks/useEffort';
+import { EffortSlider } from '@/components/EffortSlider';
 
 export const EFFORT_CYCLE_EVENT = 'effort-cycle';
 
-const EffortDots = () => {
+// Shown right after the "Effort" label, e.g. "(Extra high)" — matches the
+// Cursor extension's labelSuffix. Hidden when the model has no effort support.
+const EffortLabelSuffix = () => {
   const { supportsEffort, def } = useEffort();
   if (!supportsEffort) return null;
+  return <>({def.label})</>;
+};
 
-  return (
-    <span className="text-text-secondary flex items-center gap-1">
-      <span className="text-[1.2307rem] font-bold tracking-tighter pb-[1px] flex">
-        {Array.from({ length: def.totalDots }, (_, i) => (
-          <span
-            key={i}
-            className={i < def.filledDots ? 'text-text-secondary' : 'text-text-disabled'}
-          >
-            {'\u2022'}
-          </span>
-        ))}
-      </span>
-      <span className="text-[0.8461rem]">{def.label}</span>
-    </span>
-  );
+const EffortValue = () => {
+  const { supportsEffort } = useEffort();
+  if (!supportsEffort) return null;
+  return <EffortSlider />;
 };
 
 export const effortItem = new StaticItem('effort', 'Effort', {
   disabled: false,
   keepOpen: true,
-  valueComponent: () => <EffortDots />,
+  labelSuffix: () => <EffortLabelSuffix />,
+  valueComponent: () => <EffortValue />,
+  // Row click / Enter cycles to the next level; the slider handles direct
+  // selection (and stops its own click from reaching this row handler).
   action: async () => {
     window.dispatchEvent(new CustomEvent(EFFORT_CYCLE_EVENT));
   },

--- a/webview/src/commandPalette/types.ts
+++ b/webview/src/commandPalette/types.ts
@@ -52,6 +52,8 @@ export interface CommandPaletteCommand {
   readonly type: PanelItemType;
   readonly icon?: IconType;
   readonly valueComponent?: () => React.ReactNode;
+  /** Rendered right after the label (secondary color), e.g. Effort's "(Extra high)". */
+  readonly labelSuffix?: () => React.ReactNode;
   readonly disabled: boolean;
   readonly keepOpen?: boolean;
   readonly order?: number;
@@ -155,6 +157,7 @@ export class StaticItem implements CommandPaletteCommand {
     options?: {
       icon?: IconType;
       valueComponent?: () => React.ReactNode;
+      labelSuffix?: () => React.ReactNode;
       disabled?: boolean;
       keepOpen?: boolean;
       order?: number;
@@ -166,6 +169,7 @@ export class StaticItem implements CommandPaletteCommand {
   ) {
     this.icon = options?.icon;
     this.valueComponent = options?.valueComponent;
+    this.labelSuffix = options?.labelSuffix;
     this.disabled = options?.disabled ?? true;
     this.keepOpen = options?.keepOpen;
     this.order = options?.order;
@@ -177,6 +181,7 @@ export class StaticItem implements CommandPaletteCommand {
 
   readonly icon?: IconType;
   readonly valueComponent?: () => React.ReactNode;
+  readonly labelSuffix?: () => React.ReactNode;
 
   /** @internal Called by CommandPaletteRegistry to inject service accessor */
   _bind(getServices: () => CommandPaletteServices): void {

--- a/webview/src/commandPalette/ui/PanelItemComponent.tsx
+++ b/webview/src/commandPalette/ui/PanelItemComponent.tsx
@@ -56,8 +56,8 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
       )}
       style={{ height: 'var(--item-height, 28px)' }}
     >
-      {/* Left side: label */}
-      <div className="flex min-w-0 flex-1 items-center gap-2">
+      {/* Left side: label (+ optional suffix, e.g. Effort's "(Extra high)") */}
+      <div className="flex min-w-0 flex-1 items-center gap-1.5">
         <span
           className={cn(
             'overflow-hidden whitespace-nowrap text-ellipsis transition-colors duration-100',
@@ -73,6 +73,14 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
         >
           {item.label}
         </span>
+        {item.labelSuffix && (
+          <span
+            className="flex-shrink-0 text-[var(--secondary-text-color)]"
+            style={{ fontSize: 'var(--item-size, 13px)' }}
+          >
+            {item.labelSuffix()}
+          </span>
+        )}
       </div>
 
       {/* Right side: secondary label / toggle / icon */}

--- a/webview/src/components/EffortSlider/EffortIcon.tsx
+++ b/webview/src/components/EffortSlider/EffortIcon.tsx
@@ -1,0 +1,25 @@
+interface Props {
+  className?: string;
+}
+
+/**
+ * Dumbbell glyph for the Effort control, extracted from the Claude Code
+ * (Cursor) extension bundle. viewBox 0 0 256 256, fill=currentColor so the
+ * parent decides the color (matches ModeIcon's contract).
+ */
+export function EffortIcon(props: Props) {
+  const { className = 'w-5 h-5' } = props;
+  return (
+    <svg
+      viewBox="0 0 256 256"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`block ${className}`}
+    >
+      <path
+        d="M248,120h-8V88a16,16,0,0,0-16-16H208V64a16,16,0,0,0-16-16H168a16,16,0,0,0-16,16v56H104V64A16,16,0,0,0,88,48H64A16,16,0,0,0,48,64v8H32A16,16,0,0,0,16,88v32H8a8,8,0,0,0,0,16h8v32a16,16,0,0,0,16,16H48v8a16,16,0,0,0,16,16H88a16,16,0,0,0,16-16V136h48v56a16,16,0,0,0,16,16h24a16,16,0,0,0,16-16v-8h16a16,16,0,0,0,16-16V136h8a8,8,0,0,0,0-16ZM32,168V88H48v80Zm56,24H64V64H88V192Zm104,0H168V64h24V175.82c0,.06,0,.12,0,.18s0,.12,0,.18V192Zm32-24H208V88h16Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}

--- a/webview/src/components/EffortSlider/EffortSlider.tsx
+++ b/webview/src/components/EffortSlider/EffortSlider.tsx
@@ -13,26 +13,40 @@ const SPAN = '(100% - var(--thumb-size) - 2 * var(--thumb-inset))';
 /**
  * Effort level slider, ported from the Claude Code (Cursor) extension's
  * effort toggle (its `g$` component). A horizontal track with one notch per
- * level and a draggable thumb; clicking or dragging picks a level by
- * position. Levels come from {@link buildEffortLevels} — `[auto, …supported]` —
- * so `auto` is the leftmost stop. The ultracode step is intentionally omitted
- * (we don't wire up the workflows flag it depends on).
+ * level and a draggable thumb; clicking or dragging picks a level by position.
+ *
+ * When ultracode is available, a synthetic top step is appended (rendered
+ * purple): landing on it engages ultracode (xhigh effort + workflows) instead
+ * of setting a plain effort level. The level steps are the model's
+ * `supportedEffortLevels`; `auto` is only the unset-state label, never a step.
  *
  * Returns null when the current model doesn't support effort, so callers can
  * drop it in unconditionally.
  */
 export function EffortSlider(props: Props) {
   const { className } = props;
-  const { supportsEffort, levels: supported, current, setLevel } = useEffort();
-  // Tracks the level index the active drag last applied, so pointermove only
+  const {
+    supportsEffort,
+    levels: supported,
+    current,
+    setLevel,
+    ultracodeAvailable,
+    ultracodeEnabled,
+    enableUltracode,
+  } = useEffort();
+  // Tracks the step index the active drag last applied, so pointermove only
   // writes settings when the index actually changes.
   const dragIndexRef = useRef<number | undefined>(undefined);
 
   if (!supportsEffort) return null;
 
   const levels = buildEffortLevels(supported);
-  const count = levels.length;
-  const currentIndex = Math.max(0, levels.findIndex((l) => l.key === current));
+  // Total steps = real levels + (ultracode ? 1 trailing step : 0).
+  const count = levels.length + (ultracodeAvailable ? 1 : 0);
+  const ultracodeIndex = ultracodeAvailable ? count - 1 : -1;
+  const currentIndex = ultracodeEnabled
+    ? ultracodeIndex
+    : Math.max(0, levels.findIndex((l) => l.key === current));
   const ratio = count > 1 ? currentIndex / (count - 1) : 0;
 
   const thumbLeft = `calc(var(--thumb-inset) + ${ratio} * ${SPAN})`;
@@ -48,6 +62,10 @@ export function EffortSlider(props: Props) {
   };
 
   const applyIndex = (i: number) => {
+    if (i === ultracodeIndex) {
+      enableUltracode();
+      return;
+    }
     const level = levels[i];
     if (level) setLevel(level.key);
   };
@@ -72,11 +90,19 @@ export function EffortSlider(props: Props) {
     dragIndexRef.current = undefined;
   };
 
+  const rootClass = [
+    'effort-slider',
+    ultracodeEnabled && 'effort-slider--ultracode',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
     <button
       type="button"
-      className={className ? `effort-slider ${className}` : 'effort-slider'}
-      title="Click or drag to set effort level"
+      className={rootClass}
+      title={ultracodeAvailable ? 'Click or drag to set effort level (top step = ultracode)' : 'Click or drag to set effort level'}
       onMouseDown={(e) => e.preventDefault()}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
@@ -84,16 +110,17 @@ export function EffortSlider(props: Props) {
       onPointerCancel={endDrag}
       onLostPointerCapture={endDrag}
       // Stop the click from bubbling to a parent row handler (the slash-command
-      // row's onClick cycles effort) — the slider already applied the level.
+      // row's onClick cycles effort) — the slider already applied the step.
       onClick={(e) => e.stopPropagation()}
     >
       <span className="effort-slider__fill" style={{ width: fillWidth }} />
-      {levels.map((level, i) => {
+      {Array.from({ length: count }, (_, i) => {
         const r = count > 1 ? i / (count - 1) : 0;
+        const isUltracodeNotch = i === ultracodeIndex;
         return (
           <span
-            key={level.key}
-            className="effort-slider__notch"
+            key={i}
+            className={isUltracodeNotch ? 'effort-slider__notch effort-slider__notch--ultracode' : 'effort-slider__notch'}
             style={{ left: notchLeft(r) }}
           />
         );

--- a/webview/src/components/EffortSlider/EffortSlider.tsx
+++ b/webview/src/components/EffortSlider/EffortSlider.tsx
@@ -1,0 +1,104 @@
+import { useRef, type PointerEvent } from 'react';
+import { useEffort } from '@/hooks/useEffort';
+import { buildEffortLevels } from '@/types/effort';
+
+interface Props {
+  className?: string;
+}
+
+// Track geometry shared by the thumb/fill/notch position math (mirrors the
+// CSS custom properties in index.css so the inline calc() stays in sync).
+const SPAN = '(100% - var(--thumb-size) - 2 * var(--thumb-inset))';
+
+/**
+ * Effort level slider, ported from the Claude Code (Cursor) extension's
+ * effort toggle (its `g$` component). A horizontal track with one notch per
+ * level and a draggable thumb; clicking or dragging picks a level by
+ * position. Levels come from {@link buildEffortLevels} — `[auto, …supported]` —
+ * so `auto` is the leftmost stop. The ultracode step is intentionally omitted
+ * (we don't wire up the workflows flag it depends on).
+ *
+ * Returns null when the current model doesn't support effort, so callers can
+ * drop it in unconditionally.
+ */
+export function EffortSlider(props: Props) {
+  const { className } = props;
+  const { supportsEffort, levels: supported, current, setLevel } = useEffort();
+  // Tracks the level index the active drag last applied, so pointermove only
+  // writes settings when the index actually changes.
+  const dragIndexRef = useRef<number | undefined>(undefined);
+
+  if (!supportsEffort) return null;
+
+  const levels = buildEffortLevels(supported);
+  const count = levels.length;
+  const currentIndex = Math.max(0, levels.findIndex((l) => l.key === current));
+  const ratio = count > 1 ? currentIndex / (count - 1) : 0;
+
+  const thumbLeft = `calc(var(--thumb-inset) + ${ratio} * ${SPAN})`;
+  const fillWidth = `calc(var(--thumb-inset) + ${ratio} * ${SPAN} + var(--thumb-size) + var(--thumb-inset))`;
+  const notchLeft = (r: number) =>
+    `calc(var(--thumb-inset) + ${r} * ${SPAN} + var(--thumb-size) / 2)`;
+
+  const indexFromEvent = (e: PointerEvent<HTMLButtonElement>) => {
+    if (count <= 1) return 0;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const r = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+    return Math.round(r * (count - 1));
+  };
+
+  const applyIndex = (i: number) => {
+    const level = levels[i];
+    if (level) setLevel(level.key);
+  };
+
+  const handlePointerDown = (e: PointerEvent<HTMLButtonElement>) => {
+    if (e.button !== 0) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    const i = indexFromEvent(e);
+    dragIndexRef.current = i;
+    applyIndex(i);
+  };
+
+  const handlePointerMove = (e: PointerEvent<HTMLButtonElement>) => {
+    if (dragIndexRef.current === undefined) return;
+    const i = indexFromEvent(e);
+    if (i === dragIndexRef.current) return;
+    dragIndexRef.current = i;
+    applyIndex(i);
+  };
+
+  const endDrag = () => {
+    dragIndexRef.current = undefined;
+  };
+
+  return (
+    <button
+      type="button"
+      className={className ? `effort-slider ${className}` : 'effort-slider'}
+      title="Click or drag to set effort level"
+      onMouseDown={(e) => e.preventDefault()}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onLostPointerCapture={endDrag}
+      // Stop the click from bubbling to a parent row handler (the slash-command
+      // row's onClick cycles effort) — the slider already applied the level.
+      onClick={(e) => e.stopPropagation()}
+    >
+      <span className="effort-slider__fill" style={{ width: fillWidth }} />
+      {levels.map((level, i) => {
+        const r = count > 1 ? i / (count - 1) : 0;
+        return (
+          <span
+            key={level.key}
+            className="effort-slider__notch"
+            style={{ left: notchLeft(r) }}
+          />
+        );
+      })}
+      <span className="effort-slider__thumb" style={{ left: thumbLeft }} />
+    </button>
+  );
+}

--- a/webview/src/components/EffortSlider/index.ts
+++ b/webview/src/components/EffortSlider/index.ts
@@ -1,0 +1,2 @@
+export * from './EffortSlider';
+export * from './EffortIcon';

--- a/webview/src/hooks/useEffort.ts
+++ b/webview/src/hooks/useEffort.ts
@@ -4,9 +4,12 @@ import { useCliConfig } from '@/contexts/CliConfigContext';
 import {
   EFFORT_AUTO,
   EffortLevelDef,
+  ULTRACODE_EFFORT,
+  ULTRACODE_LABEL,
   getEffortDef,
   getModelEffortConfig,
-  nextEffortLevel,
+  isUltracodeAvailable,
+  nextEffortStep,
   parseEffortLevel,
 } from '@/types/effort';
 
@@ -15,22 +18,32 @@ export interface UseEffortReturn {
   levels: string[];
   current: string;
   def: EffortLevelDef;
+  /** Whether the model+settings allow the ultracode top step. */
+  ultracodeAvailable: boolean;
+  /** Whether ultracode is currently engaged. */
+  ultracodeEnabled: boolean;
   cycle: () => void;
   setLevel: (key: string) => void;
+  enableUltracode: () => void;
 }
 
 /**
  * Resolves the current model's effort configuration from the CLI's
- * `control_response` and the user's settings, and exposes a `cycle`
- * helper that advances to the next supported level (wrapping to auto).
+ * `control_response` and the user's settings, and exposes helpers to change it.
  *
- * Keeps the model → levels inference in one place so UI consumers
- * (command palette row, keyboard handler, future surfaces) don't
- * reimplement it.
+ * Keeps the model → levels inference in one place so UI consumers (command
+ * palette row, Modes panel, keyboard handler) don't reimplement it.
  *
- * `cycle` advances to the next level (wrapping to auto) — used by the
- * keyboard/Enter path. `setLevel` jumps straight to a chosen level —
- * used by the slider's click/drag, where the user picks a position.
+ * - `cycle` advances to the next step (Shift+Tab / Enter), including the
+ *   ultracode top step when available, wrapping back to the first level.
+ * - `setLevel` jumps straight to a chosen level (slider click/drag), clearing
+ *   ultracode if it was on.
+ * - `enableUltracode` engages ultracode = xhigh effort + the workflows flag.
+ *
+ * Note on persistence: the Cursor extension applies ultracode as a session-only
+ * flag via a runtime control. Our CLI exposes no such control (only
+ * set_model/set_permission_mode/set_max_thinking_tokens), so we persist
+ * `ultracode` to settings.json — it stays on until toggled off.
  */
 export function useEffort(): UseEffortReturn {
   const { settings, updateSetting } = useClaudeSettings();
@@ -38,20 +51,54 @@ export function useEffort(): UseEffortReturn {
 
   const { supportsEffort, levels } = getModelEffortConfig(controlResponse, settings.model);
   const current = parseEffortLevel(settings.effortLevel, levels);
-  const def = getEffortDef(current, levels);
 
-  const cycle = useCallback(() => {
-    if (!supportsEffort) return;
-    const next = nextEffortLevel(settings.effortLevel, levels);
-    void updateSetting('effortLevel', next);
-  }, [supportsEffort, levels, settings.effortLevel, updateSetting]);
+  const ultracodeAvailable =
+    supportsEffort && isUltracodeAvailable(levels, settings.disableWorkflows);
+  const ultracodeEnabled = ultracodeAvailable && settings.ultracode === true;
+
+  const def: EffortLevelDef = ultracodeEnabled
+    ? { key: 'ultracode', label: ULTRACODE_LABEL, filledDots: levels.length, totalDots: levels.length }
+    : getEffortDef(current, levels);
+
+  const enableUltracode = useCallback(() => {
+    if (!ultracodeAvailable) return;
+    // Order mirrors Cursor: pin xhigh effort first, then raise the flag.
+    void (async () => {
+      await updateSetting('effortLevel', ULTRACODE_EFFORT);
+      await updateSetting('ultracode', true);
+    })();
+  }, [ultracodeAvailable, updateSetting]);
 
   const setLevel = useCallback((key: string) => {
     if (!supportsEffort) return;
-    // `auto` is the plugin-side sentinel — persist it as `null` (CLI default),
-    // mirroring nextEffortLevel's contract so settings stay consistent.
-    void updateSetting('effortLevel', key === EFFORT_AUTO ? null : key);
-  }, [supportsEffort, updateSetting]);
+    void (async () => {
+      // Clear the ultracode flag first if it was engaged, mirroring Cursor's
+      // setEffortLevel (which writes ultracode:null before the new level).
+      if (settings.ultracode === true) await updateSetting('ultracode', null);
+      // `auto` is the plugin-side sentinel — persist it as `null` (CLI default).
+      await updateSetting('effortLevel', key === EFFORT_AUTO ? null : key);
+    })();
+  }, [supportsEffort, settings.ultracode, updateSetting]);
 
-  return { supportsEffort, levels, current, def, cycle, setLevel };
+  const cycle = useCallback(() => {
+    if (!supportsEffort) return;
+    const step = nextEffortStep(settings.effortLevel, ultracodeEnabled, levels, ultracodeAvailable);
+    if (step.kind === 'ultracode') {
+      enableUltracode();
+    } else {
+      setLevel(step.key);
+    }
+  }, [supportsEffort, settings.effortLevel, ultracodeEnabled, levels, ultracodeAvailable, enableUltracode, setLevel]);
+
+  return {
+    supportsEffort,
+    levels,
+    current,
+    def,
+    ultracodeAvailable,
+    ultracodeEnabled,
+    cycle,
+    setLevel,
+    enableUltracode,
+  };
 }

--- a/webview/src/hooks/useEffort.ts
+++ b/webview/src/hooks/useEffort.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import {
+  EFFORT_AUTO,
   EffortLevelDef,
   getEffortDef,
   getModelEffortConfig,
@@ -15,6 +16,7 @@ export interface UseEffortReturn {
   current: string;
   def: EffortLevelDef;
   cycle: () => void;
+  setLevel: (key: string) => void;
 }
 
 /**
@@ -25,6 +27,10 @@ export interface UseEffortReturn {
  * Keeps the model → levels inference in one place so UI consumers
  * (command palette row, keyboard handler, future surfaces) don't
  * reimplement it.
+ *
+ * `cycle` advances to the next level (wrapping to auto) — used by the
+ * keyboard/Enter path. `setLevel` jumps straight to a chosen level —
+ * used by the slider's click/drag, where the user picks a position.
  */
 export function useEffort(): UseEffortReturn {
   const { settings, updateSetting } = useClaudeSettings();
@@ -40,5 +46,12 @@ export function useEffort(): UseEffortReturn {
     void updateSetting('effortLevel', next);
   }, [supportsEffort, levels, settings.effortLevel, updateSetting]);
 
-  return { supportsEffort, levels, current, def, cycle };
+  const setLevel = useCallback((key: string) => {
+    if (!supportsEffort) return;
+    // `auto` is the plugin-side sentinel — persist it as `null` (CLI default),
+    // mirroring nextEffortLevel's contract so settings stay consistent.
+    void updateSetting('effortLevel', key === EFFORT_AUTO ? null : key);
+  }, [supportsEffort, updateSetting]);
+
+  return { supportsEffort, levels, current, def, cycle, setLevel };
 }

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -510,6 +510,11 @@ body {
   padding: 0;
 }
 
+.effort-slider {
+  /* Ultracode accent (the top step), mirroring Cursor's purple --app-ultracode-color. */
+  --effort-ultracode: #a78bfa;
+}
+
 .effort-slider__fill {
   position: absolute;
   top: 0;
@@ -517,7 +522,12 @@ body {
   left: 0;
   background: var(--accent-primary);
   border-radius: calc(var(--track-height) / 2);
-  transition: width 0.15s;
+  transition: width 0.15s, background 0.15s;
+}
+
+/* When ultracode is engaged the whole fill bar turns purple. */
+.effort-slider--ultracode .effort-slider__fill {
+  background: var(--effort-ultracode);
 }
 
 .effort-slider__notch {
@@ -528,6 +538,11 @@ body {
   border-radius: 50%;
   background: color-mix(in srgb, var(--text-secondary) 40%, transparent);
   transform: translate(-50%, -50%);
+}
+
+/* The ultracode top notch is always purple to signal the extra step. */
+.effort-slider__notch--ultracode {
+  background: var(--effort-ultracode);
 }
 
 .effort-slider__thumb {

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -486,3 +486,57 @@ body {
 .slash-command-panel ::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
 }
+
+/* Effort slider — ported from the Claude Code (Cursor) extension's effort
+   toggle. A horizontal track with evenly spaced notches and a draggable
+   thumb; clicking/dragging selects a level by position. The dynamic
+   left/width (thumb position, fill length) are set inline since they depend
+   on the current level ratio. */
+.effort-slider {
+  --track-height: 16px;
+  --thumb-size: 12px;
+  --thumb-inset: 2px;
+  --track-width: 72px;
+  position: relative;
+  width: var(--track-width);
+  height: var(--track-height);
+  border-radius: calc(var(--track-height) / 2);
+  background: var(--border-strong);
+  cursor: pointer;
+  overflow: hidden;
+  touch-action: none;
+  border: none;
+  flex-shrink: 0;
+  padding: 0;
+}
+
+.effort-slider__fill {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  background: var(--accent-primary);
+  border-radius: calc(var(--track-height) / 2);
+  transition: width 0.15s;
+}
+
+.effort-slider__notch {
+  position: absolute;
+  top: 50%;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--text-secondary) 40%, transparent);
+  transform: translate(-50%, -50%);
+}
+
+.effort-slider__thumb {
+  position: absolute;
+  top: var(--thumb-inset);
+  width: var(--thumb-size);
+  height: var(--thumb-size);
+  border-radius: 50%;
+  background: var(--text-primary);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+  transition: left 0.15s;
+}

--- a/webview/src/pages/ChatPage/ChatInput/ModeSelectPanel.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/ModeSelectPanel.tsx
@@ -1,6 +1,8 @@
 import { InputMode, INPUT_MODES } from '../../../types/chatInput';
 import { ModeIcon } from './ModeIcon';
 import { CheckIcon } from '@heroicons/react/16/solid';
+import { EffortSlider, EffortIcon } from '@/components/EffortSlider';
+import { useEffort } from '@/hooks/useEffort';
 
 interface Props {
   modes: InputMode[];
@@ -10,11 +12,13 @@ interface Props {
 
 /**
  * 모드 선택 패널. 입력창 모드 태그 클릭 시 위로 떠서, 가용한 권한 모드를
- * 아이콘+라벨+설명과 함께 보여준다(커서 확장 레이아웃 기준, Effort 행 제외).
+ * 아이콘+라벨+설명과 함께 보여준다(커서 확장 레이아웃 기준). 구분선 아래에는
+ * 슬래시 커맨드 패널과 동일한 Effort 슬라이더를 둔다(모델이 effort를 지원할 때만).
  * 현재 모드는 하이라이트 + 체크로 표시한다.
  */
 export function ModeSelectPanel(props: Props) {
   const { modes, currentMode, onSelect } = props;
+  const { supportsEffort, def } = useEffort();
 
   return (
     <div className="flex flex-col gap-0.5 rounded-lg border border-border-subtle bg-surface-raised py-1.5 shadow-lg min-w-[320px]">
@@ -51,6 +55,22 @@ export function ModeSelectPanel(props: Props) {
           </button>
         );
       })}
+
+      {/* 구분선 아래 Effort 슬라이더 (모델이 effort 지원 시). 슬래시 커맨드 패널과 동일 컴포넌트. */}
+      {supportsEffort && (
+        <>
+          <div className="mx-1 my-1 border-t border-border-subtle" />
+          <div className="mx-1 flex items-center gap-2.5 rounded-md px-2.5 py-2">
+            <span className="flex-shrink-0 text-text-secondary">
+              <EffortIcon className="h-5 w-5" />
+            </span>
+            <div className="min-w-0 flex-1 text-[0.9rem] font-medium text-text-primary">
+              Effort <span className="font-normal text-text-tertiary">({def.label})</span>
+            </div>
+            <EffortSlider />
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/webview/src/types/__tests__/effort.test.ts
+++ b/webview/src/types/__tests__/effort.test.ts
@@ -5,6 +5,8 @@ import {
   getEffortDef,
   nextEffortLevel,
   parseEffortLevel,
+  isUltracodeAvailable,
+  nextEffortStep,
 } from '../effort';
 
 // Mirrors the Claude Code CLI: effort levels are low/medium/high/xhigh (+max
@@ -71,5 +73,44 @@ describe('parseEffortLevel', () => {
 
   it('keeps a supported value as-is', () => {
     expect(parseEffortLevel('xhigh', SUPPORTED)).toBe('xhigh');
+  });
+});
+
+// Ultracode = a synthetic top step above xhigh (xhigh effort + workflows).
+// Available only when the model supports xhigh AND workflows aren't disabled.
+describe('isUltracodeAvailable', () => {
+  it('is available when xhigh is supported and workflows are not disabled', () => {
+    expect(isUltracodeAvailable(SUPPORTED, false)).toBe(true);
+    expect(isUltracodeAvailable(SUPPORTED, undefined)).toBe(true);
+  });
+
+  it('is unavailable when the model has no xhigh level', () => {
+    expect(isUltracodeAvailable(['low', 'medium', 'high', 'max'], false)).toBe(false);
+  });
+
+  it('is unavailable when workflows are disabled', () => {
+    expect(isUltracodeAvailable(SUPPORTED, true)).toBe(false);
+  });
+});
+
+describe('nextEffortStep', () => {
+  it('advances unset → first level', () => {
+    expect(nextEffortStep(null, false, SUPPORTED, true)).toEqual({ kind: 'level', key: 'low' });
+  });
+
+  it('advances between levels', () => {
+    expect(nextEffortStep('high', false, SUPPORTED, true)).toEqual({ kind: 'level', key: 'xhigh' });
+  });
+
+  it('advances max → ultracode when ultracode is available', () => {
+    expect(nextEffortStep('max', false, SUPPORTED, true)).toEqual({ kind: 'ultracode' });
+  });
+
+  it('advances max → first level when ultracode is NOT available', () => {
+    expect(nextEffortStep('max', false, SUPPORTED, false)).toEqual({ kind: 'level', key: 'low' });
+  });
+
+  it('advances ultracode → first level (wraps back into the level set)', () => {
+    expect(nextEffortStep('xhigh', true, SUPPORTED, true)).toEqual({ kind: 'level', key: 'low' });
   });
 });

--- a/webview/src/types/__tests__/effort.test.ts
+++ b/webview/src/types/__tests__/effort.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+  EFFORT_AUTO,
+  buildEffortLevels,
+  getEffortDef,
+  nextEffortLevel,
+  parseEffortLevel,
+} from '../effort';
+
+// Mirrors the Claude Code CLI: effort levels are low/medium/high/xhigh (+max
+// when a model reports it). "Auto" is not a level — it's the unset state. The
+// slider/labels must match the Cursor extension exactly.
+const SUPPORTED = ['low', 'medium', 'high', 'xhigh', 'max'];
+
+describe('buildEffortLevels', () => {
+  it('does not include an Auto step (Auto is the unset state, not a level)', () => {
+    const levels = buildEffortLevels(SUPPORTED);
+    expect(levels.map((l) => l.key)).toEqual(SUPPORTED);
+    expect(levels.some((l) => l.key === EFFORT_AUTO)).toBe(false);
+  });
+
+  it('labels match the Cursor extension (xhigh = "Extra high")', () => {
+    const levels = buildEffortLevels(SUPPORTED);
+    expect(levels.map((l) => l.label)).toEqual([
+      'Low',
+      'Medium',
+      'High',
+      'Extra high',
+      'Max',
+    ]);
+  });
+});
+
+describe('getEffortDef', () => {
+  it('returns the Auto label for the unset state (null/undefined/auto)', () => {
+    for (const v of [null, undefined, EFFORT_AUTO]) {
+      expect(getEffortDef(v, SUPPORTED).label).toBe('Auto');
+    }
+  });
+
+  it('returns the matching level def for a concrete level', () => {
+    expect(getEffortDef('xhigh', SUPPORTED).label).toBe('Extra high');
+    expect(getEffortDef('low', SUPPORTED).label).toBe('Low');
+  });
+});
+
+describe('nextEffortLevel', () => {
+  it('advances from the unset state to the first level', () => {
+    expect(nextEffortLevel(null, SUPPORTED)).toBe('low');
+    expect(nextEffortLevel(EFFORT_AUTO, SUPPORTED)).toBe('low');
+  });
+
+  it('advances to the adjacent level', () => {
+    expect(nextEffortLevel('high', SUPPORTED)).toBe('xhigh');
+  });
+
+  it('wraps from the last level back to the first (never returns to Auto)', () => {
+    expect(nextEffortLevel('max', SUPPORTED)).toBe('low');
+  });
+
+  it('returns null when no levels are supported', () => {
+    expect(nextEffortLevel('low', [])).toBeNull();
+  });
+});
+
+describe('parseEffortLevel', () => {
+  it('maps unset / unsupported values to the Auto sentinel', () => {
+    expect(parseEffortLevel(null, SUPPORTED)).toBe(EFFORT_AUTO);
+    expect(parseEffortLevel('nonsense', SUPPORTED)).toBe(EFFORT_AUTO);
+  });
+
+  it('keeps a supported value as-is', () => {
+    expect(parseEffortLevel('xhigh', SUPPORTED)).toBe('xhigh');
+  });
+});

--- a/webview/src/types/claude-settings.ts
+++ b/webview/src/types/claude-settings.ts
@@ -24,6 +24,8 @@ export interface ClaudeSettingsState {
   model: string | null; // full model ID like 'claude-opus-4-6' or null for default
   language: string | null; // Claude's preferred response language (e.g., "korean", "japanese")
   effortLevel: string | null; // CLI effort level — values sourced from ModelInfo.supportedEffortLevels; null = auto
+  ultracode?: boolean | null; // xhigh effort + standing workflow orchestration; the slider's top step (null = off/cleared)
+  disableWorkflows?: boolean; // CLI-owned: when true, the Workflows feature (and ultracode) is unavailable
   alwaysThinkingEnabled: boolean; // extended thinking always on
   preferFastMode: boolean; // fast output mode (Opus 4.6 only)
   useCtrlEnterToSend: boolean; // when true, Ctrl/Cmd+Enter sends; plain Enter inserts a newline

--- a/webview/src/types/commandPalette.ts
+++ b/webview/src/types/commandPalette.ts
@@ -38,6 +38,8 @@ export interface PanelItemBase {
   type: PanelItemType;
   icon?: IconType;
   valueComponent?: () => React.ReactNode;
+  /** Rendered right after the label (secondary color), e.g. Effort's "(Extra high)". */
+  labelSuffix?: () => React.ReactNode;
   disabled?: boolean;
   keepOpen?: boolean;
   /** Hidden from the panel by default; only surfaced when the filter query matches its label. */

--- a/webview/src/types/effort.ts
+++ b/webview/src/types/effort.ts
@@ -8,7 +8,10 @@
  * values (e.g. `xhigh`, `max`) and per-model differences are respected.
  *
  * `auto` is a plugin-side sentinel meaning "use the CLI default" — it is
- * persisted to `~/.claude/settings.json` as `effortLevel: null`.
+ * persisted to `~/.claude/settings.json` as `effortLevel: null`. It is NOT a
+ * slider step: matching the Cursor extension, the levels are exactly the
+ * model's `supportedEffortLevels` (low/medium/high/xhigh/max), and `auto` is
+ * only the label shown while the level is unset.
  */
 import { toModelAlias, DEFAULT_MODEL_ALIAS } from './models';
 import type { CliConfigControlResponse, ModelInfo } from './slashCommand';
@@ -22,45 +25,59 @@ export interface EffortLevelDef {
   totalDots: number;
 }
 
+// Display labels, matching the Cursor extension's map exactly
+// ({low:"Low",medium:"Medium",high:"High",xhigh:"Extra high",max:"Max"}).
 function labelFor(key: string): string {
   if (key === EFFORT_AUTO) return 'Auto';
-  if (key === 'xhigh') return 'X-High';
+  if (key === 'xhigh') return 'Extra high';
   return key.charAt(0).toUpperCase() + key.slice(1);
 }
 
+/**
+ * The slider steps: exactly the model's supported levels, no `auto` step.
+ */
 export function buildEffortLevels(supported: string[]): EffortLevelDef[] {
   const totalDots = supported.length;
-  return [
-    { key: EFFORT_AUTO, label: 'Auto', filledDots: totalDots, totalDots },
-    ...supported.map((key, i) => ({
-      key,
-      label: labelFor(key),
-      filledDots: i + 1,
-      totalDots,
-    })),
-  ];
+  return supported.map((key, i) => ({
+    key,
+    label: labelFor(key),
+    filledDots: i + 1,
+    totalDots,
+  }));
 }
 
+/**
+ * Resolve the def for the current value. Unset (null/undefined/`auto`) yields
+ * the "Auto" label with no filled dots — the slider then sits at the first
+ * stop, exactly as the Cursor extension renders an unset level.
+ */
 export function getEffortDef(
   key: string | null | undefined,
   supported: string[],
 ): EffortLevelDef {
+  if (!key || key === EFFORT_AUTO) {
+    return { key: EFFORT_AUTO, label: 'Auto', filledDots: 0, totalDots: supported.length };
+  }
   const levels = buildEffortLevels(supported);
-  return levels.find((l) => l.key === (key ?? EFFORT_AUTO)) ?? levels[0];
+  return (
+    levels.find((l) => l.key === key) ??
+    { key: EFFORT_AUTO, label: 'Auto', filledDots: 0, totalDots: supported.length }
+  );
 }
 
 /**
- * Advance to the next effort level. Returns `null` for the `auto`
- * sentinel so the caller can persist it as-is to settings.
+ * Advance to the next effort level, wrapping max → first. The unset state
+ * (`auto`/null) advances to the first level. Never returns `auto`: once a
+ * level is chosen the cycle stays within low…max, matching Cursor.
  */
 export function nextEffortLevel(
   current: string | null | undefined,
   supported: string[],
 ): string | null {
-  const levels = buildEffortLevels(supported);
-  const idx = levels.findIndex((l) => l.key === (current ?? EFFORT_AUTO));
-  const next = levels[(idx + 1) % levels.length];
-  return next.key === EFFORT_AUTO ? null : next.key;
+  if (supported.length === 0) return null;
+  // Unset/auto → indexOf is -1 → next is supported[0].
+  const idx = current ? supported.indexOf(current) : -1;
+  return supported[(idx + 1) % supported.length];
 }
 
 export function parseEffortLevel(

--- a/webview/src/types/effort.ts
+++ b/webview/src/types/effort.ts
@@ -88,6 +88,50 @@ export function parseEffortLevel(
   return supported.includes(value) ? value : EFFORT_AUTO;
 }
 
+// ─── Ultracode ───────────────────────────────────────────────────────────────
+// Ultracode is a synthetic step above the real effort levels: it means "xhigh
+// effort + standing workflow orchestration". It's not an effortLevel value — the
+// Cursor extension layers it as the slider's top notch, gated on the model
+// supporting xhigh and the Workflows feature not being disabled.
+
+export const ULTRACODE_LABEL = 'Ultracode - xhigh + workflows';
+
+/** The effort level ultracode pins (and the gate for its availability). */
+export const ULTRACODE_EFFORT = 'xhigh';
+
+export function isUltracodeAvailable(
+  supported: string[],
+  disableWorkflows: boolean | undefined,
+): boolean {
+  if (disableWorkflows === true) return false;
+  return supported.includes(ULTRACODE_EFFORT);
+}
+
+export type EffortStep =
+  | { kind: 'level'; key: string }
+  | { kind: 'ultracode' };
+
+/**
+ * The next step when cycling effort with Shift+Tab / Enter. Mirrors the Cursor
+ * extension: the steps are the supported levels plus, when available, a trailing
+ * ultracode step. Wraps ultracode (or the last level) back to the first level.
+ */
+export function nextEffortStep(
+  current: string | null | undefined,
+  ultracodeEnabled: boolean,
+  supported: string[],
+  ultracodeAvailable: boolean,
+): EffortStep {
+  const count = supported.length + (ultracodeAvailable ? 1 : 0);
+  if (count === 0) return { kind: 'level', key: '' };
+  // ultracode occupies the last index; otherwise locate the current level
+  // (unset/auto → -1 so it advances to the first level).
+  const idx = ultracodeEnabled ? count - 1 : current ? supported.indexOf(current) : -1;
+  const next = (idx + 1) % count;
+  if (ultracodeAvailable && next === count - 1) return { kind: 'ultracode' };
+  return { kind: 'level', key: supported[next] };
+}
+
 export interface ModelEffortConfig {
   supportsEffort: boolean;
   levels: string[];


### PR DESCRIPTION
## Summary

Brings the Effort control to parity with the Claude Code (Cursor) extension and fixes issue #121 (`/effort` "does nothing").

### Effort slider + #121 fix
- Replace the dot indicator with Cursor's draggable slider (track + thumb + notches) in both the slash-command panel and the Modes panel.
- Fix the slash-command Enter handler so `keepOpen` items (Effort) cycle in place instead of closing — the root cause of #121's "no feedback". Clicking already worked; Enter now matches it.
- Match Cursor's levels exactly: drop the synthetic "Auto" step (Auto is now only the unset-state label) and rename xhigh "X-High" → "Extra high". Steps are the model's `supportedEffortLevels`.
- Add a `labelSuffix` slot so "Effort (Extra high)" reads as one label.
- Add the Effort slider to the Modes panel below a divider, with a dumbbell icon sized to the mode icons.

### Ultracode top step
- Add Cursor's ultracode step — xhigh effort + standing workflow orchestration — as the slider's purple top notch, available when the model supports xhigh and Workflows aren't disabled.
- `useEffort` exposes `ultracodeAvailable`/`ultracodeEnabled`/`enableUltracode`; cycle advances max → ultracode → first level; setLevel clears the flag when leaving ultracode.
- Persist `ultracode` to settings.json (`effortLevel=xhigh` + `ultracode=true`). Unlike Cursor's session-only runtime flag, our CLI exposes no live settings control, so the file is the only delivery path.
- No settings-panel UI — confirmed by reverse-engineering that Cursor exposes ultracode/workflows only through the inline slider.

## Notes / limitations
- The CLI only accepts `set_model`/`set_permission_mode`/`set_max_thinking_tokens` runtime controls — effort/ultracode reach the CLI via settings.json at next start, not live (same constraint Cursor has). Whether the CLI honors the `ultracode` settings key as a real workflows run depends on the CLI version.
- In the Modes panel the long "Ultracode - xhigh + workflows" label wraps to two lines (single line in the slash-command panel).

## Testing
- 965 webview tests pass; type-check clean.
- Verified in the standalone browser build: slider render, Enter cycle, ultracode on/off, settings.json writes, and the Modes panel — for both panels.