### PR TITLE
fix(webview): hide Effort row on effort-unsupported models (#121)

### DIFF
--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -3,6 +3,8 @@ import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
+import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
+import { getModelEffortConfig } from '@/types/effort';
 import { getAdapter } from '@/adapters';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
@@ -53,7 +55,14 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
   const chatInputState = useChatInputState();
   const session = useSessionContext();
   const { controlResponse } = useCliConfig();
+  const { settings } = useClaudeSettings();
   const { confirmDialog, confirm } = useConfirmDialog();
+
+  // The Effort row only makes sense on models that support effort. On others
+  // (e.g. Haiku) it would render an empty, unresponsive row — the same
+  // "nothing happens" symptom as issue #121 — so we drop it, matching the
+  // Cursor extension (which unregisters the effort action for such models).
+  const supportsEffort = getModelEffortConfig(controlResponse, settings.model).supportsEffort;
 
   // Services ref - always points to current React state
   const servicesRef = useRef<CommandPaletteServices>({
@@ -208,8 +217,14 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
       sortedCommands.forEach((cmd, i) => { (cmd as { order: number }).order = i; });
       registry.registerSection(new SlashCommandsSection(), sortedCommands);
     }
-    return registry.buildSections();
-  }, [registry, commands]);
+    const built = registry.buildSections();
+    if (supportsEffort) return built;
+    // Hide the Effort row on effort-unsupported models (see note above).
+    return built.map((s) => ({
+      ...s,
+      items: s.items.filter((it) => it.id !== 'effort'),
+    }));
+  }, [registry, commands, supportsEffort]);
 
   const contextValue = useMemo<CommandPaletteRegistryContextValue>(
     () => ({ registry, keyboardRegistry, sections }),


### PR DESCRIPTION
## Summary

Closes the last edge case of #121. On models without effort support (e.g. **Haiku**), the Effort row rendered **empty** (no slider, no label) and did nothing on click/Enter — the same "nothing happens / no feedback" symptom the issue reports. The command palette now filters the Effort row out when the active model doesn't support effort, matching the Cursor extension (which unregisters the effort action for such models).

## Why this was still open

PR #129 fixed the Enter-cycle feedback on effort-capable models, but the empty/unresponsive row on effort-unsupported models is the same failing entry point and should have been handled together.

## Testing

- 965 webview tests pass; type-check clean.
- Verified in the standalone browser build: switching to **Haiku** removes the Effort row from the Model section (matching Cursor's layout); switching back to an effort-capable model restores it.

Fixes #121