### PR TITLE
feat: background dynamic workflows with live progress tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ignore/
 .gradle/
 build/
 !gradle/wrapper/gradle-wrapper.jar
+local.properties
 
 # IntelliJ
 out/

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -32,6 +32,16 @@ export function stopWorkflowsForSession(sessionId: string): void {
   workflowTracker?.stopRunning(sessionId);
 }
 
+/**
+ * Whether a workflow is still actually running in this process. Lets transcript
+ * reconstruction (on session load) keep a genuinely-running workflow as
+ * `running` while settling interrupted ones to `stopped` instead of resurrecting
+ * them as `running`.
+ */
+export function isWorkflowRunning(sessionId: string, toolUseId: string): boolean {
+  return workflowTracker?.isRunning(sessionId, toolUseId) ?? false;
+}
+
 // InputMode -> CLI --permission-mode flag mapping
 const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
   plan: 'plan',

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -22,6 +22,16 @@ function getWorkflowTracker(connections: ConnectionManager): WorkflowProgressTra
   return workflowTracker;
 }
 
+/**
+ * Settle a session's still-running background workflows as `stopped` and push a
+ * final update to the webview. Called when the user interrupts/stops generation
+ * — the CLI process stays alive, so a stopped workflow would otherwise never
+ * receive a terminal task_notification and hang on "running" in the panel.
+ */
+export function stopWorkflowsForSession(sessionId: string): void {
+  workflowTracker?.stopRunning(sessionId);
+}
+
 // InputMode -> CLI --permission-mode flag mapping
 const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
   plan: 'plan',

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -4,6 +4,7 @@ import { Claude } from './claude';
 import { diagnoseAuthError } from './features/auth-diagnosis';
 import { getStrippableAuthEnvKeys } from './features/claude-settings';
 import { EditedFileTracker } from './features/editedFileTracker';
+import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
 import { reportBackendError } from './features/telemetry';
 import { MessageType } from '../shared';
@@ -11,6 +12,15 @@ import { MessageType } from '../shared';
 // Tracks files Claude edits so the IDE can be told to reload them once the
 // edit completes on disk. Shared across sessions — tool_use ids are unique.
 const editedFileTracker = new EditedFileTracker();
+
+// Tracks background dynamic workflows and streams live progress to the webview.
+// Lazily created on the first stream event because it needs the (single,
+// process-lifetime) ConnectionManager to broadcast from its polling timers.
+let workflowTracker: WorkflowProgressTracker | null = null;
+function getWorkflowTracker(connections: ConnectionManager): WorkflowProgressTracker {
+  if (!workflowTracker) workflowTracker = WorkflowProgressTracker.create(connections);
+  return workflowTracker;
+}
 
 // InputMode -> CLI --permission-mode flag mapping
 const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
@@ -275,6 +285,7 @@ export async function ensureClaudeProcess(
 
       // 추적 정리
       sessionsWithResult.delete(targetSessionId);
+      workflowTracker?.stopSession(targetSessionId);
 
       connections.broadcastToSession(targetSessionId, MessageType.STREAM_END);
 
@@ -486,6 +497,10 @@ function handleStreamEvent(
       console.error('[node-backend]', 'Failed to refresh files in IDE:', err);
     });
   }
+
+  // Detect background dynamic workflows and stream their live progress. Pure
+  // side-effect — the raw CLI event is still forwarded unchanged below.
+  getWorkflowTracker(connections).handleEvent(targetSessionId, event);
 
   // 백엔드 고유 사이드이펙트 (WebView 전달과 무관한 서버 내부 로직)
   if (eventType === 'result') {

--- a/backend/src/core/features/__tests__/workflow-tracker.test.ts
+++ b/backend/src/core/features/__tests__/workflow-tracker.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { reconstructWorkflowTasks } from '../workflow-tracker';
+
+let dir: string;
+let transcriptDir: string;
+
+beforeAll(() => {
+  dir = mkdtempSync(join(tmpdir(), 'wf-test-'));
+  transcriptDir = join(dir, 'subagents', 'workflows', 'wf_abc123-def');
+  mkdirSync(transcriptDir, { recursive: true });
+
+  // journal: agent a1 done (with topic), agent a2 still running
+  const journal = [
+    JSON.stringify({ type: 'started', key: 'k1', agentId: 'a1' }),
+    JSON.stringify({ type: 'started', key: 'k2', agentId: 'a2' }),
+    JSON.stringify({ type: 'result', key: 'k1', agentId: 'a1', result: { topic: 'океан', fact: '…' } }),
+  ].join('\n');
+  writeFileSync(join(transcriptDir, 'journal.jsonl'), journal);
+
+  // agent a1 transcript: one assistant turn with usage + a tool_use, spanning 7s
+  const a1 = [
+    JSON.stringify({ type: 'user', timestamp: '2026-01-01T00:00:00.000Z', message: { role: 'user', content: 'go' } }),
+    JSON.stringify({
+      type: 'assistant',
+      timestamp: '2026-01-01T00:00:07.000Z',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't', name: 'Bash', input: {} }],
+        usage: { input_tokens: 15781, cache_creation_input_tokens: 18515, cache_read_input_tokens: 0, output_tokens: 244 },
+      },
+    }),
+  ].join('\n');
+  writeFileSync(join(transcriptDir, 'agent-a1.jsonl'), a1);
+
+  // agent a2 transcript: running, no usage yet
+  writeFileSync(
+    join(transcriptDir, 'agent-a2.jsonl'),
+    JSON.stringify({ type: 'user', timestamp: '2026-01-01T00:00:01.000Z', message: { role: 'user', content: 'go' } }),
+  );
+});
+
+afterAll(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function messages() {
+  const launched =
+    `Workflow launched in background. Task ID: w1\n` +
+    `Summary: demo\n` +
+    `Transcript dir: ${transcriptDir}\n` +
+    `Script file: ${transcriptDir}/script.js`;
+  const notif = [
+    '<task-notification>',
+    '<task-id>w1</task-id>',
+    '<tool-use-id>toolu_1</tool-use-id>',
+    `<output-file>${dir}/tasks/w1.output</output-file>`,
+    '<status>completed</status>',
+    '<summary>Dynamic workflow "demo" completed</summary>',
+    '<result>{"ok":true}</result>',
+    '<usage><agent_count>2</agent_count><subagent_tokens>68760</subagent_tokens><tool_uses>1</tool_uses><duration_ms>7000</duration_ms></usage>',
+    '</task-notification>',
+  ].join('\n');
+
+  return [
+    {
+      type: 'assistant',
+      timestamp: '2026-01-01T00:00:00.000Z',
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool_use',
+            id: 'toolu_1',
+            name: 'Workflow',
+            input: { description: 'demo', script: "export const meta = { name: 'demo-flow', phases: [{ title: 'Phase 1' }] }" },
+          },
+        ],
+      },
+    },
+    {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: launched }] },
+    },
+    { type: 'user', message: { role: 'user', content: notif } },
+  ] as Array<Record<string, unknown>>;
+}
+
+describe('reconstructWorkflowTasks', () => {
+  it('rebuilds a finished workflow with agents, phases, status and usage', async () => {
+    const tasks = await reconstructWorkflowTasks(messages());
+    expect(tasks).toHaveLength(1);
+    const t = tasks[0];
+
+    expect(t.toolUseId).toBe('toolu_1');
+    expect(t.name).toBe('demo-flow');
+    expect(t.taskId).toBe('w1');
+    expect(t.workflowId).toBe('wf_abc123-def');
+    expect(t.transcriptDir).toBe(transcriptDir);
+    expect(t.status).toBe('completed');
+    expect(t.summary).toContain('completed');
+    expect(t.result).toBe('{"ok":true}');
+    expect(t.phases).toEqual([{ title: 'Phase 1' }]);
+    expect(t.usage).toMatchObject({ agentCount: 2, subagentTokens: 68760, toolUses: 1, durationMs: 7000 });
+
+    // agents aggregated from transcript files
+    expect(t.agents).toHaveLength(2);
+    const a1 = t.agents.find((a) => a.agentId === 'a1')!;
+    expect(a1.status).toBe('done');
+    expect(a1.label).toBe('океан'); // derived from journal result.topic
+    expect(a1.tokens).toBe(15781 + 18515 + 244); // input + cache_creation + output
+    expect(a1.tools).toBe(1);
+    expect(a1.durationMs).toBe(7000);
+
+    const a2 = t.agents.find((a) => a.agentId === 'a2')!;
+    expect(a2.status).toBe('running');
+  });
+
+  it('returns [] when there is no Workflow tool_use', async () => {
+    const tasks = await reconstructWorkflowTasks([
+      { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },
+    ]);
+    expect(tasks).toEqual([]);
+  });
+});

--- a/backend/src/core/features/__tests__/workflow-tracker.test.ts
+++ b/backend/src/core/features/__tests__/workflow-tracker.test.ts
@@ -22,7 +22,8 @@ beforeAll(() => {
   ].join('\n');
   writeFileSync(join(transcriptDir, 'journal.jsonl'), journal);
 
-  // agent a1 transcript: one assistant turn with usage + a tool_use, spanning 7s
+  // agent a1 transcript: one assistant turn with usage + a tool_use, spanning 7s.
+  // cache_read dominates real subagent turns (context reuse), so it must be counted.
   const a1 = [
     JSON.stringify({ type: 'user', timestamp: '2026-01-01T00:00:00.000Z', message: { role: 'user', content: 'go' } }),
     JSON.stringify({
@@ -31,7 +32,7 @@ beforeAll(() => {
       message: {
         role: 'assistant',
         content: [{ type: 'tool_use', id: 't', name: 'Bash', input: {} }],
-        usage: { input_tokens: 15781, cache_creation_input_tokens: 18515, cache_read_input_tokens: 0, output_tokens: 244 },
+        usage: { input_tokens: 15781, cache_creation_input_tokens: 18515, cache_read_input_tokens: 50000, output_tokens: 244 },
       },
     }),
   ].join('\n');
@@ -112,7 +113,7 @@ describe('reconstructWorkflowTasks', () => {
     const a1 = t.agents.find((a) => a.agentId === 'a1')!;
     expect(a1.status).toBe('done');
     expect(a1.label).toBe('океан'); // derived from journal result.topic
-    expect(a1.tokens).toBe(15781 + 18515 + 244); // input + cache_creation + output
+    expect(a1.tokens).toBe(15781 + 18515 + 50000 + 244); // input + cache_creation + cache_read + output
     expect(a1.tools).toBe(1);
     expect(a1.durationMs).toBe(7000);
 

--- a/backend/src/core/features/__tests__/workflow-tracker.test.ts
+++ b/backend/src/core/features/__tests__/workflow-tracker.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { reconstructWorkflowTasks } from '../workflow-tracker';
+import { reconstructWorkflowTasks, WorkflowProgressTracker } from '../workflow-tracker';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { WorkflowTask } from '../../../shared';
 
 let dir: string;
 let transcriptDir: string;
@@ -123,5 +125,71 @@ describe('reconstructWorkflowTasks', () => {
       { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },
     ]);
     expect(tasks).toEqual([]);
+  });
+});
+
+describe('WorkflowProgressTracker stop handling', () => {
+  /** Capture WORKFLOW_PROGRESS broadcasts into a flat list. */
+  function makeTracker() {
+    const broadcasts: WorkflowTask[] = [];
+    const connections = {
+      broadcastToSession: (_sessionId: string, _type: string, payload: Record<string, unknown>) => {
+        broadcasts.push(JSON.parse(JSON.stringify(payload)) as WorkflowTask);
+      },
+    } as unknown as ConnectionManager;
+    const tracker = WorkflowProgressTracker.create(connections);
+    return { tracker, broadcasts, last: () => broadcasts[broadcasts.length - 1] };
+  }
+
+  const startedEvent = {
+    type: 'system',
+    subtype: 'task_started',
+    tool_use_id: 'toolu_1',
+    task_id: 'w1',
+    workflow_name: 'demo-flow',
+  };
+
+  it('settles a running workflow as stopped on interrupt (stopRunning) and broadcasts it', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    expect(last().status).toBe('running');
+
+    tracker.stopRunning('s1');
+    const t = last();
+    expect(t.status).toBe('stopped');
+    expect(t.endedAt).toBeGreaterThan(0);
+    expect(t.usage?.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does not overwrite a completed workflow when stopped afterwards', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    tracker.handleEvent('s1', {
+      type: 'system',
+      subtype: 'task_notification',
+      tool_use_id: 'toolu_1',
+      status: 'completed',
+    });
+    expect(last().status).toBe('completed');
+
+    tracker.stopRunning('s1');
+    expect(last().status).toBe('completed');
+  });
+
+  it('only touches workflows of the targeted session', () => {
+    const { tracker, broadcasts } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    tracker.handleEvent('s2', { ...startedEvent, tool_use_id: 'toolu_2' });
+
+    tracker.stopRunning('s1');
+    const s2 = broadcasts.filter((b) => b.toolUseId === 'toolu_2');
+    expect(s2.every((b) => b.status === 'running')).toBe(true);
+  });
+
+  it('settles still-running workflows on process close (stopSession)', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    tracker.stopSession('s1');
+    expect(last().status).toBe('stopped');
   });
 });

--- a/backend/src/core/features/__tests__/workflow-tracker.test.ts
+++ b/backend/src/core/features/__tests__/workflow-tracker.test.ts
@@ -117,8 +117,10 @@ describe('reconstructWorkflowTasks', () => {
     expect(a1.tools).toBe(1);
     expect(a1.durationMs).toBe(7000);
 
+    // a2 has no journal result, but the workflow is completed (terminal), so it
+    // is settled to done — a finished card must not show pulsing running dots.
     const a2 = t.agents.find((a) => a.agentId === 'a2')!;
-    expect(a2.status).toBe('running');
+    expect(a2.status).toBe('done');
   });
 
   it('returns [] when there is no Workflow tool_use', async () => {
@@ -126,6 +128,53 @@ describe('reconstructWorkflowTasks', () => {
       { type: 'assistant', message: { role: 'assistant', content: [{ type: 'text', text: 'hi' }] } },
     ]);
     expect(tasks).toEqual([]);
+  });
+
+  // A workflow whose transcript has no terminal <task-notification> (interrupted,
+  // or its final event was lost). Without the live check it would be resurrected
+  // as 'running' on every reload — the bug this guards against.
+  function messagesWithoutNotification() {
+    const launched = `Workflow launched in background. Task ID: w1\nTranscript dir: ${transcriptDir}`;
+    return [
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'tool_use', id: 'toolu_x', name: 'Workflow', input: { description: 'demo' } }],
+        },
+      },
+      {
+        type: 'user',
+        message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_x', content: launched }] },
+      },
+    ] as Array<Record<string, unknown>>;
+  }
+
+  it('settles a notification-less workflow to stopped when it is not live', async () => {
+    const tasks = await reconstructWorkflowTasks(messagesWithoutNotification(), () => false);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe('stopped');
+    // No agent stays running, but an interrupted one (a2, no journal result)
+    // goes grey 'stopped' — never green 'done'. a1 finished, so it stays done.
+    expect(tasks[0].agents.some((a) => a.status === 'running')).toBe(false);
+    expect(tasks[0].agents.find((a) => a.agentId === 'a1')!.status).toBe('done');
+    expect(tasks[0].agents.find((a) => a.agentId === 'a2')!.status).toBe('stopped');
+  });
+
+  it('keeps a live workflow\'s unfinished agents running', async () => {
+    const tasks = await reconstructWorkflowTasks(messagesWithoutNotification(), () => true);
+    expect(tasks[0].status).toBe('running');
+    expect(tasks[0].agents.some((a) => a.status === 'running')).toBe(true);
+  });
+
+  it('keeps a notification-less workflow running when it is still live', async () => {
+    const tasks = await reconstructWorkflowTasks(messagesWithoutNotification(), (id) => id === 'toolu_x');
+    expect(tasks[0].status).toBe('running');
+  });
+
+  it('defaults a notification-less workflow to stopped when no live check is given', async () => {
+    const tasks = await reconstructWorkflowTasks(messagesWithoutNotification());
+    expect(tasks[0].status).toBe('stopped');
   });
 });
 
