### PR TITLE
feat: live-tail external terminal sessions via SESSION_APPEND

### DIFF
--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -8,6 +8,7 @@ import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
 import { reportBackendError } from './features/telemetry';
 import { MessageType } from '../shared';
+import { getSessionJsonlWatcher } from './features/session-jsonl-watcher';
 
 // Tracks files Claude edits so the IDE can be told to reload them once the
 // edit completes on disk. Shared across sessions — tool_use ids are unique.
@@ -221,6 +222,7 @@ export async function ensureClaudeProcess(
 
   // SessionRecord에 프로세스 저장
   connections.setProcess(targetSessionId, proc);
+  getSessionJsonlWatcher()?.promoteToOwned(targetSessionId);
   connections.setBuffer(targetSessionId, '');
 
   // 모든 구독자에게 스트림 시작 알림

--- a/backend/src/core/features/__tests__/external-turn.test.ts
+++ b/backend/src/core/features/__tests__/external-turn.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import {
+  conversationalEntries,
+  isTurnWorking,
+  accumulateTurnTokens,
+  type ConvoEntry,
+} from '../external-turn';
+
+describe('conversationalEntries', () => {
+  it('keeps user/assistant/result and drops trailing metadata', () => {
+    const messages = [
+      { type: 'user' },
+      { type: 'assistant' },
+      { type: 'result' },
+      { type: 'last-prompt' },
+      { type: 'mode' },
+      { type: 'summary' },
+      null,
+      undefined,
+      {},
+    ] as any[];
+    expect(conversationalEntries(messages).map((m) => m.type)).toEqual([
+      'user',
+      'assistant',
+      'result',
+    ]);
+  });
+});
+
+describe('isTurnWorking', () => {
+  it('is false for a metadata-only (empty convo) batch', () => {
+    expect(isTurnWorking([])).toBe(false);
+  });
+
+  it('is false when the last entry is a result', () => {
+    expect(isTurnWorking([{ type: 'assistant' }, { type: 'result' }])).toBe(false);
+  });
+
+  it('is false when the assistant turn ended (terminal stop_reason)', () => {
+    for (const stop_reason of ['end_turn', 'stop_sequence', 'max_tokens']) {
+      expect(isTurnWorking([{ type: 'assistant', message: { stop_reason } }])).toBe(false);
+    }
+  });
+
+  it('is true when the assistant emitted a tool_use (more coming)', () => {
+    expect(isTurnWorking([{ type: 'assistant', message: { stop_reason: 'tool_use' } }])).toBe(true);
+  });
+
+  it('is true when the assistant stop_reason is null/absent (still streaming)', () => {
+    expect(isTurnWorking([{ type: 'assistant', message: { stop_reason: null } }])).toBe(true);
+    expect(isTurnWorking([{ type: 'assistant', message: {} }])).toBe(true);
+    expect(isTurnWorking([{ type: 'assistant' }])).toBe(true);
+  });
+
+  it('is true when the last entry is a user message', () => {
+    expect(isTurnWorking([{ type: 'user' }])).toBe(true);
+  });
+});
+
+describe('accumulateTurnTokens', () => {
+  it('counts a single assistant message once', () => {
+    const byId = new Map<string, number>();
+    const total = accumulateTurnTokens(
+      [{ type: 'assistant', message: { id: 'm1', usage: { output_tokens: 100 } } }],
+      byId,
+    );
+    expect(total).toBe(100);
+  });
+
+  it('de-duplicates content-block repeats that share a message id and output_tokens', () => {
+    const byId = new Map<string, number>();
+    // One API response written as 4 JSONL lines, all repeating output_tokens=1081.
+    const convo: ConvoEntry[] = Array.from({ length: 4 }, () => ({
+      type: 'assistant',
+      message: { id: 'msg_same', usage: { output_tokens: 1081 } },
+    }));
+    expect(accumulateTurnTokens(convo, byId)).toBe(1081);
+  });
+
+  it('is idempotent when the same batch is re-delivered (multiple subscribers)', () => {
+    const byId = new Map<string, number>();
+    const batch: ConvoEntry[] = [
+      { type: 'assistant', message: { id: 'a', usage: { output_tokens: 500 } } },
+    ];
+    expect(accumulateTurnTokens(batch, byId)).toBe(500);
+    // Same batch delivered again to a second subscriber must NOT double to 1000.
+    expect(accumulateTurnTokens(batch, byId)).toBe(500);
+  });
+
+  it('accumulates distinct messages across mid-turn batches', () => {
+    const byId = new Map<string, number>();
+    accumulateTurnTokens(
+      [{ type: 'user' }, { type: 'assistant', message: { id: 'a', usage: { output_tokens: 100 } } }],
+      byId,
+    );
+    const total = accumulateTurnTokens(
+      [{ type: 'assistant', message: { id: 'b', usage: { output_tokens: 250 } } }],
+      byId,
+    );
+    expect(total).toBe(350);
+  });
+
+  it('resets the counter when a new user turn begins', () => {
+    const byId = new Map<string, number>();
+    accumulateTurnTokens(
+      [{ type: 'assistant', message: { id: 'a', usage: { output_tokens: 900 } } }],
+      byId,
+    );
+    const total = accumulateTurnTokens(
+      [{ type: 'user' }, { type: 'assistant', message: { id: 'b', usage: { output_tokens: 40 } } }],
+      byId,
+    );
+    expect(total).toBe(40);
+  });
+
+  it('ignores assistant entries missing an id or numeric token count', () => {
+    const byId = new Map<string, number>();
+    const total = accumulateTurnTokens(
+      [
+        { type: 'assistant', message: { usage: { output_tokens: 100 } } }, // no id
+        { type: 'assistant', message: { id: 'x' } }, // no usage
+        { type: 'assistant', message: { id: 'y', usage: { output_tokens: 7 } } },
+      ],
+      byId,
+    );
+    expect(total).toBe(7);
+  });
+});

--- a/backend/src/core/features/__tests__/session-jsonl-watcher.test.ts
+++ b/backend/src/core/features/__tests__/session-jsonl-watcher.test.ts
@@ -107,4 +107,54 @@ describe('SessionJsonlWatcher', () => {
 
     expect(appendSpy).not.toHaveBeenCalled();
   });
+
+  it('unwatchConnection removes connection from all watched sessions (WebView tab close)', async () => {
+    const tempFilePath2 = join(tmpdir(), `test-watcher-multi-${Date.now()}.jsonl`);
+    await fsPromises.writeFile(tempFilePath2, '{"uuid":"a"}\n');
+
+    try {
+      await watcher.watch('conn1', 'sess1', tempFilePath);
+      await watcher.watch('conn1', 'sess2', tempFilePath2);
+
+      // conn1 is watching both sessions — simulate WebView tab close
+      watcher.unwatchConnection('conn1');
+
+      await fsPromises.appendFile(tempFilePath, '{"uuid":"2"}\n');
+      await fsPromises.appendFile(tempFilePath2, '{"uuid":"b"}\n');
+      await watcher.tailRead('sess1');
+      await watcher.tailRead('sess2');
+
+      expect(appendSpy).not.toHaveBeenCalled();
+    } finally {
+      await fsPromises.unlink(tempFilePath2).catch(() => {});
+    }
+  });
+
+  it('switching sessions: re-watching does not mix history from previous session', async () => {
+    const tempFilePath2 = join(tmpdir(), `test-watcher-switch-${Date.now()}.jsonl`);
+    await fsPromises.writeFile(tempFilePath2, '{"uuid":"a"}\n');
+
+    try {
+      // conn1 loads sess1 first
+      await watcher.watch('conn1', 'sess1', tempFilePath);
+      // conn1 switches to sess2 — must unwatch previous session first
+      watcher.unwatchConnection('conn1');
+      await watcher.watch('conn1', 'sess2', tempFilePath2);
+
+      // append to sess1 — conn1 must NOT receive it
+      await fsPromises.appendFile(tempFilePath, '{"uuid":"2","type":"user"}\n');
+      await watcher.tailRead('sess1');
+      expect(appendSpy).not.toHaveBeenCalled();
+
+      // append to sess2 — conn1 MUST receive it
+      await fsPromises.appendFile(tempFilePath2, '{"uuid":"b","type":"assistant"}\n');
+      await watcher.tailRead('sess2');
+      expect(appendSpy).toHaveBeenCalledTimes(1);
+      expect(appendSpy).toHaveBeenCalledWith('conn1', 'sess2', [
+        { uuid: 'b', type: 'assistant' },
+      ]);
+    } finally {
+      await fsPromises.unlink(tempFilePath2).catch(() => {});
+    }
+  });
 });

