### PR TITLE
fix(#120): clean up JAR-extracted temp dirs on backend exit + fix session dropdown layering

### DIFF
--- a/backend/src/core/features/__tests__/temp-cleanup.test.ts
+++ b/backend/src/core/features/__tests__/temp-cleanup.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { cleanupExtractedTempDirs } from '../temp-cleanup';
+
+/**
+ * Creates a throwaway directory under the OS temp dir with a marker file inside,
+ * mimicking the `claude-code-webview-*` / `claude-code-backend-*` dirs that Kotlin
+ * extracts from the plugin JAR. Returns the directory path.
+ */
+function makeTempDir(prefix: string): string {
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  writeFileSync(join(dir, 'marker.txt'), 'x');
+  return dir;
+}
+
+describe('cleanupExtractedTempDirs', () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    // Best-effort safety net for anything a test left behind.
+    for (const dir of created.splice(0)) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // already gone
+      }
+    }
+  });
+
+  it('removes a directory that exists', () => {
+    const dir = makeTempDir('cc-cleanup-a-');
+    created.push(dir);
+    expect(existsSync(dir)).toBe(true);
+
+    cleanupExtractedTempDirs([dir]);
+
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('removes a directory recursively, including nested files', () => {
+    const dir = makeTempDir('cc-cleanup-nested-');
+    created.push(dir);
+    const sub = join(dir, 'assets');
+    mkdirSync(sub);
+    writeFileSync(join(sub, 'bundle.js'), 'console.log(1)');
+
+    cleanupExtractedTempDirs([dir]);
+
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('does not throw for a non-existent path', () => {
+    const ghost = join(tmpdir(), 'cc-cleanup-does-not-exist-12345');
+    expect(existsSync(ghost)).toBe(false);
+    expect(() => cleanupExtractedTempDirs([ghost])).not.toThrow();
+  });
+
+  it('does not throw for an empty array', () => {
+    expect(() => cleanupExtractedTempDirs([])).not.toThrow();
+  });
+
+  it('skips empty / undefined entries without throwing', () => {
+    const dir = makeTempDir('cc-cleanup-mixed-');
+    created.push(dir);
+
+    // Intentionally pass undefined/empty to prove they are skipped.
+    cleanupExtractedTempDirs([undefined, '', dir]);
+
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  it('continues to other dirs when one removal fails', () => {
+    const good = makeTempDir('cc-cleanup-good-');
+    created.push(good);
+
+    // A path whose *parent* is a regular file — rmSync of a child under it throws
+    // ENOTDIR, exercising the per-entry try/catch without aborting the whole run.
+    const fileAsParent = join(tmpdir(), 'cc-cleanup-file-' + Date.now());
+    writeFileSync(fileAsParent, 'not a dir');
+    created.push(fileAsParent);
+    const bad = join(fileAsParent, 'child');
+
+    expect(() => cleanupExtractedTempDirs([bad, good])).not.toThrow();
+
+    // The good dir must still have been removed despite the bad entry.
+    expect(existsSync(good)).toBe(false);
+  });
+});

--- a/backend/src/core/features/temp-cleanup.ts
+++ b/backend/src/core/features/temp-cleanup.ts
@@ -1,0 +1,31 @@
+import { rmSync } from 'fs';
+
+/**
+ * Best-effort removal of the temp directories that the JetBrains plugin extracted
+ * from its JAR for this backend instance (#120):
+ *   - {tmpdir}/claude-code-webview-{instanceTag}  (static webview assets)
+ *   - {tmpdir}/claude-code-backend-{instanceTag}  (this running backend.mjs)
+ *
+ * Called from `process.on('exit')`, so it MUST stay fully synchronous (no async
+ * APIs are honored after exit begins) — hence `rmSync`.
+ *
+ * Safety contract:
+ *   - Only the exact directories passed in are removed; we never scan tmpdir for
+ *     sibling instanceTag folders (a concurrent project's active dir must survive).
+ *   - Empty / undefined entries are skipped (callers pass env values that may be unset).
+ *   - Each removal is independent: a failure on one dir (e.g. Windows self-lock on the
+ *     directory holding the running backend.mjs) is swallowed so the remaining dirs —
+ *     notably the webview assets — are still cleaned. `force: true` also ignores a
+ *     missing path.
+ */
+export function cleanupExtractedTempDirs(dirs: Array<string | undefined>): void {
+  for (const dir of dirs) {
+    if (!dir) continue;
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (err) {
+      // Swallow — exit-time cleanup is best-effort and must never throw.
+      console.error('[node-backend]', `temp cleanup failed for ${dir}:`, err);
+    }
+  }
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import { ensureProfile } from './core/features/profile';
 import { trackEvent, reportBackendError } from './core/features/telemetry';
 import { restoreTunnelState } from './core/features/tunnel-manager';
 import { restoreSleepGuardState } from './core/features/sleep-guard';
+import { cleanupExtractedTempDirs } from './core/features/temp-cleanup';
 import { isJetBrainsMode, serverPort, webviewDir } from './config/environment';
 import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
@@ -127,6 +128,22 @@ async function main() {
   process.on('SIGPIPE', () => {}); // Ignore SIGPIPE signal
   process.stdout.on('error', () => {}); // Ignore stdout EPIPE
   process.stderr.on('error', () => {}); // Ignore stderr EPIPE
+
+  // On clean exit, remove the temp dirs the JetBrains plugin extracted from its JAR
+  // for this instance (#120). Kotlin only sets these env vars when it actually
+  // extracted to a temp dir (production); in dev mode WEBVIEW_DIR/backend point at
+  // the source tree and these vars are intentionally absent, so we register nothing
+  // and never touch the source. Standalone mode also never sets them.
+  // process.on('exit') runs synchronously after every shutdown path
+  // (idle shutdown, SIGTERM/SIGINT) converges on process.exit(0), and by then every
+  // client (IDE JCEF + any browser) has disconnected — no webview can break.
+  const cleanupDirs = [
+    process.env.CLEANUP_TEMP_WEBVIEW_DIR,
+    process.env.CLEANUP_TEMP_BACKEND_DIR,
+  ].filter((d): d is string => Boolean(d));
+  if (cleanupDirs.length > 0) {
+    process.on('exit', () => cleanupExtractedTempDirs(cleanupDirs));
+  }
 
   // 1. Logger 즉시 초기화 (부트스트랩 로그도 파일에 기록)
   const logger = initLogger();

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -123,6 +123,13 @@ class NodeProcessManager(
     @Volatile
     private var disposed = false
 
+    // Temp dirs extracted from the plugin JAR for THIS instance (#120). Set ONLY when we
+    // actually extracted to java.io.tmpdir (production); left null in dev mode, where the
+    // backend/webview paths point at the source tree and must never be deleted. Passed to
+    // the backend as cleanup env so Node removes them on its own clean exit.
+    private var extractedBackendDir: File? = null
+    private var extractedWebviewDir: File? = null
+
     /** True only once the process has actually started and later exited (or failed to start). */
     val isDead: Boolean
         get() = lifecycle == Lifecycle.DEAD
@@ -223,6 +230,14 @@ class NodeProcessManager(
                         webviewDir?.let { wv ->
                             WslPathResolver.toWslPath(wv.absolutePath)?.let { put("WEBVIEW_DIR", it) }
                         }
+                        // Self-cleanup of JAR-extracted temp dirs on clean exit (#120).
+                        // Set only for production extractions; absent in dev (source tree).
+                        extractedWebviewDir?.let { d ->
+                            WslPathResolver.toWslPath(d.absolutePath)?.let { put("CLEANUP_TEMP_WEBVIEW_DIR", it) }
+                        }
+                        extractedBackendDir?.let { d ->
+                            WslPathResolver.toWslPath(d.absolutePath)?.let { put("CLEANUP_TEMP_BACKEND_DIR", it) }
+                        }
                     }
                     val cmd = WslPathResolver.buildWslNodeCommand(wslDistro, wslCwd, wslEnv, linuxBackend)
                     logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${cmd.joinToString(" ")}")
@@ -246,6 +261,11 @@ class NodeProcessManager(
                         if (webviewDir != null) {
                             put("WEBVIEW_DIR", webviewDir.absolutePath)
                         }
+                        // Self-cleanup of JAR-extracted temp dirs on clean exit (#120).
+                        // Set only for production extractions; absent in dev (source tree),
+                        // so the backend never deletes the source webview/dist or backend.mjs.
+                        extractedWebviewDir?.let { put("CLEANUP_TEMP_WEBVIEW_DIR", it.absolutePath) }
+                        extractedBackendDir?.let { put("CLEANUP_TEMP_BACKEND_DIR", it.absolutePath) }
                         // Dynamic port: backend binds an OS-assigned free port when this is 0
                         // and reports the real port via its PORT:{n} stdout line. Lets one
                         // backend per IDE project root coexist without a fixed-port clash (#57).
@@ -608,6 +628,8 @@ class NodeProcessManager(
                     }
                 }
                 logger.info("Extracted backend.mjs to: ${targetFile.absolutePath}")
+                // Production extraction only — mark this temp dir for self-cleanup (#120).
+                extractedBackendDir = tempDir
                 return targetFile
             }
 
@@ -715,6 +737,9 @@ class NodeProcessManager(
             }
 
             logger.info("Extracted WebView resources to: ${tempDir.absolutePath}")
+            // Production extraction only — mark this temp dir for self-cleanup (#120).
+            // (Dev mode returns the source webview/dist above and never reaches here.)
+            extractedWebviewDir = tempDir
             tempDir
         } catch (e: Exception) {
             logger.error("Failed to extract WebView resources", e)

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -169,7 +169,7 @@ export function ChatPage() {
   return (
     <div className="flex flex-col w-full h-screen bg-surface-base text-text-primary fixed left-0 top-0" onMouseDown={handleContainerMouseDown}>
       {/* Header - Minimal */}
-      <div className="fixed w-full top-0 bg-blend-darken bg-surface-base z-10">
+      <div className="fixed w-full top-0 bg-blend-darken bg-surface-base z-30">
         <SessionHeader />
       </div>
 


### PR DESCRIPTION
## Summary

Two fixes:

### 1. Issue #120 — orphaned temp dirs (`claude-code-webview-*`, `claude-code-backend-*`)
The plugin extracts its webview assets and `backend.mjs` from the JAR into OS temp dirs on startup, but never removed them on a clean shutdown — so a project that is not reopened left them behind forever (Windows `%TEMP%` is not purged on reboot).

**Correction to the report:** the issue blamed *session deletion*, but the temp dir is keyed **per project root** (`basePath.hashCode()`), not per session — session delete and these temp dirs are unrelated. The real defect was the missing teardown.

**Fix (Node self-cleans on its own clean exit):** the normal shutdown path detaches the process and Node self-exits once **every** WebSocket client (IDE JCEF + any browser) disconnects. A synchronous `process.on('exit')` hook `rmSync`s the exact temp dirs for this instance. Doing it at Node exit (not at IDE close) guarantees no live browser webview is served from a dir we just deleted.

- `cleanupExtractedTempDirs()` — pure, synchronous, best-effort per dir (a Windows self-lock on the running `backend.mjs` dir is swallowed so the webview dir is still cleaned).
- Kotlin passes `CLEANUP_TEMP_WEBVIEW_DIR` / `CLEANUP_TEMP_BACKEND_DIR` **only for production JAR extractions**; in dev mode these point at the source tree, so the vars are intentionally absent and the source is never touched.
- Does NOT scan tmpdir for sibling instanceTag folders — a concurrent project's active dir must survive.

### 2. Session dropdown see-through behind banners
The open session dropdown menu painted *behind* the top banners and showed through their translucent dark-theme backgrounds. Root cause was a stacking-context conflict: the dropdown (z-50) was trapped inside the header container (fixed z-10) while `BannerArea` is fixed z-20. Raised the header to z-30 so an opened dropdown overlays the banners.

## Verification
- backend unit tests (446 passed, incl. 6 new for `cleanupExtractedTempDirs`)
- real idle-shutdown run: connect → disconnect → 60s idle → `process.exit(0)` → temp dir GONE
- dropdown layering confirmed visually in standalone (dev) — dropdown opaquely overlays banners
- be-build / wv-lint / wv-build / Kotlin build all green

## Known limitations
- Force-kill / crash still leaves a dir behind (exit hook does not run); reclaimed by the existing same-tag overwrite on next start.
- Path-normalization of instanceTag (drive-letter case, WSL UNC variants) is NOT addressed here; tracked separately.
- **Not yet tested on Windows** — verified on macOS only.

Closes #120