@@ -192,5 +241,15 @@ describe('WorkflowProgressTracker stop handling', () => {
     tracker.handleEvent('s1', startedEvent);
     tracker.stopSession('s1');
     expect(last().status).toBe('stopped');
+  });
+
+  it('isRunning reflects live state and flips off once stopped', () => {
+    const { tracker } = makeTracker();
+    expect(tracker.isRunning('s1', 'toolu_1')).toBe(false); // unknown
+    tracker.handleEvent('s1', startedEvent);
+    expect(tracker.isRunning('s1', 'toolu_1')).toBe(true);
+    expect(tracker.isRunning('s2', 'toolu_1')).toBe(false); // wrong session
+    tracker.stopRunning('s1');
+    expect(tracker.isRunning('s1', 'toolu_1')).toBe(false);
   });
 });

--- a/backend/src/core/features/workflow-tracker.ts
+++ b/backend/src/core/features/workflow-tracker.ts
@@ -129,9 +129,11 @@ interface AgentStats {
 
 /**
  * Compute a subagent's stats from its transcript. Tokens are the last assistant
- * turn's billed input + cache-creation + output (matches the official UI's
- * order of magnitude); tools = count of tool_use blocks; duration = span of
- * timestamps. Approximate by design — see the file header limitation note.
+ * turn's full context — input + cache-creation + cache-read + output — which
+ * matches the live `task_progress` per-agent figure (cache-read dominates a
+ * subagent's turn via context reuse, so it must be counted, else reload reads
+ * ~30x low). tools = count of tool_use blocks; duration = span of timestamps.
+ * Approximate by design — see the file header limitation note.
  */
 async function computeAgentStats(file: string): Promise<AgentStats> {
   if (!existsSync(file)) return { tokens: 0, tools: 0, durationMs: 0 };
@@ -164,7 +166,10 @@ async function computeAgentStats(file: string): Promise<AgentStats> {
     }
   }
   const tokens = lastUsage
-    ? num(lastUsage['input_tokens']) + num(lastUsage['cache_creation_input_tokens']) + num(lastUsage['output_tokens'])
+    ? num(lastUsage['input_tokens']) +
+      num(lastUsage['cache_creation_input_tokens']) +
+      num(lastUsage['cache_read_input_tokens']) +
+      num(lastUsage['output_tokens'])
     : 0;
   const durationMs = firstTs !== undefined && lastTs !== undefined ? lastTs - firstTs : 0;
   return { tokens, tools, durationMs };

--- a/backend/src/core/features/workflow-tracker.ts
+++ b/backend/src/core/features/workflow-tracker.ts
@@ -478,10 +478,41 @@ export class WorkflowProgressTracker {
     );
   }
 
+  /**
+   * Settle a still-running workflow as `stopped` and push a final update.
+   * No-op once the workflow has reached a terminal status (completed/failed/
+   * stopped), so a normal `task_notification` finish is never overwritten.
+   */
+  private settleStopped(entry: WatchEntry): void {
+    if (entry.task.status !== 'running') return;
+    const t = entry.task;
+    t.status = 'stopped';
+    t.endedAt = Date.now();
+    for (const a of t.agents) if (a.status !== 'done') a.status = 'done';
+    t.usage = { ...t.usage, durationMs: t.usage?.durationMs ?? t.endedAt - t.startedAt };
+    this.broadcast(entry);
+  }
+
+  /**
+   * Settle every still-running workflow of a session as `stopped` (e.g. the user
+   * interrupted generation). Entries are KEPT — the CLI process is still alive,
+   * so the panel keeps showing them under "Finished" rather than dropping them.
+   */
+  stopRunning(sessionId: string): void {
+    for (const entry of this.entries.values()) {
+      if (entry.sessionId === sessionId) this.settleStopped(entry);
+    }
+  }
+
   /** Forget all workflows for a session (on CLI process close). */
   stopSession(sessionId: string): void {
     for (const [key, entry] of this.entries) {
-      if (entry.sessionId === sessionId) this.entries.delete(key);
+      if (entry.sessionId !== sessionId) continue;
+      // The process is gone, so a still-running workflow can never reach a
+      // terminal task_notification — settle + broadcast it as stopped before
+      // dropping the entry, otherwise the webview hangs it on "running" forever.
+      this.settleStopped(entry);
+      this.entries.delete(key);
     }
   }
 }

--- a/backend/src/core/features/workflow-tracker.ts
+++ b/backend/src/core/features/workflow-tracker.ts
@@ -1,0 +1,506 @@
+/**
+ * Tracks background dynamic workflows and streams live progress to the webview.
+ *
+ * Two data sources, because the runtime exposes the workflow differently live
+ * vs. on reload:
+ *
+ * 1. LIVE — the CLI stdout stream emits rich `{type:'system', subtype:'task_*'}`
+ *    events: `task_started` (id, name, script), `task_progress` (a
+ *    `workflow_progress[]` array of per-agent objects with label, phase, state,
+ *    tokens, toolCalls, durationMs) and `task_notification` (final status,
+ *    output_file, usage). We translate these straight into a {@link WorkflowTask}
+ *    and broadcast WORKFLOW_PROGRESS. These system events are NOT persisted.
+ *
+ * 2. RELOAD — {@link reconstructWorkflowTasks} rebuilds finished workflows from
+ *    the persisted transcript (Workflow tool_use + immediate tool_result + the
+ *    `<task-notification>` user message) plus the on-disk runtime files
+ *    (`journal.jsonl` + per-agent `agent-<id>.jsonl`). Here agent labels are
+ *    best-effort (derived from results) and tokens are approximated, since the
+ *    structured live events aren't available.
+ */
+
+import { join } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import type { ConnectionManager } from '../../ws/connection-manager';
+import { MessageType } from '../../shared';
+import type {
+  WorkflowTask,
+  WorkflowAgent,
+  WorkflowPhase,
+  WorkflowStatus,
+} from '../../shared';
+import { readJsonlEntries } from './readJsonlEntries';
+
+/** Live agent `state` values that count as finished. */
+const AGENT_DONE_STATES = new Set(['done', 'completed', 'success']);
+
+interface WatchEntry {
+  sessionId: string;
+  task: WorkflowTask;
+  /**
+   * Accumulated agents keyed by their stable slot `phaseIndex:index`.
+   * `task_progress` events are deltas (only the changed agent), and `agentId`
+   * is the runtime instance — it changes when a slot is retried/rerun — so we
+   * key by slot and MERGE fields, then rebuild `task.agents` ordered by slot.
+   */
+  agents: Map<string, { order: number; agent: WorkflowAgent }>;
+  lastSerialized?: string;
+}
+
+// ── event parsing helpers ────────────────────────────────────
+
+function getContentBlocks(event: Record<string, unknown>): Array<Record<string, unknown>> {
+  const message = event['message'] as { content?: unknown } | undefined;
+  const content = message?.content;
+  return Array.isArray(content) ? (content as Array<Record<string, unknown>>) : [];
+}
+
+/** Plain text of a user event whose content is a string or text-block array. */
+function getEventText(event: Record<string, unknown>): string {
+  const message = event['message'] as { content?: unknown } | undefined;
+  const content = message?.content;
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => {
+        const block = b as Record<string, unknown>;
+        return block['type'] === 'text' && typeof block['text'] === 'string' ? (block['text'] as string) : '';
+      })
+      .join('');
+  }
+  return '';
+}
+
+function parseXmlTag(text: string, tag: string): string | undefined {
+  const match = text.match(new RegExp(`<${tag}>(.*?)</${tag}>`, 's'));
+  return match?.[1]?.trim();
+}
+
+function toInt(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function parseMetaName(script: string | undefined): string | undefined {
+  if (!script) return undefined;
+  return script.match(/name\s*:\s*['"]([^'"]+)['"]/)?.[1];
+}
+
+/** Best-effort parse of `meta.phases: [{ title, detail }]` from the script. */
+function parseMetaPhases(script: string | undefined): WorkflowPhase[] {
+  if (!script) return [];
+  const block = script.match(/phases\s*:\s*\[([\s\S]*?)\]/)?.[1];
+  if (!block) return [];
+  const phases: WorkflowPhase[] = [];
+  for (const obj of block.match(/\{[^}]*\}/g) ?? []) {
+    const title = obj.match(/title\s*:\s*['"]([^'"]+)['"]/)?.[1];
+    if (!title) continue;
+    const detail = obj.match(/detail\s*:\s*['"]([^'"]+)['"]/)?.[1];
+    phases.push(detail ? { title, detail } : { title });
+  }
+  return phases;
+}
+
+function scriptPathName(scriptPath: string | undefined): string | undefined {
+  if (!scriptPath) return undefined;
+  const base = scriptPath.split(/[\\/]/).pop() ?? scriptPath;
+  return base.replace(/\.[cm]?[jt]s$/i, '');
+}
+
+/** Parse the immediate "launched in background" tool_result text. */
+function parseImmediateResult(text: string): { taskId?: string; transcriptDir?: string } {
+  const taskId = text.match(/Task ID:\s*(\S+)/)?.[1];
+  const transcriptDir = text.match(/Transcript dir:\s*(.+)/)?.[1]?.trim();
+  return { taskId, transcriptDir };
+}
+
+function num(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+// ── per-agent stat computation ───────────────────────────────
+
+interface AgentStats {
+  tokens: number;
+  tools: number;
+  durationMs: number;
+}
+
+/**
+ * Compute a subagent's stats from its transcript. Tokens are the last assistant
+ * turn's billed input + cache-creation + output (matches the official UI's
+ * order of magnitude); tools = count of tool_use blocks; duration = span of
+ * timestamps. Approximate by design — see the file header limitation note.
+ */
+async function computeAgentStats(file: string): Promise<AgentStats> {
+  if (!existsSync(file)) return { tokens: 0, tools: 0, durationMs: 0 };
+  let entries;
+  try {
+    entries = await readJsonlEntries(file);
+  } catch {
+    return { tokens: 0, tools: 0, durationMs: 0 };
+  }
+  let tools = 0;
+  let firstTs: number | undefined;
+  let lastTs: number | undefined;
+  let lastUsage: Record<string, unknown> | undefined;
+  for (const entry of entries) {
+    const ts = entry['timestamp'];
+    if (typeof ts === 'string') {
+      const t = Date.parse(ts);
+      if (Number.isFinite(t)) {
+        if (firstTs === undefined) firstTs = t;
+        lastTs = t;
+      }
+    }
+    const message = entry['message'] as { content?: unknown; usage?: unknown } | undefined;
+    const content = message?.content;
+    if (Array.isArray(content)) {
+      tools += content.filter((b) => (b as Record<string, unknown>)['type'] === 'tool_use').length;
+    }
+    if (message?.usage && typeof message.usage === 'object') {
+      lastUsage = message.usage as Record<string, unknown>;
+    }
+  }
+  const tokens = lastUsage
+    ? num(lastUsage['input_tokens']) + num(lastUsage['cache_creation_input_tokens']) + num(lastUsage['output_tokens'])
+    : 0;
+  const durationMs = firstTs !== undefined && lastTs !== undefined ? lastTs - firstTs : 0;
+  return { tokens, tools, durationMs };
+}
+
+/** Derive a display label from an agent's journal result (best-effort). */
+function deriveLabel(result: unknown, agentId: string): string {
+  if (result && typeof result === 'object') {
+    const topic = (result as Record<string, unknown>)['topic'];
+    if (typeof topic === 'string' && topic.trim()) return topic.trim();
+  }
+  return agentId.slice(0, 8);
+}
+
+/**
+ * Aggregate per-agent progress for a workflow by reading its journal + agent
+ * transcripts. Shared by the live poller and the historical reconstruction.
+ */
+async function aggregateAgents(transcriptDir: string): Promise<WorkflowAgent[]> {
+  if (!existsSync(transcriptDir)) return [];
+  const journalPath = join(transcriptDir, 'journal.jsonl');
+  if (!existsSync(journalPath)) return [];
+
+  let journal;
+  try {
+    journal = await readJsonlEntries(journalPath);
+  } catch {
+    return [];
+  }
+
+  const order: string[] = [];
+  const results = new Map<string, unknown>();
+  for (const rec of journal) {
+    const agentId = rec['agentId'];
+    if (typeof agentId !== 'string') continue;
+    if (rec['type'] === 'started' && !order.includes(agentId)) order.push(agentId);
+    if (rec['type'] === 'result') {
+      results.set(agentId, rec['result']);
+      if (!order.includes(agentId)) order.push(agentId);
+    }
+  }
+
+  const agents: WorkflowAgent[] = [];
+  for (const agentId of order) {
+    const stats = await computeAgentStats(join(transcriptDir, `agent-${agentId}.jsonl`));
+    agents.push({
+      agentId,
+      label: deriveLabel(results.get(agentId), agentId),
+      status: results.has(agentId) ? 'done' : 'running',
+      tokens: stats.tokens,
+      tools: stats.tools,
+      durationMs: stats.durationMs,
+    });
+  }
+  return agents;
+}
+
+/** Apply a `<task-notification>` envelope's fields onto a task (no I/O). */
+function applyNotification(task: WorkflowTask, text: string): void {
+  const usageBlock = parseXmlTag(text, 'usage') ?? '';
+  const status = parseXmlTag(text, 'status') as WorkflowStatus | undefined;
+  task.status = status ?? 'completed';
+  task.summary = parseXmlTag(text, 'summary');
+  task.result = parseXmlTag(text, 'result');
+  task.outputFile = parseXmlTag(text, 'output-file');
+  task.taskId = task.taskId ?? parseXmlTag(text, 'task-id');
+  task.usage = {
+    agentCount: toInt(parseXmlTag(usageBlock, 'agent_count')),
+    subagentTokens: toInt(parseXmlTag(usageBlock, 'subagent_tokens')),
+    toolUses: toInt(parseXmlTag(usageBlock, 'tool_uses')),
+    durationMs: toInt(parseXmlTag(usageBlock, 'duration_ms')),
+  };
+}
+
+function eventTimestamp(event: Record<string, unknown>): number {
+  const ts = event['timestamp'];
+  if (typeof ts === 'string') {
+    const t = Date.parse(ts);
+    if (Number.isFinite(t)) return t;
+  }
+  return 0;
+}
+
+/**
+ * Reconstruct finished/running workflows from a loaded session transcript so the
+ * Background tasks panel and inline cards populate on reload (the live stream is
+ * not replayed). Scans for the Workflow tool_use, its immediate tool_result
+ * (transcript dir) and the `<task-notification>`, then aggregates agent stats
+ * from the runtime files on disk.
+ */
+export async function reconstructWorkflowTasks(
+  messages: Array<Record<string, unknown>>,
+): Promise<WorkflowTask[]> {
+  const tasks = new Map<string, WorkflowTask>();
+
+  for (const msg of messages) {
+    if (msg['type'] !== 'assistant') continue;
+    for (const block of getContentBlocks(msg)) {
+      if (block['type'] !== 'tool_use' || block['name'] !== 'Workflow') continue;
+      const toolUseId = block['id'];
+      if (typeof toolUseId !== 'string' || tasks.has(toolUseId)) continue;
+      const input = (block['input'] as Record<string, unknown> | undefined) ?? {};
+      const script = typeof input['script'] === 'string' ? (input['script'] as string) : undefined;
+      const scriptPath = typeof input['scriptPath'] === 'string' ? (input['scriptPath'] as string) : undefined;
+      const description = typeof input['description'] === 'string' ? (input['description'] as string) : undefined;
+      tasks.set(toolUseId, {
+        toolUseId,
+        name: parseMetaName(script) || scriptPathName(scriptPath) || description || 'workflow',
+        description,
+        status: 'running',
+        startedAt: eventTimestamp(msg),
+        phases: parseMetaPhases(script),
+        agents: [],
+      });
+    }
+  }
+
+  if (tasks.size === 0) return [];
+
+  for (const msg of messages) {
+    if (msg['type'] !== 'user') continue;
+    for (const block of getContentBlocks(msg)) {
+      if (block['type'] !== 'tool_result') continue;
+      const toolUseId = block['tool_use_id'];
+      if (typeof toolUseId !== 'string') continue;
+      const task = tasks.get(toolUseId);
+      if (!task || task.transcriptDir) continue;
+      const content = block['content'];
+      const text = typeof content === 'string' ? content : getEventText(msg);
+      const { taskId, transcriptDir } = parseImmediateResult(text);
+      if (transcriptDir) {
+        task.taskId = taskId ?? task.taskId;
+        task.transcriptDir = transcriptDir;
+        task.workflowId = transcriptDir.split(/[\\/]/).pop();
+      }
+    }
+    const text = getEventText(msg);
+    if (text.includes('<task-notification>')) {
+      const toolUseId = parseXmlTag(text, 'tool-use-id');
+      const task = toolUseId ? tasks.get(toolUseId) : undefined;
+      if (task) applyNotification(task, text);
+    }
+  }
+
+  for (const task of tasks.values()) {
+    if (task.transcriptDir) {
+      task.agents = await aggregateAgents(task.transcriptDir);
+    }
+  }
+
+  return [...tasks.values()];
+}
+
+// ── the tracker ──────────────────────────────────────────────
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v ? v : undefined;
+}
+
+export class WorkflowProgressTracker {
+  /** key = `${sessionId}::${toolUseId}` */
+  private readonly entries = new Map<string, WatchEntry>();
+
+  private constructor(private readonly connections: ConnectionManager) {}
+
+  static create(connections: ConnectionManager): WorkflowProgressTracker {
+    return new WorkflowProgressTracker(connections);
+  }
+
+  /** Feed every CLI stream event here (side-effect only; never throws). */
+  handleEvent(sessionId: string, event: Record<string, unknown>): void {
+    try {
+      if (event['type'] !== 'system') return;
+      const subtype = event['subtype'];
+      if (subtype === 'task_started') this.onStarted(sessionId, event);
+      else if (subtype === 'task_progress' || subtype === 'task_updated') this.onProgress(sessionId, event);
+      else if (subtype === 'task_notification') this.onNotification(sessionId, event);
+    } catch (err) {
+      console.error('[node-backend]', 'workflow-tracker handleEvent failed:', err);
+    }
+  }
+
+  private key(sessionId: string, toolUseId: string): string {
+    return `${sessionId}::${toolUseId}`;
+  }
+
+  private ensureEntry(sessionId: string, toolUseId: string): WatchEntry {
+    const key = this.key(sessionId, toolUseId);
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = {
+        sessionId,
+        task: { toolUseId, name: 'workflow', status: 'running', startedAt: Date.now(), phases: [], agents: [] },
+        agents: new Map(),
+      };
+      this.entries.set(key, entry);
+    }
+    return entry;
+  }
+
+  private onStarted(sessionId: string, event: Record<string, unknown>): void {
+    const toolUseId = event['tool_use_id'];
+    if (typeof toolUseId !== 'string') return;
+    const entry = this.ensureEntry(sessionId, toolUseId);
+    const t = entry.task;
+    const prompt = typeof event['prompt'] === 'string' ? (event['prompt'] as string) : undefined;
+    if (typeof event['task_id'] === 'string') t.taskId = event['task_id'] as string;
+    const wfName = typeof event['workflow_name'] === 'string' ? (event['workflow_name'] as string) : '';
+    t.name = wfName || parseMetaName(prompt) || t.name;
+    if (typeof event['description'] === 'string') t.description = event['description'] as string;
+    if (t.phases.length === 0) t.phases = parseMetaPhases(prompt);
+    t.startedAt = Date.now();
+    this.broadcast(entry);
+  }
+
+  private onProgress(sessionId: string, event: Record<string, unknown>): void {
+    const toolUseId = event['tool_use_id'];
+    if (typeof toolUseId !== 'string') return;
+    const entry = this.ensureEntry(sessionId, toolUseId);
+    const t = entry.task;
+    if (typeof event['task_id'] === 'string') t.taskId = event['task_id'] as string;
+
+    const wp = event['workflow_progress'];
+    if (Array.isArray(wp)) {
+      // Merge each delta into its slot, keyed by the agent's global `index`
+      // (stable across retries/reruns, where `agentId` changes and `phaseIndex`
+      // may be absent on early "queued" deltas). Later deltas carry more
+      // complete state; empty fields fall back to the previously-seen value.
+      for (const raw of wp) {
+        if (!raw || typeof raw !== 'object') continue;
+        const a = raw as Record<string, unknown>;
+        const agentId0 = str(a['agentId']);
+        const label0 = str(a['label']);
+        // Skip pure placeholder deltas with no identity yet (no id and no label).
+        if (!agentId0 && !label0) continue;
+        const index = num(a['index']);
+        const slot = String(index);
+        const prev = entry.agents.get(slot)?.agent;
+        const state = str(a['state']);
+        const agentId = agentId0 ?? prev?.agentId ?? slot;
+        const agent: WorkflowAgent = {
+          agentId,
+          label: label0 ?? prev?.label ?? agentId.slice(0, 8),
+          status: state ? (AGENT_DONE_STATES.has(state) ? 'done' : 'running') : (prev?.status ?? 'running'),
+          tokens: a['tokens'] != null ? num(a['tokens']) : (prev?.tokens ?? 0),
+          tools: a['toolCalls'] != null ? num(a['toolCalls']) : (prev?.tools ?? 0),
+          durationMs: a['durationMs'] != null ? num(a['durationMs']) : (prev?.durationMs ?? 0),
+        };
+        entry.agents.set(slot, { order: index, agent });
+      }
+      t.agents = [...entry.agents.values()].sort((x, y) => x.order - y.order).map((v) => v.agent);
+    }
+
+    // Live workflow-level usage. Omit durationMs while running so the inline
+    // card's client-side timer keeps ticking; it is set on finalize.
+    const usage = event['usage'] as Record<string, unknown> | undefined;
+    if (usage) {
+      t.usage = {
+        agentCount: t.agents.length || undefined,
+        subagentTokens: num(usage['total_tokens']) || undefined,
+        toolUses: num(usage['tool_uses']) || undefined,
+      };
+    }
+    this.broadcast(entry);
+  }
+
+  private onNotification(sessionId: string, event: Record<string, unknown>): void {
+    const toolUseId = event['tool_use_id'];
+    if (typeof toolUseId !== 'string') return;
+    const entry = this.entries.get(this.key(sessionId, toolUseId));
+    if (!entry) return;
+    const t = entry.task;
+
+    const status = typeof event['status'] === 'string' ? (event['status'] as WorkflowStatus) : undefined;
+    t.status = status ?? 'completed';
+    // On a successful finish, any agent whose final "done" delta we missed is
+    // settled now — reflect that so the panel doesn't show stragglers as running.
+    if (t.status === 'completed') {
+      for (const a of t.agents) if (a.status !== 'done') a.status = 'done';
+    }
+    if (typeof event['summary'] === 'string') t.summary = event['summary'] as string;
+    if (typeof event['task_id'] === 'string') t.taskId = event['task_id'] as string;
+
+    const outputFile = typeof event['output_file'] === 'string' ? (event['output_file'] as string) : undefined;
+    if (outputFile) {
+      t.outputFile = outputFile;
+      const parsed = readOutputFile(outputFile);
+      if (parsed.summary && !event['summary']) t.summary = parsed.summary;
+      if (parsed.result !== undefined) t.result = parsed.result;
+    }
+
+    const usage = event['usage'] as Record<string, unknown> | undefined;
+    t.usage = {
+      agentCount: t.agents.length || num(usage?.['agent_count']) || undefined,
+      subagentTokens: num(usage?.['total_tokens']) || undefined,
+      toolUses: num(usage?.['tool_uses']) || undefined,
+      durationMs: num(usage?.['duration_ms']) || undefined,
+    };
+    t.endedAt = Date.now();
+    this.broadcast(entry);
+  }
+
+  private broadcast(entry: WatchEntry): void {
+    const serialized = JSON.stringify(entry.task);
+    if (serialized === entry.lastSerialized) return;
+    entry.lastSerialized = serialized;
+    this.connections.broadcastToSession(
+      entry.sessionId,
+      MessageType.WORKFLOW_PROGRESS,
+      entry.task as unknown as Record<string, unknown>,
+    );
+  }
+
+  /** Forget all workflows for a session (on CLI process close). */
+  stopSession(sessionId: string): void {
+    for (const [key, entry] of this.entries) {
+      if (entry.sessionId === sessionId) this.entries.delete(key);
+    }
+  }
+}
+
+/** Read a workflow task `.output` JSON file for its summary + result (best-effort). */
+function readOutputFile(path: string): { summary?: string; result?: string } {
+  try {
+    if (!existsSync(path)) return {};
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+    const summary = typeof parsed['summary'] === 'string' ? (parsed['summary'] as string) : undefined;
+    const rawResult = parsed['result'];
+    const result =
+      rawResult === undefined
+        ? undefined
+        : typeof rawResult === 'string'
+          ? rawResult
+          : JSON.stringify(rawResult, null, 2);
+    return { summary, result };
+  } catch {
+    return {};
+  }
+}