--- a/backend/src/core/features/__tests__/session-jsonl-watcher.test.ts
+++ b/backend/src/core/features/__tests__/session-jsonl-watcher.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readNewBytes, SessionJsonlWatcher } from '../session-jsonl-watcher';
+
+describe('readNewBytes', () => {
+  let tempFilePath: string;
+
+  beforeEach(() => {
+    tempFilePath = join(tmpdir(), `test-watch-${Date.now()}-${Math.random()}.jsonl`);
+  });
+
+  afterEach(async () => {
+    try {
+      await fsPromises.unlink(tempFilePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('reads new bytes from startOffset', async () => {
+    await fsPromises.writeFile(tempFilePath, 'hello world');
+    const res = await readNewBytes(tempFilePath, 6);
+    expect(res.bytesRead).toBe(5);
+    expect(res.data).toBe('world');
+  });
+
+  it('handles truncation/file-shrink by resetting startOffset to 0', async () => {
+    await fsPromises.writeFile(tempFilePath, 'hello world long text');
+    // Shrink file
+    await fsPromises.writeFile(tempFilePath, 'short');
+    const res = await readNewBytes(tempFilePath, 10);
+    expect(res.bytesRead).toBe(5);
+    expect(res.data).toBe('short');
+  });
+});
+
+describe('SessionJsonlWatcher', () => {
+  let tempFilePath: string;
+  let watcher: SessionJsonlWatcher;
+  let appendSpy: any;
+
+  beforeEach(async () => {
+    tempFilePath = join(tmpdir(), `test-watcher-class-${Date.now()}.jsonl`);
+    await fsPromises.writeFile(tempFilePath, '{"uuid":"1","type":"user","message":"hello"}\n');
+    appendSpy = vi.fn();
+    watcher = new SessionJsonlWatcher(appendSpy);
+  });
+
+  afterEach(async () => {
+    watcher.stopAll();
+    try {
+      await fsPromises.unlink(tempFilePath);
+    } catch {
+      // ignore
+    }
+  });
+
+  it('sets byteOffset to current file size on watch startup and reads new appends', async () => {
+    await watcher.watch('conn1', 'sess1', tempFilePath);
+    
+    // Append a new line
+    await fsPromises.appendFile(tempFilePath, '{"uuid":"2","type":"assistant","message":"hi"}\n');
+    
+    // Trigger tailRead manually for synchronous test testing
+    await watcher.tailRead('sess1');
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy).toHaveBeenCalledWith('conn1', 'sess1', [
+      { uuid: '2', type: 'assistant', message: 'hi' },
+    ]);
+  });
+
+  it('handles multiple connections watching same session (refcounting)', async () => {
+    const appendSpy2 = vi.fn();
+    const watcherMult = new SessionJsonlWatcher((conn, sess, msgs) => {
+      if (conn === 'conn1') appendSpy(conn, sess, msgs);
+      else appendSpy2(conn, sess, msgs);
+    });
+
+    await watcherMult.watch('conn1', 'sess1', tempFilePath);
+    await watcherMult.watch('conn2', 'sess1', tempFilePath);
+
+    await fsPromises.appendFile(tempFilePath, '{"uuid":"2","type":"assistant"}\n');
+    await watcherMult.tailRead('sess1');
+
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+    expect(appendSpy2).toHaveBeenCalledTimes(1);
+
+    // Unwatch connection 1
+    watcherMult.unwatch('conn1', 'sess1');
+    await fsPromises.appendFile(tempFilePath, '{"uuid":"3","type":"user"}\n');
+    await watcherMult.tailRead('sess1');
+
+    expect(appendSpy).toHaveBeenCalledTimes(1); // still 1
+    expect(appendSpy2).toHaveBeenCalledTimes(2); // increased to 2
+  });
+
+  it('promoteToOwned immediately stops watching and deletes entry', async () => {
+    await watcher.watch('conn1', 'sess1', tempFilePath);
+    watcher.promoteToOwned('sess1');
+
+    await fsPromises.appendFile(tempFilePath, '{"uuid":"2","type":"assistant"}\n');
+    await watcher.tailRead('sess1'); // should do nothing since entry is deleted
+
+    expect(appendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/features/external-turn.ts
+++ b/backend/src/core/features/external-turn.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for classifying an externally-tailed (live-tailed terminal) session's
+ * current turn from its raw JSONL entries. Extracted from server.ts so the edge-case
+ * logic (stop_reason variants, metadata-only batches, per-message token de-dup) is
+ * unit-testable in isolation.
+ */
+
+/** stop_reason values that mark an assistant turn as finished. */
+export const TERMINAL_STOP_REASONS = ['end_turn', 'stop_sequence', 'max_tokens'];
+
+/** The subset of a Claude Code JSONL entry this module reads. */
+export interface ConvoEntry {
+  type?: string;
+  message?: {
+    id?: string;
+    stop_reason?: string | null;
+    usage?: { output_tokens?: number };
+  };
+}
+
+/** Conversational entry types. Everything else is trailing session metadata. */
+const CONVO_TYPES = new Set(['user', 'assistant', 'result']);
+
+/**
+ * Keep only conversational entries; drop trailing session metadata lines
+ * (last-prompt / mode / pr-link / summary …) which are written after a turn and
+ * must not be treated as "still working".
+ */
+export function conversationalEntries<T extends ConvoEntry>(messages: T[]): T[] {
+  return messages.filter((m) => !!m && typeof m.type === 'string' && CONVO_TYPES.has(m.type));
+}
+
+/**
+ * Decide whether an externally-tailed session is still mid-turn, given the
+ * conversational entries from the latest append batch.
+ */
+export function isTurnWorking(convo: ConvoEntry[]): boolean {
+  const last = convo[convo.length - 1];
+  // Batch carried only metadata → no active turn signalled.
+  if (!last) return false;
+  if (last.type === 'result') return false;
+  if (last.type === 'assistant') {
+    // stop_reason lives under `message`. `tool_use` (a tool call → more coming)
+    // or an unstamped/null reason means the turn is still in progress.
+    const stopReason = last.message?.stop_reason;
+    return !stopReason || !TERMINAL_STOP_REASONS.includes(stopReason);
+  }
+  // Latest entry is a user message → assistant is about to respond.
+  return true;
+}
+
+/**
+ * Accumulate the active turn's output tokens into `tokensById`, keyed by the
+ * assistant message id.
+ *
+ * Claude Code writes one assistant API response across MULTIPLE JSONL lines (one per
+ * content block: thinking / text / tool_use …) that all repeat the SAME
+ * usage.output_tokens. Keying by message id therefore (a) de-duplicates those
+ * content-block repeats — fixing a 2x–5x overcount — and (b) makes re-delivery of the
+ * identical batch to several subscribers idempotent — fixing the per-viewer
+ * double-count. A user entry in the batch starts a fresh turn.
+ *
+ * Returns the active turn's running total.
+ */
+export function accumulateTurnTokens(convo: ConvoEntry[], tokensById: Map<string, number>): number {
+  const hasUserMsg = convo.some((m) => m && m.type === 'user');
+  if (hasUserMsg) tokensById.clear();
+
+  for (const m of convo) {
+    if (m && m.type === 'assistant') {
+      const tokens = m.message?.usage?.output_tokens;
+      const id = m.message?.id;
+      if (typeof tokens === 'number' && typeof id === 'string') {
+        tokensById.set(id, tokens);
+      }
+    }
+  }
+
+  let total = 0;
+  for (const v of tokensById.values()) total += v;
+  return total;
+}

--- a/backend/src/core/features/session-jsonl-watcher.ts
+++ b/backend/src/core/features/session-jsonl-watcher.ts
@@ -1,0 +1,226 @@
+import { watch, type FSWatcher } from 'fs';
+import * as fsPromises from 'fs/promises';
+
+interface WatchEntry {
+  sessionId: string;
+  filePath: string;
+  watcher: FSWatcher | null;
+  byteOffset: number;
+  partialLine: string;
+  subscribers: Map<string, (messages: any[]) => void>;
+  reading: boolean;
+  rereadPending: boolean;
+  debounceTimer: NodeJS.Timeout | null;
+}
+
+export async function readNewBytes(
+  filePath: string,
+  startOffset: number,
+): Promise<{ bytesRead: number; data: string }> {
+  try {
+    const stat = await fsPromises.stat(filePath);
+    const size = stat.size;
+    let actualStart = startOffset;
+    if (size < startOffset) {
+      actualStart = 0;
+    }
+    if (size <= actualStart) {
+      return { bytesRead: 0, data: '' };
+    }
+    const fd = await fsPromises.open(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(size - actualStart);
+      const { bytesRead } = await fd.read(buffer, 0, buffer.length, actualStart);
+      return { bytesRead, data: buffer.toString('utf-8') };
+    } finally {
+      await fd.close();
+    }
+  } catch (err) {
+    console.error('[SessionJsonlWatcher] Error reading new bytes:', err);
+    return { bytesRead: 0, data: '' };
+  }
+}
+
+export class SessionJsonlWatcher {
+  private entries = new Map<string, WatchEntry>();
+  private onAppend: (connectionId: string, sessionId: string, messages: any[]) => void;
+
+  constructor(onAppend: (connectionId: string, sessionId: string, messages: any[]) => void) {
+    this.onAppend = onAppend;
+  }
+
+  async watch(
+    connectionId: string,
+    sessionId: string,
+    filePath: string,
+  ): Promise<void> {
+    let entry = this.entries.get(sessionId);
+    if (!entry) {
+      let initialOffset = 0;
+      try {
+        const stat = await fsPromises.stat(filePath).catch(() => null);
+        if (stat) {
+          initialOffset = stat.size;
+        }
+      } catch {
+        // ignore
+      }
+
+      entry = {
+        sessionId,
+        filePath,
+        watcher: null,
+        byteOffset: initialOffset,
+        partialLine: '',
+        subscribers: new Map(),
+        reading: false,
+        rereadPending: false,
+        debounceTimer: null,
+      };
+
+      this.entries.set(sessionId, entry);
+
+      try {
+        const watcher = watch(filePath, (_eventType) => {
+          const ent = this.entries.get(sessionId);
+          if (!ent) return;
+
+          if (ent.debounceTimer) clearTimeout(ent.debounceTimer);
+          ent.debounceTimer = setTimeout(() => {
+            void this.tailRead(sessionId);
+          }, 100);
+        });
+        entry.watcher = watcher;
+      } catch (err) {
+        console.error(`[SessionJsonlWatcher] Failed to watch file ${filePath}:`, err);
+      }
+    }
+
+    entry.subscribers.set(connectionId, (messages) => {
+      this.onAppend(connectionId, sessionId, messages);
+    });
+  }
+
+  async tailRead(sessionId: string): Promise<void> {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return;
+
+    if (entry.reading) {
+      entry.rereadPending = true;
+      return;
+    }
+
+    entry.reading = true;
+    try {
+      const { bytesRead, data } = await readNewBytes(entry.filePath, entry.byteOffset);
+      if (bytesRead > 0) {
+        entry.byteOffset += bytesRead;
+        const fullText = entry.partialLine + data;
+        const lines = fullText.split('\n');
+        entry.partialLine = lines.pop() ?? '';
+
+        const messages: any[] = [];
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            messages.push(JSON.parse(line));
+          } catch (e) {
+            // ignore malformed lines
+          }
+        }
+
+        if (messages.length > 0) {
+          for (const callback of entry.subscribers.values()) {
+            try {
+              callback(messages);
+            } catch (e) {
+              console.error('[SessionJsonlWatcher] callback error:', e);
+            }
+          }
+        }
+      }
+    } catch (e) {
+      console.error('[SessionJsonlWatcher] Error in tailRead:', e);
+    } finally {
+      entry.reading = false;
+      if (entry.rereadPending) {
+        entry.rereadPending = false;
+        void this.tailRead(sessionId);
+      }
+    }
+  }
+
+  unwatch(connectionId: string, sessionId: string): void {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return;
+
+    entry.subscribers.delete(connectionId);
+
+    if (entry.subscribers.size === 0) {
+      if (entry.watcher) {
+        entry.watcher.close();
+      }
+      if (entry.debounceTimer) {
+        clearTimeout(entry.debounceTimer);
+      }
+      this.entries.delete(sessionId);
+    }
+  }
+
+  unwatchConnection(connectionId: string): void {
+    for (const [sessionId, entry] of this.entries.entries()) {
+      if (entry.subscribers.has(connectionId)) {
+        this.unwatch(connectionId, sessionId);
+      }
+    }
+  }
+
+  promoteToOwned(sessionId: string): void {
+    const entry = this.entries.get(sessionId);
+    if (!entry) return;
+
+    if (entry.watcher) {
+      entry.watcher.close();
+    }
+    if (entry.debounceTimer) {
+      clearTimeout(entry.debounceTimer);
+    }
+    this.entries.delete(sessionId);
+  }
+
+  stopAll(): void {
+    for (const [, entry] of this.entries.entries()) {
+      if (entry.watcher) {
+        entry.watcher.close();
+      }
+      if (entry.debounceTimer) {
+        clearTimeout(entry.debounceTimer);
+      }
+    }
+    this.entries.clear();
+    console.log('[node-backend]', 'All session jsonl watchers stopped');
+  }
+}
+
+let globalInstance: SessionJsonlWatcher | null = null;
+
+export function getSessionJsonlWatcher(): SessionJsonlWatcher | null {
+  return globalInstance;
+}
+
+export function initSessionJsonlWatcher(
+  onAppend: (connectionId: string, sessionId: string, messages: any[]) => void,
+): SessionJsonlWatcher {
+  if (globalInstance) {
+    globalInstance.stopAll();
+  }
+  globalInstance = new SessionJsonlWatcher(onAppend);
+  return globalInstance;
+}
+
+export function stopSessionJsonlWatcher(): void {
+  if (globalInstance) {
+    globalInstance.stopAll();
+    globalInstance = null;
+  }
+}

--- a/backend/src/core/features/session-jsonl-watcher.ts
+++ b/backend/src/core/features/session-jsonl-watcher.ts
@@ -44,9 +44,14 @@ export async function readNewBytes(
 export class SessionJsonlWatcher {
   private entries = new Map<string, WatchEntry>();
   private onAppend: (connectionId: string, sessionId: string, messages: any[]) => void;
+  private onSessionUnwatched?: (sessionId: string) => void;
 
-  constructor(onAppend: (connectionId: string, sessionId: string, messages: any[]) => void) {
+  constructor(
+    onAppend: (connectionId: string, sessionId: string, messages: any[]) => void,
+    onSessionUnwatched?: (sessionId: string) => void,
+  ) {
     this.onAppend = onAppend;
+    this.onSessionUnwatched = onSessionUnwatched;
   }
 
   async watch(
@@ -164,6 +169,7 @@ export class SessionJsonlWatcher {
         clearTimeout(entry.debounceTimer);
       }
       this.entries.delete(sessionId);
+      this.onSessionUnwatched?.(sessionId);
     }
   }
 
@@ -186,6 +192,7 @@ export class SessionJsonlWatcher {
       clearTimeout(entry.debounceTimer);
     }
     this.entries.delete(sessionId);
+    this.onSessionUnwatched?.(sessionId);
   }
 
   stopAll(): void {
@@ -210,11 +217,12 @@ export function getSessionJsonlWatcher(): SessionJsonlWatcher | null {
 
 export function initSessionJsonlWatcher(
   onAppend: (connectionId: string, sessionId: string, messages: any[]) => void,
+  onSessionUnwatched?: (sessionId: string) => void,
 ): SessionJsonlWatcher {
   if (globalInstance) {
     globalInstance.stopAll();
   }
-  globalInstance = new SessionJsonlWatcher(onAppend);
+  globalInstance = new SessionJsonlWatcher(onAppend, onSessionUnwatched);
   return globalInstance;
 }
 

--- a/backend/src/core/handlers/getRunningSessions.ts
+++ b/backend/src/core/handlers/getRunningSessions.ts
@@ -1,0 +1,16 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { MessageType } from '../../shared';
+
+export async function getRunningSessionsHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  connections.sendTo(connectionId, MessageType.ACK, {
+    requestId: message.requestId,
+    sessionIds: connections.getRunningSessionIds(),
+  });
+}

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -10,6 +10,7 @@ import { startSessionHandler } from './startSession';
 import { sessionChangeHandler } from './sessionChange';
 import { toolResponseHandler } from './toolResponse';
 import { getSessionsHandler } from './getSessions';
+import { getRunningSessionsHandler } from './getRunningSessions';
 import { loadSessionHandler } from './loadSession';
 import { deleteSessionHandler } from './deleteSession';
 import { renameSessionHandler } from './renameSession';
@@ -107,6 +108,9 @@ export async function handleMessage(
       break;
     case MessageType.GET_SESSIONS:
       await getSessionsHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.GET_RUNNING_SESSIONS:
+      await getRunningSessionsHandler(connectionId, message, connections, bridge);
       break;
     case MessageType.LOAD_SESSION:
       await loadSessionHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/loadSession.ts
+++ b/backend/src/core/handlers/loadSession.ts
@@ -56,8 +56,10 @@ export async function loadSessionHandler(
     }
 
     const session = connections.getSession(sessionId);
+    const watcher = getSessionJsonlWatcher();
+    // Always unwatch previous sessions for this connection before subscribing to the new one.
+    watcher?.unwatchConnection(connectionId);
     if (!session || !session.process) {
-      const watcher = getSessionJsonlWatcher();
       if (watcher) {
         try {
           const sessionsPath = await getProjectSessionsPath(workingDir);

--- a/backend/src/core/handlers/loadSession.ts
+++ b/backend/src/core/handlers/loadSession.ts
@@ -5,6 +5,9 @@ import { loadSessionMessages } from '../features/loadSessionMessages';
 import { reconstructWorkflowTasks } from '../features/workflow-tracker';
 import { markSessionAsSpawned, isWorkflowRunning } from '../claude-process';
 import { MessageType } from '../../shared';
+import { getSessionJsonlWatcher } from '../features/session-jsonl-watcher';
+import { getProjectSessionsPath } from '../features/getProjectSessionsPath';
+import { join } from 'path';
 
 export async function loadSessionHandler(
   connectionId: string,
@@ -50,6 +53,20 @@ export async function loadSessionHandler(
       }
     } catch (err) {
       console.error('[node-backend]', 'workflow reconstruction failed:', err);
+    }
+
+    const session = connections.getSession(sessionId);
+    if (!session || !session.process) {
+      const watcher = getSessionJsonlWatcher();
+      if (watcher) {
+        try {
+          const sessionsPath = await getProjectSessionsPath(workingDir);
+          const sessionFile = join(sessionsPath, `${sessionId}.jsonl`);
+          await watcher.watch(connectionId, sessionId, sessionFile);
+        } catch (err) {
+          console.error('[node-backend]', 'Failed to start jsonl file watcher:', err);
+        }
+      }
     }
   }
   connections.sendTo(connectionId, MessageType.ACK, { requestId: message.requestId });

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -5,6 +5,7 @@ import { BrowserBridge } from './bridge/browser-bridge';
 import { JetBrainsBridge } from './bridge/jetbrains-bridge';
 import { handleMessage } from './core/handlers/index';
 import { initSettingsWatcher, stopSettingsWatcher } from './core/features/settings-watcher';
+import { initSessionJsonlWatcher, stopSessionJsonlWatcher } from './core/features/session-jsonl-watcher';
 import { ensureProfile } from './core/features/profile';
 import { trackEvent, reportBackendError } from './core/features/telemetry';
 import { restoreTunnelState } from './core/features/tunnel-manager';
@@ -14,7 +15,7 @@ import { isJetBrainsMode, serverPort, webviewDir } from './config/environment';
 import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
 import { Claude } from './core/claude';
-import { ClientEnv } from './shared';
+import { ClientEnv, MessageType } from './shared';
 import type { NativeDropEntry } from './core/types';
 
 /**
@@ -248,9 +249,14 @@ async function main() {
   });
   settingsWatcher.startGlobalWatchers();
 
+  initSessionJsonlWatcher((connectionId, sessionId, messages) => {
+    connections.sendTo(connectionId, MessageType.SESSION_APPEND, { sessionId, messages });
+  });
+
   async function shutdown(signal: string) {
     console.error('[node-backend]', `${signal} received, shutting down...`);
     stopSettingsWatcher();
+    stopSessionJsonlWatcher();
     connections.shutdownAll();
     close();
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -6,6 +6,7 @@ import { JetBrainsBridge } from './bridge/jetbrains-bridge';
 import { handleMessage } from './core/handlers/index';
 import { initSettingsWatcher, stopSettingsWatcher } from './core/features/settings-watcher';
 import { initSessionJsonlWatcher, stopSessionJsonlWatcher } from './core/features/session-jsonl-watcher';
+import { conversationalEntries, isTurnWorking, accumulateTurnTokens } from './core/features/external-turn';
 import { ensureProfile } from './core/features/profile';
 import { trackEvent, reportBackendError } from './core/features/telemetry';
 import { restoreTunnelState } from './core/features/tunnel-manager';
@@ -242,6 +243,27 @@ async function main() {
   restoreTunnelState();
   restoreSleepGuardState().catch(() => {});
 
+  // Silence timeout timers for external sessions
+  const externalSessionTimers = new Map<string, NodeJS.Timeout>();
+  // Per-session accumulator of the active turn's output tokens, keyed by assistant
+  // message id (de-duplicates content-block repeats and per-subscriber re-delivery).
+  const externalTurnTokens = new Map<string, Map<string, number>>();
+
+  const clearSessionTimer = (sessionId: string) => {
+    const timer = externalSessionTimers.get(sessionId);
+    if (timer) {
+      clearTimeout(timer);
+      externalSessionTimers.delete(sessionId);
+    }
+  };
+
+  // Drop all external-session bookkeeping for a session (no one is tailing it
+  // anymore, or it was promoted to an owned process).
+  const clearExternalSessionState = (sessionId: string) => {
+    clearSessionTimer(sessionId);
+    externalTurnTokens.delete(sessionId);
+  };
+
   // Start watching all settings files for external changes
   const settingsWatcher = initSettingsWatcher((event, data) => {
     console.error('[node-backend]', `Broadcasting ${event} event`);
@@ -249,12 +271,73 @@ async function main() {
   });
   settingsWatcher.startGlobalWatchers();
 
-  initSessionJsonlWatcher((connectionId, sessionId, messages) => {
-    connections.sendTo(connectionId, MessageType.SESSION_APPEND, { sessionId, messages });
-  });
+  initSessionJsonlWatcher(
+    (connectionId, sessionId, messages) => {
+      // Only conversational entries decide whether the session is mid-turn —
+      // trailing metadata lines (last-prompt / mode / pr-link / summary …) are
+      // written after a turn and must not be treated as "still working".
+      const convo = conversationalEntries(messages);
+      const working = isTurnWorking(convo);
+
+      // Accumulate the active turn's output tokens, keyed by assistant message id.
+      let tokensById = externalTurnTokens.get(sessionId);
+      if (!tokensById) {
+        tokensById = new Map<string, number>();
+        externalTurnTokens.set(sessionId, tokensById);
+      }
+      const currentTokens = accumulateTurnTokens(convo, tokensById);
+
+      connections.sendTo(connectionId, MessageType.SESSION_APPEND, {
+        sessionId,
+        messages,
+        working,
+        tokens: currentTokens,
+      });
+
+      if (working) {
+        clearSessionTimer(sessionId);
+        const timer = setTimeout(() => {
+          console.error(`[node-backend] Silence timeout for session ${sessionId}, setting working to false`);
+          externalSessionTimers.delete(sessionId);
+          const finalById = externalTurnTokens.get(sessionId);
+          const finalTokens = finalById ? [...finalById.values()].reduce((a, b) => a + b, 0) : 0;
+          externalTurnTokens.delete(sessionId);
+          connections.broadcastToSession(sessionId, MessageType.SESSION_APPEND, {
+            sessionId,
+            messages: [],
+            working: false,
+            tokens: finalTokens,
+          });
+        }, 15000); // 15 seconds of silence
+        externalSessionTimers.set(sessionId, timer);
+      } else {
+        clearSessionTimer(sessionId);
+        externalTurnTokens.delete(sessionId);
+      }
+
+      // A *conversational* append means the session is actively working — flag it
+      // running even though no process is owned here (external / live-tailed
+      // sessions). Metadata-only batches written after a turn must NOT re-extend
+      // the running window; the callback already computed working=false for them.
+      if (convo.length > 0) {
+        connections.markSessionActivity(sessionId);
+      }
+    },
+    // No connection is tailing this session anymore (or it was promoted to an owned
+    // process). Drop its silence timer + token state so a stale timer can't later
+    // broadcast working:false to a connection that has re-attached to the session.
+    (sessionId) => {
+      clearExternalSessionState(sessionId);
+    },
+  );
 
   async function shutdown(signal: string) {
     console.error('[node-backend]', `${signal} received, shutting down...`);
+    for (const timer of externalSessionTimers.values()) {
+      clearTimeout(timer);
+    }
+    externalSessionTimers.clear();
+    externalTurnTokens.clear();
     stopSettingsWatcher();
     stopSessionJsonlWatcher();
     connections.shutdownAll();

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -35,6 +35,8 @@ export enum MessageType {
   TOOL_RESPONSE = 'TOOL_RESPONSE',
   /** Re-attach this connection to an already-running session (e.g. after reconnect). */
   RECLAIM_SESSION = 'RECLAIM_SESSION',
+  /** Get all currently running sessions. inbound webview→backend */
+  GET_RUNNING_SESSIONS = 'GET_RUNNING_SESSIONS',
 
   // -- Sessions CRUD --
   /** Create a new session (optionally in a given working directory). */
@@ -227,6 +229,8 @@ export enum MessageType {
   SESSION_APPEND = 'SESSION_APPEND',
   /** The session list changed and clients should refresh. */
   SESSIONS_UPDATED = 'SESSIONS_UPDATED',
+  /** Broadcast the set of running sessions. outbound backend→webview */
+  RUNNING_SESSIONS = 'RUNNING_SESSIONS',
   /** A user message was broadcast to all connections viewing the session. */
   USER_MESSAGE_BROADCAST = 'USER_MESSAGE_BROADCAST',
 

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -223,6 +223,8 @@ export enum MessageType {
   // -- Session push --
   /** Full session history payload in response to LOAD_SESSION. */
   SESSION_LOADED = 'SESSION_LOADED',
+  /** Incremental session history appended (external terminal tail). */
+  SESSION_APPEND = 'SESSION_APPEND',
   /** The session list changed and clients should refresh. */
   SESSIONS_UPDATED = 'SESSIONS_UPDATED',
   /** A user message was broadcast to all connections viewing the session. */

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ConnectionManager } from '../connection-manager';
+import {
+  ConnectionManager,
+  SESSION_ACTIVITY_WINDOW_MS,
+  SESSION_ACTIVITY_SWEEP_MS,
+} from '../connection-manager';
 import { ClientEnv } from '../../shared';
 import { MessageType } from '../../shared';
 
@@ -241,6 +245,129 @@ describe('ConnectionManager', () => {
       const ws = createMockWs();
       cm.addConnection(ws);
       expect(ws.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('running sessions tracking', () => {
+    it('should return running sessions and broadcast running sessions list on process changes', () => {
+      const ws = createMockWs();
+      const connId = cm.addConnection(ws);
+      const mockProc = {} as any;
+
+      cm.setProcess('sess-1', mockProc);
+      expect(cm.getRunningSessionIds()).toEqual(['sess-1']);
+
+      expect(ws.send).toHaveBeenCalled();
+      const lastCall = (ws.send as any).mock.calls[(ws.send as any).mock.calls.length - 1][0];
+      const payload = JSON.parse(lastCall);
+      expect(payload.type).toBe(MessageType.RUNNING_SESSIONS);
+      expect(payload.payload.sessionIds).toEqual(['sess-1']);
+
+      cm.setProcess('sess-1', null);
+      expect(cm.getRunningSessionIds()).toEqual([]);
+    });
+
+    it('should mark a session running from JSONL activity and expire it after the window', () => {
+      vi.useFakeTimers();
+      try {
+        const ws = createMockWs();
+        cm.addConnection(ws);
+
+        cm.markSessionActivity('sess-ext');
+        expect(cm.getRunningSessionIds()).toEqual(['sess-ext']);
+
+        // Broadcast fires on the idle→running transition.
+        const lastCall = (ws.send as any).mock.calls.at(-1)[0];
+        expect(JSON.parse(lastCall).payload.sessionIds).toEqual(['sess-ext']);
+
+        // Still running within the activity window.
+        vi.advanceTimersByTime(10_000);
+        expect(cm.getRunningSessionIds()).toEqual(['sess-ext']);
+
+        // Expires once the window elapses with no further appends.
+        vi.advanceTimersByTime(15_000);
+        expect(cm.getRunningSessionIds()).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should union process-owned and activity-based running sessions', () => {
+      vi.useFakeTimers();
+      try {
+        cm.addConnection(createMockWs());
+        cm.setProcess('sess-proc', {} as any);
+        cm.markSessionActivity('sess-ext');
+        expect(cm.getRunningSessionIds().sort()).toEqual(['sess-ext', 'sess-proc']);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should NOT re-broadcast on repeated activity within the window (only on idle→running)', () => {
+      vi.useFakeTimers();
+      try {
+        const ws = createMockWs();
+        cm.addConnection(ws);
+        (ws.send as any).mockClear();
+
+        // First mark → idle→running transition → exactly one broadcast.
+        cm.markSessionActivity('sess-ext');
+        const broadcastsAfterFirst = (ws.send as any).mock.calls.length;
+        expect(broadcastsAfterFirst).toBe(1);
+
+        // Repeated appends within the window must NOT re-broadcast (no storm).
+        vi.advanceTimersByTime(2_000);
+        cm.markSessionActivity('sess-ext');
+        vi.advanceTimersByTime(2_000);
+        cm.markSessionActivity('sess-ext');
+        expect((ws.send as any).mock.calls.length).toBe(broadcastsAfterFirst);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should broadcast exactly one running→idle update when activity expires', () => {
+      vi.useFakeTimers();
+      try {
+        const ws = createMockWs();
+        cm.addConnection(ws);
+
+        cm.markSessionActivity('sess-ext');
+        (ws.send as any).mockClear();
+
+        // Sweep past the window: exactly one expiry broadcast with an empty set.
+        vi.advanceTimersByTime(SESSION_ACTIVITY_WINDOW_MS + SESSION_ACTIVITY_SWEEP_MS);
+        const expiryBroadcasts = (ws.send as any).mock.calls
+          .map((c: any[]) => JSON.parse(c[0]))
+          .filter((m: any) => m.type === MessageType.RUNNING_SESSIONS);
+        expect(expiryBroadcasts).toHaveLength(1);
+        expect(expiryBroadcasts[0].payload.sessionIds).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should drop external activity tracking once a session is promoted to an owned process', () => {
+      vi.useFakeTimers();
+      try {
+        cm.addConnection(createMockWs());
+
+        // External activity marks it running.
+        cm.markSessionActivity('sess-x');
+        expect(cm.getRunningSessionIds()).toEqual(['sess-x']);
+
+        // Promote to an owned process — running follows the process now.
+        cm.setProcess('sess-x', {} as any);
+        expect(cm.getRunningSessionIds()).toEqual(['sess-x']);
+
+        // When the owned process ends, the session goes idle immediately — no stale
+        // activity timestamp keeps it running for the rest of the window.
+        cm.setProcess('sess-x', null);
+        expect(cm.getRunningSessionIds()).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -6,6 +6,13 @@ import { ClientEnv, MessageType } from '../shared';
 const SESSION_CLEANUP_GRACE_MS = 30_000;
 const IDLE_SHUTDOWN_GRACE_MS = 60_000;
 /**
+ * How long after the last JSONL append a session is still considered "running".
+ * Generous enough to bridge pauses between streamed messages / tool calls so the
+ * indicator doesn't flicker, short enough to clear soon after a session goes idle.
+ */
+export const SESSION_ACTIVITY_WINDOW_MS = 20_000;
+export const SESSION_ACTIVITY_SWEEP_MS = 5_000;
+/**
  * How long an editor-context payload stays valid while waiting for a webview to
  * connect. The "Add to Claude" action can fire before the JCEF panel has opened
  * its /ws socket (cold start); we stash the payload and replay it to the first
@@ -63,6 +70,12 @@ export class ConnectionManager {
   // Editor context awaiting a webview connection. Replayed to the first
   // connection that arrives within PENDING_EDITOR_CONTEXT_TTL_MS, then cleared.
   private pendingEditorContext: PendingEditorContext | null = null;
+  // sessionId → last JSONL append timestamp. A session whose history file is
+  // being actively appended counts as "running" even when no process is owned
+  // here (external terminal sessions / live-tailed sessions). Marked by the
+  // jsonl watcher's onAppend; expired by activitySweepTimer.
+  private sessionActivity = new Map<string, number>();
+  private activitySweepTimer: NodeJS.Timeout | null = null;
   private nextId = 0;
 
   // ─── Connection lifecycle ───────────────────────────────────────────────────
@@ -327,9 +340,71 @@ export class ConnectionManager {
 
   // ─── Process accessors ─────────────────────────────────────────────────────
 
+  /**
+   * A session is "running" if either this backend owns a live process for it
+   * (GUI-started) or its JSONL was appended within the activity window (external
+   * / live-tailed sessions). Returns the union, deduplicated.
+   */
+  getRunningSessionIds(): string[] {
+    const ids = new Set<string>();
+    for (const s of this.sessionRegistry.values()) {
+      if (s.process) ids.add(s.sessionId);
+    }
+    const now = Date.now();
+    for (const [sessionId, ts] of this.sessionActivity) {
+      if (now - ts < SESSION_ACTIVITY_WINDOW_MS) ids.add(sessionId);
+    }
+    return [...ids];
+  }
+
+  broadcastRunningSessions(): void {
+    this.broadcastToAll(MessageType.RUNNING_SESSIONS, { sessionIds: this.getRunningSessionIds() });
+  }
+
   setProcess(sessionId: string, proc: ChildProcess | null): void {
     const session = this.getOrCreateSession(sessionId);
     session.process = proc;
+    if (proc) {
+      // Promoted to an owned process: drop any external JSONL-activity tracking so
+      // the running flag follows the process lifecycle. Otherwise a stale activity
+      // timestamp could keep the session "running" for up to the activity window
+      // after the owned process ends.
+      this.sessionActivity.delete(sessionId);
+    }
+    this.broadcastRunningSessions();
+  }
+
+  /**
+   * Record live JSONL append activity for a session (from the jsonl watcher).
+   * Marks the session running for SESSION_ACTIVITY_WINDOW_MS and broadcasts only
+   * on the idle→running transition; the sweep handles the running→idle edge.
+   */
+  markSessionActivity(sessionId: string): void {
+    const wasRunning = this.sessionActivity.has(sessionId)
+      && Date.now() - (this.sessionActivity.get(sessionId) ?? 0) < SESSION_ACTIVITY_WINDOW_MS;
+    this.sessionActivity.set(sessionId, Date.now());
+    this.ensureActivitySweep();
+    if (!wasRunning) this.broadcastRunningSessions();
+  }
+
+  private ensureActivitySweep(): void {
+    if (this.activitySweepTimer) return;
+    this.activitySweepTimer = setInterval(() => {
+      const now = Date.now();
+      let expired = false;
+      for (const [sessionId, ts] of this.sessionActivity) {
+        if (now - ts >= SESSION_ACTIVITY_WINDOW_MS) {
+          this.sessionActivity.delete(sessionId);
+          expired = true;
+        }
+      }
+      if (this.sessionActivity.size === 0 && this.activitySweepTimer) {
+        clearInterval(this.activitySweepTimer);
+        this.activitySweepTimer = null;
+      }
+      if (expired) this.broadcastRunningSessions();
+    }, SESSION_ACTIVITY_SWEEP_MS);
+    this.activitySweepTimer.unref?.();
   }
 
   getProcess(sessionId: string): ChildProcess | null {
@@ -357,6 +432,12 @@ export class ConnectionManager {
     this.cleanupTimers.clear();
 
     this.cancelIdleShutdown();
+
+    if (this.activitySweepTimer) {
+      clearInterval(this.activitySweepTimer);
+      this.activitySweepTimer = null;
+    }
+    this.sessionActivity.clear();
 
     let killedSessions = 0;
     let closedConnections = 0;
@@ -421,5 +502,6 @@ export class ConnectionManager {
 
     this.sessionRegistry.delete(sessionId);
     console.error('[node-backend]', `Session ${sessionId} cleaned up`);
+    this.broadcastRunningSessions();
   }
 }

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -12,6 +12,7 @@ import { getPluginVersion } from '../core/handlers/getVersion';
 import { cancelLogin } from '../core/handlers/login';
 import { reportBackendError, trackActivity } from '../core/features/telemetry';
 import { LogWebSocketServer } from '../logging/log-ws';
+import { getSessionJsonlWatcher } from '../core/features/session-jsonl-watcher';
 
 const ALLOWED_WS_ORIGINS = new Set([
   'http://localhost',
@@ -221,6 +222,7 @@ export function startWebSocketServer(
         // An interactive `claude auth login` waiting on stdin won't exit on its
         // own once the webview is gone — kill it so it can't linger as a zombie.
         cancelLogin(connectionId);
+        getSessionJsonlWatcher()?.unwatchConnection(connectionId);
         connections.removeConnection(connectionId);
       });
     });

--- a/webview/src/components/SessionList/SessionItem.tsx
+++ b/webview/src/components/SessionList/SessionItem.tsx
@@ -8,13 +8,14 @@ interface Props {
   isSelected: boolean;
   /** Keyboard-navigation highlight (distinct from isSelected = current session). */
   isHighlighted?: boolean;
+  isRunning?: boolean;
   onSelect: () => void;
   onDelete: () => void;
   onRename: (title: string) => void;
 }
 
 export function SessionItem(props: Props) {
-  const { session, isSelected, isHighlighted = false, onSelect, onDelete, onRename } = props;
+  const { session, isSelected, isHighlighted = false, isRunning = false, onSelect, onDelete, onRename } = props;
   const scale = useSessionListScale();
   const [isHovered, setIsHovered] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -115,6 +116,9 @@ export function SessionItem(props: Props) {
       }`}
       title={session.title}
     >
+      {isRunning && (
+        <span className="flex-shrink-0 w-2 h-2 rounded-full bg-state-success-fg animate-pulse" />
+      )}
       <span className="truncate flex-1">{session.title}</span>
       {isHovered ? (
         <span className="flex-shrink-0 flex items-center gap-1.5">

--- a/webview/src/components/SessionList/__tests__/SessionItem.test.tsx
+++ b/webview/src/components/SessionList/__tests__/SessionItem.test.tsx
@@ -156,4 +156,32 @@ describe('SessionItem', () => {
 
     expect(onRename).not.toHaveBeenCalled();
   });
+
+  it('renders a pulsing green dot when isRunning is true', () => {
+    const { container } = render(
+      <SessionItem
+        session={createMockSession()}
+        isSelected={false}
+        isRunning={true}
+        onSelect={onSelect}
+        onDelete={onDelete}
+        onRename={onRename}
+      />
+    );
+    expect(container.querySelector('.bg-state-success-fg')).not.toBeNull();
+  });
+
+  it('does not render a pulsing green dot when isRunning is false', () => {
+    const { container } = render(
+      <SessionItem
+        session={createMockSession()}
+        isSelected={false}
+        isRunning={false}
+        onSelect={onSelect}
+        onDelete={onDelete}
+        onRename={onRename}
+      />
+    );
+    expect(container.querySelector('.bg-state-success-fg')).toBeNull();
+  });
 });

--- a/webview/src/components/SessionList/index.tsx
+++ b/webview/src/components/SessionList/index.tsx
@@ -1,6 +1,7 @@
 import { GroupedSessions, GROUP_ORDER, GROUP_LABELS } from './utils';
 import { SessionItem } from './SessionItem';
 import { useSessionListScale } from './scale';
+import { useRunningSessions } from '@/hooks/useRunningSessions';
 
 interface Props {
   groupedSessions: GroupedSessions;
@@ -17,6 +18,7 @@ interface Props {
 export function SessionList(props: Props) {
   const { groupedSessions, currentSessionId, highlightedSessionId = null, onSelectSession, onDeleteSession, onRenameSession, className = 'max-h-80' } = props;
   const scale = useSessionListScale();
+  const { running } = useRunningSessions();
 
   return (
     <div className={`${className} overflow-y-auto ${scale.listPad} flex flex-col gap-0.5`}>
@@ -35,6 +37,7 @@ export function SessionList(props: Props) {
                 session={session}
                 isSelected={session.id === currentSessionId}
                 isHighlighted={session.id === highlightedSessionId}
+                isRunning={running.has(session.id) && session.id !== currentSessionId}
                 onSelect={() => onSelectSession(session.id)}
                 onDelete={() => onDeleteSession(session.id)}
                 onRename={(title) => onRenameSession(session.id, title)}

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -50,7 +50,7 @@ function SessionLoader({ children }: { children: ReactNode }) {
     loadSessions, sessions, currentSessionId, navigateToNewSession,
     isNewlyCreatedSession, setSessionState,
   } = useSessionContext();
-  const { loadMessages, resetForSessionSwitch } = useChatStreamContext();
+  const { loadMessages, appendLoadedEntries, isStreaming, resetForSessionSwitch } = useChatStreamContext();
 
   // Ref to track currentSessionId for SESSION_LOADED validation (avoids stale closure)
   const currentSessionIdRef = useRef<string | null>(currentSessionId);
@@ -131,6 +131,21 @@ function SessionLoader({ children }: { children: ReactNode }) {
       }
     });
   }, [subscribe, loadMessages, isNewlyCreatedSession]);
+
+  useEffect(() => {
+    return subscribe(MessageType.SESSION_APPEND, (message) => {
+      if (isStreaming) return;
+      if (message.payload?.messages) {
+        const rawMessages = message.payload.messages as LoadedMessageDto[];
+        const sid = message.payload?.sessionId as string | undefined;
+
+        if (sid && sid !== currentSessionIdRef.current) return;
+
+        console.log('[SessionLoader] Session append, injecting raw messages:', rawMessages);
+        appendLoadedEntries(rawMessages);
+      }
+    });
+  }, [subscribe, appendLoadedEntries, isStreaming]);
 
   // 4. Validate session exists in list — redirect bad URLs
   useEffect(() => {

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -23,6 +23,7 @@ import { SessionState } from '../types';
 import type { LoadedMessageDto } from '../types';
 import { MessageType } from '@/shared';
 import { useClaudeSettings } from './ClaudeSettingsContext';
+import { RunningSessionsProvider } from './RunningSessionsContext';
 
 interface AppProvidersProps {
   children: ReactNode;
@@ -50,7 +51,7 @@ function SessionLoader({ children }: { children: ReactNode }) {
     loadSessions, sessions, currentSessionId, navigateToNewSession,
     isNewlyCreatedSession, setSessionState,
   } = useSessionContext();
-  const { loadMessages, appendLoadedEntries, isStreaming, resetForSessionSwitch } = useChatStreamContext();
+  const { loadMessages, appendLoadedEntries, isStreaming, resetForSessionSwitch, setExternalWorking, setExternalTokens } = useChatStreamContext();
 
   // Ref to track currentSessionId for SESSION_LOADED validation (avoids stale closure)
   const currentSessionIdRef = useRef<string | null>(currentSessionId);
@@ -134,18 +135,26 @@ function SessionLoader({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     return subscribe(MessageType.SESSION_APPEND, (message) => {
+      const sid = message.payload?.sessionId as string | undefined;
+
+      // External working/tokens indicator. Processed BEFORE the isStreaming guard:
+      // a backend silence-timeout working:false can arrive while the GUI is mid-stream
+      // and must not be dropped, otherwise externalWorking stays stuck true.
+      if (sid && sid === currentSessionIdRef.current && message.payload && 'working' in message.payload) {
+        setExternalWorking(!!message.payload.working);
+        if (typeof message.payload.tokens === 'number') {
+          setExternalTokens(message.payload.tokens);
+        }
+      }
+
       if (isStreaming) return;
       if (message.payload?.messages) {
         const rawMessages = message.payload.messages as LoadedMessageDto[];
-        const sid = message.payload?.sessionId as string | undefined;
-
         if (sid && sid !== currentSessionIdRef.current) return;
-
-        console.log('[SessionLoader] Session append, injecting raw messages:', rawMessages);
         appendLoadedEntries(rawMessages);
       }
     });
-  }, [subscribe, appendLoadedEntries, isStreaming]);
+  }, [subscribe, appendLoadedEntries, isStreaming, setExternalWorking, setExternalTokens]);
 
   // 4. Validate session exists in list — redirect bad URLs
   useEffect(() => {
@@ -260,9 +269,11 @@ export function AppProviders({ children }: AppProvidersProps) {
                 <ClaudeSettingsProvider>
                   <AuthProvider>
                     <SessionProvider>
-                      <WorkflowStateProvider>
-                        <ChatProviderBridge>{children}</ChatProviderBridge>
-                      </WorkflowStateProvider>
+                      <RunningSessionsProvider>
+                        <WorkflowStateProvider>
+                          <ChatProviderBridge>{children}</ChatProviderBridge>
+                        </WorkflowStateProvider>
+                      </RunningSessionsProvider>
                     </SessionProvider>
                   </AuthProvider>
                 </ClaudeSettingsProvider>

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -34,6 +34,12 @@ interface ChatStreamContextType {
   // From useChatStream
   messages: LoadedMessageDto[];
   isStreaming: boolean;
+  externalWorking: boolean;
+  setExternalWorking: (working: boolean) => void;
+  externalWorkingStartedAt: number | null;
+  setExternalWorkingStartedAt: (startedAt: number | null) => void;
+  externalTokens: number;
+  setExternalTokens: (tokens: number) => void;
   streamingMessageId: string | null;
   error: Error | null;
   authDiagnosis: { envApiKeys: string[]; message: string } | null;
@@ -117,6 +123,20 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
   const [isThinkingExpanded, setIsThinkingExpanded] = useState(false);
   const toggleThinkingExpanded = useCallback(() => setIsThinkingExpanded(prev => !prev), []);
   const [sessionModel, setSessionModel] = useState<string | null>(null);
+  const [externalWorking, setExternalWorking] = useState(false);
+  const [externalWorkingStartedAt, setExternalWorkingStartedAt] = useState<number | null>(null);
+  const [externalTokens, setExternalTokens] = useState(0);
+
+  useEffect(() => {
+    if (externalWorking) {
+      if (externalWorkingStartedAt === null) {
+        setExternalWorkingStartedAt(Date.now());
+      }
+    } else {
+      setExternalWorkingStartedAt(null);
+      setExternalTokens(0);
+    }
+  }, [externalWorking, externalWorkingStartedAt]);
 
   // EnterPlanMode 진입 전의 모드를 저장 (ExitPlanMode 시 복원용)
   const prePlanModeRef = useRef<InputMode | null>(null);
@@ -220,6 +240,9 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
   const resetForSessionSwitch = useCallback(() => {
     chatStreamClearMessages();
     chatStreamResetStreamState();
+    setExternalWorking(false);
+    setExternalWorkingStartedAt(null);
+    setExternalTokens(0);
     // Restore draft input from cache (tab move/split restoration)
     let draft: string | null = null;
     try {
@@ -236,7 +259,17 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     diffs.clearDiffs();
     queuedMessageRef.current = null;
     prePlanModeRef.current = null;
-  }, [chatStreamClearMessages, chatStreamResetStreamState, setInput, tools.clearToolUses, diffs.clearDiffs, session.currentSessionId]);
+  }, [
+    chatStreamClearMessages,
+    chatStreamResetStreamState,
+    setInput,
+    tools.clearToolUses,
+    diffs.clearDiffs,
+    session.currentSessionId,
+    setExternalWorking,
+    setExternalWorkingStartedAt,
+    setExternalTokens
+  ]);
 
   // resetForSessionSwitch is called directly by SessionLoader
   // when currentSessionId changes (URL-driven reactive pattern)
@@ -404,6 +437,12 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     // From useChatStream
     messages: chatStream.messages,
     isStreaming: chatStream.isStreaming,
+    externalWorking,
+    setExternalWorking,
+    externalWorkingStartedAt,
+    setExternalWorkingStartedAt,
+    externalTokens,
+    setExternalTokens,
     streamingMessageId: chatStream.streamingMessageId,
     error: chatStream.error,
     authDiagnosis: chatStream.authDiagnosis,
@@ -443,6 +482,12 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
   }), [
     chatStream.messages,
     chatStream.isStreaming,
+    externalWorking,
+    setExternalWorking,
+    externalWorkingStartedAt,
+    setExternalWorkingStartedAt,
+    externalTokens,
+    setExternalTokens,
     chatStream.streamingMessageId,
     chatStream.error,
     chatStream.authDiagnosis,

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -49,6 +49,7 @@ interface ChatStreamContextType {
   // From useChatStream (message manipulation)
   clearMessages: () => void;
   loadMessages: (msgs: LoadedMessageDto[]) => void;
+  appendLoadedEntries: (msgs: LoadedMessageDto[]) => void;
   appendMessage: (message: LoadedMessageDto) => void;
   updateMessage: (id: string, updates: Partial<LoadedMessageDto>) => void;
 
@@ -171,6 +172,7 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     addUserMessage,
     clearMessages: chatStreamClearMessages,
     loadMessages: chatStreamLoadMessages,
+    appendLoadedEntries: chatStreamAppendLoadedEntries,
     appendMessage: chatStreamAppendMessage,
     updateMessage: chatStreamUpdateMessage,
     resetStreamState: chatStreamResetStreamState,
@@ -418,6 +420,7 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     // Message manipulation
     clearMessages: chatStreamClearMessages,
     loadMessages: chatStreamLoadMessages,
+    appendLoadedEntries: chatStreamAppendLoadedEntries,
     appendMessage: chatStreamAppendMessage,
     updateMessage: chatStreamUpdateMessage,
 
@@ -448,6 +451,7 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     chatStreamResetStreamState,
     chatStreamClearMessages,
     chatStreamLoadMessages,
+    chatStreamAppendLoadedEntries,
     chatStreamAppendMessage,
     chatStreamUpdateMessage,
     sendMessage,

--- a/webview/src/contexts/RunningSessionsContext.tsx
+++ b/webview/src/contexts/RunningSessionsContext.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, ReactNode, useState, useEffect } from 'react';
+import { useBridgeContext } from './BridgeContext';
+import { MessageType } from '@/shared';
+
+interface RunningSessionsContextType {
+  running: Set<string>;
+}
+
+const RunningSessionsContext = createContext<RunningSessionsContextType | null>(null);
+
+export function RunningSessionsProvider({ children }: { children: ReactNode }) {
+  const { isConnected, send, subscribe } = useBridgeContext();
+  const [running, setRunning] = useState<Set<string>>(new Set());
+
+  // 1. Initial load on connection
+  useEffect(() => {
+    if (isConnected) {
+      send(MessageType.GET_RUNNING_SESSIONS)
+        .then((res: any) => {
+          if (res?.sessionIds) {
+            setRunning(new Set(res.sessionIds));
+          }
+        })
+        .catch((err) => {
+          console.error('[RunningSessionsProvider] Failed to fetch running sessions:', err);
+        });
+    } else {
+      setRunning(new Set());
+    }
+  }, [isConnected, send]);
+
+  // 2. Subscribe to push updates
+  useEffect(() => {
+    const unsubscribe = subscribe(MessageType.RUNNING_SESSIONS, (msg: any) => {
+      if (msg?.payload?.sessionIds) {
+        setRunning(new Set(msg.payload.sessionIds));
+      }
+    });
+    return unsubscribe;
+  }, [subscribe]);
+
+  return (
+    <RunningSessionsContext.Provider value={{ running }}>
+      {children}
+    </RunningSessionsContext.Provider>
+  );
+}
+
+export function useRunningSessionsContext() {
+  const context = useContext(RunningSessionsContext);
+  return context;
+}

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -858,4 +858,33 @@ describe('useChatStream', () => {
       expect(typeof block[0].durationMillis).toBe('number');
     });
   });
+
+  describe('appendLoadedEntries', () => {
+    it('appends and dedups messages, updating active chain', () => {
+      const { bridge } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        result.current.loadMessages([
+          { uuid: '1', type: 'user', parentUuid: null, message: { type: 'text', text: 'hello' }, timestamp: '2026-06-30T00:00:00.000Z' } as any
+        ]);
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0].uuid).toBe('1');
+
+      // Append new message
+      act(() => {
+        result.current.appendLoadedEntries([
+          { uuid: '1', type: 'user', parentUuid: null, message: { type: 'text', text: 'hello updated' }, timestamp: '2026-06-30T00:00:00.000Z' } as any,
+          { uuid: '2', type: 'assistant', parentUuid: '1', message: { type: 'text', text: 'hi' }, timestamp: '2026-06-30T00:00:01.000Z' } as any
+        ]);
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[0].uuid).toBe('1');
+      expect((result.current.messages[0].message as any)?.text).toBe('hello updated'); // updated!
+      expect(result.current.messages[1].uuid).toBe('2');
+    });
+  });
 });

--- a/webview/src/hooks/__tests__/useRunningSessions.test.tsx
+++ b/webview/src/hooks/__tests__/useRunningSessions.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import { useRunningSessions } from '../useRunningSessions';
+import { RunningSessionsProvider } from '@/contexts/RunningSessionsContext';
+import { MessageType } from '@/shared';
+
+const { mockSend, mockSubscribe } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+  mockSubscribe: vi.fn()
+}));
+
+let connected = true;
+let pushHandler: ((msg: any) => void) | null = null;
+
+vi.mock('@/contexts/BridgeContext', () => ({
+  useBridgeContext: () => ({
+    isConnected: connected,
+    send: mockSend,
+    subscribe: mockSubscribe,
+    lastError: null
+  }),
+}));
+
+function Probe() {
+  const { running } = useRunningSessions();
+  return (
+    <div>
+      <span data-testid="running-count">{running.size}</span>
+      <span data-testid="is-running-s1">{running.has('sess-1') ? 'yes' : 'no'}</span>
+    </div>
+  );
+}
+
+describe('useRunningSessions and RunningSessionsProvider', () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockSubscribe.mockReset();
+    connected = true;
+    pushHandler = null;
+
+    mockSubscribe.mockImplementation((type: string, handler: (msg: any) => void) => {
+      if (type === MessageType.RUNNING_SESSIONS) {
+        pushHandler = handler;
+      }
+      return () => undefined;
+    });
+  });
+
+  it('initially requests running sessions and updates state', async () => {
+    mockSend.mockResolvedValue({ sessionIds: ['sess-1'] });
+
+    render(
+      <RunningSessionsProvider>
+        <Probe />
+      </RunningSessionsProvider>
+    );
+
+    // Initial check
+    expect(mockSend).toHaveBeenCalledWith(MessageType.GET_RUNNING_SESSIONS);
+    await waitFor(() => {
+      expect(screen.getByTestId('running-count').textContent).toBe('1');
+    });
+    expect(screen.getByTestId('is-running-s1').textContent).toBe('yes');
+  });
+
+  it('updates state when receiving a RUNNING_SESSIONS push event', async () => {
+    mockSend.mockResolvedValue({ sessionIds: [] });
+
+    render(
+      <RunningSessionsProvider>
+        <Probe />
+      </RunningSessionsProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('running-count').textContent).toBe('0');
+    });
+
+    // Simulate push event
+    act(() => {
+      if (pushHandler) {
+        pushHandler({
+          payload: { sessionIds: ['sess-1', 'sess-2'] }
+        });
+      }
+    });
+
+    expect(screen.getByTestId('running-count').textContent).toBe('2');
+    expect(screen.getByTestId('is-running-s1').textContent).toBe('yes');
+  });
+
+  it('returns an empty set if used outside of provider', () => {
+    render(<Probe />);
+    expect(screen.getByTestId('running-count').textContent).toBe('0');
+    expect(screen.getByTestId('is-running-s1').textContent).toBe('no');
+  });
+});

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -475,6 +475,13 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
   // Load messages from raw JSONL entries.
   // LoadedMessageDto's @Type/@Transform decorators handle nested transformation automatically.
   const loadMessages = useCallback((msgs: LoadedMessageDto[]) => {
+    const sysInitMsg = msgs.find(
+      (m: any) => m && m.type === 'system' && m.subtype === 'init'
+    );
+    if (sysInitMsg) {
+      setSystemInit(sysInitMsg as any);
+    }
+
     const convertedMessages = msgs
       // .filter(raw => raw.type === LoadedMessageType.User || raw.type === LoadedMessageType.Assistant)
       .map(raw => toInstance(LoadedMessageDto, raw));
@@ -510,9 +517,16 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
         }
       }
     }
-  }, []);
+  }, [setSystemInit]);
 
   const appendLoadedEntries = useCallback((msgs: LoadedMessageDto[]) => {
+    const sysInitMsg = msgs.find(
+      (m: any) => m && m.type === 'system' && m.subtype === 'init'
+    );
+    if (sysInitMsg) {
+      setSystemInit(sysInitMsg as any);
+    }
+
     const incoming = msgs.map(raw => toInstance(LoadedMessageDto, raw));
     setMessages(prev => {
       const byUuid = new Map<string, LoadedMessageDto>();
@@ -580,7 +594,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
 
       return activeMessages;
     });
-  }, []);
+  }, [setSystemInit]);
 
   // Retry
   const retry = useCallback((messageId: string) => {

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -74,6 +74,7 @@ export interface UseChatStreamReturn {
   addUserMessage: (content: string, context?: Context[], attachments?: Attachment[]) => void;
   clearMessages: () => void;
   loadMessages: (msgs: LoadedMessageDto[]) => void;
+  appendLoadedEntries: (msgs: LoadedMessageDto[]) => void;
   appendMessage: (message: LoadedMessageDto) => void;
   updateMessage: (id: string, updates: Partial<LoadedMessageDto>) => void;
 
@@ -509,6 +510,76 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
         }
       }
     }
+  }, []);
+
+  const appendLoadedEntries = useCallback((msgs: LoadedMessageDto[]) => {
+    const incoming = msgs.map(raw => toInstance(LoadedMessageDto, raw));
+    setMessages(prev => {
+      const byUuid = new Map<string, LoadedMessageDto>();
+      for (const msg of prev) {
+        if (msg.uuid) {
+          byUuid.set(msg.uuid, msg);
+        }
+      }
+
+      for (const msg of incoming) {
+        if (msg.uuid) {
+          byUuid.set(msg.uuid, msg);
+        }
+      }
+
+      const orderedUuids = new Set<string>();
+      const combinedList: LoadedMessageDto[] = [];
+
+      for (const msg of prev) {
+        if (msg.uuid) {
+          if (!orderedUuids.has(msg.uuid)) {
+            combinedList.push(byUuid.get(msg.uuid)!);
+            orderedUuids.add(msg.uuid);
+          }
+        } else {
+          combinedList.push(msg);
+        }
+      }
+
+      for (const msg of incoming) {
+        if (msg.uuid) {
+          if (!orderedUuids.has(msg.uuid)) {
+            combinedList.push(msg);
+            orderedUuids.add(msg.uuid);
+          }
+        } else {
+          combinedList.push(msg);
+        }
+      }
+
+      const activeMessages = filterActiveChain(combinedList);
+
+      for (let i = activeMessages.length - 1; i >= 0; i--) {
+        const msg = activeMessages[i];
+        if (msg.type === LoadedMessageType.Assistant && msg.message?.usage) {
+          const usage = msg.message.usage as {
+            input_tokens?: number;
+            output_tokens?: number;
+            cache_creation_input_tokens?: number;
+            cache_read_input_tokens?: number;
+          };
+          if (typeof usage.input_tokens === 'number') {
+            setContextWindowUsage({
+              totalTokens: usage.input_tokens
+                + (usage.cache_creation_input_tokens ?? 0)
+                + (usage.cache_read_input_tokens ?? 0)
+                + (usage.output_tokens ?? 0),
+              contextWindow: 200_000,
+              maxOutputTokens: 0,
+            });
+            break;
+          }
+        }
+      }
+
+      return activeMessages;
+    });
   }, []);
 
   // Retry
@@ -1059,6 +1130,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     addUserMessage,
     clearMessages,
     loadMessages,
+    appendLoadedEntries,
     appendMessage,
     updateMessage,
     retry,

--- a/webview/src/hooks/useRunningSessions.ts
+++ b/webview/src/hooks/useRunningSessions.ts
@@ -1,0 +1,8 @@
+import { useRunningSessionsContext } from '@/contexts/RunningSessionsContext';
+
+const DEFAULT_RUNNING = new Set<string>();
+
+export function useRunningSessions() {
+  const context = useRunningSessionsContext();
+  return { running: context?.running ?? DEFAULT_RUNNING };
+}

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -336,6 +336,10 @@ export function ChatInput() {
     }
   }, [currentSessionId, clearAttachments, initHistory]);
 
+  // NOTE: externalWorking is intentionally NOT part of isActive. An external /
+  // live-tailed terminal session is not owned by this backend, so there is no
+  // process to interrupt — surfacing a Stop button for it would do nothing and read
+  // as broken. The activity is shown purely informationally via the StreamingIndicator.
   const isActive = isStreaming
     || sessionState === SessionState.WaitingPermission
     || sessionState === SessionState.HasDiff;

--- a/webview/src/pages/ChatPage/ChatMessageArea.tsx
+++ b/webview/src/pages/ChatPage/ChatMessageArea.tsx
@@ -17,7 +17,7 @@ interface Props {
 export function ChatMessageArea(props: Props) {
   const { isStreaming } = props;
   const { workingDirectory } = useSessionContext();
-  const { messages, retry: onRetry } = useChatStreamContext();
+  const { messages, retry: onRetry, externalWorking, externalWorkingStartedAt, externalTokens } = useChatStreamContext();
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Auto-scroll is driven entirely by ChatPage's single poll loop, which scrolls
@@ -41,11 +41,6 @@ export function ChatMessageArea(props: Props) {
     return <ProjectSelectorPage />;
   }
 
-  const log = () => {
-    // console.log('messages', messages);
-    // console.log('mergedMessages', mergedMessages)
-  }
-
   // Empty state: no messages yet
   if (isEmpty) {
     return <EmptyState />;
@@ -53,13 +48,21 @@ export function ChatMessageArea(props: Props) {
 
   // Render messages with widgets
   return (
-    <div ref={containerRef} className="flex-1 text-xs" onClick={log}>
+    <div ref={containerRef} className="flex-1 text-xs">
       {mergedMessages.map((message) => (
-        <div key={message.uuid} onClick={() => console.log('message', message.uuid, message)}>
+        <div key={message.uuid}>
           <MessageBubble message={message} onRetry={onRetry} />
         </div>
       ))}
-      {isStreaming && <StreamingIndicator />}
+      {(isStreaming || externalWorking) && (
+        <StreamingIndicator
+          meta={
+            !isStreaming && externalWorking
+              ? { startedAt: externalWorkingStartedAt, tokens: externalTokens }
+              : undefined
+          }
+        />
+      )}
       <StreamErrorBanner />
     </div>
   );

--- a/webview/src/pages/ChatPage/StreamingIndicator/__tests__/formatElapsed.test.ts
+++ b/webview/src/pages/ChatPage/StreamingIndicator/__tests__/formatElapsed.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { formatElapsed } from '../index';
+
+describe('formatElapsed', () => {
+  it('renders sub-minute durations in seconds', () => {
+    expect(formatElapsed(0)).toBe('0s');
+    expect(formatElapsed(5_000)).toBe('5s');
+    expect(formatElapsed(59_999)).toBe('59s');
+  });
+
+  it('switches to minutes + seconds at the 60s boundary', () => {
+    expect(formatElapsed(60_000)).toBe('1m 0s');
+    expect(formatElapsed(65_000)).toBe('1m 5s');
+  });
+
+  it('formats multi-minute durations', () => {
+    expect(formatElapsed(125_000)).toBe('2m 5s');
+    expect(formatElapsed(600_000)).toBe('10m 0s');
+  });
+
+  it('floors partial seconds rather than rounding', () => {
+    expect(formatElapsed(1_900)).toBe('1s');
+    expect(formatElapsed(61_900)).toBe('1m 1s');
+  });
+});

--- a/webview/src/pages/ChatPage/StreamingIndicator/index.tsx
+++ b/webview/src/pages/ChatPage/StreamingIndicator/index.tsx
@@ -2,17 +2,38 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { ICON_FRAMES, TEXT_CHANGE_DELAYS, VERBS } from './constants.ts';
 import { useScramble } from './useScramble.ts';
 import { randomPick } from './utils.ts';
+import { formatThinkingTokens } from '@/utils/formatThinkingTokens.ts';
 
-export const StreamingIndicator: React.FC = () => {
+export function formatElapsed(elapsedMs: number): string {
+    const seconds = Math.floor(elapsedMs / 1000);
+    if (seconds < 60) {
+        return `${seconds}s`;
+    }
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}m ${remainingSeconds}s`;
+}
+
+export interface StreamingIndicatorProps {
+    meta?: {
+        startedAt: number | null;
+        tokens: number;
+    };
+}
+
+export const StreamingIndicator: React.FC<StreamingIndicatorProps> = ({ meta }) => {
     // 아이콘 프레임 인덱스
     const [frameIdx, setFrameIdx] = useState(0);
 
     // 현재 동사
     const [verb, setVerb] = useState<string>(() => randomPick(VERBS));
 
-    // 텍스트 변경 카운트 (딜레이 스케줄 추적)
+    // 텍스트 변경 카운트 (딜лей 스케줄 추적)
     const changeCountRef = useRef<number>(0);
     const textTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    // 경과 시간 (ms)
+    const [elapsed, setElapsed] = useState(0);
 
     // 다음 텍스트 변경 딜레이 계산
     const getNextDelay = useCallback(() => {
@@ -59,8 +80,29 @@ export const StreamingIndicator: React.FC = () => {
         };
     }, []);
 
+    // 경과 시간 타이머
+    useEffect(() => {
+        if (!meta?.startedAt) {
+            setElapsed(0);
+            return;
+        }
+
+        setElapsed(Date.now() - meta.startedAt);
+
+        const timer = setInterval(() => {
+            if (meta?.startedAt) {
+                setElapsed(Date.now() - meta.startedAt);
+            }
+        }, 1000);
+
+        return () => clearInterval(timer);
+    }, [meta?.startedAt]);
+
     // 스크램블 디스플레이
     const displayText = useScramble(verb);
+
+    const tokenStr = meta ? formatThinkingTokens(meta.tokens) : null;
+    const elapsedStr = meta?.startedAt ? formatElapsed(elapsed) : null;
 
     return (
         <div>
@@ -75,6 +117,11 @@ export const StreamingIndicator: React.FC = () => {
                     <div className="flex-1 min-w-0">
                         <span className="text-text-tertiary text-base font-mono">
                             {displayText}...
+                            {elapsedStr && (
+                                <span className="text-text-tertiary ml-2 select-none opacity-60">
+                                    · {elapsedStr}{tokenStr ? ` · ${tokenStr}` : ''}
+                                </span>
+                            )}
                         </span>
                     </div>
                 </div>

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -35,6 +35,8 @@ export enum MessageType {
   TOOL_RESPONSE = 'TOOL_RESPONSE',
   /** Re-attach this connection to an already-running session (e.g. after reconnect). */
   RECLAIM_SESSION = 'RECLAIM_SESSION',
+  /** Get all currently running sessions. inbound webview→backend */
+  GET_RUNNING_SESSIONS = 'GET_RUNNING_SESSIONS',
 
   // -- Sessions CRUD --
   /** Create a new session (optionally in a given working directory). */
@@ -227,6 +229,8 @@ export enum MessageType {
   SESSION_APPEND = 'SESSION_APPEND',
   /** The session list changed and clients should refresh. */
   SESSIONS_UPDATED = 'SESSIONS_UPDATED',
+  /** Broadcast the set of running sessions. outbound backend→webview */
+  RUNNING_SESSIONS = 'RUNNING_SESSIONS',
   /** A user message was broadcast to all connections viewing the session. */
   USER_MESSAGE_BROADCAST = 'USER_MESSAGE_BROADCAST',
 

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -223,6 +223,8 @@ export enum MessageType {
   // -- Session push --
   /** Full session history payload in response to LOAD_SESSION. */
   SESSION_LOADED = 'SESSION_LOADED',
+  /** Incremental session history appended (external terminal tail). */
+  SESSION_APPEND = 'SESSION_APPEND',
   /** The session list changed and clients should refresh. */
   SESSIONS_UPDATED = 'SESSIONS_UPDATED',
   /** A user message was broadcast to all connections viewing the session. */

--- a/webview/vitest.config.ts
+++ b/webview/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     },
   },
   test: {
+    pool: 'threads',
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],


### PR DESCRIPTION
## Summary

- Adds `SessionJsonlWatcher` that tails a session's `.jsonl` file on disk when the session is loaded without an active process (started from an external terminal)
- New `SESSION_APPEND` message type pushes incremental history to the WebView, which merges entries by `uuid` to avoid duplicates
- Watcher lifecycle is properly managed: starts on `LOAD_SESSION`, promotes to "owned" when a process spawns, stops on WebSocket disconnect

## Changes

| Layer | File | What changed |
|-------|------|-------------|
| Shared | `message-type.ts` (×2) | Add `SESSION_APPEND` |
| Backend | `session-jsonl-watcher.ts` | New watcher module |
| Backend | `loadSession.ts` | Start watcher for idle sessions |
| Backend | `claude-process.ts` | Promote watcher on process spawn |
| Backend | `ws-server.ts` | Unwatchconnection on disconnect |
| Backend | `server.ts` | Init/stop watcher lifecycle |
| WebView | `useChatStream.ts` | `appendLoadedEntries` (uuid-dedup merge) |
| WebView | `ChatStreamContext.tsx` | Expose `appendLoadedEntries` |
| WebView | `AppProviders.tsx` | Subscribe to `SESSION_APPEND` |

## Test plan

- [x] Open a session in the plugin, then run `claude` in an external terminal for the same project — new messages should appear live without refreshing
- [ ] Switching sessions stops the previous watcher and doesn't mix history
- [ ] Closing the WebView tab properly unregisters the watcher
- [x] Unit tests: `session-jsonl-watcher.test.ts`, `useChatStream.test.ts`