--- a/backend/src/core/features/workflow-tracker.ts
+++ b/backend/src/core/features/workflow-tracker.ts
@@ -244,6 +244,18 @@ function applyNotification(task: WorkflowTask, text: string): void {
   };
 }
 
+/**
+ * Settle still-running agents to match a terminal workflow status: a `completed`
+ * workflow finished them (→ `done`, green); a `stopped`/`failed` one cut them off
+ * (→ `stopped`, grey). Never paint an interrupted agent as a success. No-op while
+ * the workflow is still running.
+ */
+function settleAgents(agents: WorkflowAgent[], status: WorkflowStatus): void {
+  if (status === 'running') return;
+  const settled = status === 'completed' ? 'done' : 'stopped';
+  for (const a of agents) if (a.status === 'running') a.status = settled;
+}
+
 function eventTimestamp(event: Record<string, unknown>): number {
   const ts = event['timestamp'];
   if (typeof ts === 'string') {
@@ -259,9 +271,17 @@ function eventTimestamp(event: Record<string, unknown>): number {
  * not replayed). Scans for the Workflow tool_use, its immediate tool_result
  * (transcript dir) and the `<task-notification>`, then aggregates agent stats
  * from the runtime files on disk.
+ *
+ * `isLive(toolUseId)` reports whether the workflow is still actually running in
+ * this process (its live tracker entry exists and is `running`). A workflow with
+ * no terminal `<task-notification>` is otherwise indistinguishable from one that
+ * was interrupted — without this check reconstruction would resurrect a stopped
+ * workflow as `running` on every reload. When not live, such a workflow settles
+ * to `stopped`; the live stream still drives genuinely-running ones.
  */
 export async function reconstructWorkflowTasks(
   messages: Array<Record<string, unknown>>,
+  isLive?: (toolUseId: string) => boolean,
 ): Promise<WorkflowTask[]> {
   const tasks = new Map<string, WorkflowTask>();
 
@@ -279,7 +299,10 @@ export async function reconstructWorkflowTasks(
         toolUseId,
         name: parseMetaName(script) || scriptPathName(scriptPath) || description || 'workflow',
         description,
-        status: 'running',
+        // Default only — overwritten by applyNotification when a terminal
+        // <task-notification> exists. A workflow with no notification that is
+        // not live was interrupted, so it must not come back as 'running'.
+        status: isLive?.(toolUseId) ? 'running' : 'stopped',
         startedAt: eventTimestamp(msg),
         phases: parseMetaPhases(script),
         agents: [],
@@ -318,6 +341,10 @@ export async function reconstructWorkflowTasks(
     if (task.transcriptDir) {
       task.agents = await aggregateAgents(task.transcriptDir);
     }
+    // A terminal workflow has no running agents — settle any the journal left
+    // open (no `result` recorded) so a finished card doesn't show pulsing
+    // "running" dots after reload. Interrupted agents go grey, not green.
+    settleAgents(task.agents, task.status);
   }
 
   return [...tasks.values()];
@@ -445,11 +472,9 @@ export class WorkflowProgressTracker {
 
     const status = typeof event['status'] === 'string' ? (event['status'] as WorkflowStatus) : undefined;
     t.status = status ?? 'completed';
-    // On a successful finish, any agent whose final "done" delta we missed is
-    // settled now — reflect that so the panel doesn't show stragglers as running.
-    if (t.status === 'completed') {
-      for (const a of t.agents) if (a.status !== 'done') a.status = 'done';
-    }
+    // Settle stragglers whose final delta we missed: a completed workflow
+    // finished them (green); a stopped/failed one cut them off (grey).
+    settleAgents(t.agents, t.status);
     if (typeof event['summary'] === 'string') t.summary = event['summary'] as string;
     if (typeof event['task_id'] === 'string') t.taskId = event['task_id'] as string;
 
@@ -493,9 +518,19 @@ export class WorkflowProgressTracker {
     const t = entry.task;
     t.status = 'stopped';
     t.endedAt = Date.now();
-    for (const a of t.agents) if (a.status !== 'done') a.status = 'done';
+    settleAgents(t.agents, t.status);
     t.usage = { ...t.usage, durationMs: t.usage?.durationMs ?? t.endedAt - t.startedAt };
     this.broadcast(entry);
+  }
+
+  /**
+   * Whether a workflow is still actually running in this process — a live entry
+   * exists and has not reached a terminal status. Used by reconstruction to tell
+   * a genuinely-running workflow apart from a stopped one that lacks a terminal
+   * `<task-notification>` in the transcript.
+   */
+  isRunning(sessionId: string, toolUseId: string): boolean {
+    return this.entries.get(this.key(sessionId, toolUseId))?.task.status === 'running';
   }
 
   /**

--- a/backend/src/core/handlers/loadSession.ts
+++ b/backend/src/core/handlers/loadSession.ts
@@ -3,7 +3,7 @@ import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { loadSessionMessages } from '../features/loadSessionMessages';
 import { reconstructWorkflowTasks } from '../features/workflow-tracker';
-import { markSessionAsSpawned } from '../claude-process';
+import { markSessionAsSpawned, isWorkflowRunning } from '../claude-process';
 import { MessageType } from '../../shared';
 
 export async function loadSessionHandler(
@@ -37,7 +37,10 @@ export async function loadSessionHandler(
     // and the Background tasks panel populate on reload (the live progress
     // stream is not replayed). Best-effort — never blocks the session load.
     try {
-      const workflows = await reconstructWorkflowTasks(messages as Array<Record<string, unknown>>);
+      const workflows = await reconstructWorkflowTasks(
+        messages as Array<Record<string, unknown>>,
+        (toolUseId) => isWorkflowRunning(sessionId, toolUseId),
+      );
       for (const task of workflows) {
         connections.sendTo(
           connectionId,

--- a/backend/src/core/handlers/loadSession.ts
+++ b/backend/src/core/handlers/loadSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { loadSessionMessages } from '../features/loadSessionMessages';
+import { reconstructWorkflowTasks } from '../features/workflow-tracker';
 import { markSessionAsSpawned } from '../claude-process';
 import { MessageType } from '../../shared';
 
@@ -31,6 +32,22 @@ export async function loadSessionHandler(
       sessionId,
       messages,
     });
+
+    // Rebuild background-workflow state from the transcript so the inline cards
+    // and the Background tasks panel populate on reload (the live progress
+    // stream is not replayed). Best-effort — never blocks the session load.
+    try {
+      const workflows = await reconstructWorkflowTasks(messages as Array<Record<string, unknown>>);
+      for (const task of workflows) {
+        connections.sendTo(
+          connectionId,
+          MessageType.WORKFLOW_PROGRESS,
+          task as unknown as Record<string, unknown>,
+        );
+      }
+    } catch (err) {
+      console.error('[node-backend]', 'workflow reconstruction failed:', err);
+    }
   }
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });
 }

--- a/backend/src/core/handlers/reclaimSession.ts
+++ b/backend/src/core/handlers/reclaimSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { loadSessionMessages } from '../features/loadSessionMessages';
+import { reconstructWorkflowTasks } from '../features/workflow-tracker';
 import { markSessionAsSpawned } from '../claude-process';
 import { MessageType } from '../../shared';
 
@@ -48,6 +49,20 @@ export async function reclaimSessionHandler(
     sessionId,
     messages,
   });
+
+  // Rebuild background-workflow state from the transcript (see loadSession).
+  try {
+    const workflows = await reconstructWorkflowTasks(messages as Array<Record<string, unknown>>);
+    for (const task of workflows) {
+      connections.sendTo(
+        connectionId,
+        MessageType.WORKFLOW_PROGRESS,
+        task as unknown as Record<string, unknown>,
+      );
+    }
+  } catch (err) {
+    console.error('[node-backend]', 'workflow reconstruction failed:', err);
+  }
 
   console.error('[node-backend]', `Session ${sessionId} reclaimed successfully`);
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });

--- a/backend/src/core/handlers/reclaimSession.ts
+++ b/backend/src/core/handlers/reclaimSession.ts
@@ -3,7 +3,7 @@ import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { loadSessionMessages } from '../features/loadSessionMessages';
 import { reconstructWorkflowTasks } from '../features/workflow-tracker';
-import { markSessionAsSpawned } from '../claude-process';
+import { markSessionAsSpawned, isWorkflowRunning } from '../claude-process';
 import { MessageType } from '../../shared';
 
 export async function reclaimSessionHandler(
@@ -52,7 +52,10 @@ export async function reclaimSessionHandler(
 
   // Rebuild background-workflow state from the transcript (see loadSession).
   try {
-    const workflows = await reconstructWorkflowTasks(messages as Array<Record<string, unknown>>);
+    const workflows = await reconstructWorkflowTasks(
+      messages as Array<Record<string, unknown>>,
+      (toolUseId) => isWorkflowRunning(sessionId, toolUseId),
+    );
     for (const task of workflows) {
       connections.sendTo(
         connectionId,

--- a/backend/src/core/handlers/stopGeneration.ts
+++ b/backend/src/core/handlers/stopGeneration.ts
@@ -1,7 +1,7 @@
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
-import { sendInterruptToProcess } from '../claude-process';
+import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
 import { MessageType } from '../../shared';
 
 export function stopGenerationHandler(
@@ -21,6 +21,9 @@ export function stopGenerationHandler(
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
         session.process.kill('SIGTERM');
       }
+      // Settle any background workflows the interrupt just cancelled so the panel
+      // doesn't leave them hanging on "running".
+      stopWorkflowsForSession(sessionId);
     }
   }
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });

--- a/backend/src/core/handlers/stopSession.ts
+++ b/backend/src/core/handlers/stopSession.ts
@@ -1,7 +1,7 @@
 import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
-import { sendInterruptToProcess } from '../claude-process';
+import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
 import { MessageType } from '../../shared';
 
 export function stopSessionHandler(
@@ -24,6 +24,9 @@ export function stopSessionHandler(
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
         session.process.kill('SIGTERM');
       }
+      // Settle any background workflows the stop just cancelled so the panel
+      // doesn't leave them hanging on "running".
+      stopWorkflowsForSession(sessionId);
     }
   }
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });

--- a/backend/src/shared/index.ts
+++ b/backend/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './client-env';
 export * from './message-type';
+export * from './workflow';

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -201,6 +201,8 @@ export enum MessageType {
   TOOL_USE = 'TOOL_USE',
   /** A tool invocation completed (with result). */
   TOOL_COMPLETE = 'TOOL_COMPLETE',
+  /** Live progress of a background dynamic workflow; payload is a WorkflowTask. */
+  WORKFLOW_PROGRESS = 'WORKFLOW_PROGRESS',
 
   // -- Diff push --
   /** A diff is available to review. */

--- a/backend/src/shared/workflow.ts
+++ b/backend/src/shared/workflow.ts
@@ -17,7 +17,9 @@ export interface WorkflowPhase {
 export interface WorkflowAgent {
   agentId: string;
   label: string;
-  status: 'running' | 'done';
+  /** `done` = finished successfully; `stopped` = cut off when the workflow was
+   *  interrupted (never settle an unfinished agent to `done`). */
+  status: 'running' | 'done' | 'stopped';
   tokens: number;
   tools: number;
   durationMs: number;

--- a/backend/src/shared/workflow.ts
+++ b/backend/src/shared/workflow.ts
@@ -1,0 +1,57 @@
+// Shared dynamic-workflow types. MUST stay 1:1 with webview/src/shared/workflow.ts
+// (see CLAUDE.md). Payload of MessageType.WORKFLOW_PROGRESS (backend → webview).
+
+export type WorkflowStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+/** A declared phase from the workflow script's `meta.phases`. */
+export interface WorkflowPhase {
+  title: string;
+  detail?: string;
+}
+
+/**
+ * One subagent of a workflow. Stats are computed by the backend from the agent
+ * transcript files; `label` is best-effort (derived from the agent's result) as
+ * the runtime does not persist the script-supplied label.
+ */
+export interface WorkflowAgent {
+  agentId: string;
+  label: string;
+  status: 'running' | 'done';
+  tokens: number;
+  tools: number;
+  durationMs: number;
+}
+
+/** Aggregate usage, populated from the final `<task-notification>` `<usage>`. */
+export interface WorkflowUsage {
+  agentCount?: number;
+  subagentTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+/** Live + final state of a single background dynamic workflow. */
+export interface WorkflowTask {
+  /** Workflow tool_use id — the stable key correlating card, panel and events. */
+  toolUseId: string;
+  /** Background task id (e.g. "w94mspihl") from the immediate tool_result. */
+  taskId?: string;
+  /** Workflow run id (e.g. "wf_ce882bfa-ddf"), the transcript dir basename. */
+  workflowId?: string;
+  name: string;
+  description?: string;
+  /** Absolute path to …/subagents/workflows/wf_<id>. */
+  transcriptDir?: string;
+  /** Absolute path to the task output file (from the notification). */
+  outputFile?: string;
+  status: WorkflowStatus;
+  startedAt: number;
+  endedAt?: number;
+  phases: WorkflowPhase[];
+  agents: WorkflowAgent[];
+  summary?: string;
+  /** Workflow return value (raw `<result>` text). */
+  result?: string;
+  usage?: WorkflowUsage;
+}

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -7,6 +7,7 @@ import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { getModelEffortConfig } from '@/types/effort';
 import { getAdapter } from '@/adapters';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
+import { useWorkflowState } from '@/contexts/WorkflowStateContext';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { ROTATE_MODEL_EVENT } from '@/pages/ChatPage/ChatInput/ModelTag';
 import { PanelSection } from '@/types/commandPalette';
@@ -57,6 +58,7 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
   const { controlResponse } = useCliConfig();
   const { settings } = useClaudeSettings();
   const { confirmDialog, confirm } = useConfirmDialog();
+  const workflowState = useWorkflowState();
 
   // The Effort row only makes sense on models that support effort. On others
   // (e.g. Haiku) it would render an empty, unresponsive row — the same
@@ -95,6 +97,9 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     ui: {
       confirm,
     },
+    workflowState: {
+      openPanel: workflowState.openPanel,
+    },
   });
 
   // Update servicesRef on every render
@@ -127,6 +132,9 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
     },
     ui: {
       confirm,
+    },
+    workflowState: {
+      openPanel: workflowState.openPanel,
     },
   };
 

--- a/webview/src/commandPalette/sections/context/__tests__/items.test.ts
+++ b/webview/src/commandPalette/sections/context/__tests__/items.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+import { contextItems } from '../items';
+import { StaticItem } from '../../../types';
+import type { CommandPaletteServices } from '../../../types';
+
+const byId = (id: string): StaticItem =>
+  contextItems.find((item) => item.id === id) as StaticItem;
+
+describe('contextItems — open-workflows', () => {
+  it('is a search-only item that surfaces under the /workflows query', () => {
+    const wf = byId('open-workflows');
+    expect(wf).toBeDefined();
+    expect(wf.label).toBe('Workflow: Show background tasks');
+    expect(wf.searchOnly).toBe(true);
+    expect(wf.keywords).toContain('workflows');
+  });
+
+  it('opens the Background tasks panel without sending a message to Claude', async () => {
+    const openPanel = vi.fn();
+    const sendMessage = vi.fn();
+    const services = {
+      chatStream: { sendMessage },
+      workflowState: { openPanel },
+    } as unknown as CommandPaletteServices;
+
+    const wf = byId('open-workflows');
+    wf._bind(() => services);
+
+    await wf.execute();
+
+    expect(openPanel).toHaveBeenCalledTimes(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/commandPalette/sections/context/items.ts
+++ b/webview/src/commandPalette/sections/context/items.ts
@@ -39,4 +39,15 @@ export const contextItems = [
       window.dispatchEvent(new CustomEvent(OPEN_SESSION_DROPDOWN_EVENT));
     },
   }),
+  // Search-only: surfaces when the user types `/workflows` (mirrors the CLI's
+  // /workflows). Opens the Background tasks panel — a local action, no message
+  // is sent to Claude.
+  new StaticItem('open-workflows', 'Workflow: Show background tasks', {
+    disabled: false,
+    searchOnly: true,
+    keywords: ['workflows', 'workflow'],
+    serviceAction: async (services) => {
+      services.workflowState.openPanel();
+    },
+  }),
 ];

--- a/webview/src/commandPalette/sections/slashCommands/__tests__/CliPassthroughCommand.test.ts
+++ b/webview/src/commandPalette/sections/slashCommands/__tests__/CliPassthroughCommand.test.ts
@@ -39,6 +39,9 @@ function makeServices(overrides: {
     ui: {
       confirm: vi.fn().mockResolvedValue(true),
     },
+    workflowState: {
+      openPanel: vi.fn(),
+    },
   };
   return { services, sendMessage };
 }

--- a/webview/src/commandPalette/types.ts
+++ b/webview/src/commandPalette/types.ts
@@ -40,6 +40,10 @@ export interface CommandPaletteServices {
   ui: {
     confirm: (options: ConfirmOptions) => Promise<boolean>;
   };
+  workflowState: {
+    /** Open the Background tasks panel; optional toolUseId to focus a workflow. */
+    openPanel: (toolUseId?: string) => void;
+  };
 }
 
 /**

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -14,6 +14,7 @@ import { CliConfigProvider } from './CliConfigContext';
 import { ChatInputFocusProvider } from './ChatInputFocusContext';
 import { ChatInputStateProvider } from './ChatInputStateContext';
 import { WorkingDirProvider } from './WorkingDirContext';
+import { WorkflowStateProvider } from './WorkflowStateContext';
 import { CommandPaletteProvider } from '../commandPalette/CommandPaletteProvider';
 import { useApi } from './ApiContext';
 import { SessionState } from '../types';
@@ -215,7 +216,9 @@ export function AppProviders({ children }: AppProvidersProps) {
                 <ClaudeSettingsProvider>
                   <AuthProvider>
                     <SessionProvider>
-                      <ChatProviderBridge>{children}</ChatProviderBridge>
+                      <WorkflowStateProvider>
+                        <ChatProviderBridge>{children}</ChatProviderBridge>
+                      </WorkflowStateProvider>
                     </SessionProvider>
                   </AuthProvider>
                 </ClaudeSettingsProvider>

--- a/webview/src/contexts/WorkflowStateContext.tsx
+++ b/webview/src/contexts/WorkflowStateContext.tsx
@@ -1,0 +1,90 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, ReactNode } from 'react';
+import { useBridgeContext } from './BridgeContext';
+import { useSessionContext } from './SessionContext';
+import { MessageType } from '@/shared';
+import type { WorkflowTask } from '@/shared';
+
+interface WorkflowStateValue {
+  /** All known workflows for the current session (running + finished). */
+  tasks: WorkflowTask[];
+  getByToolUseId: (toolUseId: string) => WorkflowTask | undefined;
+  runningTasks: WorkflowTask[];
+  finishedTasks: WorkflowTask[];
+  /** Drop finished workflows (the panel's "Clear" action). */
+  clearFinished: () => void;
+  // Background tasks panel UI state
+  panelOpen: boolean;
+  /** Open the panel; pass a toolUseId to scroll/highlight that workflow. */
+  openPanel: (toolUseId?: string) => void;
+  closePanel: () => void;
+  focusedToolUseId: string | null;
+}
+
+const WorkflowStateContext = createContext<WorkflowStateValue | null>(null);
+
+/**
+ * Holds live dynamic-workflow progress streamed from the backend via
+ * WORKFLOW_PROGRESS. Keyed by the Workflow tool_use id so the inline card and
+ * the Background tasks panel read the same source. Resets on session change.
+ */
+export function WorkflowStateProvider({ children }: { children: ReactNode }) {
+  const { subscribe, isConnected } = useBridgeContext();
+  const { currentSessionId } = useSessionContext();
+  const [taskMap, setTaskMap] = useState<Map<string, WorkflowTask>>(new Map());
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [focusedToolUseId, setFocusedToolUseId] = useState<string | null>(null);
+
+  // currentSessionId is derived from the URL (SSOT) — clear when it changes.
+  useEffect(() => {
+    setTaskMap(new Map());
+    setPanelOpen(false);
+    setFocusedToolUseId(null);
+  }, [currentSessionId]);
+
+  const openPanel = useCallback((toolUseId?: string) => {
+    setFocusedToolUseId(toolUseId ?? null);
+    setPanelOpen(true);
+  }, []);
+  const closePanel = useCallback(() => setPanelOpen(false), []);
+
+  useEffect(() => {
+    if (!isConnected) return;
+    return subscribe(MessageType.WORKFLOW_PROGRESS, (message) => {
+      const task = message.payload as unknown as WorkflowTask;
+      if (!task?.toolUseId) return;
+      setTaskMap((prev) => {
+        const next = new Map(prev);
+        next.set(task.toolUseId, task);
+        return next;
+      });
+    });
+  }, [isConnected, subscribe]);
+
+  const value = useMemo<WorkflowStateValue>(() => {
+    const tasks = Array.from(taskMap.values());
+    return {
+      tasks,
+      getByToolUseId: (id) => taskMap.get(id),
+      runningTasks: tasks.filter((t) => t.status === 'running'),
+      finishedTasks: tasks.filter((t) => t.status !== 'running'),
+      clearFinished: () =>
+        setTaskMap((prev) => {
+          const next = new Map<string, WorkflowTask>();
+          for (const [k, v] of prev) if (v.status === 'running') next.set(k, v);
+          return next;
+        }),
+      panelOpen,
+      openPanel,
+      closePanel,
+      focusedToolUseId,
+    };
+  }, [taskMap, panelOpen, openPanel, closePanel, focusedToolUseId]);
+
+  return <WorkflowStateContext.Provider value={value}>{children}</WorkflowStateContext.Provider>;
+}
+
+export function useWorkflowState(): WorkflowStateValue {
+  const ctx = useContext(WorkflowStateContext);
+  if (!ctx) throw new Error('useWorkflowState must be used within a WorkflowStateProvider');
+  return ctx;
+}

--- a/webview/src/contexts/WorkflowStateContext.tsx
+++ b/webview/src/contexts/WorkflowStateContext.tsx
@@ -12,6 +12,9 @@ interface WorkflowStateValue {
   finishedTasks: WorkflowTask[];
   /** Drop finished workflows (the panel's "Clear" action). */
   clearFinished: () => void;
+  /** Drop a single workflow by tool_use id (the per-row "✕" — also clears a
+   *  workflow stuck on "running" when the runtime lost its final event). */
+  dismissTask: (toolUseId: string) => void;
   // Background tasks panel UI state
   panelOpen: boolean;
   /** Open the panel; pass a toolUseId to scroll/highlight that workflow. */
@@ -71,6 +74,13 @@ export function WorkflowStateProvider({ children }: { children: ReactNode }) {
         setTaskMap((prev) => {
           const next = new Map<string, WorkflowTask>();
           for (const [k, v] of prev) if (v.status === 'running') next.set(k, v);
+          return next;
+        }),
+      dismissTask: (id) =>
+        setTaskMap((prev) => {
+          if (!prev.has(id)) return prev;
+          const next = new Map(prev);
+          next.delete(id);
           return next;
         }),
       panelOpen,

--- a/webview/src/contexts/WorkflowStateContext.tsx
+++ b/webview/src/contexts/WorkflowStateContext.tsx
@@ -10,10 +10,12 @@ interface WorkflowStateValue {
   getByToolUseId: (toolUseId: string) => WorkflowTask | undefined;
   runningTasks: WorkflowTask[];
   finishedTasks: WorkflowTask[];
-  /** Drop finished workflows (the panel's "Clear" action). */
+  /** Hide finished workflows from the panel (the "Clear" action). The inline
+   *  chat cards keep their last status — only the panel list is affected. */
   clearFinished: () => void;
-  /** Drop a single workflow by tool_use id (the per-row "✕" — also clears a
-   *  workflow stuck on "running" when the runtime lost its final event). */
+  /** Hide a single workflow from the panel by tool_use id (the per-row "✕").
+   *  The inline chat card keeps its status; this only removes it from the
+   *  Background tasks list. */
   dismissTask: (toolUseId: string) => void;
   // Background tasks panel UI state
   panelOpen: boolean;
@@ -34,12 +36,17 @@ export function WorkflowStateProvider({ children }: { children: ReactNode }) {
   const { subscribe, isConnected } = useBridgeContext();
   const { currentSessionId } = useSessionContext();
   const [taskMap, setTaskMap] = useState<Map<string, WorkflowTask>>(new Map());
+  // Workflows hidden from the panel via "Clear"/"✕". They stay in taskMap so the
+  // inline chat card keeps rendering its real status — dismissing must not make
+  // getByToolUseId return undefined (which would fall back to "running").
+  const [dismissedIds, setDismissedIds] = useState<Set<string>>(new Set());
   const [panelOpen, setPanelOpen] = useState(false);
   const [focusedToolUseId, setFocusedToolUseId] = useState<string | null>(null);
 
   // currentSessionId is derived from the URL (SSOT) — clear when it changes.
   useEffect(() => {
     setTaskMap(new Map());
+    setDismissedIds(new Set());
     setPanelOpen(false);
     setFocusedToolUseId(null);
   }, [currentSessionId]);
@@ -65,22 +72,25 @@ export function WorkflowStateProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo<WorkflowStateValue>(() => {
     const tasks = Array.from(taskMap.values());
+    // Panel lists exclude dismissed workflows; getByToolUseId (inline card) does
+    // not — the card must always reflect the workflow's real status.
+    const visible = tasks.filter((t) => !dismissedIds.has(t.toolUseId));
     return {
-      tasks,
+      tasks: visible,
       getByToolUseId: (id) => taskMap.get(id),
-      runningTasks: tasks.filter((t) => t.status === 'running'),
-      finishedTasks: tasks.filter((t) => t.status !== 'running'),
+      runningTasks: visible.filter((t) => t.status === 'running'),
+      finishedTasks: visible.filter((t) => t.status !== 'running'),
       clearFinished: () =>
-        setTaskMap((prev) => {
-          const next = new Map<string, WorkflowTask>();
-          for (const [k, v] of prev) if (v.status === 'running') next.set(k, v);
+        setDismissedIds((prev) => {
+          const next = new Set(prev);
+          for (const t of taskMap.values()) if (t.status !== 'running') next.add(t.toolUseId);
           return next;
         }),
       dismissTask: (id) =>
-        setTaskMap((prev) => {
-          if (!prev.has(id)) return prev;
-          const next = new Map(prev);
-          next.delete(id);
+        setDismissedIds((prev) => {
+          if (prev.has(id)) return prev;
+          const next = new Set(prev);
+          next.add(id);
           return next;
         }),
       panelOpen,
@@ -88,7 +98,7 @@ export function WorkflowStateProvider({ children }: { children: ReactNode }) {
       closePanel,
       focusedToolUseId,
     };
-  }, [taskMap, panelOpen, openPanel, closePanel, focusedToolUseId]);
+  }, [taskMap, dismissedIds, panelOpen, openPanel, closePanel, focusedToolUseId]);
 
   return <WorkflowStateContext.Provider value={value}>{children}</WorkflowStateContext.Provider>;
 }

--- a/webview/src/contexts/__tests__/WorkflowStateContext.test.tsx
+++ b/webview/src/contexts/__tests__/WorkflowStateContext.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { WorkflowStateProvider, useWorkflowState } from '../WorkflowStateContext';
+import type { WorkflowTask } from '@/shared';
+
+// Capture the WORKFLOW_PROGRESS subscriber so tests can push backend updates.
+let capturedHandler: ((msg: { payload: unknown }) => void) | null = null;
+const mockSubscribe = vi.fn((_type: string, cb: (msg: { payload: unknown }) => void) => {
+  capturedHandler = cb;
+  return vi.fn();
+});
+
+vi.mock('../BridgeContext', () => ({
+  useBridgeContext: () => ({ subscribe: mockSubscribe, isConnected: true }),
+}));
+
+let mockSessionId: string | null = 's1';
+vi.mock('../SessionContext', () => ({
+  useSessionContext: () => ({ currentSessionId: mockSessionId }),
+}));
+
+let ctx: ReturnType<typeof useWorkflowState>;
+function Harness() {
+  ctx = useWorkflowState();
+  return null;
+}
+
+function emit(task: Partial<WorkflowTask> & Pick<WorkflowTask, 'toolUseId'>) {
+  act(() => {
+    capturedHandler?.({
+      payload: { name: 'wf', status: 'running', startedAt: 0, phases: [], agents: [], ...task },
+    });
+  });
+}
+
+beforeEach(() => {
+  capturedHandler = null;
+  mockSessionId = 's1';
+  render(
+    <WorkflowStateProvider>
+      <Harness />
+    </WorkflowStateProvider>,
+  );
+});
+
+describe('WorkflowStateContext', () => {
+  it('ingests WORKFLOW_PROGRESS into the task list keyed by toolUseId', () => {
+    emit({ toolUseId: 't1' });
+    expect(ctx.tasks).toHaveLength(1);
+    // A later update for the same id replaces (not duplicates) the task.
+    emit({ toolUseId: 't1', status: 'completed' });
+    expect(ctx.tasks).toHaveLength(1);
+    expect(ctx.finishedTasks).toHaveLength(1);
+    expect(ctx.runningTasks).toHaveLength(0);
+  });
+
+  it('dismissTask drops a single workflow — including one stuck on running', () => {
+    emit({ toolUseId: 't1', status: 'running' });
+    emit({ toolUseId: 't2', status: 'completed' });
+    expect(ctx.tasks).toHaveLength(2);
+
+    act(() => ctx.dismissTask('t1'));
+    expect(ctx.tasks.map((t) => t.toolUseId)).toEqual(['t2']);
+  });
+
+  it('clearFinished keeps running workflows and removes finished ones', () => {
+    emit({ toolUseId: 't1', status: 'running' });
+    emit({ toolUseId: 't2', status: 'completed' });
+    emit({ toolUseId: 't3', status: 'stopped' });
+
+    act(() => ctx.clearFinished());
+    expect(ctx.tasks.map((t) => t.toolUseId)).toEqual(['t1']);
+  });
+});

--- a/webview/src/contexts/__tests__/WorkflowStateContext.test.tsx
+++ b/webview/src/contexts/__tests__/WorkflowStateContext.test.tsx
@@ -54,21 +54,27 @@ describe('WorkflowStateContext', () => {
     expect(ctx.runningTasks).toHaveLength(0);
   });
 
-  it('dismissTask drops a single workflow — including one stuck on running', () => {
-    emit({ toolUseId: 't1', status: 'running' });
+  it('dismissTask hides a workflow from the panel but keeps it for the inline card', () => {
+    emit({ toolUseId: 't1', status: 'stopped' });
     emit({ toolUseId: 't2', status: 'completed' });
     expect(ctx.tasks).toHaveLength(2);
 
     act(() => ctx.dismissTask('t1'));
+    // Gone from the panel list…
     expect(ctx.tasks.map((t) => t.toolUseId)).toEqual(['t2']);
+    // …but still resolvable for the inline chat card, with its real status
+    // (so it does NOT fall back to "running").
+    expect(ctx.getByToolUseId('t1')?.status).toBe('stopped');
   });
 
-  it('clearFinished keeps running workflows and removes finished ones', () => {
+  it('clearFinished hides finished workflows from the panel, inline cards keep status', () => {
     emit({ toolUseId: 't1', status: 'running' });
     emit({ toolUseId: 't2', status: 'completed' });
     emit({ toolUseId: 't3', status: 'stopped' });
 
     act(() => ctx.clearFinished());
     expect(ctx.tasks.map((t) => t.toolUseId)).toEqual(['t1']);
+    expect(ctx.getByToolUseId('t2')?.status).toBe('completed');
+    expect(ctx.getByToolUseId('t3')?.status).toBe('stopped');
   });
 });

--- a/webview/src/dto/message/ContentBlockDto.ts
+++ b/webview/src/dto/message/ContentBlockDto.ts
@@ -39,6 +39,33 @@ export class ToolUseBlockDto extends ContentBlockDto {
   childMessages?: LoadedMessageDto[];
   /** Runtime-only: progress entries from sub-agent (for Task tool only) */
   subAgentMessages?: SubAgentMessage[];
+  /**
+   * Runtime-only: parsed `<task-notification>` for a dynamic-workflow Workflow
+   * tool_use (for the Workflow tool only). Merged in by mergeToolResults from the
+   * later user message whose `<tool-use-id>` matches this block's id, so the
+   * Workflow renderer can show the final status/summary/result on reload.
+   */
+  workflowNotification?: WorkflowNotification;
+}
+
+/**
+ * Parsed `<task-notification>` envelope the CLI emits when a background dynamic
+ * workflow finishes. Field names mirror the source tags; `usage` mirrors the
+ * `<usage>` sub-block. All optional — the envelope shape can vary by status.
+ */
+export interface WorkflowNotification {
+  taskId?: string;
+  toolUseId?: string;
+  outputFile?: string;
+  status?: string;
+  summary?: string;
+  result?: string;
+  usage?: {
+    agentCount?: number;
+    subagentTokens?: number;
+    toolUses?: number;
+    durationMs?: number;
+  };
 }
 
 /**

--- a/webview/src/pages/ChatPage/ApprovalPanel/index.tsx
+++ b/webview/src/pages/ChatPage/ApprovalPanel/index.tsx
@@ -5,6 +5,8 @@ import { useApprovalKeyboard } from './useApprovalKeyboard';
 interface Props {
   title: string;
   subtitle?: string;
+  /** Optional highlighted note shown under the title (e.g. a usage warning). */
+  notice?: string;
   options: OptionItem[];
   onOptionSelect: (index: number) => void;
   textareaPlaceholder?: string;
@@ -13,7 +15,7 @@ interface Props {
 }
 
 export function ApprovalPanel(props: Props) {
-  const { title, subtitle, options, onOptionSelect, textareaPlaceholder = 'Tell Claude what to do instead', onTextSubmit, onCancel } = props;
+  const { title, subtitle, notice, options, onOptionSelect, textareaPlaceholder = 'Tell Claude what to do instead', onTextSubmit, onCancel } = props;
 
   const [focusedIndex, setFocusedIndex] = useState(0);
   const [feedbackText, setFeedbackText] = useState('');
@@ -64,6 +66,11 @@ export function ApprovalPanel(props: Props) {
           <p className="text-[1.0769rem] font-semibold text-text-primary leading-snug">{title}</p>
           {subtitle && (
             <p className="text-[1rem] text-text-secondary mt-1">{subtitle}</p>
+          )}
+          {notice && (
+            <p className="text-[0.9230rem] text-text-secondary mt-2 px-2.5 py-2 rounded-[4px] bg-surface-hover border border-border-subtle">
+              {notice}
+            </p>
           )}
         </div>
 

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -142,23 +142,34 @@ export function BackgroundTasksPanel() {
     const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, dismissTask, focusedToolUseId } =
         useWorkflowState();
     const [showFinished, setShowFinished] = useState(true);
+    const panelRef = useRef<HTMLDivElement>(null);
     const now = useNow(panelOpen && runningTasks.length > 0);
 
-    // Close on Escape.
+    // When the panel opens, move focus into it so keystrokes (notably Escape)
+    // act on the panel — closing it — instead of the chat input behind it. On
+    // close, restore focus to wherever it was (e.g. the chat input).
     useEffect(() => {
         if (!panelOpen) return;
-        const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') closePanel();
-        };
-        window.addEventListener('keydown', onKey);
-        return () => window.removeEventListener('keydown', onKey);
-    }, [panelOpen, closePanel]);
+        const prevFocus = document.activeElement as HTMLElement | null;
+        panelRef.current?.focus();
+        return () => prevFocus?.focus?.();
+    }, [panelOpen]);
 
     if (!panelOpen) return null;
 
     return (
         <Portal>
-            <div className="fixed right-0 top-0 bottom-0 w-[24rem] max-w-[92vw] z-40 flex flex-col bg-surface-raised border-l border-border-default shadow-2xl">
+            <div
+                ref={panelRef}
+                tabIndex={-1}
+                onKeyDown={(e) => {
+                    if (e.key === 'Escape') {
+                        e.stopPropagation();
+                        closePanel();
+                    }
+                }}
+                className="fixed right-0 top-0 bottom-0 w-[24rem] max-w-[92vw] z-40 flex flex-col bg-surface-raised border-l border-border-default shadow-2xl outline-none"
+            >
                 <div className="flex items-center justify-between px-4 h-[44px] border-b border-border-subtle shrink-0">
                     <div className="text-text-primary text-[1rem] font-semibold">Background tasks</div>
                     <button

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -38,8 +38,10 @@ function WorkflowTaskRow({
     const durationMs =
         task.usage?.durationMs ?? (isRunning ? now - task.startedAt : undefined);
     const duration = formatDuration(durationMs);
+    // Authoritative workflow-level total first; per-agent sum is only a fallback
+    // (see WorkflowRenderer) so the header stays consistent with the agent table.
     const liveTokens = task.agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
-    const tokens = formatTokens(liveTokens || task.usage?.subagentTokens);
+    const tokens = formatTokens(task.usage?.subagentTokens || liveTokens);
 
     return (
         <div

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -3,7 +3,7 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
 import { useWorkflowState } from '@/contexts/WorkflowStateContext';
 import type { WorkflowTask } from '@/shared';
-import { formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
+import { agentDotClass, formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
 
 /** Re-render every second while `active` so running timers tick. */
 function useNow(active: boolean): number {
@@ -120,9 +120,7 @@ function WorkflowTaskRow({
                                 <tr key={a.agentId} className="text-text-primary/75">
                                     <td className="py-0.5 pr-2 max-w-[10rem] truncate">
                                         <span
-                                            className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle ${
-                                                a.status === 'done' ? 'bg-state-success-fg' : 'bg-text-link animate-pulse'
-                                            }`}
+                                            className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle ${agentDotClass(a.status)}`}
                                         />
                                         {a.label}
                                     </td>

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useRef, useState } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { Portal } from '@/components/Portal';
+import { useWorkflowState } from '@/contexts/WorkflowStateContext';
+import type { WorkflowTask } from '@/shared';
+import { formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
+
+/** Re-render every second while `active` so running timers tick. */
+function useNow(active: boolean): number {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        if (!active) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [active]);
+    return now;
+}
+
+function WorkflowTaskRow({ task, now, focused }: { task: WorkflowTask; now: number; focused: boolean }) {
+    const ref = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        if (focused) ref.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }, [focused]);
+
+    const isRunning = task.status === 'running';
+    const statusColor = WORKFLOW_STATUS_COLOR[task.status] || 'text-text-primary/60';
+    const agentCount = task.agents.length || task.usage?.agentCount;
+    const durationMs =
+        task.usage?.durationMs ?? (isRunning ? now - task.startedAt : undefined);
+    const duration = formatDuration(durationMs);
+    const liveTokens = task.agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
+    const tokens = formatTokens(liveTokens || task.usage?.subagentTokens);
+
+    return (
+        <div
+            ref={ref}
+            className={`rounded-lg border bg-surface-base px-3 py-2.5 ${
+                focused ? 'border-border-focus' : 'border-border-subtle'
+            }`}
+        >
+            <div className="flex items-center gap-2">
+                <div className="min-w-0 flex-1 text-text-primary text-[0.9230rem] font-semibold truncate">
+                    {task.name}
+                </div>
+                <span className={`text-[0.8461rem] shrink-0 ${statusColor}`}>{task.status}</span>
+            </div>
+
+            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.8461rem] text-text-primary/60">
+                <span>Workflow</span>
+                {agentCount !== undefined && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span>{agentCount} agents</span>
+                    </>
+                )}
+                {tokens && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span>{tokens} tokens</span>
+                    </>
+                )}
+                {duration && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span>{duration}</span>
+                    </>
+                )}
+            </div>
+
+            {task.description && (
+                <div className="mt-1 text-[0.8461rem] text-text-primary/50">{task.description}</div>
+            )}
+
+            {task.phases.length > 0 && (
+                <div className="mt-2">
+                    <div className="text-[0.7692rem] uppercase tracking-wide text-text-tertiary mb-1">Phases</div>
+                    <div className="space-y-0.5">
+                        {task.phases.map((p, i) => (
+                            <div key={i} className="flex items-center gap-2 text-[0.8461rem] text-text-primary/70">
+                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-text-tertiary" />
+                                <span className="truncate">{p.title}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+
+            {task.agents.length > 0 && (
+                <div className="mt-2 overflow-x-auto no-scrollbar">
+                    <table className="w-full text-[0.8461rem] font-mono">
+                        <thead>
+                            <tr className="text-text-tertiary text-left">
+                                <th className="font-normal pb-1 pr-2">Agent</th>
+                                <th className="font-normal pb-1 px-2 text-right">Tokens</th>
+                                <th className="font-normal pb-1 px-2 text-right">Tools</th>
+                                <th className="font-normal pb-1 pl-2 text-right">Time</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {task.agents.map((a) => (
+                                <tr key={a.agentId} className="text-text-primary/75">
+                                    <td className="py-0.5 pr-2 max-w-[10rem] truncate">
+                                        <span
+                                            className={`inline-block w-1.5 h-1.5 rounded-full mr-1.5 align-middle ${
+                                                a.status === 'done' ? 'bg-state-success-fg' : 'bg-text-link animate-pulse'
+                                            }`}
+                                        />
+                                        {a.label}
+                                    </td>
+                                    <td className="py-0.5 px-2 text-right">{formatTokens(a.tokens) ?? '0'}</td>
+                                    <td className="py-0.5 px-2 text-right">{a.tools}</td>
+                                    <td className="py-0.5 pl-2 text-right">{formatDuration(a.durationMs) ?? '—'}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+        </div>
+    );
+}
+
+export function BackgroundTasksPanel() {
+    const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, focusedToolUseId } =
+        useWorkflowState();
+    const [showFinished, setShowFinished] = useState(true);
+    const now = useNow(panelOpen && runningTasks.length > 0);
+
+    // Close on Escape.
+    useEffect(() => {
+        if (!panelOpen) return;
+        const onKey = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') closePanel();
+        };
+        window.addEventListener('keydown', onKey);
+        return () => window.removeEventListener('keydown', onKey);
+    }, [panelOpen, closePanel]);
+
+    if (!panelOpen) return null;
+
+    return (
+        <Portal>
+            <div className="fixed right-0 top-0 bottom-0 w-[24rem] max-w-[92vw] z-40 flex flex-col bg-surface-raised border-l border-border-default shadow-2xl">
+                <div className="flex items-center justify-between px-4 h-[44px] border-b border-border-subtle shrink-0">
+                    <div className="text-text-primary text-[1rem] font-semibold">Background tasks</div>
+                    <button
+                        onClick={closePanel}
+                        className="p-1 rounded hover:bg-surface-hover transition-colors"
+                        title="Close"
+                    >
+                        <XMarkIcon className="w-5 h-5 text-text-secondary" />
+                    </button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto p-3 space-y-4">
+                    {runningTasks.length === 0 && finishedTasks.length === 0 && (
+                        <div className="text-text-primary/50 text-[0.9230rem] text-center mt-8">
+                            No background workflows yet.
+                        </div>
+                    )}
+
+                    {runningTasks.length > 0 && (
+                        <section className="space-y-2">
+                            <div className="text-[0.7692rem] uppercase tracking-wide text-text-tertiary">Running</div>
+                            {runningTasks.map((t) => (
+                                <WorkflowTaskRow
+                                    key={t.toolUseId}
+                                    task={t}
+                                    now={now}
+                                    focused={t.toolUseId === focusedToolUseId}
+                                />
+                            ))}
+                        </section>
+                    )}
+
+                    {finishedTasks.length > 0 && (
+                        <section className="space-y-2">
+                            <div className="flex items-center justify-between">
+                                <button
+                                    onClick={() => setShowFinished((v) => !v)}
+                                    className="text-[0.7692rem] uppercase tracking-wide text-text-tertiary hover:text-text-secondary transition-colors"
+                                >
+                                    Finished {finishedTasks.length} {showFinished ? '▾' : '▸'}
+                                </button>
+                                <button
+                                    onClick={clearFinished}
+                                    className="text-[0.8461rem] text-text-secondary hover:text-text-primary transition-colors"
+                                >
+                                    Clear
+                                </button>
+                            </div>
+                            {showFinished &&
+                                finishedTasks.map((t) => (
+                                    <WorkflowTaskRow
+                                        key={t.toolUseId}
+                                        task={t}
+                                        now={now}
+                                        focused={t.toolUseId === focusedToolUseId}
+                                    />
+                                ))}
+                        </section>
+                    )}
+                </div>
+            </div>
+        </Portal>
+    );
+}

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -16,7 +16,17 @@ function useNow(active: boolean): number {
     return now;
 }
 
-function WorkflowTaskRow({ task, now, focused }: { task: WorkflowTask; now: number; focused: boolean }) {
+function WorkflowTaskRow({
+    task,
+    now,
+    focused,
+    onDismiss,
+}: {
+    task: WorkflowTask;
+    now: number;
+    focused: boolean;
+    onDismiss: (toolUseId: string) => void;
+}) {
     const ref = useRef<HTMLDivElement>(null);
     useEffect(() => {
         if (focused) ref.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
@@ -43,6 +53,13 @@ function WorkflowTaskRow({ task, now, focused }: { task: WorkflowTask; now: numb
                     {task.name}
                 </div>
                 <span className={`text-[0.8461rem] shrink-0 ${statusColor}`}>{task.status}</span>
+                <button
+                    onClick={() => onDismiss(task.toolUseId)}
+                    className="shrink-0 p-0.5 rounded hover:bg-surface-hover transition-colors"
+                    title={isRunning ? 'Dismiss (clears a stuck workflow)' : 'Dismiss'}
+                >
+                    <XMarkIcon className="w-3.5 h-3.5 text-text-tertiary hover:text-text-secondary" />
+                </button>
             </div>
 
             <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.8461rem] text-text-primary/60">
@@ -122,7 +139,7 @@ function WorkflowTaskRow({ task, now, focused }: { task: WorkflowTask; now: numb
 }
 
 export function BackgroundTasksPanel() {
-    const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, focusedToolUseId } =
+    const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, dismissTask, focusedToolUseId } =
         useWorkflowState();
     const [showFinished, setShowFinished] = useState(true);
     const now = useNow(panelOpen && runningTasks.length > 0);
@@ -169,6 +186,7 @@ export function BackgroundTasksPanel() {
                                     task={t}
                                     now={now}
                                     focused={t.toolUseId === focusedToolUseId}
+                                    onDismiss={dismissTask}
                                 />
                             ))}
                         </section>
@@ -197,6 +215,7 @@ export function BackgroundTasksPanel() {
                                         task={t}
                                         now={now}
                                         focused={t.toolUseId === focusedToolUseId}
+                                        onDismiss={dismissTask}
                                     />
                                 ))}
                         </section>

--- a/webview/src/pages/ChatPage/PermissionBanner.tsx
+++ b/webview/src/pages/ChatPage/PermissionBanner.tsx
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { ApprovalPanel } from './ApprovalPanel';
 import { OptionItem } from './ApprovalPanel/OptionButton';
 import { PendingPermission } from '../../hooks/usePendingPermissions';
+import { parseWorkflowName } from '@/utils/workflowName';
 
 interface Props {
   permission: PendingPermission;
@@ -9,6 +10,9 @@ interface Props {
   onApproveForSession: () => void;
   onDeny: (reason?: string) => void;
 }
+
+const WORKFLOW_NOTICE =
+  'Dynamic workflows run many subagents in parallel and can use a lot of your usage limit. Stop them any time from the tasks panel.';
 
 function basename(filePath: string): string {
   return filePath.split('/').pop() || filePath;
@@ -31,6 +35,8 @@ function generateTitle(toolName: string, input: Record<string, unknown>): string
       return file ? `Read ${file}?` : 'Read this file?';
     case 'NotebookEdit':
       return file ? `Edit notebook ${file}?` : 'Edit this notebook?';
+    case 'Workflow':
+      return `Allow Claude to run a workflow ${parseWorkflowName(input)}?`;
     default:
       return `Allow ${toolName}?`;
   }
@@ -48,6 +54,8 @@ function getSessionLabel(toolName: string): string {
       return 'Yes, allow all deletions this session';
     case 'Read':
       return 'Yes, allow all reads this session';
+    case 'Workflow':
+      return 'Yes, allow all workflows this session';
     default:
       return `Yes, allow all ${toolName} this session`;
   }
@@ -60,6 +68,10 @@ export function PermissionBanner(props: Props) {
     () => generateTitle(permission.toolName, permission.input),
     [permission.toolName, permission.input],
   );
+
+  const isWorkflow = permission.toolName === 'Workflow';
+  const subtitle = isWorkflow ? (permission.input.description as string | undefined) : undefined;
+  const notice = isWorkflow ? WORKFLOW_NOTICE : undefined;
 
   const options: OptionItem[] = useMemo(() => [
     { key: '1', label: 'Yes' },
@@ -76,6 +88,8 @@ export function PermissionBanner(props: Props) {
   return (
     <ApprovalPanel
       title={title}
+      subtitle={subtitle}
+      notice={notice}
       options={options}
       onOptionSelect={handleOptionSelect}
       textareaPlaceholder="Tell Claude what to do instead"

--- a/webview/src/pages/ChatPage/SessionHeader/BackgroundTasksButton.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/BackgroundTasksButton.tsx
@@ -1,0 +1,32 @@
+import { QueueListIcon } from '@heroicons/react/24/outline';
+import { useWorkflowState } from '@/contexts/WorkflowStateContext';
+
+/**
+ * Toggles the Background tasks panel. Hidden until at least one workflow exists
+ * this session; shows a running-count badge while workflows are in flight.
+ */
+export function BackgroundTasksButton() {
+    const { tasks, runningTasks, panelOpen, openPanel, closePanel } = useWorkflowState();
+    if (tasks.length === 0) return null;
+
+    const runningCount = runningTasks.length;
+
+    return (
+        <button
+            onClick={() => (panelOpen ? closePanel() : openPanel())}
+            className="relative p-1 rounded transition-colors hover:bg-surface-hover"
+            title="Background tasks"
+        >
+            <QueueListIcon
+                className={`w-5 h-5 ${
+                    runningCount > 0 ? 'text-text-link' : 'text-text-secondary hover:text-text-primary'
+                }`}
+            />
+            {runningCount > 0 && (
+                <span className="absolute -top-0.5 -right-0.5 min-w-[14px] h-[14px] px-[3px] rounded-full bg-text-link text-text-inverse text-[0.6153rem] font-semibold leading-[14px] text-center">
+                    {runningCount}
+                </span>
+            )}
+        </button>
+    );
+}

--- a/webview/src/pages/ChatPage/SessionHeader/index.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/index.tsx
@@ -1,6 +1,7 @@
 import { SessionDropdown } from './SessionDropdown';
 import { WorkingDirDropdown } from './WorkingDirDropdown';
 import { TokenBatteryButton } from './TokenBatteryButton';
+import { BackgroundTasksButton } from './BackgroundTasksButton';
 import { TunnelButton } from './TunnelButton';
 import { SettingsButton } from './SettingsButton';
 import { NewTabButton } from './NewTabButton';
@@ -26,6 +27,7 @@ export function SessionHeader() {
       {/* Right: buttons */}
       <div className="flex items-center gap-1 flex-shrink-0">
         <TokenBatteryButton />
+        <BackgroundTasksButton />
         <TunnelButton />
         <SettingsButton />
         <NewTabButton />

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -60,6 +60,21 @@ vi.mock('../../../contexts/WorkingDirContext', () => ({
   }),
 }));
 
+// Mock WorkflowStateContext (BackgroundTasksButton uses useWorkflowState)
+vi.mock('../../../contexts/WorkflowStateContext', () => ({
+  useWorkflowState: () => ({
+    tasks: [],
+    getByToolUseId: () => undefined,
+    runningTasks: [],
+    finishedTasks: [],
+    clearFinished: vi.fn(),
+    panelOpen: false,
+    openPanel: vi.fn(),
+    closePanel: vi.fn(),
+    focusedToolUseId: null,
+  }),
+}));
+
 // Mock ChatStreamContext (TokenBatteryButton → useUsageData → useChatStreamContext)
 vi.mock('../../../contexts/ChatStreamContext', () => ({
   useChatStreamContext: () => ({

--- a/webview/src/pages/ChatPage/__tests__/mergeToolResults.test.ts
+++ b/webview/src/pages/ChatPage/__tests__/mergeToolResults.test.ts
@@ -88,6 +88,40 @@ describe('mergeToolResults', () => {
     expect(originalBlock!.tool_result).toBeUndefined();
   });
 
+  it('attaches a <task-notification> to its Workflow tool_use and hides the raw bubble', () => {
+    const notif = [
+      '<task-notification>',
+      '<task-id>w123</task-id>',
+      '<tool-use-id>tool1</tool-use-id>',
+      '<output-file>/tmp/x.output</output-file>',
+      '<status>completed</status>',
+      '<summary>Dynamic workflow "demo" completed</summary>',
+      '<result>{"ok":true}</result>',
+      '<usage><agent_count>5</agent_count><subagent_tokens>171500</subagent_tokens><tool_uses>5</tool_uses><duration_ms>7000</duration_ms></usage>',
+      '</task-notification>',
+    ].join('\n');
+    const notifMsg = {
+      uuid: 'u1',
+      type: LoadedMessageType.User,
+      message: { role: MessageRole.User, content: notif },
+      timestamp: '2026-01-01T00:00:02.000Z',
+    } as unknown as LoadedMessageDto;
+
+    const merged = mergeToolResults([assistantWithTool('a1', 'tool1', 'Workflow'), notifMsg]);
+
+    // raw <task-notification> bubble is hidden
+    expect(merged.find(m => m.uuid === 'u1')).toBeUndefined();
+
+    const block = getToolUseBlock(merged.find(m => m.uuid === 'a1')!);
+    const wf = block!.workflowNotification as Record<string, any> | undefined;
+    expect(wf).toBeDefined();
+    expect(wf!.status).toBe('completed');
+    expect(wf!.toolUseId).toBe('tool1');
+    expect(wf!.summary).toContain('completed');
+    expect(wf!.usage.agentCount).toBe(5);
+    expect(wf!.usage.subagentTokens).toBe(171500);
+  });
+
   it('keeps non-tool messages as their original references', () => {
     const userMsg = {
       uuid: 'u0',

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -10,6 +10,7 @@ import { BannerArea } from './BannerArea';
 import { UpdateBanner } from './UpdateBanner';
 import { ConnectionLostBanner } from './ConnectionLostBanner';
 import { BrowserPermissionBanner } from './BrowserPermissionBanner';
+import { BackgroundTasksPanel } from './BackgroundTasksPanel';
 import { useChatInputFocus } from '../../contexts/ChatInputFocusContext';
 import { useChatStreamContext } from '../../contexts/ChatStreamContext';
 import { useSessionContext } from '../../contexts/SessionContext';
@@ -222,6 +223,8 @@ export function ChatPage() {
           Scroll to bottom
         </button>
       )}
+
+      <BackgroundTasksPanel />
     </div>
   );
 }

--- a/webview/src/pages/ChatPage/mergeToolResults.ts
+++ b/webview/src/pages/ChatPage/mergeToolResults.ts
@@ -1,8 +1,9 @@
-import { LoadedMessageDto, isContentBlockArray } from '../../types';
+import { LoadedMessageDto, isContentBlockArray, getTextContent } from '../../types';
 import { ToolUseBlockDto, ToolResultBlockDto, ContentBlockType } from '../../dto/message/ContentBlockDto';
 import { transformContentBlocks } from '../../mappers/contentBlockTransformer';
 import type { SubAgentMessage } from '../../dto/message/ContentBlockDto';
 import { LoadedMessageType, MessageRole } from '../../dto/common';
+import { parseWorkflowNotification, hasWorkflowNotification } from './message-renderers/utils/parseWorkflowNotification';
 
 /**
  * Convert progress entries into SubAgentMessage array.
@@ -64,6 +65,7 @@ export function mergeToolResults(messages: LoadedMessageDto[]): LoadedMessageDto
           tool_result: undefined,
           childMessages: undefined,
           subAgentMessages: undefined,
+          workflowNotification: undefined,
         });
       }
     }
@@ -83,6 +85,23 @@ export function mergeToolResults(messages: LoadedMessageDto[]): LoadedMessageDto
   const mergedUserMsgs = new Set<LoadedMessageDto>();
   for (const msg of messages) {
     if (msg.type !== LoadedMessageType.User) continue;
+
+    // Phase 2-pre: Attach a dynamic-workflow <task-notification> to its Workflow
+    // tool_use (matched by <tool-use-id>) and hide the raw XML user bubble. Only
+    // hidden when the target tool_use is present in this chain — otherwise the
+    // message falls through and stays visible rather than vanishing silently.
+    const text = getTextContent(msg);
+    if (text && hasWorkflowNotification(text)) {
+      const notification = parseWorkflowNotification(text);
+      const toolUseBlock = notification?.toolUseId
+        ? toolUseMap.get(notification.toolUseId)
+        : undefined;
+      if (notification && toolUseBlock) {
+        toolUseBlock.workflowNotification = notification;
+        mergedUserMsgs.add(msg);
+        continue;
+      }
+    }
 
     // Phase 2a: Attach child messages linked via sourceToolUseID (e.g. skill-expanded prompts)
     if (msg.sourceToolUseID) {

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/TaskOutputRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/TaskOutputRenderer.tsx
@@ -4,6 +4,7 @@ import { Container, LabelValue, RendererProps, ToolHeader, ToolWrapper } from '.
 import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { MessageType } from '@/shared';
+import { parseXmlTag } from '@/utils/parseXmlTag';
 
 class TaskOutputToolUseDto extends ToolUseBlockDto {
     declare input: {
@@ -24,11 +25,6 @@ enum TaskStatus {
     Completed = 'completed',
     Failed = 'failed',
     Stopped = 'stopped',
-}
-
-function parseXmlTag(text: string, tag: string): string | undefined {
-    const match = text.match(new RegExp(`<${tag}>(.*?)</${tag}>`, 's'));
-    return match?.[1]?.trim();
 }
 
 function retrievalStatusLabel(status: string): string {

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from 'react';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ToolUseBlockDto } from '@/dto';
+import type { WorkflowNotification } from '@/dto/message/ContentBlockDto';
+import { ContextPills } from '@/pages/ChatPage/message-renderers';
+import { useWorkflowState } from '@/contexts/WorkflowStateContext';
+import type { WorkflowTask } from '@/shared';
+import { formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
+import { parseWorkflowName } from '@/utils/workflowName';
+import { RendererProps, toolResultText } from './common';
+
+/** Workflow tool input — either an inline `script` or a `scriptPath` resume. */
+class WorkflowToolUseDto extends ToolUseBlockDto {
+    declare input: {
+        description?: string;
+        script?: string;
+        scriptPath?: string;
+        resumeFromRunId?: string;
+    };
+}
+
+/** Re-render every second while `active` so a running workflow's timer ticks. */
+function useNow(active: boolean): number {
+    const [now, setNow] = useState(() => Date.now());
+    useEffect(() => {
+        if (!active) return;
+        const id = setInterval(() => setNow(Date.now()), 1000);
+        return () => clearInterval(id);
+    }, [active]);
+    return now;
+}
+
+const MAX_INLINE_DOTS = 24;
+
+export function WorkflowRenderer(props: RendererProps) {
+    const toolUse = props.toolUse as unknown as WorkflowToolUseDto;
+    const { getByToolUseId, openPanel } = useWorkflowState();
+    const live: WorkflowTask | undefined = getByToolUseId(toolUse.id);
+    const notification: WorkflowNotification | undefined = toolUse.workflowNotification;
+
+    const launched = !!toolResultText(props.toolResult);
+    const status = live?.status ?? notification?.status ?? (launched ? 'running' : undefined);
+    const isRunning = status === 'running';
+    const statusColor = (status && WORKFLOW_STATUS_COLOR[status]) || 'text-text-primary/60';
+
+    const now = useNow(isRunning && !!live);
+
+    const name = live?.name || parseWorkflowName(toolUse.input);
+    const description = live?.description ?? toolUse.input?.description;
+
+    const agents = live?.agents ?? [];
+    const agentCount =
+        agents.length ||
+        live?.usage?.agentCount ||
+        notification?.usage?.agentCount ||
+        undefined;
+
+    const durationMs =
+        live?.usage?.durationMs ??
+        notification?.usage?.durationMs ??
+        (live && isRunning ? now - live.startedAt : undefined);
+    const duration = formatDuration(durationMs);
+
+    const liveTokens = agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
+    const tokens = formatTokens(
+        liveTokens || live?.usage?.subagentTokens || notification?.usage?.subagentTokens,
+    );
+
+    const summary = live?.summary ?? notification?.summary;
+    const usage = live?.usage ?? notification?.usage;
+
+    const metaParts = [
+        'Workflow',
+        agentCount !== undefined ? `${agentCount} agents` : undefined,
+        duration,
+        tokens ? `${tokens} tokens` : undefined,
+    ].filter(Boolean) as string[];
+
+    const showDots = agentCount !== undefined && agentCount <= MAX_INLINE_DOTS && agents.length > 0;
+
+    return (
+        <div className="group pt-2 pb-4 pl-6 pr-3">
+            <div className="max-w-[44rem]">
+                <div className="rounded-lg border border-border-default bg-surface-raised overflow-hidden">
+                    {/* Header: workflow name + status + chevron (opens the panel) */}
+                    <button
+                        type="button"
+                        onClick={() => openPanel(toolUse.id)}
+                        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-surface-hover transition-colors"
+                    >
+                        <div className="min-w-0 flex-1 text-text-primary text-[1rem] font-semibold truncate">
+                            {name}
+                        </div>
+                        {status && (
+                            <span className={`text-[0.8461rem] shrink-0 ${statusColor}`}>{status}</span>
+                        )}
+                        <ChevronRightIcon className="w-4 h-4 text-text-tertiary shrink-0" />
+                    </button>
+
+                    {/* Meta line: Workflow · N agents · duration · tokens */}
+                    <div className="px-3 pb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.8461rem] text-text-primary/60">
+                        {metaParts.map((part, i) => (
+                            <span key={i} className="flex items-center gap-2">
+                                {i > 0 && <span className="text-text-tertiary">·</span>}
+                                {part}
+                            </span>
+                        ))}
+                    </div>
+
+                    {/* Per-agent progress dots */}
+                    {showDots && (
+                        <div className="px-3 pb-2 flex flex-wrap gap-1">
+                            {agents.map((a) => (
+                                <span
+                                    key={a.agentId}
+                                    title={a.label}
+                                    className={`inline-block w-1.5 h-1.5 rounded-full ${
+                                        a.status === 'done'
+                                            ? 'bg-state-success-fg'
+                                            : 'bg-text-link animate-pulse'
+                                    }`}
+                                />
+                            ))}
+                        </div>
+                    )}
+
+                    {/* Body: running hint, or final summary/result */}
+                    {isRunning && !summary && (
+                        <div className="px-3 pb-2.5 text-[0.8461rem] text-text-primary/50">
+                            Running in background…
+                        </div>
+                    )}
+
+                    {(summary || usage) && (
+                        <div className="border-t border-border-subtle px-3 py-2.5 space-y-2">
+                            {summary && (
+                                <div className="text-[0.9230rem] text-text-primary/80">{summary}</div>
+                            )}
+                            {usage && (
+                                <div className="flex flex-wrap gap-x-4 gap-y-1 text-[0.8461rem] text-text-primary/50 font-mono">
+                                    {usage.agentCount !== undefined && <span>agents {usage.agentCount}</span>}
+                                    {tokens && <span>tokens {tokens}</span>}
+                                    {usage.toolUses !== undefined && <span>tools {usage.toolUses}</span>}
+                                    {duration && <span>{duration}</span>}
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+
+                {description && name !== description && (
+                    <div className="mt-1 px-1 text-[0.8461rem] text-text-primary/50">{description}</div>
+                )}
+
+                {props.message?.context && <ContextPills context={props.message.context} />}
+            </div>
+        </div>
+    );
+}

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
@@ -61,9 +61,12 @@ export function WorkflowRenderer(props: RendererProps) {
         (live && isRunning ? now - live.startedAt : undefined);
     const duration = formatDuration(durationMs);
 
+    // Prefer the authoritative workflow-level total (live usage / final
+    // notification) over summing per-agent tokens, which fall back only while the
+    // total isn't known yet (e.g. early in a live run).
     const liveTokens = agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
     const tokens = formatTokens(
-        liveTokens || live?.usage?.subagentTokens || notification?.usage?.subagentTokens,
+        live?.usage?.subagentTokens || notification?.usage?.subagentTokens || liveTokens,
     );
 
     const summary = live?.summary ?? notification?.summary;

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
@@ -4,7 +4,7 @@ import { ToolUseBlockDto } from '@/dto';
 import type { WorkflowNotification } from '@/dto/message/ContentBlockDto';
 import { useWorkflowState } from '@/contexts/WorkflowStateContext';
 import type { WorkflowTask } from '@/shared';
-import { formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
+import { agentDotClass, formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
 import { parseWorkflowName } from '@/utils/workflowName';
 import { RendererProps, ToolHeader, ToolWrapper, toolResultText } from './common';
 
@@ -128,11 +128,7 @@ export function WorkflowRenderer(props: RendererProps) {
                                 <span
                                     key={a.agentId}
                                     title={a.label}
-                                    className={`inline-block w-1.5 h-1.5 rounded-full ${
-                                        a.status === 'done'
-                                            ? 'bg-state-success-fg'
-                                            : 'bg-text-link animate-pulse'
-                                    }`}
+                                    className={`inline-block w-1.5 h-1.5 rounded-full ${agentDotClass(a.status)}`}
                                 />
                             ))}
                         </div>

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/WorkflowRenderer.tsx
@@ -2,12 +2,11 @@ import { useEffect, useState } from 'react';
 import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { ToolUseBlockDto } from '@/dto';
 import type { WorkflowNotification } from '@/dto/message/ContentBlockDto';
-import { ContextPills } from '@/pages/ChatPage/message-renderers';
 import { useWorkflowState } from '@/contexts/WorkflowStateContext';
 import type { WorkflowTask } from '@/shared';
 import { formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
 import { parseWorkflowName } from '@/utils/workflowName';
-import { RendererProps, toolResultText } from './common';
+import { RendererProps, ToolHeader, ToolWrapper, toolResultText } from './common';
 
 /** Workflow tool input — either an inline `script` or a `scriptPath` resume. */
 class WorkflowToolUseDto extends ToolUseBlockDto {
@@ -48,6 +47,8 @@ export function WorkflowRenderer(props: RendererProps) {
     const name = live?.name || parseWorkflowName(toolUse.input);
     const description = live?.description ?? toolUse.input?.description;
 
+    const phases = live?.phases ?? [];
+
     const agents = live?.agents ?? [];
     const agentCount =
         agents.length ||
@@ -72,8 +73,9 @@ export function WorkflowRenderer(props: RendererProps) {
     const summary = live?.summary ?? notification?.summary;
     const usage = live?.usage ?? notification?.usage;
 
+    // 'Workflow' now lives in the ToolHeader (consistent with other tools), so
+    // the meta line carries only the runtime stats.
     const metaParts = [
-        'Workflow',
         agentCount !== undefined ? `${agentCount} agents` : undefined,
         duration,
         tokens ? `${tokens} tokens` : undefined,
@@ -81,9 +83,16 @@ export function WorkflowRenderer(props: RendererProps) {
 
     const showDots = agentCount !== undefined && agentCount <= MAX_INLINE_DOTS && agents.length > 0;
 
+    // Header detail next to the "Workflow" title — only once we have a task id,
+    // so a not-yet-started run never renders "Task ID: undefined".
+    const phaseSuffix =
+        phases.length > 0 ? ` (${phases.length} phase${phases.length === 1 ? '' : 's'})` : '';
+    const headerDetail = live?.taskId ? `Task ID: ${live.taskId}${phaseSuffix}` : '';
+
     return (
-        <div className="group pt-2 pb-4 pl-6 pr-3">
-            <div className="max-w-[44rem]">
+        <ToolWrapper message={props.message}>
+            <ToolHeader name="Workflow" description={headerDetail} />
+            <div className="mt-4 max-w-[44rem]">
                 <div className="rounded-lg border border-border-default bg-surface-raised overflow-hidden">
                     {/* Header: workflow name + status + chevron (opens the panel) */}
                     <button
@@ -100,15 +109,17 @@ export function WorkflowRenderer(props: RendererProps) {
                         <ChevronRightIcon className="w-4 h-4 text-text-tertiary shrink-0" />
                     </button>
 
-                    {/* Meta line: Workflow · N agents · duration · tokens */}
-                    <div className="px-3 pb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.8461rem] text-text-primary/60">
-                        {metaParts.map((part, i) => (
-                            <span key={i} className="flex items-center gap-2">
-                                {i > 0 && <span className="text-text-tertiary">·</span>}
-                                {part}
-                            </span>
-                        ))}
-                    </div>
+                    {/* Meta line: N agents · duration · tokens */}
+                    {metaParts.length > 0 && (
+                        <div className="px-3 pb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[0.8461rem] text-text-primary/60">
+                            {metaParts.map((part, i) => (
+                                <span key={i} className="flex items-center gap-2">
+                                    {i > 0 && <span className="text-text-tertiary">·</span>}
+                                    {part}
+                                </span>
+                            ))}
+                        </div>
+                    )}
 
                     {/* Per-agent progress dots */}
                     {showDots && (
@@ -154,9 +165,7 @@ export function WorkflowRenderer(props: RendererProps) {
                 {description && name !== description && (
                     <div className="mt-1 px-1 text-[0.8461rem] text-text-primary/50">{description}</div>
                 )}
-
-                {props.message?.context && <ContextPills context={props.message.context} />}
             </div>
-        </div>
+        </ToolWrapper>
     );
 }

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/index.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/index.tsx
@@ -23,6 +23,7 @@ import {TaskGetRenderer} from "./TaskGetRenderer.tsx";
 import {TaskListRenderer} from "./TaskListRenderer.tsx";
 import {TaskUpdateRenderer} from "./TaskUpdateRenderer.tsx";
 import {NotebookEditRenderer} from "./NotebookEditRenderer.tsx";
+import {WorkflowRenderer} from "./WorkflowRenderer.tsx";
 import {McpRenderers} from "./Mcp";
 
 interface ToolRendererProps {
@@ -56,5 +57,6 @@ export const ToolRendererMap = new Map<string, FC<ToolRendererProps>>([
     ['TaskOutput', TaskOutputRenderer],
     ['TaskStop', TaskStopRenderer],
     ['NotebookEdit', NotebookEditRenderer],
+    ['Workflow', WorkflowRenderer],
     ...McpRenderers,
 ]);

--- a/webview/src/pages/ChatPage/message-renderers/utils/__tests__/parseWorkflowNotification.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/__tests__/parseWorkflowNotification.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { hasWorkflowNotification, parseWorkflowNotification } from '../parseWorkflowNotification';
+
+const SAMPLE = [
+  '<task-notification>',
+  '<task-id>wzzuuhjwu</task-id>',
+  '<tool-use-id>toolu_011Fk6wuDvjsEDFe7whGqGrc</tool-use-id>',
+  '<output-file>/private/tmp/x/tasks/wzzuuhjwu.output</output-file>',
+  '<status>completed</status>',
+  '<summary>Dynamic workflow "Analyze 68 batches" completed</summary>',
+  '<result>{"completed":68,"total":68}</result>',
+  '<usage><agent_count>68</agent_count><subagent_tokens>4569489</subagent_tokens><tool_uses>801</tool_uses><duration_ms>1598048</duration_ms></usage>',
+  '</task-notification>',
+].join('\n');
+
+describe('parseWorkflowNotification', () => {
+  it('detects the notification envelope', () => {
+    expect(hasWorkflowNotification(SAMPLE)).toBe(true);
+    expect(hasWorkflowNotification('no envelope here')).toBe(false);
+  });
+
+  it('returns null for non-notification text', () => {
+    expect(parseWorkflowNotification('just some text')).toBeNull();
+  });
+
+  it('parses every field including the usage sub-block', () => {
+    const n = parseWorkflowNotification(SAMPLE)!;
+    expect(n.taskId).toBe('wzzuuhjwu');
+    expect(n.toolUseId).toBe('toolu_011Fk6wuDvjsEDFe7whGqGrc');
+    expect(n.outputFile).toBe('/private/tmp/x/tasks/wzzuuhjwu.output');
+    expect(n.status).toBe('completed');
+    expect(n.summary).toContain('completed');
+    expect(n.result).toBe('{"completed":68,"total":68}');
+    expect(n.usage).toEqual({
+      agentCount: 68,
+      subagentTokens: 4569489,
+      toolUses: 801,
+      durationMs: 1598048,
+    });
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/utils/parseWorkflowNotification.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/parseWorkflowNotification.ts
@@ -1,0 +1,40 @@
+import { parseXmlTag } from '@/utils/parseXmlTag';
+import type { WorkflowNotification } from '@/dto/message/ContentBlockDto';
+
+const NOTIFICATION_TAG = '<task-notification>';
+
+/** Cheap check before the heavier parse. */
+export function hasWorkflowNotification(text: string): boolean {
+    return text.includes(NOTIFICATION_TAG);
+}
+
+function toInt(value: string | undefined): number | undefined {
+    if (value === undefined) return undefined;
+    const n = parseInt(value, 10);
+    return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Parse a `<task-notification>` envelope into a {@link WorkflowNotification}.
+ * Returns null when the text carries no notification. The `<usage>` sub-block is
+ * parsed from its own slice so the inner numeric tags don't collide with any
+ * same-named tags elsewhere in the message.
+ */
+export function parseWorkflowNotification(text: string): WorkflowNotification | null {
+    if (!hasWorkflowNotification(text)) return null;
+    const usage = parseXmlTag(text, 'usage') ?? '';
+    return {
+        taskId: parseXmlTag(text, 'task-id'),
+        toolUseId: parseXmlTag(text, 'tool-use-id'),
+        outputFile: parseXmlTag(text, 'output-file'),
+        status: parseXmlTag(text, 'status'),
+        summary: parseXmlTag(text, 'summary'),
+        result: parseXmlTag(text, 'result'),
+        usage: {
+            agentCount: toInt(parseXmlTag(usage, 'agent_count')),
+            subagentTokens: toInt(parseXmlTag(usage, 'subagent_tokens')),
+            toolUses: toInt(parseXmlTag(usage, 'tool_uses')),
+            durationMs: toInt(parseXmlTag(usage, 'duration_ms')),
+        },
+    };
+}

--- a/webview/src/shared/index.ts
+++ b/webview/src/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './client-env';
 export * from './message-type';
+export * from './workflow';

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -201,6 +201,8 @@ export enum MessageType {
   TOOL_USE = 'TOOL_USE',
   /** A tool invocation completed (with result). */
   TOOL_COMPLETE = 'TOOL_COMPLETE',
+  /** Live progress of a background dynamic workflow; payload is a WorkflowTask. */
+  WORKFLOW_PROGRESS = 'WORKFLOW_PROGRESS',
 
   // -- Diff push --
   /** A diff is available to review. */

--- a/webview/src/shared/workflow.ts
+++ b/webview/src/shared/workflow.ts
@@ -17,7 +17,9 @@ export interface WorkflowPhase {
 export interface WorkflowAgent {
   agentId: string;
   label: string;
-  status: 'running' | 'done';
+  /** `done` = finished successfully; `stopped` = cut off when the workflow was
+   *  interrupted (never settle an unfinished agent to `done`). */
+  status: 'running' | 'done' | 'stopped';
   tokens: number;
   tools: number;
   durationMs: number;

--- a/webview/src/shared/workflow.ts
+++ b/webview/src/shared/workflow.ts
@@ -1,0 +1,57 @@
+// Shared dynamic-workflow types. MUST stay 1:1 with webview/src/shared/workflow.ts
+// (see CLAUDE.md). Payload of MessageType.WORKFLOW_PROGRESS (backend → webview).
+
+export type WorkflowStatus = 'running' | 'completed' | 'failed' | 'stopped';
+
+/** A declared phase from the workflow script's `meta.phases`. */
+export interface WorkflowPhase {
+  title: string;
+  detail?: string;
+}
+
+/**
+ * One subagent of a workflow. Stats are computed by the backend from the agent
+ * transcript files; `label` is best-effort (derived from the agent's result) as
+ * the runtime does not persist the script-supplied label.
+ */
+export interface WorkflowAgent {
+  agentId: string;
+  label: string;
+  status: 'running' | 'done';
+  tokens: number;
+  tools: number;
+  durationMs: number;
+}
+
+/** Aggregate usage, populated from the final `<task-notification>` `<usage>`. */
+export interface WorkflowUsage {
+  agentCount?: number;
+  subagentTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+/** Live + final state of a single background dynamic workflow. */
+export interface WorkflowTask {
+  /** Workflow tool_use id — the stable key correlating card, panel and events. */
+  toolUseId: string;
+  /** Background task id (e.g. "w94mspihl") from the immediate tool_result. */
+  taskId?: string;
+  /** Workflow run id (e.g. "wf_ce882bfa-ddf"), the transcript dir basename. */
+  workflowId?: string;
+  name: string;
+  description?: string;
+  /** Absolute path to …/subagents/workflows/wf_<id>. */
+  transcriptDir?: string;
+  /** Absolute path to the task output file (from the notification). */
+  outputFile?: string;
+  status: WorkflowStatus;
+  startedAt: number;
+  endedAt?: number;
+  phases: WorkflowPhase[];
+  agents: WorkflowAgent[];
+  summary?: string;
+  /** Workflow return value (raw `<result>` text). */
+  result?: string;
+  usage?: WorkflowUsage;
+}

--- a/webview/src/utils/parseXmlTag.ts
+++ b/webview/src/utils/parseXmlTag.ts
@@ -1,0 +1,10 @@
+/**
+ * Extract the inner text of the first `<tag>…</tag>` occurrence (dot matches
+ * newlines). Returns the trimmed inner text, or `undefined` when the tag is
+ * absent. Used to read the pseudo-XML envelopes the CLI emits for background
+ * tasks and dynamic-workflow `<task-notification>` messages.
+ */
+export function parseXmlTag(text: string, tag: string): string | undefined {
+    const match = text.match(new RegExp(`<${tag}>(.*?)</${tag}>`, 's'));
+    return match?.[1]?.trim();
+}

--- a/webview/src/utils/workflowFormat.ts
+++ b/webview/src/utils/workflowFormat.ts
@@ -22,3 +22,19 @@ export const WORKFLOW_STATUS_COLOR: Record<string, string> = {
     failed: 'text-state-error-fg',
     stopped: 'text-state-warning-fg',
 };
+
+/**
+ * Tailwind background for an agent progress dot. `done` is green (succeeded),
+ * `stopped` is a muted grey (cut off when the workflow was interrupted — not a
+ * success), `running` pulses blue.
+ */
+export function agentDotClass(status: 'running' | 'done' | 'stopped'): string {
+    switch (status) {
+        case 'done':
+            return 'bg-state-success-fg';
+        case 'stopped':
+            return 'bg-text-tertiary';
+        default:
+            return 'bg-text-link animate-pulse';
+    }
+}

--- a/webview/src/utils/workflowFormat.ts
+++ b/webview/src/utils/workflowFormat.ts
@@ -1,0 +1,24 @@
+/** Format a millisecond duration as "Ns" / "Nm" / "Nm Ms". Returns undefined for 0/none. */
+export function formatDuration(ms?: number): string | undefined {
+    if (!ms || ms <= 0) return undefined;
+    const totalSec = Math.round(ms / 1000);
+    if (totalSec < 60) return `${totalSec}s`;
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
+    return sec ? `${min}m ${sec}s` : `${min}m`;
+}
+
+/** Format a token count as "1.2k" once it crosses 1000. Returns undefined for 0/none. */
+export function formatTokens(n?: number): string | undefined {
+    if (n === undefined || n <= 0) return undefined;
+    if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+    return String(n);
+}
+
+/** Tailwind text color for a workflow/agent status. */
+export const WORKFLOW_STATUS_COLOR: Record<string, string> = {
+    running: 'text-text-link',
+    completed: 'text-state-success-fg',
+    failed: 'text-state-error-fg',
+    stopped: 'text-state-warning-fg',
+};

--- a/webview/src/utils/workflowName.ts
+++ b/webview/src/utils/workflowName.ts
@@ -1,0 +1,20 @@
+interface WorkflowInputLike {
+    script?: string;
+    scriptPath?: string;
+    description?: string;
+}
+
+/**
+ * Best-effort display name for a Workflow tool_use: the script's `meta.name`,
+ * else the resumed scriptPath basename (sans extension), else the description.
+ */
+export function parseWorkflowName(input: WorkflowInputLike | undefined): string {
+    if (!input) return 'workflow';
+    const fromScript = input.script?.match(/name\s*:\s*['"]([^'"]+)['"]/)?.[1];
+    if (fromScript) return fromScript;
+    if (input.scriptPath) {
+        const base = input.scriptPath.split(/[\\/]/).pop() ?? input.scriptPath;
+        return base.replace(/\.[cm]?[jt]s$/i, '');
+    }
+    return input.description || 'workflow';
+}


### PR DESCRIPTION
Add Workflow tool support that tracks background dynamic workflows and streams live per-agent progress to the webview.

Backend:
- WorkflowProgressTracker translates CLI task_started/task_progress/ task_notification stream events into WorkflowTask state and broadcasts WORKFLOW_PROGRESS; cleared per session on process close.
- reconstructWorkflowTasks rebuilds finished/running workflows from the persisted transcript + runtime files on session load/reclaim.

Webview:
- WorkflowStateContext holds live workflow state keyed by tool_use id, reset on session change.
- WorkflowRenderer inline card + BackgroundTasksPanel with a header button.
- mergeToolResults attaches task-notification envelopes to their Workflow tool_use and hides the raw XML bubble.

Also ignore local.properties (machine-specific Gradle SDK path).