### PR TITLE
feat: MCP server management GUI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 JetBrains IDE용 Claude Code GUI 플러그인. Cursor의 Claude Code 확장과 동일한 UX를 JetBrains 환경에서 제공하는 것이 목표.
 
+## ★ 핵심 원칙 — CLI 동등성 & 공식 지원 비의존 (최우선, 위반 금지)
+
+이 프로젝트의 존재 이유는 **JetBrains 공식 Claude Code 플러그인이 Cursor 공식 확장보다 조잡한데 업데이트가 없어서, 우리가 직접 더 나은 것을 만든다**는 것이다. 따라서 다음을 **모든 기능 설계의 기준선**으로 삼는다. (신규 기여자·에이전트는 기능 작업 전에 반드시 숙지할 것.)
+
+1. **CLI 동등성**: "기존 사용자가 CLI(`claude ...`)에서 할 수 있는 것은 GUI로도 할 수 있어야 한다." 기능을 설계할 때 **"이걸 CLI 사용자는 무슨 명령으로 하나?"를 먼저 묻고**, 그 공식 명령을 기준 인터페이스로 삼는다.
+
+2. **공식 지원 비의존**: Claude의 **공식 SDK 라이브러리나 미문서화 내부 프로토콜에 의존하지 않는다.** 의존하면 "CLI에선 되는데 정책상·미출시로 GUI만 막히는" 종속이 생기고, 그 순간 이 프로젝트의 존재 이유가 무너진다. 공식 지원에 기댈 거였으면 애초에 시작할 이유가 없었다.
+
+3. **참고 대상은 UX만 모방한다**: Cursor 등 참고 대상에서 따라야 할 것은 **화면·기능(UX)**이지, 그것을 만드는 **내부 구현 수단**이 아니다. 예: Cursor가 MCP 상태 조회에 미문서화 `control_request{subtype:"mcp_status"}` 내부 프로토콜을 쓰더라도, 우리는 그 화면을 공식 `claude mcp list` 명령으로 구현한다.
+
+4. **우리가 직접 제어하는 통신은 우리 자산이다**: 우리가 stdin/stdout으로 claude를 직접 제어하는 것(`control_request`의 interrupt/set_model 등, `backend/src/core/claude-process.ts`)은 "공식 SDK 라이브러리 의존"이 **아니라 우리가 구현한 통신**이다. 그 완성도를 높이는 것은 옳다 — 단, 미문서화 subtype에 **의존하지 말고 보조 최적화로만 쓰며, 공식 CLI 명령 폴백을 항상 1순위로 보장**한다.
+
+> 안정성 판단 기준: **사용자가 터미널에서 직접 쓰는 공식 명령의 출력 계약**(예: `claude mcp list`의 텍스트 출력) > **프로그램 간 미문서화 내부 프로토콜**. 후자가 더 "구조화"돼 있어 편해 보여도, 안정성과 우리 철학 양면에서 전자가 우선이다.
+
 ## 아키텍처
 
 3개 레이어로 구성:

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,6 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ws": "^8.18.0"
   },
   "devDependencies": {

--- a/backend/pnpm-lock.yaml
+++ b/backend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       ws:
         specifier: ^8.18.0
         version: 8.19.0
@@ -372,6 +375,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -381,6 +390,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
@@ -551,6 +570,21 @@ packages:
   '@vitest/utils@4.1.1':
     resolution: {integrity: sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -558,19 +592,99 @@ packages:
   ast-v8-to-istanbul@1.0.0:
     resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
     engines: {node: '>=18'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.24.2:
     resolution: {integrity: sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==}
@@ -582,12 +696,43 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -598,20 +743,84 @@ packages:
       picomatch:
         optional: true
 
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -625,8 +834,17 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -712,13 +930,66 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -730,9 +1001,33 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -742,10 +1037,52 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -756,6 +1093,10 @@ packages:
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -779,6 +1120,10 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -787,6 +1132,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -794,6 +1143,14 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@8.0.1:
     resolution: {integrity: sha512-wt+Z2qIhfFt85uiyRt5LPU4oVEJBXj8hZNWKeqFG4gRG/0RaRGJ7njQCwzFVjO+v4+Ipmf5CY7VdmZRAYYBPHw==}
@@ -873,10 +1230,18 @@ packages:
       jsdom:
         optional: true
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
@@ -889,6 +1254,14 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1076,6 +1449,10 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
@@ -1084,6 +1461,28 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
@@ -1232,6 +1631,22 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@1.0.0:
@@ -1240,13 +1655,84 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
   chai@6.2.2: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
 
   convert-source-map@2.0.0: {}
 
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  depd@2.0.0: {}
+
   detect-libc@2.1.2: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.24.2:
     optionalDependencies:
@@ -1305,26 +1791,145 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
 
+  escape-html@1.0.3: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
 
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gopd@1.2.0: {}
+
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.27: {}
+
   html-escaper@2.0.2: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -1339,7 +1944,13 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  jose@6.2.3: {}
+
   js-tokens@10.0.0: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1404,9 +2015,43 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
 
@@ -1414,11 +2059,34 @@ snapshots:
 
   picomatch@4.0.3: {}
 
+  pkce-challenge@5.0.1: {}
+
   postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -1443,13 +2111,88 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.10
       '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.10
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -1468,6 +2211,8 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  toidentifier@1.0.1: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -1478,9 +2223,19 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
   typescript@5.9.3: {}
 
   undici-types@6.21.0: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
 
   vite@8.0.1(@types/node@22.19.13)(esbuild@0.24.2)(tsx@4.21.0):
     dependencies:
@@ -1522,9 +2277,21 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wrappy@1.0.2: {}
+
   ws@8.19.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/backend/src/core/features/__tests__/account-store.test.ts
+++ b/backend/src/core/features/__tests__/account-store.test.ts
@@ -36,6 +36,8 @@ function meta(id: string, email: string): StoredAccount {
     authMethod: 'claudeai',
     createdAt: 1,
     updatedAt: 2,
+    usageCached: null,
+    usageCachedAt: 0,
   };
 }
 

--- a/backend/src/core/features/__tests__/mcp-manager.test.ts
+++ b/backend/src/core/features/__tests__/mcp-manager.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mergeDisabledServers } from '../mcp-manager';
+import { McpServerStatus, McpServerScope, McpTransportType } from '../../../shared';
+import type { McpServer } from '../../../shared';
+
+function server(name: string, overrides: Partial<McpServer> = {}): McpServer {
+  return {
+    name,
+    status: McpServerStatus.FAILED,
+    scope: McpServerScope.USER,
+    config: { type: McpTransportType.SSE, url: 'http://localhost:64342/sse' },
+    tools: [],
+    error: 'Unable to connect: connection refused.',
+    ...overrides,
+  };
+}
+
+describe('mergeDisabledServers', () => {
+  // Regression: `claude mcp list` still reports disabled servers (it ignores
+  // disabledMcpServers), so a server present in the list AND in the disabled
+  // set must be overridden to DISABLED — not left as its live FAILED status.
+  it('overrides a disabled server that still appears in the list', async () => {
+    const servers = [server('jetbrains'), server('playwright', { status: McpServerStatus.CONNECTED, error: null })];
+    const fetchDetails = vi.fn();
+
+    await mergeDisabledServers(servers, ['jetbrains'], fetchDetails);
+
+    const jetbrains = servers.find((s) => s.name === 'jetbrains')!;
+    expect(jetbrains.status).toBe(McpServerStatus.DISABLED);
+    expect(jetbrains.error).toBeNull();
+    // Non-disabled server is untouched.
+    expect(servers.find((s) => s.name === 'playwright')!.status).toBe(McpServerStatus.CONNECTED);
+    // No synthetic fetch needed since it was already in the list.
+    expect(fetchDetails).not.toHaveBeenCalled();
+  });
+
+  it('adds a synthetic DISABLED entry for a config-only disabled server, forcing DISABLED even if details report FAILED', async () => {
+    const servers: McpServer[] = [];
+    // Even though `claude mcp get` reports FAILED, the merged entry must be DISABLED.
+    const fetchDetails = vi.fn().mockResolvedValue(server('config-only', { status: McpServerStatus.FAILED }));
+
+    await mergeDisabledServers(servers, ['config-only'], fetchDetails);
+
+    expect(servers).toHaveLength(1);
+    expect(servers[0].name).toBe('config-only');
+    expect(servers[0].status).toBe(McpServerStatus.DISABLED);
+    expect(servers[0].error).toBeNull();
+    // Config details (transport/url) are preserved from the fetch.
+    expect(servers[0].config?.url).toBe('http://localhost:64342/sse');
+    expect(fetchDetails).toHaveBeenCalledWith('config-only');
+  });
+
+  it('falls back to a minimal user-scope entry when details are unavailable', async () => {
+    const servers: McpServer[] = [];
+    const fetchDetails = vi.fn().mockResolvedValue(null);
+
+    await mergeDisabledServers(servers, ['ghost'], fetchDetails);
+
+    expect(servers).toEqual([
+      {
+        name: 'ghost',
+        scope: McpServerScope.USER,
+        config: null,
+        tools: [],
+        status: McpServerStatus.DISABLED,
+        error: null,
+      },
+    ]);
+  });
+
+  it('is a no-op when the disabled list is empty', async () => {
+    const servers = [server('jetbrains', { status: McpServerStatus.CONNECTED, error: null })];
+    const fetchDetails = vi.fn();
+
+    await mergeDisabledServers(servers, [], fetchDetails);
+
+    expect(servers[0].status).toBe(McpServerStatus.CONNECTED);
+    expect(fetchDetails).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/features/__tests__/mcp-manager.test.ts
+++ b/backend/src/core/features/__tests__/mcp-manager.test.ts
@@ -1,7 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mergeDisabledServers } from '../mcp-manager';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mergeDisabledServers, addMcpServer, removeMcpServer, extractServerConfig } from '../mcp-manager';
+import { Claude } from '../../claude';
 import { McpServerStatus, McpServerScope, McpTransportType } from '../../../shared';
 import type { McpServer } from '../../../shared';
+
+vi.mock('../../claude', () => ({ Claude: { exec: vi.fn() } }));
 
 function server(name: string, overrides: Partial<McpServer> = {}): McpServer {
   return {
@@ -76,5 +79,56 @@ describe('mergeDisabledServers', () => {
 
     expect(servers[0].status).toBe(McpServerStatus.CONNECTED);
     expect(fetchDetails).not.toHaveBeenCalled();
+  });
+});
+
+// Regression: project/local scope writes `.mcp.json` relative to the CLI's cwd.
+// Without forwarding the workspace root, the file landed in the backend's own
+// directory (backend/.mcp.json) instead of the user's project. Every MCP
+// command must run with cwd === workspace root.
+describe('MCP commands run in the workspace cwd', () => {
+  const execMock = vi.mocked(Claude.exec);
+
+  beforeEach(() => {
+    execMock.mockReset();
+    execMock.mockResolvedValue({ stdout: 'Added', stderr: '' });
+  });
+
+  it('forwards cwd to `claude mcp add-json` so project scope writes at the workspace root', async () => {
+    await addMcpServer('srv', { command: 'npx' }, 'project', '/ws/root');
+    expect(execMock).toHaveBeenCalledWith(
+      ['mcp', 'add-json', 'srv', JSON.stringify({ command: 'npx' }), '-s', 'project'],
+      expect.objectContaining({ cwd: '/ws/root' }),
+    );
+  });
+
+  it('forwards cwd to `claude mcp remove` to target the right project .mcp.json', async () => {
+    await removeMcpServer('srv', 'project', '/ws/root');
+    expect(execMock).toHaveBeenCalledWith(
+      ['mcp', 'remove', 'srv', '-s', 'project'],
+      expect.objectContaining({ cwd: '/ws/root' }),
+    );
+  });
+});
+
+// Regression: `claude mcp get` drops headers/env (and omits config entirely for
+// non-connected servers). The settings file is the source of truth, so config
+// recovery must return it verbatim — otherwise Edit would silently lose headers.
+describe('extractServerConfig', () => {
+  it('returns the server config verbatim, including headers', () => {
+    const data = { mcpServers: { srv: { type: 'http', url: 'u', headers: { 'X-Test': '1' } } } };
+    expect(extractServerConfig(data, 'srv')).toEqual({ type: 'http', url: 'u', headers: { 'X-Test': '1' } });
+  });
+
+  it('preserves stdio env verbatim', () => {
+    const data = { mcpServers: { srv: { command: 'npx', args: ['x'], env: { API_KEY: 'secret' } } } };
+    expect(extractServerConfig(data, 'srv')).toEqual({ command: 'npx', args: ['x'], env: { API_KEY: 'secret' } });
+  });
+
+  it('returns null when the server is absent or the shape is malformed', () => {
+    expect(extractServerConfig({ mcpServers: {} }, 'srv')).toBeNull();
+    expect(extractServerConfig({}, 'srv')).toBeNull();
+    expect(extractServerConfig(null, 'srv')).toBeNull();
+    expect(extractServerConfig({ mcpServers: { srv: 'not-an-object' } }, 'srv')).toBeNull();
   });
 });

--- a/backend/src/core/features/__tests__/mcp-parser.test.ts
+++ b/backend/src/core/features/__tests__/mcp-parser.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect } from 'vitest';
+import { parseMcpList, parseMcpGet } from '../mcp-parser';
+import { McpServerStatus, McpServerScope, McpTransportType } from '../../../shared';
+
+// ─── parseMcpList ────────────────────────────────────────────────────────────
+
+describe('parseMcpList', () => {
+  const FIXTURE_LIST = `Checking MCP server health…
+
+claude.ai Claude Code Remote: https://api.anthropic.com/v1/code/mcp/meta - ✔ Connected
+playwright: npx @executeautomation/playwright-mcp-server - ✔ Connected
+vibe_kanban: npx -y vibe-kanban@latest --mcp - ✘ Failed to connect
+jetbrains: http://localhost:64342/sse (SSE) - ✘ Failed to connect
+slack: npx -y @modelcontextprotocol/server-slack - ✔ Connected
+taskmaster-ai: npx -y task-master-ai - ✔ Connected
+workspace-mcp: http://localhost:8000/mcp (HTTP) - ✔ Connected`;
+
+  it('extracts all server names', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    const names = result.map((r) => r.name);
+    expect(names).toEqual([
+      'claude.ai Claude Code Remote',
+      'playwright',
+      'vibe_kanban',
+      'jetbrains',
+      'slack',
+      'taskmaster-ai',
+      'workspace-mcp',
+    ]);
+  });
+
+  it('maps ✔ Connected to CONNECTED', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    expect(result.find((r) => r.name === 'playwright')?.status).toBe(McpServerStatus.CONNECTED);
+  });
+
+  it('maps ✘ Failed to connect to FAILED', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    expect(result.find((r) => r.name === 'vibe_kanban')?.status).toBe(McpServerStatus.FAILED);
+    expect(result.find((r) => r.name === 'jetbrains')?.status).toBe(McpServerStatus.FAILED);
+  });
+
+  it('handles server names containing dots (claude.ai)', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    expect(result.find((r) => r.name === 'claude.ai Claude Code Remote')?.status).toBe(
+      McpServerStatus.CONNECTED,
+    );
+  });
+
+  it('handles args with hyphens without confusing the ` - ` status separator', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    expect(result.find((r) => r.name === 'vibe_kanban')?.status).toBe(McpServerStatus.FAILED);
+  });
+
+  it('skips the "Checking MCP" header line', () => {
+    const result = parseMcpList(FIXTURE_LIST);
+    expect(result.some((r) => r.name.startsWith('Checking'))).toBe(false);
+  });
+
+  it('returns empty array for empty output', () => {
+    expect(parseMcpList('')).toEqual([]);
+  });
+
+  it('returns empty array when only header present', () => {
+    expect(parseMcpList('Checking MCP server health…\n')).toEqual([]);
+  });
+});
+
+// ─── parseMcpGet ─────────────────────────────────────────────────────────────
+
+describe('parseMcpGet', () => {
+  describe('stdio server (playwright)', () => {
+    const FIXTURE = `playwright:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: stdio
+  Command: npx
+  Args: @executeautomation/playwright-mcp-server
+  Environment:
+
+To remove this server, run: claude mcp remove "playwright" -s user`;
+
+    it('parses name', () => {
+      expect(parseMcpGet(FIXTURE)?.name).toBe('playwright');
+    });
+
+    it('parses status as CONNECTED', () => {
+      expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.CONNECTED);
+    });
+
+    it('parses scope as USER', () => {
+      expect(parseMcpGet(FIXTURE)?.scope).toBe(McpServerScope.USER);
+    });
+
+    it('parses stdio config with command and args', () => {
+      const config = parseMcpGet(FIXTURE)?.config;
+      expect(config?.type).toBe(McpTransportType.STDIO);
+      expect(config?.command).toBe('npx');
+      expect(config?.args).toEqual(['@executeautomation/playwright-mcp-server']);
+    });
+
+    it('returns no env for empty Environment line', () => {
+      expect(parseMcpGet(FIXTURE)?.config?.env).toBeUndefined();
+    });
+  });
+
+  describe('stdio server with multiple args (taskmaster-ai)', () => {
+    const FIXTURE = `taskmaster-ai:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: stdio
+  Command: npx
+  Args: -y task-master-ai
+  Environment:
+
+To remove this server, run: claude mcp remove "taskmaster-ai" -s user`;
+
+    it('splits args by whitespace', () => {
+      expect(parseMcpGet(FIXTURE)?.config?.args).toEqual(['-y', 'task-master-ai']);
+    });
+  });
+
+  describe('http server (workspace-mcp)', () => {
+    const FIXTURE = `workspace-mcp:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: http
+  URL: http://localhost:8000/mcp
+
+To remove this server, run: claude mcp remove "workspace-mcp" -s user`;
+
+    it('parses http config with URL', () => {
+      const config = parseMcpGet(FIXTURE)?.config;
+      expect(config?.type).toBe(McpTransportType.HTTP);
+      expect(config?.url).toBe('http://localhost:8000/mcp');
+    });
+  });
+
+  describe('sse server (jetbrains)', () => {
+    const FIXTURE = `jetbrains:
+  Scope: User config (available in all your projects)
+  Status: ✘ Failed to connect
+  Type: sse
+  URL: http://localhost:64342/sse
+
+To remove this server, run: claude mcp remove "jetbrains" -s user`;
+
+    it('parses sse config with URL', () => {
+      const config = parseMcpGet(FIXTURE)?.config;
+      expect(config?.type).toBe(McpTransportType.SSE);
+      expect(config?.url).toBe('http://localhost:64342/sse');
+    });
+
+    it('parses status as FAILED', () => {
+      expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.FAILED);
+    });
+  });
+
+  describe('claude.ai connector (no transport details)', () => {
+    const FIXTURE = `claude.ai Claude Code Remote:
+  Scope: claude.ai config
+  Status: ✔ Connected
+
+To remove this server, run: claude mcp remove "claude.ai Claude Code Remote" -s claudeai`;
+
+    it('parses name correctly (contains dots)', () => {
+      expect(parseMcpGet(FIXTURE)?.name).toBe('claude.ai Claude Code Remote');
+    });
+
+    it('parses scope as CLAUDEAI', () => {
+      expect(parseMcpGet(FIXTURE)?.scope).toBe(McpServerScope.CLAUDEAI);
+    });
+
+    it('returns null config when no Type field', () => {
+      expect(parseMcpGet(FIXTURE)?.config).toBeNull();
+    });
+
+    it('parses status as CONNECTED', () => {
+      expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.CONNECTED);
+    });
+  });
+
+  describe('server with no type in get output (slack)', () => {
+    const FIXTURE = `slack:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+
+To remove this server, run: claude mcp remove "slack" -s user`;
+
+    it('returns null config when Type is absent', () => {
+      expect(parseMcpGet(FIXTURE)?.config).toBeNull();
+    });
+  });
+
+  describe('hypothetical needs-auth status', () => {
+    const FIXTURE = `my-server:
+  Scope: User config (available in all your projects)
+  Status: needs-auth
+  Type: sse
+  URL: https://example.com/sse
+
+To remove this server, run: claude mcp remove "my-server" -s user`;
+
+    it('parses needs-auth status', () => {
+      expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.NEEDS_AUTH);
+    });
+  });
+
+  describe('hypothetical disabled status', () => {
+    const FIXTURE = `my-server:
+  Scope: User config (available in all your projects)
+  Status: disabled
+  Type: stdio
+  Command: npx
+  Args: some-package
+
+To remove this server, run: claude mcp remove "my-server" -s user`;
+
+    it('parses disabled status', () => {
+      expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.DISABLED);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns null for empty string', () => {
+      expect(parseMcpGet('')).toBeNull();
+    });
+
+    it('returns null when first line has no trailing colon', () => {
+      expect(parseMcpGet('not a server name\n  Scope: User')).toBeNull();
+    });
+
+    it('initialises tools as empty array', () => {
+      const FIXTURE = `playwright:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: stdio
+  Command: npx
+  Args: some-pkg`;
+      expect(parseMcpGet(FIXTURE)?.tools).toEqual([]);
+    });
+
+    it('initialises error as null', () => {
+      const FIXTURE = `playwright:
+  Scope: User config (available in all your projects)
+  Status: ✔ Connected
+  Type: stdio
+  Command: npx
+  Args: some-pkg`;
+      expect(parseMcpGet(FIXTURE)?.error).toBeNull();
+    });
+  });
+});

--- a/backend/src/core/features/__tests__/mcp-registry.test.ts
+++ b/backend/src/core/features/__tests__/mcp-registry.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeRegistryServer } from '../mcp-registry';
+import { McpTransportType } from '../../../shared';
+
+// Sample raw entries mirror the real official-registry shape:
+//   GET https://registry.modelcontextprotocol.io/v0/servers
+// Each item is { server: {...}, _meta: {...} }; the installable data lives in
+// packages[] (stdio) and remotes[] (http/sse).
+
+describe('normalizeRegistryServer', () => {
+  it('returns null when the entry has no server object', () => {
+    expect(normalizeRegistryServer({ _meta: {} })).toBeNull();
+    expect(normalizeRegistryServer(null)).toBeNull();
+    expect(normalizeRegistryServer('nope')).toBeNull();
+  });
+
+  it('maps top-level metadata (name, description, version, repository url)', () => {
+    const r = normalizeRegistryServer({
+      server: {
+        name: 'io.github.acme/widget',
+        description: 'A widget server',
+        version: '1.2.3',
+        repository: { url: 'https://github.com/acme/widget', source: 'github' },
+        packages: [{ registryType: 'npm', identifier: 'widget-mcp', transport: { type: 'stdio' } }],
+      },
+    });
+    expect(r).not.toBeNull();
+    expect(r!.name).toBe('io.github.acme/widget');
+    expect(r!.description).toBe('A widget server');
+    expect(r!.version).toBe('1.2.3');
+    expect(r!.repositoryUrl).toBe('https://github.com/acme/widget');
+  });
+
+  it('defaults missing description/version to empty string and repositoryUrl to null', () => {
+    const r = normalizeRegistryServer({
+      server: { name: 'x', packages: [{ registryType: 'npm', identifier: 'x-mcp' }] },
+    });
+    expect(r!.description).toBe('');
+    expect(r!.version).toBe('');
+    expect(r!.repositoryUrl).toBeNull();
+  });
+
+  describe('npm package → stdio config', () => {
+    it('builds command=npx with -y and the package identifier', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'n',
+          packages: [{
+            registryType: 'npm',
+            identifier: 'my-mcp-server',
+            runtimeHint: 'npx',
+            transport: { type: 'stdio' },
+            runtimeArguments: [{ value: '-y', type: 'positional' }],
+          }],
+        },
+      });
+      expect(r!.config).toEqual({
+        type: McpTransportType.STDIO,
+        command: 'npx',
+        args: ['-y', 'my-mcp-server'],
+      });
+      expect(r!.requiredInputs).toEqual([]);
+    });
+
+    it('falls back to npx when runtimeHint is absent', () => {
+      const r = normalizeRegistryServer({
+        server: { name: 'n', packages: [{ registryType: 'npm', identifier: 'pkg' }] },
+      });
+      expect(r!.config).toMatchObject({ command: 'npx', args: ['pkg'] });
+    });
+
+    it('uses uvx for pypi packages', () => {
+      const r = normalizeRegistryServer({
+        server: { name: 'n', packages: [{ registryType: 'pypi', identifier: 'py-mcp' }] },
+      });
+      expect(r!.config).toMatchObject({ command: 'uvx', args: ['py-mcp'] });
+    });
+
+    it('includes only required env vars (blank values) and lists them in requiredInputs', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'n',
+          packages: [{
+            registryType: 'npm',
+            identifier: 'pkg',
+            environmentVariables: [
+              { name: 'REQ_KEY', isRequired: true },
+              { name: 'OPT_KEY' },
+              { name: 'REQ_DEFAULT', isRequired: true, default: 'x' },
+            ],
+          }],
+        },
+      });
+      expect(r!.config).toMatchObject({
+        env: { REQ_KEY: '', REQ_DEFAULT: 'x' },
+      });
+      expect(r!.config!.env).not.toHaveProperty('OPT_KEY');
+      expect(r!.requiredInputs).toEqual(['REQ_KEY', 'REQ_DEFAULT']);
+    });
+
+    it('appends package arguments after the identifier (named → flag + value, positional → value)', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'n',
+          packages: [{
+            registryType: 'npm',
+            identifier: 'pkg',
+            runtimeArguments: [{ value: '-y', type: 'positional' }],
+            packageArguments: [
+              { type: 'named', name: '--port', value: '8080' },
+              { type: 'positional', value: '/data' },
+            ],
+          }],
+        },
+      });
+      // runtime args, then identifier, then package args
+      expect(r!.config!.args).toEqual(['-y', 'pkg', '--port', '8080', '/data']);
+    });
+  });
+
+  describe('remote → http/sse config', () => {
+    it('maps streamable-http to HTTP transport', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'r',
+          remotes: [{ type: 'streamable-http', url: 'https://example.com/mcp' }],
+        },
+      });
+      expect(r!.config).toEqual({ type: McpTransportType.HTTP, url: 'https://example.com/mcp' });
+    });
+
+    it('maps sse to SSE transport', () => {
+      const r = normalizeRegistryServer({
+        server: { name: 'r', remotes: [{ type: 'sse', url: 'https://example.com/sse' }] },
+      });
+      expect(r!.config).toMatchObject({ type: McpTransportType.SSE, url: 'https://example.com/sse' });
+    });
+
+    it('includes required headers (placeholder values kept) and lists them in requiredInputs', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'r',
+          remotes: [{
+            type: 'streamable-http',
+            url: 'https://server.smithery.ai/mcp',
+            headers: [
+              { name: 'Authorization', value: 'Bearer {smithery_api_key}', isRequired: true },
+              { name: 'X-Optional', value: 'maybe' },
+            ],
+          }],
+        },
+      });
+      expect(r!.config).toMatchObject({
+        headers: { Authorization: 'Bearer {smithery_api_key}' },
+      });
+      expect(r!.config!.headers).not.toHaveProperty('X-Optional');
+      expect(r!.requiredInputs).toEqual(['Authorization']);
+    });
+  });
+
+  describe('package vs remote precedence', () => {
+    it('prefers a stdio package over a remote when both are present', () => {
+      const r = normalizeRegistryServer({
+        server: {
+          name: 'both',
+          packages: [{ registryType: 'npm', identifier: 'pkg' }],
+          remotes: [{ type: 'streamable-http', url: 'https://example.com/mcp' }],
+        },
+      });
+      expect(r!.config).toMatchObject({ type: McpTransportType.STDIO, command: 'npx' });
+    });
+  });
+
+  it('returns config=null when there is neither a package nor a remote', () => {
+    const r = normalizeRegistryServer({ server: { name: 'empty' } });
+    expect(r!.config).toBeNull();
+    expect(r!.requiredInputs).toEqual([]);
+  });
+});

--- a/backend/src/core/features/__tests__/mcp-tools.test.ts
+++ b/backend/src/core/features/__tests__/mcp-tools.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { mapMcpTool, buildTransport } from '../mcp-tools';
+import { McpTransportType } from '../../../shared';
+import type { McpServerConfig } from '../../../shared';
+
+describe('mapMcpTool', () => {
+  it('keeps only the name when no annotations are present', () => {
+    expect(mapMcpTool({ name: 'playwright_navigate' })).toEqual({ name: 'playwright_navigate' });
+  });
+
+  it('omits the annotations object when annotations is empty', () => {
+    expect(mapMcpTool({ name: 't', annotations: {} })).toEqual({ name: 't' });
+  });
+
+  it('maps readOnlyHint -> readOnly', () => {
+    expect(mapMcpTool({ name: 't', annotations: { readOnlyHint: true } })).toEqual({
+      name: 't',
+      annotations: { readOnly: true },
+    });
+  });
+
+  it('maps destructiveHint -> destructive', () => {
+    expect(mapMcpTool({ name: 't', annotations: { destructiveHint: true } })).toEqual({
+      name: 't',
+      annotations: { destructive: true },
+    });
+  });
+
+  it('maps both hints together', () => {
+    expect(
+      mapMcpTool({ name: 't', annotations: { readOnlyHint: false, destructiveHint: true } }),
+    ).toEqual({ name: 't', annotations: { readOnly: false, destructive: true } });
+  });
+});
+
+describe('buildTransport', () => {
+  it('returns a transport for a stdio server with a command', () => {
+    const config: McpServerConfig = {
+      type: McpTransportType.STDIO,
+      command: 'npx',
+      args: ['@executeautomation/playwright-mcp-server'],
+    };
+    expect(buildTransport(config)).not.toBeNull();
+  });
+
+  it('returns null for a stdio server without a command', () => {
+    expect(buildTransport({ type: McpTransportType.STDIO })).toBeNull();
+  });
+
+  it('returns a transport for an http server with a url', () => {
+    expect(buildTransport({ type: McpTransportType.HTTP, url: 'http://localhost:8000/mcp' })).not.toBeNull();
+  });
+
+  it('returns a transport for an sse server with a url', () => {
+    expect(buildTransport({ type: McpTransportType.SSE, url: 'http://localhost:64342/sse' })).not.toBeNull();
+  });
+
+  it('returns null for http/sse without a url', () => {
+    expect(buildTransport({ type: McpTransportType.HTTP })).toBeNull();
+    expect(buildTransport({ type: McpTransportType.SSE })).toBeNull();
+  });
+
+  it('returns null for claudeai-proxy (needs OAuth, not directly probeable)', () => {
+    expect(buildTransport({ type: McpTransportType.CLAUDEAI_PROXY, url: 'https://example' })).toBeNull();
+  });
+});

--- a/backend/src/core/features/mcp-manager.ts
+++ b/backend/src/core/features/mcp-manager.ts
@@ -1,0 +1,245 @@
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { homedir } from 'os';
+import { Claude } from '../claude';
+import { parseMcpList, parseMcpGet } from './mcp-parser';
+import { McpServerStatus } from '../../shared';
+import type { McpServer, McpServersResult, McpServerScope } from '../../shared';
+
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
+/** Path to the global claude config file that stores disabledMcpServers. */
+function claudeJsonPath(): string {
+  return join(process.env.CLAUDE_CONFIG_DIR ?? homedir(), '.claude.json');
+}
+
+async function readClaudeJson(): Promise<Record<string, unknown>> {
+  try {
+    const p = claudeJsonPath();
+    if (!existsSync(p)) return {};
+    return JSON.parse(await readFile(p, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+async function writeClaudeJson(data: Record<string, unknown>): Promise<void> {
+  const p = claudeJsonPath();
+  await mkdir(dirname(p), { recursive: true });
+  await writeFile(p, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+}
+
+// ─── Scope ordering for stable list rendering ──────────────────────────────────
+
+const SCOPE_ORDER: string[] = ['project', 'local', 'user', 'claudeai', 'managed', 'enterprise'];
+
+function scopeRank(scope: McpServerScope | string): number {
+  const i = SCOPE_ORDER.indexOf(scope as string);
+  return i === -1 ? 99 : i;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Fetch all MCP servers with status, scope, config, and disabled state.
+ *
+ * Strategy (CLI-first, per CLAUDE.md):
+ *   1. `claude mcp list` → names + basic status (performs health check)
+ *   2. `claude mcp get <name>` in parallel → full details per server
+ *   3. Read disabledMcpServers from ~/.claude.json → mark DISABLED
+ *
+ * Servers are sorted by scope priority then name.
+ */
+export async function getMcpServers(): Promise<McpServersResult> {
+  const [listOut, disabled] = await Promise.all([runMcpList(), readDisabledServers()]);
+  const names = parseMcpList(listOut).map((s) => s.name);
+
+  if (names.length === 0 && disabled.length === 0) {
+    return { servers: [] };
+  }
+
+  // Fetch details for all connected/failed servers in parallel.
+  const settled = await Promise.allSettled(names.map((name) => fetchServerDetails(name)));
+
+  const servers: McpServer[] = settled.flatMap((r) => {
+    if (r.status === 'fulfilled' && r.value !== null) return [r.value];
+    return [];
+  });
+
+  // Mark disabled servers. The CLI doesn't report them in `mcp list`, so we
+  // add synthetic entries for those not already in the results (config-only servers).
+  for (const disabledName of disabled) {
+    const existing = servers.find((s) => s.name === disabledName);
+    if (existing) {
+      // Server appeared in list (perhaps was recently re-enabled) — leave its status.
+    } else {
+      // Config-only disabled server: try to get its config details.
+      const details = await fetchServerDetails(disabledName).catch(() => null);
+      servers.push(details ?? {
+        name: disabledName,
+        status: 'disabled' as McpServer['status'],
+        scope: 'user',
+        config: null,
+        tools: [],
+        error: null,
+      });
+    }
+  }
+
+  servers.sort((a, b) => {
+    const scopeDiff = scopeRank(a.scope) - scopeRank(b.scope);
+    if (scopeDiff !== 0) return scopeDiff;
+    return a.name.localeCompare(b.name);
+  });
+
+  return { servers };
+}
+
+/**
+ * Re-fetch a single server's details (used as a "reconnect" health-check).
+ * `claude mcp get` tries to connect when invoked, so re-running it is the
+ * CLI-equivalent of a reconnect probe.
+ */
+export async function reconnectMcpServer(name: string): Promise<McpServer | null> {
+  return fetchServerDetails(name);
+}
+
+/**
+ * Toggle the enabled/disabled state of a named MCP server.
+ * Edits the `disabledMcpServers` array in ~/.claude.json.
+ * (No CLI command exists for this — CLI users also edit the file directly.)
+ */
+export async function setMcpServerEnabled(name: string, enabled: boolean): Promise<void> {
+  const data = await readClaudeJson();
+  const current: string[] = Array.isArray(data.disabledMcpServers)
+    ? (data.disabledMcpServers as string[])
+    : [];
+
+  const updated = enabled
+    ? current.filter((n) => n !== name)
+    : current.includes(name) ? current : [...current, name];
+
+  await writeClaudeJson({ ...data, disabledMcpServers: updated });
+}
+
+/**
+ * Add a new MCP server via `claude mcp add-json`.
+ * @param scope  One of: user | project | local
+ */
+export async function addMcpServer(
+  name: string,
+  config: Record<string, unknown>,
+  scope: string,
+): Promise<void> {
+  const json = JSON.stringify(config);
+  const scopeFlag = scopeCliFlag(scope);
+  const args = ['mcp', 'add-json', name, json];
+  if (scopeFlag) args.push('-s', scopeFlag);
+  const { stdout, stderr } = await Claude.exec(args, { timeout: 15000 });
+  const combined = `${stdout}\n${stderr}`.toLowerCase();
+  if (combined.includes('error') && !combined.includes('already exists')) {
+    throw new Error(`claude mcp add-json failed: ${stderr || stdout}`);
+  }
+}
+
+/**
+ * Remove a named MCP server via `claude mcp remove`.
+ */
+export async function removeMcpServer(name: string, scope: string): Promise<void> {
+  const scopeFlag = scopeCliFlag(scope);
+  const args = ['mcp', 'remove', name];
+  if (scopeFlag) args.push('-s', scopeFlag);
+  const { stderr } = await Claude.exec(args, { timeout: 10000 });
+  if (stderr.toLowerCase().includes('error')) {
+    throw new Error(`claude mcp remove failed: ${stderr}`);
+  }
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+async function runMcpList(): Promise<string> {
+  try {
+    const { stdout } = await Claude.exec(['mcp', 'list'], { timeout: 20000 });
+    return stdout;
+  } catch {
+    return '';
+  }
+}
+
+async function fetchServerDetails(name: string): Promise<McpServer | null> {
+  try {
+    const { stdout } = await Claude.exec(['mcp', 'get', name], { timeout: 12000 });
+    const server = parseMcpGet(stdout);
+    if (!server) return null;
+    return await enrichWithProbeError(server);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * For SSE/HTTP servers in a failed/auth-required state, probe the URL directly
+ * to surface a richer error message (e.g. ECONNREFUSED, HTTP 4xx/5xx).
+ * CLI only reports "Failed to connect"; this gives us the actual cause.
+ */
+async function enrichWithProbeError(server: McpServer): Promise<McpServer> {
+  if (
+    (server.status === McpServerStatus.FAILED || server.status === McpServerStatus.NEEDS_AUTH) &&
+    server.config &&
+    'url' in server.config &&
+    typeof server.config.url === 'string'
+  ) {
+    const probeError = await probeUrl(server.config.url);
+    if (probeError) return { ...server, error: probeError };
+  }
+  return server;
+}
+
+async function probeUrl(url: string): Promise<string | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { Accept: 'text/event-stream, application/json, */*' },
+    });
+    clearTimeout(timer);
+    if (!res.ok) return `HTTP ${res.status} ${res.statusText}`;
+    return null;
+  } catch (err: unknown) {
+    clearTimeout(timer);
+    if (!(err instanceof Error)) return 'Connection failed';
+    if (err.name === 'AbortError') return `Connection timed out. Is the server running at ${url}?`;
+
+    // Node.js fetch wraps low-level errors in a TypeError with a `cause`.
+    // cause can be AggregateError (ECONNREFUSED) where message is empty — check code too.
+    const cause = (err as { cause?: { message?: string; code?: string } }).cause;
+    const causeCode = cause?.code ?? '';
+    const detail = (cause?.message || '').trim() || err.message;
+
+    if (causeCode === 'ECONNREFUSED' || detail.includes('ECONNREFUSED')) {
+      return `Unable to connect: connection refused. Is the server running at ${url}?`;
+    }
+    if (causeCode === 'ENOTFOUND' || detail.includes('ENOTFOUND') || detail.includes('getaddrinfo')) {
+      return `Unable to connect: hostname not found. Is the URL correct? (${url})`;
+    }
+    return detail || 'Connection failed';
+  }
+}
+
+async function readDisabledServers(): Promise<string[]> {
+  const data = await readClaudeJson();
+  return Array.isArray(data.disabledMcpServers) ? (data.disabledMcpServers as string[]) : [];
+}
+
+/** Map our scope string to the -s flag value the CLI accepts. */
+function scopeCliFlag(scope: string): string | null {
+  switch (scope) {
+    case 'user': return 'user';
+    case 'project': return 'project';
+    case 'local': return 'local';
+    default: return null;
+  }
+}

--- a/backend/src/core/features/mcp-manager.ts
+++ b/backend/src/core/features/mcp-manager.ts
@@ -14,6 +14,17 @@ function claudeJsonPath(): string {
   return join(process.env.CLAUDE_CONFIG_DIR ?? homedir(), '.claude.json');
 }
 
+/**
+ * Display form of the global config path, shown next to the user/local scope
+ * groups in the UI. Resolves to `~/.claude.json` normally, or the absolute
+ * `$CLAUDE_CONFIG_DIR/.claude.json` when that env var overrides the home dir —
+ * so the displayed source path always matches where `claude mcp add` writes.
+ */
+export function claudeJsonDisplayPath(): string {
+  const dir = process.env.CLAUDE_CONFIG_DIR;
+  return dir ? join(dir, '.claude.json') : '~/.claude.json';
+}
+
 async function readClaudeJson(): Promise<Record<string, unknown>> {
   try {
     const p = claudeJsonPath();
@@ -56,7 +67,7 @@ export async function getMcpServers(): Promise<McpServersResult> {
   const names = parseMcpList(listOut).map((s) => s.name);
 
   if (names.length === 0 && disabled.length === 0) {
-    return { servers: [] };
+    return { servers: [], configPath: claudeJsonDisplayPath() };
   }
 
   // Fetch details for all connected/failed servers in parallel.
@@ -78,7 +89,7 @@ export async function getMcpServers(): Promise<McpServersResult> {
     return a.name.localeCompare(b.name);
   });
 
-  return { servers };
+  return { servers, configPath: claudeJsonDisplayPath() };
 }
 
 /**

--- a/backend/src/core/features/mcp-manager.ts
+++ b/backend/src/core/features/mcp-manager.ts
@@ -5,7 +5,7 @@ import { homedir } from 'os';
 import { Claude } from '../claude';
 import { parseMcpList, parseMcpGet } from './mcp-parser';
 import { McpServerStatus, McpServerScope } from '../../shared';
-import type { McpServer, McpServersResult } from '../../shared';
+import type { McpServer, McpServersResult, McpServerConfig } from '../../shared';
 
 // ─── Path helpers ─────────────────────────────────────────────────────────────
 
@@ -62,8 +62,8 @@ function scopeRank(scope: McpServerScope | string): number {
  *
  * Servers are sorted by scope priority then name.
  */
-export async function getMcpServers(): Promise<McpServersResult> {
-  const [listOut, disabled] = await Promise.all([runMcpList(), readDisabledServers()]);
+export async function getMcpServers(cwd?: string): Promise<McpServersResult> {
+  const [listOut, disabled] = await Promise.all([runMcpList(cwd), readDisabledServers()]);
   const names = parseMcpList(listOut).map((s) => s.name);
 
   if (names.length === 0 && disabled.length === 0) {
@@ -71,17 +71,39 @@ export async function getMcpServers(): Promise<McpServersResult> {
   }
 
   // Fetch details for all connected/failed servers in parallel.
-  const settled = await Promise.allSettled(names.map((name) => fetchServerDetails(name)));
+  const settled = await Promise.allSettled(names.map((name) => fetchServerDetails(name, cwd)));
 
   const servers: McpServer[] = settled.flatMap((r) => {
     if (r.status === 'fulfilled' && r.value !== null) return [r.value];
     return [];
   });
 
+  // `claude mcp get` is an unreliable source for config: it omits transport
+  // details for non-connected servers, and even when present it drops headers/
+  // env (and its text format is brittle). For user/project servers the settings
+  // file IS the source of truth, so overwrite with the file's verbatim config
+  // (full env/headers preserved) — this is what makes Failed/Pending servers
+  // show their config and become editable.
+  const userData = await readClaudeJson();
+  const projectData = cwd ? await readProjectMcpJson(cwd) : null;
+  // local scope lives under projects[cwd] in ~/.claude.json (same mcpServers shape).
+  const localData = cwd ? extractProjectEntry(userData, cwd) : null;
+  for (const s of servers) {
+    const fromFile =
+      s.scope === McpServerScope.USER
+        ? extractServerConfig(userData, s.name)
+        : s.scope === McpServerScope.PROJECT
+          ? extractServerConfig(projectData, s.name)
+          : s.scope === McpServerScope.LOCAL
+            ? extractServerConfig(localData, s.name)
+            : null;
+    if (fromFile) s.config = fromFile;
+  }
+
   // Apply disabled state. `claude mcp list` does NOT honour disabledMcpServers —
   // it still reports those servers (and health-checks them), so their status must
   // be overridden to DISABLED here, plus synthetic entries for config-only ones.
-  await mergeDisabledServers(servers, disabled, fetchServerDetails);
+  await mergeDisabledServers(servers, disabled, (name) => fetchServerDetails(name, cwd));
 
   servers.sort((a, b) => {
     const scopeDiff = scopeRank(a.scope) - scopeRank(b.scope);
@@ -133,8 +155,8 @@ export async function mergeDisabledServers(
  * `claude mcp get` tries to connect when invoked, so re-running it is the
  * CLI-equivalent of a reconnect probe.
  */
-export async function reconnectMcpServer(name: string): Promise<McpServer | null> {
-  return fetchServerDetails(name);
+export async function reconnectMcpServer(name: string, cwd?: string): Promise<McpServer | null> {
+  return fetchServerDetails(name, cwd);
 }
 
 /**
@@ -158,17 +180,21 @@ export async function setMcpServerEnabled(name: string, enabled: boolean): Promi
 /**
  * Add a new MCP server via `claude mcp add-json`.
  * @param scope  One of: user | project | local
+ * @param cwd    Working directory to run the CLI in. CRITICAL for `project`/`local`
+ *               scope: those write `.mcp.json` / project config relative to cwd, so
+ *               this MUST be the user's workspace root — not the backend's own dir.
  */
 export async function addMcpServer(
   name: string,
   config: Record<string, unknown>,
   scope: string,
+  cwd?: string,
 ): Promise<void> {
   const json = JSON.stringify(config);
   const scopeFlag = scopeCliFlag(scope);
   const args = ['mcp', 'add-json', name, json];
   if (scopeFlag) args.push('-s', scopeFlag);
-  const { stdout, stderr } = await Claude.exec(args, { timeout: 15000 });
+  const { stdout, stderr } = await Claude.exec(args, { timeout: 15000, cwd });
   const combined = `${stdout}\n${stderr}`.toLowerCase();
   if (combined.includes('error') && !combined.includes('already exists')) {
     throw new Error(`claude mcp add-json failed: ${stderr || stdout}`);
@@ -177,12 +203,14 @@ export async function addMcpServer(
 
 /**
  * Remove a named MCP server via `claude mcp remove`.
+ * @param cwd  Workspace root (see addMcpServer) — needed to target the right
+ *             `.mcp.json` when removing a `project`/`local` scope server.
  */
-export async function removeMcpServer(name: string, scope: string): Promise<void> {
+export async function removeMcpServer(name: string, scope: string, cwd?: string): Promise<void> {
   const scopeFlag = scopeCliFlag(scope);
   const args = ['mcp', 'remove', name];
   if (scopeFlag) args.push('-s', scopeFlag);
-  const { stderr } = await Claude.exec(args, { timeout: 10000 });
+  const { stderr } = await Claude.exec(args, { timeout: 10000, cwd });
   if (stderr.toLowerCase().includes('error')) {
     throw new Error(`claude mcp remove failed: ${stderr}`);
   }
@@ -190,18 +218,18 @@ export async function removeMcpServer(name: string, scope: string): Promise<void
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────
 
-async function runMcpList(): Promise<string> {
+async function runMcpList(cwd?: string): Promise<string> {
   try {
-    const { stdout } = await Claude.exec(['mcp', 'list'], { timeout: 20000 });
+    const { stdout } = await Claude.exec(['mcp', 'list'], { timeout: 20000, cwd });
     return stdout;
   } catch {
     return '';
   }
 }
 
-async function fetchServerDetails(name: string): Promise<McpServer | null> {
+async function fetchServerDetails(name: string, cwd?: string): Promise<McpServer | null> {
   try {
-    const { stdout } = await Claude.exec(['mcp', 'get', name], { timeout: 12000 });
+    const { stdout } = await Claude.exec(['mcp', 'get', name], { timeout: 12000, cwd });
     const server = parseMcpGet(stdout);
     if (!server) return null;
     return await enrichWithProbeError(server);
@@ -264,6 +292,43 @@ async function probeUrl(url: string): Promise<string | null> {
 async function readDisabledServers(): Promise<string[]> {
   const data = await readClaudeJson();
   return Array.isArray(data.disabledMcpServers) ? (data.disabledMcpServers as string[]) : [];
+}
+
+/**
+ * Read and parse `{cwd}/.mcp.json` (project-scope server configs). Returns null
+ * on absent/invalid file — config enrichment is best-effort.
+ */
+async function readProjectMcpJson(cwd: string): Promise<unknown> {
+  try {
+    const p = join(cwd, '.mcp.json');
+    if (!existsSync(p)) return null;
+    return JSON.parse(await readFile(p, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull the per-project entry (`projects[cwd]`) out of `~/.claude.json`, where
+ * local-scope servers live under its `mcpServers`. Returns null when absent.
+ */
+export function extractProjectEntry(data: unknown, cwd: string): unknown {
+  if (!data || typeof data !== 'object') return null;
+  const projects = (data as Record<string, unknown>).projects;
+  if (!projects || typeof projects !== 'object') return null;
+  return (projects as Record<string, unknown>)[cwd] ?? null;
+}
+
+/**
+ * Pull one server's raw config out of an `mcpServers` map, verbatim (no key
+ * renaming) per the original-data-preservation rule.
+ */
+export function extractServerConfig(data: unknown, name: string): McpServerConfig | null {
+  if (!data || typeof data !== 'object') return null;
+  const servers = (data as Record<string, unknown>).mcpServers;
+  if (!servers || typeof servers !== 'object') return null;
+  const cfg = (servers as Record<string, unknown>)[name];
+  return cfg && typeof cfg === 'object' ? (cfg as McpServerConfig) : null;
 }
 
 /** Map our scope string to the -s flag value the CLI accepts. */

--- a/backend/src/core/features/mcp-manager.ts
+++ b/backend/src/core/features/mcp-manager.ts
@@ -4,8 +4,8 @@ import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { Claude } from '../claude';
 import { parseMcpList, parseMcpGet } from './mcp-parser';
-import { McpServerStatus } from '../../shared';
-import type { McpServer, McpServersResult, McpServerScope } from '../../shared';
+import { McpServerStatus, McpServerScope } from '../../shared';
+import type { McpServer, McpServersResult } from '../../shared';
 
 // ─── Path helpers ─────────────────────────────────────────────────────────────
 
@@ -67,25 +67,10 @@ export async function getMcpServers(): Promise<McpServersResult> {
     return [];
   });
 
-  // Mark disabled servers. The CLI doesn't report them in `mcp list`, so we
-  // add synthetic entries for those not already in the results (config-only servers).
-  for (const disabledName of disabled) {
-    const existing = servers.find((s) => s.name === disabledName);
-    if (existing) {
-      // Server appeared in list (perhaps was recently re-enabled) — leave its status.
-    } else {
-      // Config-only disabled server: try to get its config details.
-      const details = await fetchServerDetails(disabledName).catch(() => null);
-      servers.push(details ?? {
-        name: disabledName,
-        status: 'disabled' as McpServer['status'],
-        scope: 'user',
-        config: null,
-        tools: [],
-        error: null,
-      });
-    }
-  }
+  // Apply disabled state. `claude mcp list` does NOT honour disabledMcpServers —
+  // it still reports those servers (and health-checks them), so their status must
+  // be overridden to DISABLED here, plus synthetic entries for config-only ones.
+  await mergeDisabledServers(servers, disabled, fetchServerDetails);
 
   servers.sort((a, b) => {
     const scopeDiff = scopeRank(a.scope) - scopeRank(b.scope);
@@ -94,6 +79,42 @@ export async function getMcpServers(): Promise<McpServersResult> {
   });
 
   return { servers };
+}
+
+/**
+ * Override the status of servers in the `disabledMcpServers` list to DISABLED.
+ *
+ * `claude mcp list` ignores `disabledMcpServers` and still reports those servers
+ * with their live status (usually FAILED, since a disabled server isn't running),
+ * so a disabled server would otherwise render as "Failed" and offer no way back.
+ * For servers the CLI didn't report at all (config-only), a synthetic entry is
+ * fetched and added. Mutates and returns `servers`.
+ */
+export async function mergeDisabledServers(
+  servers: McpServer[],
+  disabled: string[],
+  fetchDetails: (name: string) => Promise<McpServer | null>,
+): Promise<McpServer[]> {
+  for (const disabledName of disabled) {
+    const existing = servers.find((s) => s.name === disabledName);
+    if (existing) {
+      existing.status = McpServerStatus.DISABLED;
+      existing.error = null;
+    } else {
+      const details = await fetchDetails(disabledName).catch(() => null);
+      servers.push({
+        ...(details ?? {
+          name: disabledName,
+          scope: McpServerScope.USER,
+          config: null,
+          tools: [],
+        }),
+        status: McpServerStatus.DISABLED,
+        error: null,
+      });
+    }
+  }
+  return servers;
 }
 
 /**

--- a/backend/src/core/features/mcp-parser.ts
+++ b/backend/src/core/features/mcp-parser.ts
@@ -1,0 +1,168 @@
+import {
+  McpServer,
+  McpServerConfig,
+  McpServerScope,
+  McpServerStatus,
+  McpTransportType,
+} from '../../shared';
+
+/**
+ * Parse the stdout of `claude mcp list` into a lightweight list of names and statuses.
+ *
+ * Example input line:
+ *   playwright: npx @executeautomation/playwright-mcp-server - ✔ Connected
+ *   jetbrains: http://localhost:64342/sse (SSE) - ✘ Failed to connect
+ */
+export function parseMcpList(output: string): Array<{ name: string; status: McpServerStatus }> {
+  return output
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.startsWith('Checking MCP'))
+    .flatMap((line) => {
+      const colonIdx = line.indexOf(': ');
+      if (colonIdx === -1) return [];
+      const name = line.slice(0, colonIdx).trim();
+      const rest = line.slice(colonIdx + 2);
+      const dashIdx = rest.lastIndexOf(' - ');
+      if (dashIdx === -1) return [];
+      const statusPart = rest.slice(dashIdx + 3).trim();
+      return [{ name, status: parseStatusText(statusPart) }];
+    });
+}
+
+/**
+ * Parse the stdout of `claude mcp get <name>` into a McpServer object.
+ *
+ * Example input:
+ *   playwright:
+ *     Scope: User config (available in all your projects)
+ *     Status: ✔ Connected
+ *     Type: stdio
+ *     Command: npx
+ *     Args: @executeautomation/playwright-mcp-server
+ *     Environment:
+ *
+ *   To remove this server, run: claude mcp remove "playwright" -s user
+ *
+ * Returns null when the output cannot be parsed (empty, malformed, error message).
+ */
+export function parseMcpGet(output: string): McpServer | null {
+  const lines = output.split('\n').map((l) => l.trimEnd());
+  if (lines.length === 0) return null;
+
+  // First non-empty line: "<name>:"
+  const nameLine = lines[0]?.trim();
+  if (!nameLine || !nameLine.endsWith(':')) return null;
+  const name = nameLine.slice(0, -1).trim();
+
+  // Collect key: value pairs from indented lines.
+  // Handles both "Key: Value" and "Key:" (empty value) forms.
+  const fields: Record<string, string> = {};
+  for (const line of lines.slice(1)) {
+    const trimmed = line.trimStart();
+    if (!trimmed || trimmed.startsWith('To remove')) break;
+    const colonIdx = trimmed.indexOf(':');
+    if (colonIdx === -1) continue;
+    const key = trimmed.slice(0, colonIdx).trim().toLowerCase();
+    const val = trimmed.slice(colonIdx + 1).trim();
+    fields[key] = val;
+  }
+
+  const statusRaw = fields['status'] ?? '';
+  const status = parseStatusText(statusRaw);
+  const scope = parseScopeText(fields['scope'] ?? '');
+  const config = buildConfig(fields);
+
+  // CLI does not provide a separate error field — use the status text as the error message
+  // when the server is in a failed or auth-required state.
+  const statusText = statusRaw.replace(/^[✔✘]\s*/, '').trim();
+  const error =
+    (status === McpServerStatus.FAILED || status === McpServerStatus.NEEDS_AUTH) && statusText
+      ? statusText
+      : null;
+
+  return {
+    name,
+    status,
+    scope,
+    config,
+    tools: [],
+    error,
+  };
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+function parseStatusText(text: string): McpServerStatus {
+  // Strip leading icon characters (✔, ✘) and normalise.
+  const t = text.replace(/^[✔✘]\s*/, '').toLowerCase();
+  if (t.startsWith('connected')) return McpServerStatus.CONNECTED;
+  if (t.startsWith('failed')) return McpServerStatus.FAILED;
+  if (t.startsWith('needs-auth') || t.startsWith('needs auth')) return McpServerStatus.NEEDS_AUTH;
+  if (t.startsWith('pending') || t.startsWith('connecting')) return McpServerStatus.PENDING;
+  if (t.startsWith('disabled')) return McpServerStatus.DISABLED;
+  // Unknown status text — treat as failed so the UI doesn't silently show a connected badge.
+  return McpServerStatus.FAILED;
+}
+
+function parseScopeText(text: string): McpServerScope | string {
+  const lower = text.toLowerCase();
+  if (lower.startsWith('user')) return McpServerScope.USER;
+  if (lower.startsWith('claude.ai')) return McpServerScope.CLAUDEAI;
+  if (lower.startsWith('project')) return McpServerScope.PROJECT;
+  if (lower.startsWith('local')) return McpServerScope.LOCAL;
+  if (lower.startsWith('managed')) return McpServerScope.MANAGED;
+  if (lower.startsWith('enterprise')) return McpServerScope.ENTERPRISE;
+  // Return raw text so the caller can still group by it.
+  return text;
+}
+
+function buildConfig(fields: Record<string, string>): McpServerConfig | null {
+  const type = fields['type']?.toLowerCase();
+  if (!type) {
+    // Some servers (e.g. claude.ai connectors, servers added via external tooling)
+    // do not expose transport details in `claude mcp get` output.
+    return null;
+  }
+
+  if (type === 'stdio') {
+    const args = fields['args'] ? fields['args'].split(/\s+/).filter(Boolean) : undefined;
+    const env = parseEnvLine(fields['environment']);
+    return {
+      type: McpTransportType.STDIO,
+      command: fields['command'] || undefined,
+      args: args?.length ? args : undefined,
+      env: env && Object.keys(env).length ? env : undefined,
+    };
+  }
+
+  if (type === 'http') {
+    return { type: McpTransportType.HTTP, url: fields['url'] || undefined };
+  }
+
+  if (type === 'sse') {
+    return { type: McpTransportType.SSE, url: fields['url'] || undefined };
+  }
+
+  if (type === 'ws') {
+    return { type: McpTransportType.WS, url: fields['url'] || undefined };
+  }
+
+  return null;
+}
+
+/**
+ * Parse the Environment: line from `claude mcp get` output.
+ * The format is not yet observed in the wild — kept for future robustness.
+ * Returns undefined for empty / absent environment fields.
+ */
+function parseEnvLine(envText: string | undefined): Record<string, string> | undefined {
+  if (!envText || envText.trim() === '') return undefined;
+  const result: Record<string, string> = {};
+  for (const part of envText.split(',')) {
+    const eqIdx = part.indexOf('=');
+    if (eqIdx === -1) continue;
+    result[part.slice(0, eqIdx).trim()] = part.slice(eqIdx + 1).trim();
+  }
+  return result;
+}

--- a/backend/src/core/features/mcp-registry.ts
+++ b/backend/src/core/features/mcp-registry.ts
@@ -1,0 +1,200 @@
+/**
+ * Official MCP Registry client + normaliser.
+ *
+ * Source of truth: the community-driven Generic MCP Registry API, hosted at
+ *   https://registry.modelcontextprotocol.io/v0/servers
+ * (backed by Anthropic/GitHub/Microsoft/PulseMCP). We talk to its PUBLIC REST
+ * contract only — no Claude SDK, no undocumented protocol — so this honours the
+ * project's CLI-equivalence / no-official-dependency principle. The endpoint is
+ * isolated here so a future swap to another spec-compatible sub-registry
+ * (PulseMCP etc.) is a one-line change.
+ *
+ * Each raw entry carries install metadata in `packages[]` (stdio) and
+ * `remotes[]` (http/sse). We convert one entry into a single `config` ready for
+ * `claude mcp add-json`, and surface env vars / headers that still need a
+ * user-supplied value via `requiredInputs`.
+ */
+
+import { McpTransportType } from '../../shared';
+import type { McpServerConfig, McpRegistryServer, McpRegistrySearchResult } from '../../shared';
+
+const REGISTRY_BASE = 'https://registry.modelcontextprotocol.io/v0/servers';
+const PAGE_LIMIT = 30;
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// ─── Raw registry shapes (the public API's response contract) ──────────────────
+
+interface RawArgument {
+  type?: string;
+  name?: string;
+  value?: string | number;
+}
+interface RawEnvVar {
+  name?: string;
+  isRequired?: boolean;
+  isSecret?: boolean;
+  default?: string;
+}
+interface RawHeader {
+  name?: string;
+  value?: string;
+  isRequired?: boolean;
+}
+interface RawPackage {
+  registryType?: string;
+  identifier?: string;
+  runtimeHint?: string;
+  transport?: { type?: string };
+  runtimeArguments?: RawArgument[];
+  packageArguments?: RawArgument[];
+  environmentVariables?: RawEnvVar[];
+}
+interface RawRemote {
+  type?: string;
+  url?: string;
+  headers?: RawHeader[];
+}
+interface RawServer {
+  name?: string;
+  description?: string;
+  version?: string;
+  repository?: { url?: string };
+  packages?: RawPackage[];
+  remotes?: RawRemote[];
+}
+interface RawEntry {
+  server?: RawServer;
+}
+interface RawSearchResponse {
+  servers?: unknown[];
+  metadata?: { nextCursor?: string };
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Search the official registry by name substring. `query` empty returns the
+ * first page unfiltered. Throws on network error / non-2xx so the handler can
+ * report it.
+ */
+export async function searchMcpRegistry(
+  query: string,
+  cursor?: string,
+): Promise<McpRegistrySearchResult> {
+  const params = new URLSearchParams();
+  if (query.trim()) params.set('search', query.trim());
+  params.set('limit', String(PAGE_LIMIT));
+  if (cursor) params.set('cursor', cursor);
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${REGISTRY_BASE}?${params.toString()}`, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: { Accept: 'application/json' },
+    });
+    if (!res.ok) {
+      throw new Error(`MCP registry returned HTTP ${res.status} ${res.statusText}`);
+    }
+    const data = (await res.json()) as RawSearchResponse;
+    const servers: McpRegistryServer[] = (data.servers ?? [])
+      .map(normalizeRegistryServer)
+      .filter((s): s is McpRegistryServer => s !== null);
+    return { servers, nextCursor: data.metadata?.nextCursor ?? null };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Convert one raw registry entry into a normalised, install-ready summary.
+ * Returns null when the entry has no usable `server` object. A stdio package is
+ * preferred over a remote when both are present (local execution is the default
+ * CLI users expect from `claude mcp add`).
+ */
+export function normalizeRegistryServer(entry: unknown): McpRegistryServer | null {
+  if (!entry || typeof entry !== 'object') return null;
+  const server = (entry as RawEntry).server;
+  if (!server || typeof server !== 'object') return null;
+
+  const requiredInputs: string[] = [];
+  const config = buildConfig(server, requiredInputs);
+
+  return {
+    name: typeof server.name === 'string' ? server.name : '',
+    description: typeof server.description === 'string' ? server.description : '',
+    version: typeof server.version === 'string' ? server.version : '',
+    repositoryUrl:
+      server.repository && typeof server.repository.url === 'string'
+        ? server.repository.url
+        : null,
+    config,
+    requiredInputs,
+  };
+}
+
+// ─── Internal: raw entry → McpServerConfig ─────────────────────────────────────
+
+function buildConfig(server: RawServer, requiredInputs: string[]): McpServerConfig | null {
+  const pkg = server.packages?.[0];
+  if (pkg) return buildStdioConfig(pkg, requiredInputs);
+
+  const remote = server.remotes?.[0];
+  if (remote) return buildRemoteConfig(remote, requiredInputs);
+
+  return null;
+}
+
+function buildStdioConfig(pkg: RawPackage, requiredInputs: string[]): McpServerConfig {
+  const command = pkg.runtimeHint?.trim() || defaultRuntime(pkg.registryType);
+
+  const args: string[] = [];
+  for (const arg of pkg.runtimeArguments ?? []) pushArg(args, arg);
+  if (pkg.identifier) args.push(pkg.identifier);
+  for (const arg of pkg.packageArguments ?? []) pushArg(args, arg);
+
+  const env: Record<string, string> = {};
+  for (const ev of pkg.environmentVariables ?? []) {
+    if (ev.isRequired && ev.name) {
+      env[ev.name] = ev.default ?? '';
+      requiredInputs.push(ev.name);
+    }
+  }
+
+  const config: McpServerConfig = { type: McpTransportType.STDIO, command, args };
+  if (Object.keys(env).length > 0) config.env = env;
+  return config;
+}
+
+function buildRemoteConfig(remote: RawRemote, requiredInputs: string[]): McpServerConfig {
+  const type = remote.type === 'sse' ? McpTransportType.SSE : McpTransportType.HTTP;
+
+  const headers: Record<string, string> = {};
+  for (const h of remote.headers ?? []) {
+    if (h.isRequired && h.name) {
+      headers[h.name] = h.value ?? '';
+      requiredInputs.push(h.name);
+    }
+  }
+
+  const config: McpServerConfig = { type, url: remote.url ?? '' };
+  if (Object.keys(headers).length > 0) config.headers = headers;
+  return config;
+}
+
+/** Append one CLI argument: named → `--flag value`, positional → `value`. */
+function pushArg(args: string[], arg: RawArgument): void {
+  if (arg.type === 'named' && arg.name) {
+    args.push(arg.name);
+    if (arg.value !== undefined && arg.value !== null) args.push(String(arg.value));
+    return;
+  }
+  if (arg.value !== undefined && arg.value !== null) args.push(String(arg.value));
+}
+
+/** npm → npx, pypi → uvx; default to npx for unknown registry types. */
+function defaultRuntime(registryType?: string): string {
+  if (registryType === 'pypi') return 'uvx';
+  return 'npx';
+}

--- a/backend/src/core/features/mcp-tools.ts
+++ b/backend/src/core/features/mcp-tools.ts
@@ -1,0 +1,118 @@
+/**
+ * Fetch the tool list of a single MCP server by connecting to it directly with
+ * the official MCP client SDK and calling the standard `tools/list` request.
+ *
+ * Why not the CLI? `claude mcp get/list` report status + transport only — they
+ * never expose a server's tools. There is no official `claude` command for this
+ * (verified against CLI 2.1.x), so the CLI-equivalent of "what tools does this
+ * server expose?" is to speak the open MCP protocol ourselves. The SDK
+ * (`@modelcontextprotocol/sdk`, MIT, vendor-neutral) is a client for that open
+ * standard — it does NOT route through Claude's API/account/policy, so this
+ * stays within the "no Claude-SDK / no undocumented protocol" rule in CLAUDE.md.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { McpTransportType } from '../../shared';
+import type { McpServerTool, McpServerConfig } from '../../shared';
+
+/** Hard ceiling for a connect + list round-trip, so a hung server can't wedge the UI. */
+const TOOLS_TIMEOUT_MS = 15_000;
+
+/** Shape of a single tool as returned by the SDK's `listTools()` (subset we use). */
+interface RawMcpTool {
+  name: string;
+  annotations?: {
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+  };
+}
+
+/**
+ * Map a raw SDK tool to our wire shape. Only carries the annotation flags the UI
+ * renders; omits the `annotations` object entirely when neither hint is present
+ * so the WebView's `tool.annotations?.readOnly` checks stay falsy. Pure.
+ */
+export function mapMcpTool(tool: RawMcpTool): McpServerTool {
+  const { readOnlyHint, destructiveHint } = tool.annotations ?? {};
+  if (readOnlyHint === undefined && destructiveHint === undefined) {
+    return { name: tool.name };
+  }
+  const annotations: NonNullable<McpServerTool['annotations']> = {};
+  if (readOnlyHint !== undefined) annotations.readOnly = readOnlyHint;
+  if (destructiveHint !== undefined) annotations.destructive = destructiveHint;
+  return { name: tool.name, annotations };
+}
+
+/**
+ * Build the SDK transport for a server config, or null when the transport can't
+ * be probed directly (claudeai-proxy needs OAuth; ws is rare; missing url/cmd).
+ */
+export function buildTransport(config: McpServerConfig): Transport | null {
+  switch (config.type) {
+    case McpTransportType.STDIO:
+      if (!config.command) return null;
+      return new StdioClientTransport({
+        command: config.command,
+        args: config.args ?? [],
+        // stdio transports do NOT inherit env by default (SDK security choice);
+        // pass the backend's env so `npx`/`node` resolve via PATH, then layer
+        // the server's own env overrides on top.
+        env: stdioEnv(config.env),
+      });
+    case McpTransportType.HTTP:
+      if (!config.url) return null;
+      return new StreamableHTTPClientTransport(new URL(config.url), {
+        requestInit: config.headers ? { headers: config.headers } : undefined,
+      });
+    case McpTransportType.SSE:
+      if (!config.url) return null;
+      return new SSEClientTransport(new URL(config.url), {
+        requestInit: config.headers ? { headers: config.headers } : undefined,
+      });
+    default:
+      return null;
+  }
+}
+
+/** process.env with undefined values stripped, merged with per-server overrides. */
+function stdioEnv(overrides?: Record<string, string>): Record<string, string> {
+  const base: Record<string, string> = {};
+  for (const [key, val] of Object.entries(process.env)) {
+    if (val !== undefined) base[key] = val;
+  }
+  return { ...base, ...(overrides ?? {}) };
+}
+
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      (e) => { clearTimeout(timer); reject(e); },
+    );
+  });
+}
+
+/**
+ * Connect to a single MCP server (by its config) and return its tools. Returns
+ * an empty array for transports that can't be probed directly (e.g. claude.ai
+ * connectors) or a null config. Throws on connection/protocol failure so the
+ * caller can surface the reason.
+ */
+export async function fetchServerTools(config: McpServerConfig | null): Promise<McpServerTool[]> {
+  if (!config) return [];
+  const transport = buildTransport(config);
+  if (!transport) return [];
+
+  const client = new Client({ name: 'claude-code-gui', version: '1.0.0' });
+  try {
+    await withTimeout(client.connect(transport), TOOLS_TIMEOUT_MS, 'MCP connect');
+    const result = await withTimeout(client.listTools(), TOOLS_TIMEOUT_MS, 'MCP tools/list');
+    return result.tools.map(mapMcpTool);
+  } finally {
+    await client.close().catch(() => { /* best-effort cleanup */ });
+  }
+}

--- a/backend/src/core/handlers/getMcpServerToolsHandler.ts
+++ b/backend/src/core/handlers/getMcpServerToolsHandler.ts
@@ -1,0 +1,37 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { MessageType } from '../../shared';
+import type { McpServerConfig } from '../../shared';
+import { fetchServerTools } from '../features/mcp-tools';
+
+/**
+ * GET_MCP_SERVER_TOOLS — connect to one MCP server and return its tool list.
+ *
+ * The server's `config` is sent by the WebView (it already holds it from the
+ * list), so the backend connects directly via the MCP SDK without re-running
+ * `claude mcp get`. There is no `claude` command that reports tools, so speaking
+ * the open MCP protocol (tools/list) is the CLI-equivalent here.
+ */
+export async function getMcpServerToolsHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const config = (message.payload as { config?: McpServerConfig | null })?.config ?? null;
+  try {
+    const tools = await fetchServerTools(config);
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'ok',
+      tools,
+    });
+  } catch (err) {
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/core/handlers/getMcpServersHandler.ts
+++ b/backend/src/core/handlers/getMcpServersHandler.ts
@@ -24,6 +24,7 @@ export async function getMcpServersHandler(
       requestId: message.requestId,
       status: 'ok',
       servers: result.servers,
+      configPath: result.configPath,
     });
   } catch (err) {
     connections.sendTo(connectionId, MessageType.ACK, {

--- a/backend/src/core/handlers/getMcpServersHandler.ts
+++ b/backend/src/core/handlers/getMcpServersHandler.ts
@@ -1,0 +1,35 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { MessageType } from '../../shared';
+import { getMcpServers } from '../features/mcp-manager';
+
+/**
+ * GET_MCP_SERVERS — list all MCP servers with status, scope, and config.
+ *
+ * Data source priority (CLI-first, per CLAUDE.md):
+ *   1. `claude mcp list` (health check + names)
+ *   2. `claude mcp get <name>` (full details per server)
+ *   3. disabledMcpServers in ~/.claude.json (disabled state)
+ */
+export async function getMcpServersHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  try {
+    const result = await getMcpServers();
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'ok',
+      servers: result.servers,
+    });
+  } catch (err) {
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/core/handlers/getMcpServersHandler.ts
+++ b/backend/src/core/handlers/getMcpServersHandler.ts
@@ -19,7 +19,10 @@ export async function getMcpServersHandler(
   _bridge: Bridge,
 ): Promise<void> {
   try {
-    const result = await getMcpServers();
+    // Run the CLI in the user's workspace root so project-scope (.mcp.json)
+    // servers resolve from the right place, matching the chat session's cwd.
+    const workingDir = (message.payload as { workingDir?: string })?.workingDir;
+    const result = await getMcpServers(workingDir);
     connections.sendTo(connectionId, MessageType.ACK, {
       requestId: message.requestId,
       status: 'ok',

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -78,6 +78,7 @@ import {
   submitMcpOauthCallbackUrlHandler,
   addMcpServerHandler,
   removeMcpServerHandler,
+  searchMcpRegistryHandler,
 } from './mcpActionsHandler';
 
 export async function handleMessage(
@@ -318,6 +319,9 @@ export async function handleMessage(
       break;
     case MessageType.REMOVE_MCP_SERVER:
       await removeMcpServerHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.SEARCH_MCP_REGISTRY:
+      await searchMcpRegistryHandler(connectionId, message, connections, bridge);
       break;
     default:
       console.error('[node-backend]', `Unknown message type: ${message.type}`);

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -70,6 +70,7 @@ import { playSystemSoundHandler } from './playSystemSound';
 import { clientInfoHandler } from './clientInfo';
 import { clientErrorHandler } from './clientError';
 import { getMcpServersHandler } from './getMcpServersHandler';
+import { getMcpServerToolsHandler } from './getMcpServerToolsHandler';
 import {
   reconnectMcpServerHandler,
   authenticateMcpServerHandler,
@@ -322,6 +323,9 @@ export async function handleMessage(
       break;
     case MessageType.SEARCH_MCP_REGISTRY:
       await searchMcpRegistryHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.GET_MCP_SERVER_TOOLS:
+      await getMcpServerToolsHandler(connectionId, message, connections, bridge);
       break;
     default:
       console.error('[node-backend]', `Unknown message type: ${message.type}`);

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -69,6 +69,16 @@ import { listSystemSoundsHandler } from './listSystemSounds';
 import { playSystemSoundHandler } from './playSystemSound';
 import { clientInfoHandler } from './clientInfo';
 import { clientErrorHandler } from './clientError';
+import { getMcpServersHandler } from './getMcpServersHandler';
+import {
+  reconnectMcpServerHandler,
+  authenticateMcpServerHandler,
+  clearMcpServerAuthHandler,
+  setMcpServerEnabledHandler,
+  submitMcpOauthCallbackUrlHandler,
+  addMcpServerHandler,
+  removeMcpServerHandler,
+} from './mcpActionsHandler';
 
 export async function handleMessage(
   connectionId: string,
@@ -284,6 +294,30 @@ export async function handleMessage(
       break;
     case MessageType.CLIENT_ERROR:
       clientErrorHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.GET_MCP_SERVERS:
+      await getMcpServersHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.RECONNECT_MCP_SERVER:
+      await reconnectMcpServerHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.AUTHENTICATE_MCP_SERVER:
+      await authenticateMcpServerHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.CLEAR_MCP_SERVER_AUTH:
+      await clearMcpServerAuthHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.SET_MCP_SERVER_ENABLED:
+      await setMcpServerEnabledHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.SUBMIT_MCP_OAUTH_CALLBACK_URL:
+      await submitMcpOauthCallbackUrlHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.ADD_MCP_SERVER:
+      await addMcpServerHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.REMOVE_MCP_SERVER:
+      await removeMcpServerHandler(connectionId, message, connections, bridge);
       break;
     default:
       console.error('[node-backend]', `Unknown message type: ${message.type}`);

--- a/backend/src/core/handlers/mcpActionsHandler.ts
+++ b/backend/src/core/handlers/mcpActionsHandler.ts
@@ -46,7 +46,7 @@ export async function reconnectMcpServerHandler(
     return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
   }
   try {
-    const server = await reconnectMcpServer(name);
+    const server = await reconnectMcpServer(name, getStringPayload(message, 'workingDir') ?? undefined);
     ack(connectionId, message, connections, { status: 'ok', server });
   } catch (err) {
     ack(connectionId, message, connections, {
@@ -189,7 +189,7 @@ export async function addMcpServerHandler(
     });
   }
   try {
-    await addMcpServer(name, config, scope);
+    await addMcpServer(name, config, scope, getStringPayload(message, 'workingDir') ?? undefined);
     ack(connectionId, message, connections, { status: 'ok', name });
   } catch (err) {
     ack(connectionId, message, connections, {
@@ -251,7 +251,7 @@ export async function removeMcpServerHandler(
     return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
   }
   try {
-    await removeMcpServer(name, scope);
+    await removeMcpServer(name, scope, getStringPayload(message, 'workingDir') ?? undefined);
     ack(connectionId, message, connections, { status: 'ok', name });
   } catch (err) {
     ack(connectionId, message, connections, {

--- a/backend/src/core/handlers/mcpActionsHandler.ts
+++ b/backend/src/core/handlers/mcpActionsHandler.ts
@@ -8,6 +8,7 @@ import {
   addMcpServer,
   removeMcpServer,
 } from '../features/mcp-manager';
+import { searchMcpRegistry } from '../features/mcp-registry';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -190,6 +191,36 @@ export async function addMcpServerHandler(
   try {
     await addMcpServer(name, config, scope);
     ack(connectionId, message, connections, { status: 'ok', name });
+  } catch (err) {
+    ack(connectionId, message, connections, {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ─── SEARCH_MCP_REGISTRY ──────────────────────────────────────────────────────
+
+/**
+ * Search the official MCP registry for installable servers.
+ * Payload: { query: string, cursor?: string }
+ *
+ * CLI-equivalence note: `claude mcp` has no `search` subcommand, so this is a
+ * GUI-only capability backed by the registry's PUBLIC REST API (not the Claude
+ * SDK). Installation still goes through `claude mcp add-json` (ADD_MCP_SERVER).
+ */
+export async function searchMcpRegistryHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const payload = message.payload as Record<string, unknown>;
+  const query = typeof payload?.query === 'string' ? payload.query : '';
+  const cursor = typeof payload?.cursor === 'string' ? payload.cursor : undefined;
+  try {
+    const result = await searchMcpRegistry(query, cursor);
+    ack(connectionId, message, connections, { status: 'ok', ...result });
   } catch (err) {
     ack(connectionId, message, connections, {
       status: 'error',

--- a/backend/src/core/handlers/mcpActionsHandler.ts
+++ b/backend/src/core/handlers/mcpActionsHandler.ts
@@ -1,0 +1,231 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { MessageType } from '../../shared';
+import {
+  reconnectMcpServer,
+  setMcpServerEnabled,
+  addMcpServer,
+  removeMcpServer,
+} from '../features/mcp-manager';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function ack(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  payload: Record<string, unknown>,
+): void {
+  connections.sendTo(connectionId, MessageType.ACK, {
+    requestId: message.requestId,
+    ...payload,
+  });
+}
+
+function getStringPayload(message: IPCMessage, key: string): string | null {
+  const val = (message.payload as Record<string, unknown>)?.[key];
+  return typeof val === 'string' && val.trim() ? val.trim() : null;
+}
+
+// ─── RECONNECT_MCP_SERVER ─────────────────────────────────────────────────────
+
+/**
+ * Re-fetch a server via `claude mcp get <name>`. The CLI health-checks the
+ * connection when invoked, so re-running it serves as a CLI-first reconnect probe.
+ */
+export async function reconnectMcpServerHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const name = getStringPayload(message, 'name');
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  try {
+    const server = await reconnectMcpServer(name);
+    ack(connectionId, message, connections, { status: 'ok', server });
+  } catch (err) {
+    ack(connectionId, message, connections, {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ─── AUTHENTICATE_MCP_SERVER ──────────────────────────────────────────────────
+
+/**
+ * Trigger auth for an MCP server.
+ *
+ * CLI-first note: `claude mcp login` exists in v2.1.186+ but runs interactively
+ * (opens a browser and blocks until completion). We cannot run it in the
+ * non-interactive backend exec path without a terminal. For now we return a
+ * terminal instruction; the control_request auxiliary path (mcp_authenticate)
+ * is handled by the active claude process, not here.
+ *
+ * TODO: When the CLI provides a non-interactive auth flow, replace this with
+ * `Claude.exec(['mcp', 'login', name])`.
+ */
+export async function authenticateMcpServerHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const name = getStringPayload(message, 'name');
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  // Return a hint so the webview can display guidance.
+  ack(connectionId, message, connections, {
+    status: 'terminal-required',
+    hint: `Run in terminal: claude mcp login "${name}"`,
+  });
+}
+
+// ─── CLEAR_MCP_SERVER_AUTH ────────────────────────────────────────────────────
+
+/**
+ * Clear saved auth for an MCP server.
+ * Same constraint as authenticate — no non-interactive CLI command available yet.
+ */
+export async function clearMcpServerAuthHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const name = getStringPayload(message, 'name');
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  ack(connectionId, message, connections, {
+    status: 'terminal-required',
+    hint: `Run in terminal: claude mcp logout "${name}"`,
+  });
+}
+
+// ─── SET_MCP_SERVER_ENABLED ───────────────────────────────────────────────────
+
+/**
+ * Enable or disable a named MCP server by editing disabledMcpServers in ~/.claude.json.
+ * No CLI command exists for this — CLI users also edit the file directly.
+ */
+export async function setMcpServerEnabledHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const name = getStringPayload(message, 'name');
+  const enabled = (message.payload as Record<string, unknown>)?.enabled;
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  if (typeof enabled !== 'boolean') {
+    return ack(connectionId, message, connections, {
+      status: 'error',
+      error: 'Missing or invalid enabled (must be boolean)',
+    });
+  }
+  try {
+    await setMcpServerEnabled(name, enabled);
+    ack(connectionId, message, connections, { status: 'ok', name, enabled });
+  } catch (err) {
+    ack(connectionId, message, connections, {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ─── SUBMIT_MCP_OAUTH_CALLBACK_URL ───────────────────────────────────────────
+
+/**
+ * Submit an OAuth callback URL for a server that failed to redirect automatically.
+ * Requires the active claude process to handle the OAuth flow — not implementable
+ * as a standalone CLI command. Returns a guidance message for now.
+ */
+export async function submitMcpOauthCallbackUrlHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  ack(connectionId, message, connections, {
+    status: 'not-implemented',
+    hint: 'OAuth callback URL submission requires an active Claude session.',
+  });
+}
+
+// ─── ADD_MCP_SERVER (Phase 3) ─────────────────────────────────────────────────
+
+/**
+ * Add a new MCP server via `claude mcp add-json`.
+ * Payload: { name: string, config: object, scope: 'user' | 'project' | 'local' }
+ */
+export async function addMcpServerHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const payload = message.payload as Record<string, unknown>;
+  const name = typeof payload?.name === 'string' ? payload.name.trim() : '';
+  const config = payload?.config as Record<string, unknown> | undefined;
+  const scope = typeof payload?.scope === 'string' ? payload.scope : 'user';
+
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  if (!config || typeof config !== 'object') {
+    return ack(connectionId, message, connections, {
+      status: 'error',
+      error: 'Missing or invalid config',
+    });
+  }
+  try {
+    await addMcpServer(name, config, scope);
+    ack(connectionId, message, connections, { status: 'ok', name });
+  } catch (err) {
+    ack(connectionId, message, connections, {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+// ─── REMOVE_MCP_SERVER (Phase 3) ──────────────────────────────────────────────
+
+/**
+ * Remove a named MCP server via `claude mcp remove`.
+ * Payload: { name: string, scope: 'user' | 'project' | 'local' | 'claudeai' }
+ */
+export async function removeMcpServerHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  const name = getStringPayload(message, 'name');
+  const scope =
+    typeof (message.payload as Record<string, unknown>)?.scope === 'string'
+      ? ((message.payload as Record<string, unknown>).scope as string)
+      : 'user';
+
+  if (!name) {
+    return ack(connectionId, message, connections, { status: 'error', error: 'Missing name' });
+  }
+  try {
+    await removeMcpServer(name, scope);
+    ack(connectionId, message, connections, { status: 'ok', name });
+  } catch (err) {
+    ack(connectionId, message, connections, {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/shared/index.ts
+++ b/backend/src/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './account';
 export * from './client-env';
+export * from './mcp';
 export * from './message-type';
 export * from './workflow';

--- a/backend/src/shared/mcp.ts
+++ b/backend/src/shared/mcp.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared MCP (Model Context Protocol) server management types.
+ *
+ * NOTE: This file is mirrored 1:1 in `webview/src/shared/mcp.ts`.
+ * Any edit here MUST be copied there (see `shared/CLAUDE.md`).
+ */
+
+/** Runtime connection status of an MCP server. Source: `claude mcp list/get` or control protocol. */
+export enum McpServerStatus {
+  CONNECTED = 'connected',
+  FAILED = 'failed',
+  /** Server requires authentication before it can connect. */
+  NEEDS_AUTH = 'needs-auth',
+  /** Connection attempt in progress. */
+  PENDING = 'pending',
+  /** Manually disabled by the user (disabledMcpServers list). Not reported by CLI — derived from config file. */
+  DISABLED = 'disabled',
+}
+
+/** Config scope the server belongs to. Used as the list grouping key. */
+export enum McpServerScope {
+  /** ~/.mcp.json or `.mcp.json` in the project root. */
+  PROJECT = 'project',
+  /** Local project-level config (settings.local.json or .clauderc). */
+  LOCAL = 'local',
+  /** User-level config in ~/.claude.json. */
+  USER = 'user',
+  /** Managed by claude.ai (connectors like Gmail, Calendar, Notion). */
+  CLAUDEAI = 'claudeai',
+  MANAGED = 'managed',
+  ENTERPRISE = 'enterprise',
+}
+
+/** Transport protocol of the MCP server. */
+export enum McpTransportType {
+  STDIO = 'stdio',
+  HTTP = 'http',
+  /** Server-Sent Events (legacy, deprecated upstream). */
+  SSE = 'sse',
+  WS = 'ws',
+  /** claude.ai managed connector (OAuth via claude.ai org URL, no Clear auth). */
+  CLAUDEAI_PROXY = 'claudeai-proxy',
+}
+
+export interface McpServerConfig {
+  type: McpTransportType;
+  /** stdio: the executable command. */
+  command?: string;
+  /** stdio: positional arguments to the command. */
+  args?: string[];
+  /** stdio: environment variable overrides passed to the server process. */
+  env?: Record<string, string>;
+  /** http / sse / ws: server endpoint URL. */
+  url?: string;
+  /** http: extra request headers. */
+  headers?: Record<string, string>;
+  /** claudeai-proxy: internal connector identifier. */
+  id?: string;
+  /** claudeai-proxy: human-readable connector display name. */
+  displayName?: string;
+  /** claudeai-proxy: connector icon URL. */
+  iconUrl?: string;
+}
+
+export interface McpServerTool {
+  name: string;
+  annotations?: {
+    /** Tool only reads data — no side effects. */
+    readOnly?: boolean;
+    /** Tool can perform irreversible destructive operations. */
+    destructive?: boolean;
+  };
+}
+
+export interface McpServer {
+  name: string;
+  status: McpServerStatus;
+  /** Grouping key for the list UI. Cast to McpServerScope when known; raw string otherwise. */
+  scope: McpServerScope | string;
+  /**
+   * Null when the CLI does not report transport details for this server
+   * (e.g. claude.ai connectors, or servers added without an explicit type).
+   * WebView: filter out "Add transport" prompts for null-config servers.
+   */
+  config: McpServerConfig | null;
+  /** Available tools reported by the server. Empty array when not yet fetched. */
+  tools: McpServerTool[];
+  /** Human-readable error message, populated when status === FAILED or NEEDS_AUTH. */
+  error: string | null;
+}
+
+/** Payload of GET_MCP_SERVERS ACK response. */
+export interface McpServersResult {
+  servers: McpServer[];
+}
+
+/**
+ * xme rule (from Cursor source analysis): only sse/http/claudeai-proxy servers
+ * expose authentication buttons. stdio servers have no auth flow.
+ */
+export function canAuthenticate(server: McpServer): boolean {
+  if (!server.config) return false;
+  return (
+    server.config.type === McpTransportType.SSE ||
+    server.config.type === McpTransportType.HTTP ||
+    server.config.type === McpTransportType.CLAUDEAI_PROXY
+  );
+}

--- a/backend/src/shared/mcp.ts
+++ b/backend/src/shared/mcp.ts
@@ -92,6 +92,43 @@ export interface McpServer {
 /** Payload of GET_MCP_SERVERS ACK response. */
 export interface McpServersResult {
   servers: McpServer[];
+  /**
+   * Display path of the global config file that backs the user/local scopes —
+   * `~/.claude.json`, or `$CLAUDE_CONFIG_DIR/.claude.json` when that env var is set.
+   * Used to label scope groups with their real source path.
+   */
+  configPath?: string;
+}
+
+/**
+ * A single MCP server entry from the official MCP Registry, normalised into a
+ * config ready for the Add form (`claude mcp add-json` shape).
+ *
+ * Source: https://registry.modelcontextprotocol.io/v0/servers (Generic MCP
+ * Registry API). The raw entry's packages[]/remotes[] are converted server-side
+ * into a single `config`; env vars / headers that need a user-supplied value are
+ * listed in `requiredInputs` so the UI can flag them.
+ */
+export interface McpRegistryServer {
+  /** Reverse-DNS identifier, e.g. "io.github.owner/server-name". */
+  name: string;
+  /** Short human-readable summary (may be empty). */
+  description: string;
+  /** Latest version string reported by the registry. */
+  version: string;
+  /** Source repository URL, or null when not reported. */
+  repositoryUrl: string | null;
+  /** Pre-built config for the Add form. Null when the entry has no installable package/remote. */
+  config: McpServerConfig | null;
+  /** Names of env vars / headers the user must fill in before the server will connect. */
+  requiredInputs: string[];
+}
+
+/** Payload of SEARCH_MCP_REGISTRY ACK response. */
+export interface McpRegistrySearchResult {
+  servers: McpRegistryServer[];
+  /** Opaque cursor for the next page, or null when there are no more results. */
+  nextCursor: string | null;
 }
 
 /**

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -163,6 +163,8 @@ export enum MessageType {
   ADD_MCP_SERVER = 'ADD_MCP_SERVER',
   /** Remove a named MCP server via `claude mcp remove`. inbound webview→backend */
   REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
+  /** Search the official MCP registry for installable servers. inbound webview→backend */
+  SEARCH_MCP_REGISTRY = 'SEARCH_MCP_REGISTRY',
 
   // -- Plugin updates --
   /** Check for available plugin updates. */

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -165,6 +165,8 @@ export enum MessageType {
   REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
   /** Search the official MCP registry for installable servers. inbound webview→backend */
   SEARCH_MCP_REGISTRY = 'SEARCH_MCP_REGISTRY',
+  /** Fetch the tool list of one MCP server by connecting to it (MCP tools/list). inbound webview→backend */
+  GET_MCP_SERVER_TOOLS = 'GET_MCP_SERVER_TOOLS',
 
   // -- Plugin updates --
   /** Check for available plugin updates. */

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -146,6 +146,24 @@ export enum MessageType {
   /** Detect the path to the `node` binary. */
   GET_DETECTED_NODE_PATH = 'GET_DETECTED_NODE_PATH',
 
+  // -- MCP server management --
+  /** List all MCP servers with status, scope, and config. inbound webview→backend */
+  GET_MCP_SERVERS = 'GET_MCP_SERVERS',
+  /** Reconnect (restart) a named MCP server. inbound webview→backend */
+  RECONNECT_MCP_SERVER = 'RECONNECT_MCP_SERVER',
+  /** Trigger the OAuth/auth flow for a named MCP server. inbound webview→backend */
+  AUTHENTICATE_MCP_SERVER = 'AUTHENTICATE_MCP_SERVER',
+  /** Clear saved authentication for a named MCP server. inbound webview→backend */
+  CLEAR_MCP_SERVER_AUTH = 'CLEAR_MCP_SERVER_AUTH',
+  /** Enable or disable a named MCP server (edits disabledMcpServers in config). inbound webview→backend */
+  SET_MCP_SERVER_ENABLED = 'SET_MCP_SERVER_ENABLED',
+  /** Submit a manual OAuth callback URL after a failed redirect. inbound webview→backend */
+  SUBMIT_MCP_OAUTH_CALLBACK_URL = 'SUBMIT_MCP_OAUTH_CALLBACK_URL',
+  /** Add a new MCP server via `claude mcp add-json`. inbound webview→backend */
+  ADD_MCP_SERVER = 'ADD_MCP_SERVER',
+  /** Remove a named MCP server via `claude mcp remove`. inbound webview→backend */
+  REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
+
   // -- Plugin updates --
   /** Check for available plugin updates. */
   GET_PLUGIN_UPDATES = 'GET_PLUGIN_UPDATES',

--- a/docs/features/003-mcp_server_management/en.md
+++ b/docs/features/003-mcp_server_management/en.md
@@ -1,0 +1,49 @@
+# MCP Server Management
+
+> Languages: [한국어](./ko.md) · **English**
+>
+> Related: [PR #135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135)
+
+## What's new
+
+You can now **view, add, remove, enable, disable, and reconnect MCP servers directly from the GUI** — no terminal required. Type `/MCP Servers` in the slash-command palette (or click the **MCP Servers** item under Customize) to open the panel.
+
+## Features
+
+### Server list
+
+Servers are grouped by scope (Project → Local → User → claude.ai) and sorted alphabetically within each group. Each card shows:
+
+- **Server name** (monospace)
+- **Status badge** — solid-pill colour coding:
+  - Green "✓ Connected"
+  - Red "✗ Failed"
+  - Yellow "Needs auth"
+  - Grey text "Pending" / "Disabled" (no badge)
+
+### Detail view
+
+Click any server card to open its detail screen:
+
+- **Error box** — displayed above the server name when the server is in a failed or auth-required state. For SSE / HTTP servers, the GUI probes the endpoint directly and surfaces the real network error (e.g. "connection refused") instead of the generic "Failed to connect".
+- **Action buttons** (in priority order):
+  1. **Authenticate** (primary / blue CTA) — visible when the server supports OAuth and is failed or needs-auth.
+  2. **Reconnect** — re-runs `claude mcp get <name>` to attempt a fresh connection. While reconnecting the button shows "Reconnecting" and all other buttons are disabled.
+  3. **Clear authentication** — visible for connected OAuth servers (except claude.ai proxy).
+  4. **Enable / Disable** — toggles the server in `disabledMcpServers` without removing its config.
+- **Remove server** — confirms before calling `claude mcp remove`.
+
+### Add server
+
+Click **+** in the modal header to open the add form. Fill in name, transport type (stdio / http / sse), command / URL, optional args and env vars, and scope (user / project / local). Submits via `claude mcp add-json`.
+
+### Pre-fetch & caching
+
+The server list is fetched as soon as the chat page mounts (React Query, `staleTime: 0`, `gcTime: 5 min`), so opening the modal for the first time shows data immediately instead of a loading spinner.
+
+## Implementation notes
+
+- All data comes from **`claude mcp list`** (health-check + name enumeration) and **`claude mcp get <name>`** (full config per server) — no undocumented internal protocols.
+- SSE / HTTP error enrichment: when a server is failed, the backend makes a 5-second `fetch` probe to the server URL and replaces the generic status text with the actual network error.
+- Disabled servers are sourced from `~/.claude.json → disabledMcpServers`; the CLI does not report them in `mcp list`.
+- IPC message types live in the shared `MessageType` enum (`GET_MCP_SERVERS`, `RECONNECT_MCP_SERVER`, `AUTHENTICATE_MCP_SERVER`, `CLEAR_MCP_SERVER_AUTH`, `SET_MCP_SERVER_ENABLED`, `ADD_MCP_SERVER`, `REMOVE_MCP_SERVER`).

--- a/docs/features/003-mcp_server_management/en.md
+++ b/docs/features/003-mcp_server_management/en.md
@@ -2,11 +2,11 @@
 
 > Languages: [한국어](./ko.md) · **English**
 >
-> Related: [PR #135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135)
+> Related: [PR #136](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/136)
 
 ## What's new
 
-You can now **view, add, remove, enable, disable, and reconnect MCP servers directly from the GUI** — no terminal required. Type `/MCP Servers` in the slash-command palette (or click the **MCP Servers** item under Customize) to open the panel.
+You can now **view, add, edit, remove, enable, disable, and reconnect MCP servers directly from the GUI** — no terminal required. Type `/MCP Servers` in the slash-command palette (or click the **MCP Servers** item under Customize) to open the panel.
 
 ## Features
 
@@ -25,6 +25,7 @@ Servers are grouped by scope (Project → Local → User → claude.ai) and sort
 
 Click any server card to open its detail screen:
 
+- **Edit** — a chip next to the status badge opens the add form prefilled with the server's current configuration. Available for user / project / local scope servers (claude.ai connectors are managed elsewhere and can't be edited here). Because the CLI has no dedicated edit command, saving runs `claude mcp remove` followed by `claude mcp add-json`; if the re-add fails, the original config is restored so a failed edit never deletes your server. Servers that are **Failed or Pending can be edited too** — their config is recovered from the settings file even when the CLI doesn't report it.
 - **Error box** — displayed above the server name when the server is in a failed or auth-required state. For SSE / HTTP servers, the GUI probes the endpoint directly and surfaces the real network error (e.g. "connection refused") instead of the generic "Failed to connect".
 - **Action buttons** (in priority order):
   1. **Authenticate** (primary / blue CTA) — visible when the server supports OAuth and is failed or needs-auth.
@@ -33,9 +34,11 @@ Click any server card to open its detail screen:
   4. **Enable / Disable** — toggles the server in `disabledMcpServers` without removing its config.
 - **Remove server** — confirms before calling `claude mcp remove`.
 
-### Add server
+### Add / edit a server
 
-Click **+** in the modal header to open the add form. Fill in name, transport type (stdio / http / sse), command / URL, optional args and env vars, and scope (user / project / local). Submits via `claude mcp add-json`.
+Click **+** in the modal header to open the add form, or **Edit** on a server to change an existing one. Give the server a name, pick a scope (user / project / local), and paste its configuration as JSON — either a single server config or a full `mcpServers` wrapper. Add submits via `claude mcp add-json`. You can also browse the **MCP registry** (search icon in the header) to pick a server and prefill the form.
+
+While a save is in progress the whole modal is locked (inputs disabled, can't be closed or dismissed), the **Save button turns into a spinner**, and a toast confirms the result on completion (**"Added …"** / **"Saved …"**).
 
 ### Pre-fetch & caching
 
@@ -43,7 +46,9 @@ The server list is fetched as soon as the chat page mounts (React Query, `staleT
 
 ## Implementation notes
 
-- All data comes from **`claude mcp list`** (health-check + name enumeration) and **`claude mcp get <name>`** (full config per server) — no undocumented internal protocols.
+- All data comes from **`claude mcp list`** (health-check + name enumeration) and **`claude mcp get <name>`** (per-server status) — no undocumented internal protocols.
+- **Workspace-relative commands**: every MCP CLI command (`list` / `get` / `add-json` / `remove`) runs in the open project's root directory — the same working directory chat uses. Project- and local-scope configs (`.mcp.json` / per-project config) are resolved relative to that directory, so they are written and read in the right place rather than the backend's own folder.
+- **Config recovery for non-connected servers**: `claude mcp get` omits transport details for Failed/Pending servers (and drops headers/env even when present), which would leave them non-editable. The GUI instead reads the original config **verbatim** from its settings file — `~/.claude.json` (user), `{project}/.mcp.json` (project), or the per-project entry in `~/.claude.json` (local) — preserving env and headers. This is what lets you view and edit servers that aren't currently connected.
 - SSE / HTTP error enrichment: when a server is failed, the backend makes a 5-second `fetch` probe to the server URL and replaces the generic status text with the actual network error.
 - Disabled servers are sourced from `~/.claude.json → disabledMcpServers`; the CLI does not report them in `mcp list`.
 - IPC message types live in the shared `MessageType` enum (`GET_MCP_SERVERS`, `RECONNECT_MCP_SERVER`, `AUTHENTICATE_MCP_SERVER`, `CLEAR_MCP_SERVER_AUTH`, `SET_MCP_SERVER_ENABLED`, `ADD_MCP_SERVER`, `REMOVE_MCP_SERVER`).

--- a/docs/features/003-mcp_server_management/ko.md
+++ b/docs/features/003-mcp_server_management/ko.md
@@ -1,0 +1,49 @@
+# MCP 서버 관리
+
+> Languages: **한국어** · [English](./en.md)
+>
+> Related: [PR #135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135)
+
+## 새로운 기능
+
+이제 **터미널 없이 GUI에서 MCP 서버를 조회·추가·제거·활성화/비활성화·재연결**할 수 있습니다. 슬래시 커맨드 팔레트에서 `/MCP Servers`를 입력하거나 Customize 섹션의 **MCP Servers** 항목을 클릭하면 패널이 열립니다.
+
+## 기능 상세
+
+### 서버 목록
+
+서버는 scope(Project → Local → User → claude.ai) 순으로 그룹화되고, 각 그룹 내에서 알파벳 순으로 정렬됩니다. 각 카드에는 다음이 표시됩니다.
+
+- **서버 이름** (고정폭 폰트)
+- **상태 배지** — solid pill 색상 구분:
+  - 초록 "✓ Connected"
+  - 빨강 "✗ Failed"
+  - 노랑 "Needs auth"
+  - 회색 텍스트 "Pending" / "Disabled" (배지 없음)
+
+### 상세 화면
+
+서버 카드를 클릭하면 상세 화면으로 이동합니다.
+
+- **에러 박스** — 연결 실패(Failed) 또는 인증 필요(Needs auth) 상태일 때 서버명 위에 표시됩니다. SSE/HTTP 타입 서버는 GUI가 해당 URL로 직접 연결을 시도해 실제 네트워크 에러(예: "connection refused")를 표시합니다.
+- **액션 버튼** (우선순위 순서):
+  1. **Authenticate** (파란 CTA 버튼) — OAuth를 지원하는 서버가 실패하거나 인증이 필요할 때 표시됩니다.
+  2. **Reconnect** — `claude mcp get <name>`을 재실행해 새로운 연결을 시도합니다. 재연결 중에는 버튼 텍스트가 "Reconnecting"으로 바뀌고 다른 버튼은 비활성화됩니다.
+  3. **Clear authentication** — 연결된 OAuth 서버(claude.ai 프록시 제외)에서 인증 정보를 초기화합니다.
+  4. **Enable / Disable** — 서버 설정을 제거하지 않고 `disabledMcpServers`에서 토글합니다.
+- **Remove server** — 확인 후 `claude mcp remove`를 실행합니다.
+
+### 서버 추가
+
+모달 헤더의 **+** 버튼을 클릭하면 추가 폼이 열립니다. 이름, 전송 타입(stdio / http / sse), 커맨드/URL, 선택적 인수와 환경변수, scope(user / project / local)를 입력하고 제출하면 `claude mcp add-json`으로 등록됩니다.
+
+### 사전 로드 및 캐싱
+
+채팅 페이지가 마운트되는 즉시 서버 목록을 가져옵니다(React Query, `staleTime: 0`, `gcTime: 5분`). 덕분에 모달을 처음 열어도 로딩 스피너 없이 바로 목록이 표시됩니다.
+
+## 구현 노트
+
+- 모든 데이터는 **`claude mcp list`**(상태 확인 + 이름 목록)와 **`claude mcp get <name>`**(서버별 설정 상세)에서 가져옵니다. 비공개 내부 프로토콜은 사용하지 않습니다.
+- SSE/HTTP 에러 보강: 서버가 실패 상태일 때 백엔드가 해당 URL로 5초 타임아웃 `fetch` 탐침을 보내, 일반 상태 텍스트 대신 실제 네트워크 에러를 표시합니다.
+- Disabled 서버는 `~/.claude.json → disabledMcpServers`에서 읽어옵니다. CLI의 `mcp list`에는 표시되지 않습니다.
+- IPC 메시지 타입은 공유 `MessageType` enum에 정의됩니다(`GET_MCP_SERVERS`, `RECONNECT_MCP_SERVER`, `AUTHENTICATE_MCP_SERVER`, `CLEAR_MCP_SERVER_AUTH`, `SET_MCP_SERVER_ENABLED`, `ADD_MCP_SERVER`, `REMOVE_MCP_SERVER`).

--- a/docs/features/003-mcp_server_management/ko.md
+++ b/docs/features/003-mcp_server_management/ko.md
@@ -2,11 +2,11 @@
 
 > Languages: **한국어** · [English](./en.md)
 >
-> Related: [PR #135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135)
+> Related: [PR #136](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/136)
 
 ## 새로운 기능
 
-이제 **터미널 없이 GUI에서 MCP 서버를 조회·추가·제거·활성화/비활성화·재연결**할 수 있습니다. 슬래시 커맨드 팔레트에서 `/MCP Servers`를 입력하거나 Customize 섹션의 **MCP Servers** 항목을 클릭하면 패널이 열립니다.
+이제 **터미널 없이 GUI에서 MCP 서버를 조회·추가·편집·제거·활성화/비활성화·재연결**할 수 있습니다. 슬래시 커맨드 팔레트에서 `/MCP Servers`를 입력하거나 Customize 섹션의 **MCP Servers** 항목을 클릭하면 패널이 열립니다.
 
 ## 기능 상세
 
@@ -25,6 +25,7 @@
 
 서버 카드를 클릭하면 상세 화면으로 이동합니다.
 
+- **Edit** — 상태 배지 옆의 칩을 누르면 현재 설정이 채워진 상태로 추가 폼이 열립니다. user / project / local scope 서버에서 사용할 수 있습니다(claude.ai 커넥터는 별도로 관리되며 여기서 편집할 수 없습니다). CLI에는 전용 편집 명령이 없으므로, 저장 시 `claude mcp remove` 후 `claude mcp add-json`을 실행합니다. 다시 추가가 실패하면 원래 설정을 되돌려 편집 실패로 서버가 삭제되는 일이 없습니다. **연결 실패(Failed)·승인 대기(Pending) 서버도 편집할 수 있습니다** — CLI가 설정을 알려주지 않더라도 설정 파일에서 원본을 복구하기 때문입니다.
 - **에러 박스** — 연결 실패(Failed) 또는 인증 필요(Needs auth) 상태일 때 서버명 위에 표시됩니다. SSE/HTTP 타입 서버는 GUI가 해당 URL로 직접 연결을 시도해 실제 네트워크 에러(예: "connection refused")를 표시합니다.
 - **액션 버튼** (우선순위 순서):
   1. **Authenticate** (파란 CTA 버튼) — OAuth를 지원하는 서버가 실패하거나 인증이 필요할 때 표시됩니다.
@@ -33,9 +34,11 @@
   4. **Enable / Disable** — 서버 설정을 제거하지 않고 `disabledMcpServers`에서 토글합니다.
 - **Remove server** — 확인 후 `claude mcp remove`를 실행합니다.
 
-### 서버 추가
+### 서버 추가 / 편집
 
-모달 헤더의 **+** 버튼을 클릭하면 추가 폼이 열립니다. 이름, 전송 타입(stdio / http / sse), 커맨드/URL, 선택적 인수와 환경변수, scope(user / project / local)를 입력하고 제출하면 `claude mcp add-json`으로 등록됩니다.
+모달 헤더의 **+** 버튼을 누르면 추가 폼이, 서버 상세의 **Edit**을 누르면 편집 폼이 열립니다. 이름을 입력하고 scope(user / project / local)를 고른 뒤, 설정을 JSON으로 붙여넣습니다 — 단일 서버 설정이거나 `mcpServers` 래퍼 전체 모두 가능합니다. 추가는 `claude mcp add-json`으로 등록됩니다. 헤더의 검색 아이콘으로 **MCP 레지스트리**를 둘러보고 서버를 골라 폼을 자동으로 채울 수도 있습니다.
+
+저장이 진행되는 동안에는 모달 전체가 잠기고(입력 비활성화, 닫거나 취소 불가), **저장 버튼이 스피너로 바뀌며**, 완료되면 토스트로 결과를 알립니다(**"Added …"** / **"Saved …"**).
 
 ### 사전 로드 및 캐싱
 
@@ -43,7 +46,9 @@
 
 ## 구현 노트
 
-- 모든 데이터는 **`claude mcp list`**(상태 확인 + 이름 목록)와 **`claude mcp get <name>`**(서버별 설정 상세)에서 가져옵니다. 비공개 내부 프로토콜은 사용하지 않습니다.
+- 모든 데이터는 **`claude mcp list`**(상태 확인 + 이름 목록)와 **`claude mcp get <name>`**(서버별 상태)에서 가져옵니다. 비공개 내부 프로토콜은 사용하지 않습니다.
+- **워크스페이스 기준 실행**: 모든 MCP CLI 명령(`list` / `get` / `add-json` / `remove`)은 열려 있는 프로젝트 루트 디렉토리에서 실행됩니다 — 채팅이 사용하는 작업 디렉토리와 동일합니다. project·local scope 설정(`.mcp.json` / 프로젝트별 설정)은 그 디렉토리를 기준으로 해석되므로, 백엔드 자체 폴더가 아니라 올바른 위치에 기록·조회됩니다.
+- **비연결 서버 설정 복구**: `claude mcp get`은 Failed/Pending 서버의 전송 설정을 생략하고(있어도 headers/env를 누락), 그러면 편집이 불가능해집니다. 그래서 GUI는 설정 파일에서 원본을 **그대로(verbatim)** 읽어옵니다 — `~/.claude.json`(user), `{project}/.mcp.json`(project), `~/.claude.json`의 프로젝트별 항목(local) — env와 headers까지 보존합니다. 현재 연결되지 않은 서버도 조회·편집할 수 있는 이유입니다.
 - SSE/HTTP 에러 보강: 서버가 실패 상태일 때 백엔드가 해당 URL로 5초 타임아웃 `fetch` 탐침을 보내, 일반 상태 텍스트 대신 실제 네트워크 에러를 표시합니다.
 - Disabled 서버는 `~/.claude.json → disabledMcpServers`에서 읽어옵니다. CLI의 `mcp list`에는 표시되지 않습니다.
 - IPC 메시지 타입은 공유 `MessageType` enum에 정의됩니다(`GET_MCP_SERVERS`, `RECONNECT_MCP_SERVER`, `AUTHENTICATE_MCP_SERVER`, `CLEAR_MCP_SERVER_AUTH`, `SET_MCP_SERVER_ENABLED`, `ADD_MCP_SERVER`, `REMOVE_MCP_SERVER`).

--- a/docs/features/CLAUDE.md
+++ b/docs/features/CLAUDE.md
@@ -8,3 +8,4 @@
 
 - [Editor Context Tag](./001-editor_context_tag/en.md) — 에디터에서 연 파일이나 선택한 코드를 자동으로 채팅 컨텍스트로 첨부하는 토글 태그 ([#122](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/122), [#133](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/133))
 - [Multi-Account Management](./002-multi_account_management/en.md) — 여러 Claude 계정을 저장하고 전환하며, 계정별 사용량을 한 화면에서 비교하는 멀티 계정 기능 ([#134](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/134))
+- [MCP Server Management](./003-mcp_server_management/en.md) — GUI에서 MCP 서버를 조회·추가·제거·활성화·재연결하는 MCP 서버 관리 패널 ([#135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135))

--- a/docs/features/CLAUDE.md
+++ b/docs/features/CLAUDE.md
@@ -8,4 +8,4 @@
 
 - [Editor Context Tag](./001-editor_context_tag/en.md) — 에디터에서 연 파일이나 선택한 코드를 자동으로 채팅 컨텍스트로 첨부하는 토글 태그 ([#122](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/122), [#133](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/133))
 - [Multi-Account Management](./002-multi_account_management/en.md) — 여러 Claude 계정을 저장하고 전환하며, 계정별 사용량을 한 화면에서 비교하는 멀티 계정 기능 ([#134](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/134))
-- [MCP Server Management](./003-mcp_server_management/en.md) — GUI에서 MCP 서버를 조회·추가·제거·활성화·재연결하는 MCP 서버 관리 패널 ([#135](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/135))
+- [MCP Server Management](./003-mcp_server_management/en.md) — GUI에서 MCP 서버를 조회·추가·편집·제거·활성화·재연결하는 MCP 서버 관리 패널 ([#136](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/136))

--- a/webview/src/commandPalette/sections/customize/items.ts
+++ b/webview/src/commandPalette/sections/customize/items.ts
@@ -1,14 +1,20 @@
 import { IconType } from '@/types/commandPalette';
 import { StaticItem } from '../../types';
 
+export const OPEN_MCP_MODAL_EVENT = 'open-mcp-modal';
+
 export const customizeItems = [
-  new StaticItem('output-styles', 'Output styles', { icon: IconType.Terminal }),
-  new StaticItem('agents', 'Agents', { icon: IconType.Terminal }),
-  new StaticItem('hooks', 'Hooks', { icon: IconType.Terminal }),
-  new StaticItem('memory', 'Memory', { icon: IconType.Terminal }),
-  new StaticItem('permissions', 'Permissions', { icon: IconType.Terminal }),
-  new StaticItem('mcp-status', 'MCP status'),
-  new StaticItem('manage-mcp', 'Manage MCP servers', { icon: IconType.Terminal }),
+  new StaticItem('output-styles', 'Output styles'),
+  new StaticItem('agents', 'Agents'),
+  new StaticItem('hooks', 'Hooks'),
+  new StaticItem('memory', 'Memory'),
+  new StaticItem('permissions', 'Permissions'),
+  new StaticItem('manage-mcp', 'MCP Servers', {
+    disabled: false,
+    action: async () => {
+      window.dispatchEvent(new CustomEvent(OPEN_MCP_MODAL_EVENT));
+    },
+  }),
   new StaticItem('manage-plugins', 'Manage plugins'),
   new StaticItem('open-terminal', 'Open Claude in Terminal', {
     icon: IconType.Terminal,

--- a/webview/src/commandPalette/sections/customize/items.ts
+++ b/webview/src/commandPalette/sections/customize/items.ts
@@ -11,6 +11,9 @@ export const customizeItems = [
   new StaticItem('permissions', 'Permissions'),
   new StaticItem('manage-mcp', 'MCP Servers', {
     disabled: false,
+    // Label is "MCP Servers" (matches "/mcp"); these keywords also surface it
+    // for "/manage-mcp" and the bare "/manage" query.
+    keywords: ['manage-mcp', 'mcp'],
     action: async () => {
       window.dispatchEvent(new CustomEvent(OPEN_MCP_MODAL_EVENT));
     },

--- a/webview/src/components/McpModal/McpAddForm.tsx
+++ b/webview/src/components/McpModal/McpAddForm.tsx
@@ -1,0 +1,166 @@
+import { useState } from 'react';
+import { McpTransportType } from '@/shared';
+
+interface Props {
+  onAdd: (name: string, config: Record<string, unknown>, scope: string) => Promise<void>;
+  onCancel: () => void;
+}
+
+type TransportTab = 'stdio' | 'http' | 'sse';
+
+export function McpAddForm(props: Props) {
+  const { onAdd, onCancel } = props;
+  const [name, setName] = useState('');
+  const [scope, setScope] = useState('user');
+  const [transport, setTransport] = useState<TransportTab>('stdio');
+  const [command, setCommand] = useState('');
+  const [args, setArgs] = useState('');
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
+    e.preventDefault();
+    if (!name.trim()) { setError('Name is required'); return; }
+    setError(null);
+    setBusy(true);
+    try {
+      const config = buildConfig();
+      await onAdd(name.trim(), config, scope);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function buildConfig(): Record<string, unknown> {
+    if (transport === 'stdio') {
+      const argList = args.trim() ? args.trim().split(/\s+/) : [];
+      return {
+        type: McpTransportType.STDIO,
+        command: command.trim(),
+        args: argList.length ? argList : undefined,
+      };
+    }
+    return {
+      type: transport === 'http' ? McpTransportType.HTTP : McpTransportType.SSE,
+      url: url.trim(),
+    };
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col h-full">
+      <div className="flex-1 overflow-y-auto px-4 pt-4 pb-2 flex-shrink-0 space-y-3">
+        <h3 className="text-lg font-semibold text-text-primary">Add MCP Server</h3>
+
+        {error && (
+          <p className="text-xs text-state-error-fg">{error}</p>
+        )}
+
+        {/* Name */}
+        <Field label="Name">
+          <input
+            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-server"
+            autoFocus
+          />
+        </Field>
+
+        {/* Scope */}
+        <Field label="Scope">
+          <select
+            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
+            value={scope}
+            onChange={(e) => setScope(e.target.value)}
+          >
+            <option value="user">User (all projects)</option>
+            <option value="project">Project (.mcp.json)</option>
+            <option value="local">Local (this project only)</option>
+          </select>
+        </Field>
+
+        {/* Transport tabs */}
+        <div>
+          <label className="block text-sm text-text-tertiary mb-1">Transport</label>
+          <div className="flex gap-2">
+            {(['stdio', 'http', 'sse'] as TransportTab[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                className={`text-md px-3 py-1 rounded transition-colors ${
+                  transport === t
+                    ? 'bg-accent-primary text-white'
+                    : 'bg-surface-hover text-text-secondary hover:bg-surface-raised'
+                }`}
+                onClick={() => setTransport(t)}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Transport-specific fields */}
+        {transport === 'stdio' ? (
+          <>
+            <Field label="Command">
+              <input
+                className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+                value={command}
+                onChange={(e) => setCommand(e.target.value)}
+                placeholder="npx"
+              />
+            </Field>
+            <Field label="Arguments (space-separated)">
+              <input
+                className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+                value={args}
+                onChange={(e) => setArgs(e.target.value)}
+                placeholder="-y my-mcp-server"
+              />
+            </Field>
+          </>
+        ) : (
+          <Field label="URL">
+            <input
+              className="w-full text-sm bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="http://localhost:3000/mcp"
+            />
+          </Field>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="px-4 pb-4 pt-2 flex gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 text-md py-2 rounded bg-surface-hover text-text-secondary hover:bg-surface-raised transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={busy}
+          className="flex-1 text-md py-2 rounded bg-accent-primary text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+        >
+          {busy ? 'Adding…' : 'Add server'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Field(props: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-sm text-text-tertiary mb-1.5">{props.label}</label>
+      {props.children}
+    </div>
+  );
+}

--- a/webview/src/components/McpModal/McpAddForm.tsx
+++ b/webview/src/components/McpModal/McpAddForm.tsx
@@ -1,13 +1,24 @@
 import { useState } from 'react';
+import { ArrowPathIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { parseMcpJson, ParsedMcpServer } from '@/utils/parseMcpJson';
 
 interface Props {
-  /** Pre-fill the Name field (used when arriving from the marketplace). */
+  /** Pre-fill the Name field (used when arriving from the marketplace or editing). */
   initialName?: string;
-  /** Pre-fill the JSON box (used when arriving from the marketplace). */
+  /** Pre-fill the JSON box (used when arriving from the marketplace or editing). */
   initialJson?: string;
+  /** Pre-select the Scope dropdown (used when editing an existing server). */
+  initialScope?: string;
+  /**
+   * 'add' (default) shows the Add UI. 'edit' relabels title/submit and means the
+   * submit handler replaces an existing server (remove → add-json) rather than
+   * creating a new one. The on-wire path is identical — only the copy differs.
+   */
+  mode?: 'add' | 'edit';
   onAdd: (servers: ParsedMcpServer[], scope: string) => Promise<void>;
   onCancel: () => void;
+  /** Report submit-in-progress so the parent can lock the whole modal. */
+  onBusyChange?: (busy: boolean) => void;
 }
 
 const PLACEHOLDER = `{
@@ -20,9 +31,10 @@ const PLACEHOLDER = `{
 }`;
 
 export function McpAddForm(props: Props) {
-  const { onAdd, onCancel, initialName, initialJson } = props;
+  const { onAdd, onCancel, initialName, initialJson, initialScope, mode = 'add', onBusyChange } = props;
+  const isEdit = mode === 'edit';
   const [name, setName] = useState(initialName ?? '');
-  const [scope, setScope] = useState('user');
+  const [scope, setScope] = useState(initialScope ?? 'user');
   const [json, setJson] = useState(initialJson ?? '');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -36,19 +48,32 @@ export function McpAddForm(props: Props) {
     }
     setError(null);
     setBusy(true);
+    onBusyChange?.(true);
     try {
       await onAdd(parsed.servers, scope);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
+      onBusyChange?.(false);
     }
   }
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col h-full">
       <div className="flex-1 overflow-y-auto px-4 pt-4 pb-2 flex-shrink-0 space-y-3">
-        <h3 className="text-lg font-semibold text-text-primary">Add MCP Server</h3>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors flex-shrink-0 disabled:opacity-50"
+            title="Back"
+          >
+            <ArrowLeftIcon className="w-5 h-5" />
+          </button>
+          <h3 className="text-lg font-semibold text-text-primary">{isEdit ? 'Edit MCP Server' : 'Add MCP Server'}</h3>
+        </div>
 
         {error && (
           <p className="text-xs text-state-error-fg whitespace-pre-wrap">{error}</p>
@@ -57,19 +82,21 @@ export function McpAddForm(props: Props) {
         {/* Name (optional — used only when the pasted JSON has no mcpServers wrapper) */}
         <Field label="Name" hint="Optional — only used when your JSON has no “mcpServers” wrapper">
           <input
-            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
+            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary disabled:opacity-50"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="my-server"
+            disabled={busy}
           />
         </Field>
 
         {/* Scope */}
         <Field label="Scope">
           <select
-            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
+            className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary disabled:opacity-50"
             value={scope}
             onChange={(e) => setScope(e.target.value)}
+            disabled={busy}
           >
             <option value="user">User (all projects)</option>
             <option value="project">Project (.mcp.json)</option>
@@ -80,31 +107,36 @@ export function McpAddForm(props: Props) {
         {/* JSON config */}
         <Field label="Configuration (JSON)" hint="Paste an mcpServers config or a single server config">
           <textarea
-            className="w-full h-44 text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono resize-y focus:outline-none focus:border-accent-primary"
+            className="w-full h-44 text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono resize-y focus:outline-none focus:border-accent-primary disabled:opacity-50"
             value={json}
             onChange={(e) => setJson(e.target.value)}
             placeholder={PLACEHOLDER}
             autoFocus
             spellCheck={false}
+            disabled={busy}
           />
         </Field>
       </div>
 
-      {/* Footer */}
+      {/* Footer — while saving, hide Cancel and make the spinner button full-width */}
       <div className="px-4 pb-4 pt-2 flex gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          className="flex-1 text-md py-2 rounded bg-surface-hover text-text-secondary hover:bg-surface-raised transition-colors"
-        >
-          Cancel
-        </button>
+        {!busy && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="flex-1 text-md py-2 rounded bg-surface-hover text-text-secondary hover:bg-surface-raised transition-colors"
+          >
+            Cancel
+          </button>
+        )}
         <button
           type="submit"
           disabled={busy}
-          className="flex-1 text-md py-2 rounded bg-accent-primary text-white hover:opacity-90 transition-opacity disabled:opacity-50"
+          className={`text-md py-2 rounded bg-accent-primary text-white hover:opacity-90 transition-opacity disabled:opacity-50 flex items-center justify-center ${busy ? 'w-full' : 'flex-1'}`}
         >
-          {busy ? 'Adding…' : 'Add server'}
+          {busy ? (
+            <ArrowPathIcon className="w-5 h-5 animate-spin" aria-label={isEdit ? 'Saving' : 'Adding'} />
+          ) : isEdit ? 'Save' : 'Add server'}
         </button>
       </div>
     </form>

--- a/webview/src/components/McpModal/McpAddForm.tsx
+++ b/webview/src/components/McpModal/McpAddForm.tsx
@@ -1,52 +1,48 @@
 import { useState } from 'react';
-import { McpTransportType } from '@/shared';
+import { parseMcpJson, ParsedMcpServer } from '@/utils/parseMcpJson';
 
 interface Props {
-  onAdd: (name: string, config: Record<string, unknown>, scope: string) => Promise<void>;
+  /** Pre-fill the Name field (used when arriving from the marketplace). */
+  initialName?: string;
+  /** Pre-fill the JSON box (used when arriving from the marketplace). */
+  initialJson?: string;
+  onAdd: (servers: ParsedMcpServer[], scope: string) => Promise<void>;
   onCancel: () => void;
 }
 
-type TransportTab = 'stdio' | 'http' | 'sse';
+const PLACEHOLDER = `{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "my-mcp-server"]
+    }
+  }
+}`;
 
 export function McpAddForm(props: Props) {
-  const { onAdd, onCancel } = props;
-  const [name, setName] = useState('');
+  const { onAdd, onCancel, initialName, initialJson } = props;
+  const [name, setName] = useState(initialName ?? '');
   const [scope, setScope] = useState('user');
-  const [transport, setTransport] = useState<TransportTab>('stdio');
-  const [command, setCommand] = useState('');
-  const [args, setArgs] = useState('');
-  const [url, setUrl] = useState('');
+  const [json, setJson] = useState(initialJson ?? '');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault();
-    if (!name.trim()) { setError('Name is required'); return; }
+    const parsed = parseMcpJson(json, name);
+    if (!parsed.ok) {
+      setError(parsed.error);
+      return;
+    }
     setError(null);
     setBusy(true);
     try {
-      const config = buildConfig();
-      await onAdd(name.trim(), config, scope);
+      await onAdd(parsed.servers, scope);
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setBusy(false);
     }
-  }
-
-  function buildConfig(): Record<string, unknown> {
-    if (transport === 'stdio') {
-      const argList = args.trim() ? args.trim().split(/\s+/) : [];
-      return {
-        type: McpTransportType.STDIO,
-        command: command.trim(),
-        args: argList.length ? argList : undefined,
-      };
-    }
-    return {
-      type: transport === 'http' ? McpTransportType.HTTP : McpTransportType.SSE,
-      url: url.trim(),
-    };
   }
 
   return (
@@ -55,17 +51,16 @@ export function McpAddForm(props: Props) {
         <h3 className="text-lg font-semibold text-text-primary">Add MCP Server</h3>
 
         {error && (
-          <p className="text-xs text-state-error-fg">{error}</p>
+          <p className="text-xs text-state-error-fg whitespace-pre-wrap">{error}</p>
         )}
 
-        {/* Name */}
-        <Field label="Name">
+        {/* Name (optional — used only when the pasted JSON has no mcpServers wrapper) */}
+        <Field label="Name" hint="Optional — only used when your JSON has no “mcpServers” wrapper">
           <input
             className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="my-server"
-            autoFocus
           />
         </Field>
 
@@ -82,57 +77,17 @@ export function McpAddForm(props: Props) {
           </select>
         </Field>
 
-        {/* Transport tabs */}
-        <div>
-          <label className="block text-sm text-text-tertiary mb-1">Transport</label>
-          <div className="flex gap-2">
-            {(['stdio', 'http', 'sse'] as TransportTab[]).map((t) => (
-              <button
-                key={t}
-                type="button"
-                className={`text-md px-3 py-1 rounded transition-colors ${
-                  transport === t
-                    ? 'bg-accent-primary text-white'
-                    : 'bg-surface-hover text-text-secondary hover:bg-surface-raised'
-                }`}
-                onClick={() => setTransport(t)}
-              >
-                {t}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        {/* Transport-specific fields */}
-        {transport === 'stdio' ? (
-          <>
-            <Field label="Command">
-              <input
-                className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-                value={command}
-                onChange={(e) => setCommand(e.target.value)}
-                placeholder="npx"
-              />
-            </Field>
-            <Field label="Arguments (space-separated)">
-              <input
-                className="w-full text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-                value={args}
-                onChange={(e) => setArgs(e.target.value)}
-                placeholder="-y my-mcp-server"
-              />
-            </Field>
-          </>
-        ) : (
-          <Field label="URL">
-            <input
-              className="w-full text-sm bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono focus:outline-none focus:border-accent-primary"
-              value={url}
-              onChange={(e) => setUrl(e.target.value)}
-              placeholder="http://localhost:3000/mcp"
-            />
-          </Field>
-        )}
+        {/* JSON config */}
+        <Field label="Configuration (JSON)" hint="Paste an mcpServers config or a single server config">
+          <textarea
+            className="w-full h-44 text-md bg-surface-hover border border-border-default rounded px-2 py-1.5 text-text-primary font-mono resize-y focus:outline-none focus:border-accent-primary"
+            value={json}
+            onChange={(e) => setJson(e.target.value)}
+            placeholder={PLACEHOLDER}
+            autoFocus
+            spellCheck={false}
+          />
+        </Field>
       </div>
 
       {/* Footer */}
@@ -156,11 +111,12 @@ export function McpAddForm(props: Props) {
   );
 }
 
-function Field(props: { label: string; children: React.ReactNode }) {
+function Field(props: { label: string; hint?: string; children: React.ReactNode }) {
   return (
     <div>
       <label className="block text-sm text-text-tertiary mb-1.5">{props.label}</label>
       {props.children}
+      {props.hint && <p className="mt-1 text-xs text-text-tertiary">{props.hint}</p>}
     </div>
   );
 }

--- a/webview/src/components/McpModal/McpMarketplace.tsx
+++ b/webview/src/components/McpModal/McpMarketplace.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { ArrowLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { useEffect, useMemo, useState } from 'react';
+import { ArrowLeftIcon, ArrowTopRightOnSquareIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { McpRegistryServer } from '@/shared';
 import { useMcpRegistry } from '@/hooks/useMcpRegistry';
 
@@ -22,8 +22,21 @@ export function McpMarketplace(props: Props) {
   const { servers, loading, error } = useMcpRegistry(query);
   const hasQuery = query.trim().length > 0;
 
+  // The registry returns one entry per published version, so the same server
+  // (identical reverse-DNS name) shows up multiple times. Collapse to the first
+  // occurrence — the result list has no per-version UI, so the duplicates are
+  // pure visual noise.
+  const uniqueServers = useMemo(() => {
+    const seen = new Set<string>();
+    return servers.filter((s) => {
+      if (seen.has(s.name)) return false;
+      seen.add(s.name);
+      return true;
+    });
+  }, [servers]);
+
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-h-0">
       {/* Header: back + search box */}
       <div className="flex items-center gap-2 px-4 pt-4 pb-2 flex-shrink-0">
         <button
@@ -46,7 +59,7 @@ export function McpMarketplace(props: Props) {
       </div>
 
       {/* Results */}
-      <div className="flex-1 overflow-y-auto px-4 py-2">
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-2">
         {!hasQuery && (
           <p className="px-1 py-8 text-center text-sm text-text-tertiary">
             Search the official MCP registry to find and install servers.
@@ -58,12 +71,12 @@ export function McpMarketplace(props: Props) {
         {hasQuery && !loading && error && (
           <p className="px-1 py-8 text-center text-sm text-state-error-fg">{error}</p>
         )}
-        {hasQuery && !loading && !error && servers.length === 0 && (
+        {hasQuery && !loading && !error && uniqueServers.length === 0 && (
           <p className="px-1 py-8 text-center text-sm text-text-tertiary">No servers found.</p>
         )}
-        {hasQuery && !loading && !error && servers.length > 0 && (
+        {hasQuery && !loading && !error && uniqueServers.length > 0 && (
           <div className="flex flex-col gap-2">
-            {servers.map((server) => (
+            {uniqueServers.map((server) => (
               <McpRegistryCard key={server.name} server={server} onPick={onPick} />
             ))}
           </div>
@@ -82,7 +95,20 @@ function McpRegistryCard(props: { server: McpRegistryServer; onPick: (s: McpRegi
     <div className="flex items-start justify-between gap-3 p-3.5 bg-surface-base border border-border-default rounded-lg">
       <div className="min-w-0 flex-1">
         <div className="flex items-baseline gap-2">
-          <span className="text-sm font-semibold text-text-primary truncate">{shortName}</span>
+          {server.repositoryUrl ? (
+            <a
+              href={server.repositoryUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group/title inline-flex items-center gap-1 min-w-0 text-sm font-semibold text-text-primary hover:text-accent-primary transition-colors"
+              title={`Open ${server.repositoryUrl}`}
+            >
+              <span className="truncate underline-offset-2 group-hover/title:underline">{shortName}</span>
+              <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5 flex-shrink-0 text-text-tertiary group-hover/title:text-accent-primary" />
+            </a>
+          ) : (
+            <span className="text-sm font-semibold text-text-primary truncate">{shortName}</span>
+          )}
           <span className="text-xs text-text-tertiary font-mono truncate">{server.name}</span>
         </div>
         {server.description && (

--- a/webview/src/components/McpModal/McpMarketplace.tsx
+++ b/webview/src/components/McpModal/McpMarketplace.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useState } from 'react';
+import { ArrowLeftIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { McpRegistryServer } from '@/shared';
+import { useMcpRegistry } from '@/hooks/useMcpRegistry';
+
+interface Props {
+  onPick: (server: McpRegistryServer) => void;
+  onBack: () => void;
+}
+
+export function McpMarketplace(props: Props) {
+  const { onPick, onBack } = props;
+  const [input, setInput] = useState('');
+  const [query, setQuery] = useState('');
+
+  // Debounce the search box so each keystroke doesn't hit the registry.
+  useEffect(() => {
+    const t = setTimeout(() => setQuery(input), 300);
+    return () => clearTimeout(t);
+  }, [input]);
+
+  const { servers, loading, error } = useMcpRegistry(query);
+  const hasQuery = query.trim().length > 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header: back + search box */}
+      <div className="flex items-center gap-2 px-4 pt-4 pb-2 flex-shrink-0">
+        <button
+          onClick={onBack}
+          className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors flex-shrink-0"
+          title="Back"
+        >
+          <ArrowLeftIcon className="w-5 h-5" />
+        </button>
+        <div className="relative flex-1">
+          <MagnifyingGlassIcon className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-text-tertiary pointer-events-none" />
+          <input
+            className="w-full text-md bg-surface-hover border border-border-default rounded pl-8 pr-2 py-1.5 text-text-primary focus:outline-none focus:border-accent-primary"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Search the MCP registry…"
+            autoFocus
+          />
+        </div>
+      </div>
+
+      {/* Results */}
+      <div className="flex-1 overflow-y-auto px-4 py-2">
+        {!hasQuery && (
+          <p className="px-1 py-8 text-center text-sm text-text-tertiary">
+            Search the official MCP registry to find and install servers.
+          </p>
+        )}
+        {hasQuery && loading && (
+          <p className="px-1 py-8 text-center text-sm text-text-tertiary">Searching…</p>
+        )}
+        {hasQuery && !loading && error && (
+          <p className="px-1 py-8 text-center text-sm text-state-error-fg">{error}</p>
+        )}
+        {hasQuery && !loading && !error && servers.length === 0 && (
+          <p className="px-1 py-8 text-center text-sm text-text-tertiary">No servers found.</p>
+        )}
+        {hasQuery && !loading && !error && servers.length > 0 && (
+          <div className="flex flex-col gap-2">
+            {servers.map((server) => (
+              <McpRegistryCard key={server.name} server={server} onPick={onPick} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function McpRegistryCard(props: { server: McpRegistryServer; onPick: (s: McpRegistryServer) => void }) {
+  const { server, onPick } = props;
+  const shortName = server.name.split('/').pop() || server.name;
+  const installable = server.config !== null;
+
+  return (
+    <div className="flex items-start justify-between gap-3 p-3.5 bg-surface-base border border-border-default rounded-lg">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-baseline gap-2">
+          <span className="text-sm font-semibold text-text-primary truncate">{shortName}</span>
+          <span className="text-xs text-text-tertiary font-mono truncate">{server.name}</span>
+        </div>
+        {server.description && (
+          <p className="mt-1 text-xs text-text-secondary line-clamp-2">{server.description}</p>
+        )}
+        {server.requiredInputs.length > 0 && (
+          <p className="mt-1 text-xs text-text-tertiary">
+            Needs {server.requiredInputs.length} input{server.requiredInputs.length > 1 ? 's' : ''}:{' '}
+            {server.requiredInputs.join(', ')}
+          </p>
+        )}
+      </div>
+      <button
+        disabled={!installable}
+        onClick={() => onPick(server)}
+        className="flex-shrink-0 text-md px-3 py-1.5 rounded bg-accent-primary text-white hover:opacity-90 transition-opacity disabled:opacity-40 disabled:cursor-not-allowed"
+        title={installable ? 'Configure & add' : 'No install info available'}
+      >
+        Add
+      </button>
+    </div>
+  );
+}

--- a/webview/src/components/McpModal/McpServerDetail.tsx
+++ b/webview/src/components/McpModal/McpServerDetail.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronLeftIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/20/solid';
 import { McpServer, McpServerStatus, McpTransportType, canAuthenticate } from '@/shared';
+import { useMcpServerTools } from '@/hooks/useMcpServerTools';
 import { McpStatusBadge } from './McpStatusBadge';
 
 interface Props {
@@ -27,6 +28,14 @@ export function McpServerDetail(props: Props) {
   const isDisabled = server.status === McpServerStatus.DISABLED;
   const isFailed = server.status === McpServerStatus.FAILED;
   const needsAuth = server.status === McpServerStatus.NEEDS_AUTH;
+
+  // Tools are fetched live by connecting to the server (MCP tools/list); only
+  // attempt it for connected servers, where a connection actually succeeds.
+  const { data: tools = [], isFetching: toolsLoading, error: toolsError } = useMcpServerTools(
+    server.name,
+    server.config,
+    isConnected,
+  );
 
   async function wrap(action: string, fn: () => Promise<void>): Promise<void> {
     setBusyAction(action);
@@ -163,35 +172,43 @@ export function McpServerDetail(props: Props) {
           />
         </div>
 
-        {/* View tools */}
-        {server.tools.length > 0 && (
+        {/* View tools — fetched live via MCP tools/list for connected servers */}
+        {isConnected && (
           <div>
-            <button
-              className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
-              onClick={() => setToolsOpen((p) => !p)}
-            >
-              {toolsOpen ? (
-                <ChevronUpIcon className="w-4 h-4" />
-              ) : (
-                <ChevronDownIcon className="w-4 h-4" />
-              )}
-              View tools ({server.tools.length})
-            </button>
-            {toolsOpen && (
-              <div className="mt-2 space-y-1">
-                {server.tools.map((tool) => (
-                  <div key={tool.name} className="flex items-center gap-2 text-xs">
-                    <span className="font-mono text-text-primary">{tool.name}</span>
-                    {tool.annotations?.readOnly && (
-                      <span className="px-1 py-0.5 rounded bg-surface-hover text-text-tertiary">read-only</span>
-                    )}
-                    {tool.annotations?.destructive && (
-                      <span className="px-1 py-0.5 rounded bg-state-error-bg text-state-error-fg">destructive</span>
-                    )}
+            {toolsLoading && tools.length === 0 ? (
+              <span className="text-sm text-text-tertiary">Loading tools…</span>
+            ) : toolsError ? (
+              <span className="text-sm text-state-error-fg">Couldn't load tools</span>
+            ) : tools.length > 0 ? (
+              <>
+                <button
+                  className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+                  onClick={() => setToolsOpen((p) => !p)}
+                >
+                  {toolsOpen ? (
+                    <ChevronUpIcon className="w-4 h-4" />
+                  ) : (
+                    <ChevronDownIcon className="w-4 h-4" />
+                  )}
+                  View tools ({tools.length})
+                </button>
+                {toolsOpen && (
+                  <div className="mt-2 space-y-1">
+                    {tools.map((tool) => (
+                      <div key={tool.name} className="flex items-center gap-2 text-xs">
+                        <span className="font-mono text-text-primary">{tool.name}</span>
+                        {tool.annotations?.readOnly && (
+                          <span className="px-1 py-0.5 rounded bg-surface-hover text-text-tertiary">read-only</span>
+                        )}
+                        {tool.annotations?.destructive && (
+                          <span className="px-1 py-0.5 rounded bg-state-error-bg text-state-error-fg">destructive</span>
+                        )}
+                      </div>
+                    ))}
                   </div>
-                ))}
-              </div>
-            )}
+                )}
+              </>
+            ) : null}
           </div>
         )}
 

--- a/webview/src/components/McpModal/McpServerDetail.tsx
+++ b/webview/src/components/McpModal/McpServerDetail.tsx
@@ -1,0 +1,257 @@
+import { useState } from 'react';
+import { ChevronLeftIcon, ChevronDownIcon, ChevronUpIcon } from '@heroicons/react/20/solid';
+import { McpServer, McpServerStatus, McpTransportType, canAuthenticate } from '@/shared';
+import { McpStatusBadge } from './McpStatusBadge';
+
+interface Props {
+  server: McpServer;
+  onBack: () => void;
+  onReconnect: (name: string) => Promise<void>;
+  onAuthenticate: (name: string) => Promise<{ hint?: string }>;
+  onClearAuth: (name: string) => Promise<{ hint?: string }>;
+  onToggleEnabled: (name: string, enabled: boolean) => Promise<void>;
+  onRemove: (name: string, scope: string) => Promise<void>;
+}
+
+export function McpServerDetail(props: Props) {
+  const { server, onBack, onReconnect, onAuthenticate, onClearAuth, onToggleEnabled, onRemove } = props;
+  const [toolsOpen, setToolsOpen] = useState(false);
+  const [busyAction, setBusyAction] = useState<string | null>(null);
+  const [hint, setHint] = useState<string | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const busy = busyAction !== null;
+  const isClaudeAiProxy = server.config?.type === McpTransportType.CLAUDEAI_PROXY;
+  const canAuth = canAuthenticate(server);
+  const isConnected = server.status === McpServerStatus.CONNECTED;
+  const isDisabled = server.status === McpServerStatus.DISABLED;
+  const isFailed = server.status === McpServerStatus.FAILED;
+  const needsAuth = server.status === McpServerStatus.NEEDS_AUTH;
+
+  async function wrap(action: string, fn: () => Promise<void>): Promise<void> {
+    setBusyAction(action);
+    setHint(null);
+    try {
+      await fn();
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleReconnect(): Promise<void> {
+    await wrap('reconnect', () => onReconnect(server.name));
+  }
+
+  async function handleAuthenticate(): Promise<void> {
+    await wrap('authenticate', async () => {
+      const result = await onAuthenticate(server.name);
+      if (result.hint) setHint(result.hint);
+    });
+  }
+
+  async function handleClearAuth(): Promise<void> {
+    await wrap('clear-auth', async () => {
+      const result = await onClearAuth(server.name);
+      if (result.hint) setHint(result.hint);
+    });
+  }
+
+  async function handleToggle(): Promise<void> {
+    await wrap('toggle', () => onToggleEnabled(server.name, isDisabled));
+  }
+
+  async function handleRemove(): Promise<void> {
+    await wrap('remove', () => onRemove(server.name, server.scope as string));
+    onBack();
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-2.5 pt-4 pb-2">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-1 text-md text-text-secondary hover:text-text-primary transition-colors"
+        >
+          <ChevronLeftIcon className="w-6 h-6" />
+          <span>Back to list</span>
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-4">
+        {/* Error box — above server name,커서 스타일 */}
+        {server.error && (
+          <div className="p-3 rounded-lg border border-state-error-fg/40 bg-state-error-bg text-sm text-state-error-fg">
+            {server.error}
+          </div>
+        )}
+
+        {/* Server header */}
+        <div className="flex items-center justify-between">
+          <h3 className="text-xl font-mono text-base font-semibold text-text-primary leading-none m-0">{server.name}</h3>
+          <McpStatusBadge status={server.status} />
+        </div>
+
+        {/* Config details */}
+        {server.config && (
+          <div className="text-sm text-text-tertiary space-y-0.5">
+            <div>Type: {server.config.type}</div>
+            {server.config.command && (
+              <div className="font-mono truncate">
+                {server.config.command}
+                {server.config.args?.length ? ' ' + server.config.args.join(' ') : ''}
+              </div>
+            )}
+            {server.config.url && (
+              <div className="font-mono truncate">{server.config.url}</div>
+            )}
+          </div>
+        )}
+
+        {/* Hint (terminal instruction) */}
+        {hint && (
+          <div className="text-sm text-text-secondary bg-surface-hover rounded p-2 font-mono">
+            {hint}
+          </div>
+        )}
+
+        {/* Action buttons — 순서: Authenticate(CTA) → Reconnect → Clear auth → Disable */}
+        <div className="flex flex-col gap-4">
+          {/* Authenticate — CTA primary, 최상단 */}
+          {canAuth && (needsAuth || isFailed) && (
+            <ActionButton
+              label="Authenticate"
+              anyBusy={busy}
+              activeAction="authenticate"
+              busyAction={busyAction}
+              onClick={handleAuthenticate}
+              variant="primary"
+            />
+          )}
+
+          {/* Reconnect */}
+          {!isDisabled && (
+            <ActionButton
+              label="Reconnect"
+              busyLabel="Reconnecting"
+              anyBusy={busy}
+              activeAction="reconnect"
+              busyAction={busyAction}
+              onClick={handleReconnect}
+            />
+          )}
+
+          {/* Clear authentication */}
+          {canAuth && !isClaudeAiProxy && isConnected && (
+            <ActionButton
+              label="Clear authentication"
+              anyBusy={busy}
+              activeAction="clear-auth"
+              busyAction={busyAction}
+              onClick={handleClearAuth}
+            />
+          )}
+
+          {/* Enable / Disable */}
+          <ActionButton
+            label={isDisabled ? 'Enable' : 'Disable'}
+            anyBusy={busy}
+            activeAction="toggle"
+            busyAction={busyAction}
+            onClick={handleToggle}
+            variant={isDisabled ? 'primary' : 'secondary'}
+          />
+        </div>
+
+        {/* View tools */}
+        {server.tools.length > 0 && (
+          <div>
+            <button
+              className="flex items-center gap-1 text-sm text-text-secondary hover:text-text-primary transition-colors"
+              onClick={() => setToolsOpen((p) => !p)}
+            >
+              {toolsOpen ? (
+                <ChevronUpIcon className="w-4 h-4" />
+              ) : (
+                <ChevronDownIcon className="w-4 h-4" />
+              )}
+              View tools ({server.tools.length})
+            </button>
+            {toolsOpen && (
+              <div className="mt-2 space-y-1">
+                {server.tools.map((tool) => (
+                  <div key={tool.name} className="flex items-center gap-2 text-xs">
+                    <span className="font-mono text-text-primary">{tool.name}</span>
+                    {tool.annotations?.readOnly && (
+                      <span className="px-1 py-0.5 rounded bg-surface-hover text-text-tertiary">read-only</span>
+                    )}
+                    {tool.annotations?.destructive && (
+                      <span className="px-1 py-0.5 rounded bg-state-error-bg text-state-error-fg">destructive</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Remove */}
+        <div className="pt-2">
+          {confirmDelete ? (
+            <div className="space-y-2">
+              <p className="text-xs text-text-secondary">Remove "{server.name}"?</p>
+              <div className="flex gap-2">
+                <button
+                  className="flex-1 text-xs py-1.5 rounded bg-state-error-bg text-state-error-fg hover:opacity-80 transition-opacity"
+                  onClick={handleRemove}
+                  disabled={busy}
+                >
+                  Remove
+                </button>
+                <button
+                  className="flex-1 text-xs py-1.5 rounded bg-surface-hover text-text-secondary hover:bg-surface-raised transition-colors"
+                  onClick={() => setConfirmDelete(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              className="text-xs text-state-error-fg hover:underline underline-offset-2"
+              onClick={() => setConfirmDelete(true)}
+            >
+              Remove server
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ActionButtonProps {
+  label: string;
+  busyLabel?: string;
+  anyBusy: boolean;
+  activeAction: string;
+  busyAction: string | null;
+  onClick: () => void;
+  variant?: 'primary' | 'secondary';
+}
+
+function ActionButton(props: ActionButtonProps) {
+  const { label, busyLabel, anyBusy, activeAction, busyAction, onClick, variant = 'secondary' } = props;
+  const isActive = busyAction === activeAction;
+  const base = 'text-md py-2.5 rounded border border-border-default transition-colors';
+  const disabledCls = anyBusy && !isActive ? 'opacity-50 pointer-events-none' : '';
+  const cls =
+    variant === 'primary'
+      ? `${base} bg-accent-primary text-white hover:opacity-90 ${disabledCls}`
+      : `${base} bg-surface-hover text-text-primary hover:bg-surface-raised ${disabledCls}`;
+  return (
+    <button className={cls} disabled={anyBusy} onClick={onClick}>
+      {isActive ? (busyLabel ?? label) : label}
+    </button>
+  );
+}

--- a/webview/src/components/McpModal/McpServerDetail.tsx
+++ b/webview/src/components/McpModal/McpServerDetail.tsx
@@ -4,9 +4,13 @@ import { McpServer, McpServerStatus, McpTransportType, canAuthenticate } from '@
 import { useMcpServerTools } from '@/hooks/useMcpServerTools';
 import { McpStatusBadge } from './McpStatusBadge';
 
+/** Scopes a server can live in that the CLI `add`/`remove` commands can manage. */
+const EDITABLE_SCOPES = ['user', 'project', 'local'];
+
 interface Props {
   server: McpServer;
   onBack: () => void;
+  onEdit: (server: McpServer) => void;
   onReconnect: (name: string) => Promise<void>;
   onAuthenticate: (name: string) => Promise<{ hint?: string }>;
   onClearAuth: (name: string) => Promise<{ hint?: string }>;
@@ -15,7 +19,7 @@ interface Props {
 }
 
 export function McpServerDetail(props: Props) {
-  const { server, onBack, onReconnect, onAuthenticate, onClearAuth, onToggleEnabled, onRemove } = props;
+  const { server, onBack, onEdit, onReconnect, onAuthenticate, onClearAuth, onToggleEnabled, onRemove } = props;
   const [toolsOpen, setToolsOpen] = useState(false);
   const [busyAction, setBusyAction] = useState<string | null>(null);
   const [hint, setHint] = useState<string | null>(null);
@@ -24,6 +28,13 @@ export function McpServerDetail(props: Props) {
   const busy = busyAction !== null;
   const isClaudeAiProxy = server.config?.type === McpTransportType.CLAUDEAI_PROXY;
   const canAuth = canAuthenticate(server);
+  // Editable only when we have a transport config we could re-create via the CLI,
+  // and the scope is one `claude mcp add/remove` actually manages. claude.ai
+  // connectors (claudeai-proxy / null config) are provisioned elsewhere — no Edit.
+  const canEdit =
+    server.config != null &&
+    !isClaudeAiProxy &&
+    EDITABLE_SCOPES.includes(server.scope as string);
   const isConnected = server.status === McpServerStatus.CONNECTED;
   const isDisabled = server.status === McpServerStatus.DISABLED;
   const isFailed = server.status === McpServerStatus.FAILED;
@@ -98,7 +109,20 @@ export function McpServerDetail(props: Props) {
         {/* Server header */}
         <div className="flex items-center justify-between">
           <h3 className="text-xl font-mono text-base font-semibold text-text-primary leading-none m-0">{server.name}</h3>
-          <McpStatusBadge status={server.status} />
+          <div className="flex items-center gap-2">
+            <McpStatusBadge status={server.status} />
+            {/* Edit chip — badge shape, but button background/border (see onEdit) */}
+            {canEdit && (
+              <button
+                type="button"
+                onClick={() => onEdit(server)}
+                disabled={busy}
+                className="inline-flex items-center gap-1 text-sm font-medium px-2.5 py-1.5 rounded-md flex-shrink-0 border border-border-default bg-surface-hover text-text-primary hover:bg-surface-raised transition-colors disabled:opacity-50"
+              >
+                Edit
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Config details */}

--- a/webview/src/components/McpModal/McpServerDetail.tsx
+++ b/webview/src/components/McpModal/McpServerDetail.tsx
@@ -75,7 +75,7 @@ export function McpServerDetail(props: Props) {
   }
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full min-h-0">
       {/* Header */}
       <div className="flex items-center gap-2 px-2.5 pt-4 pb-2">
         <button
@@ -87,7 +87,7 @@ export function McpServerDetail(props: Props) {
         </button>
       </div>
 
-      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-4">
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-2 space-y-4">
         {/* Error box — above server name,커서 스타일 */}
         {server.error && (
           <div className="p-3 rounded-lg border border-state-error-fg/40 bg-state-error-bg text-sm text-state-error-fg">
@@ -193,19 +193,21 @@ export function McpServerDetail(props: Props) {
                   View tools ({tools.length})
                 </button>
                 {toolsOpen && (
-                  <div className="mt-2 space-y-1">
+                  <ul className="mt-2 space-y-3.5 pl-8">
                     {tools.map((tool) => (
-                      <div key={tool.name} className="flex items-center gap-2 text-xs">
-                        <span className="font-mono text-text-primary">{tool.name}</span>
-                        {tool.annotations?.readOnly && (
-                          <span className="px-1 py-0.5 rounded bg-surface-hover text-text-tertiary">read-only</span>
-                        )}
-                        {tool.annotations?.destructive && (
-                          <span className="px-1 py-0.5 rounded bg-state-error-bg text-state-error-fg">destructive</span>
-                        )}
-                      </div>
+                      <li key={tool.name} className="list-disc">
+                        <div className="flex items-center gap-2">
+                          <span className="font-mono text-gray-400">{tool.name}</span>
+                          {tool.annotations?.readOnly && (
+                            <span className="px-1 py-0.5 rounded bg-surface-hover text-text-tertiary">read-only</span>
+                          )}
+                          {tool.annotations?.destructive && (
+                            <span className="px-1 py-0.5 rounded bg-state-error-bg text-state-error-fg">destructive</span>
+                          )}
+                        </div>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 )}
               </>
             ) : null}

--- a/webview/src/components/McpModal/McpServerList.tsx
+++ b/webview/src/components/McpModal/McpServerList.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { McpServer, McpServerScope, McpServerStatus } from '@/shared';
+import { McpStatusBadge } from './McpStatusBadge';
+
+interface Props {
+  servers: McpServer[];
+  onSelect: (name: string) => void;
+}
+
+const SCOPE_LABEL: Record<string, string> = {
+  [McpServerScope.PROJECT]: 'Project',
+  [McpServerScope.LOCAL]: 'Local',
+  [McpServerScope.USER]: 'User',
+  [McpServerScope.CLAUDEAI]: 'claude.ai',
+  [McpServerScope.MANAGED]: 'Managed',
+  [McpServerScope.ENTERPRISE]: 'Enterprise',
+};
+
+const SCOPE_ORDER: string[] = ['project', 'local', 'user', 'claudeai', 'managed', 'enterprise'];
+
+export function McpServerList(props: Props) {
+  const { servers, onSelect } = props;
+
+  const groups = useMemo(() => {
+    const map = new Map<string, McpServer[]>();
+    for (const s of servers) {
+      const key = s.scope as string;
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(s);
+    }
+    return SCOPE_ORDER
+      .filter((k) => map.has(k))
+      .concat([...map.keys()].filter((k) => !SCOPE_ORDER.includes(k)))
+      .map((k) => ({ scope: k, label: SCOPE_LABEL[k] ?? k, servers: map.get(k)! }));
+  }, [servers]);
+
+  if (servers.length === 0) {
+    return (
+      <div className="px-4 py-8 text-center text-sm text-text-tertiary">
+        No MCP servers configured.{' '}
+        <button
+          className="text-accent-primary underline underline-offset-2 hover:no-underline"
+          onClick={() => onSelect('__add__')}
+        >
+          Add one
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-2">
+      {groups.map(({ scope, label, servers: group }) => (
+        <div key={scope} className="mb-3">
+          <div className="py-1.5 text-sm font-semibold text-gray-400">
+            {label} ({group.length})
+          </div>
+          <div className="flex flex-col gap-2">
+            {group.map((server) => (
+              <button
+                key={server.name}
+                className={`w-full flex items-center justify-between p-3.5 text-left bg-surface-base border border-border-default rounded-lg hover:bg-surface-hover transition-colors ${server.status === McpServerStatus.DISABLED ? 'opacity-45' : ''}`}
+                onClick={() => onSelect(server.name)}
+              >
+                <span className="text-sm text-text-primary font-mono truncate mr-3">{server.name}</span>
+                <McpStatusBadge status={server.status} />
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/webview/src/components/McpModal/McpServerList.tsx
+++ b/webview/src/components/McpModal/McpServerList.tsx
@@ -4,6 +4,8 @@ import { McpStatusBadge } from './McpStatusBadge';
 
 interface Props {
   servers: McpServer[];
+  /** Global config path (~/.claude.json or $CLAUDE_CONFIG_DIR/.claude.json) backing user/local scopes. */
+  configPath?: string;
   onSelect: (name: string) => void;
 }
 
@@ -18,8 +20,38 @@ const SCOPE_LABEL: Record<string, string> = {
 
 const SCOPE_ORDER: string[] = ['project', 'local', 'user', 'claudeai', 'managed', 'enterprise'];
 
+/**
+ * Source location shown at the right of each scope group header, matching where
+ * `claude mcp add -s <scope>` actually writes. `configPath` is the real global
+ * config path resolved by the backend (~/.claude.json, or
+ * `$CLAUDE_CONFIG_DIR/.claude.json` when that env var is set), so the displayed
+ * path follows CLAUDE_CONFIG_DIR. claude.ai / managed / enterprise have no local
+ * config file, so they return null and are left blank.
+ */
+function scopeSource(scope: string, configPath: string): { short: string; full: string } | null {
+  switch (scope) {
+    case McpServerScope.USER:
+      return {
+        short: `$.mcpServers in ${configPath}`,
+        full: `$.mcpServers in ${configPath} — all your projects`,
+      };
+    case McpServerScope.LOCAL:
+      return {
+        short: `$.projects[<cwd>].mcpServers in ${configPath}`,
+        full: `$.projects[<cwd>].mcpServers in ${configPath} — this project only, private to you`,
+      };
+    case McpServerScope.PROJECT:
+      return {
+        short: `<project>/.mcp.json`,
+        full: `<project>/.mcp.json — shared with the team (committed to git)`,
+      };
+    default:
+      return null;
+  }
+}
+
 export function McpServerList(props: Props) {
-  const { servers, onSelect } = props;
+  const { servers, configPath = '~/.claude.json', onSelect } = props;
 
   const groups = useMemo(() => {
     const map = new Map<string, McpServer[]>();
@@ -50,10 +82,22 @@ export function McpServerList(props: Props) {
 
   return (
     <div className="flex-1 overflow-y-auto px-4 py-2">
-      {groups.map(({ scope, label, servers: group }) => (
+      {groups.map(({ scope, label, servers: group }) => {
+        const src = scopeSource(scope, configPath);
+        return (
         <div key={scope} className="mb-3">
-          <div className="py-1.5 text-sm font-semibold text-gray-400">
-            {label} ({group.length})
+          <div className="flex items-baseline justify-between gap-2 py-1.5">
+            <span className="text-sm font-semibold text-gray-400 flex-shrink-0">
+              {label} ({group.length})
+            </span>
+            {src && (
+              <span
+                className="text-xs text-text-tertiary font-mono truncate"
+                title={src.full}
+              >
+                {src.short}
+              </span>
+            )}
           </div>
           <div className="flex flex-col gap-2">
             {group.map((server) => (
@@ -68,7 +112,8 @@ export function McpServerList(props: Props) {
             ))}
           </div>
         </div>
-      ))}
+        );
+      })}
     </div>
   );
 }

--- a/webview/src/components/McpModal/McpStatusBadge.tsx
+++ b/webview/src/components/McpModal/McpStatusBadge.tsx
@@ -1,0 +1,51 @@
+import { McpServerStatus } from '@/shared';
+
+interface Props {
+  status: McpServerStatus | string;
+}
+
+interface BadgeConfig {
+  label: string;
+  icon: string;
+  pill: string | null;
+}
+
+const STATUS_CONFIG: Record<string, BadgeConfig> = {
+  [McpServerStatus.CONNECTED]: {
+    label: 'Connected',
+    icon: '✓',
+    pill: 'bg-green-600 text-white',
+  },
+  [McpServerStatus.FAILED]: {
+    label: 'Failed',
+    icon: '✕',
+    pill: 'bg-red-600 text-white',
+  },
+  [McpServerStatus.NEEDS_AUTH]: {
+    label: 'Needs Auth',
+    icon: '!',
+    pill: 'bg-yellow-500 text-white',
+  },
+  [McpServerStatus.PENDING]: {
+    label: 'Connecting…',
+    icon: '○',
+    pill: null,
+  },
+  [McpServerStatus.DISABLED]: {
+    label: 'Disabled',
+    icon: '○',
+    pill: null,
+  },
+};
+
+export function McpStatusBadge(props: Props) {
+  const { status } = props;
+  const cfg: BadgeConfig = STATUS_CONFIG[status] ?? { label: status, icon: '○', pill: null };
+
+  return (
+    <span className={`inline-flex items-center gap-1 text-sm font-medium px-2.5 py-1.5 rounded-md flex-shrink-0 ${cfg.pill || ''}`}>
+      <span className="leading-none">{cfg.icon}</span>
+      {cfg.label}
+    </span>
+  );
+}

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from 'react';
+import { XMarkIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { Portal } from '@/components/Portal';
+import { McpServer } from '@/shared';
+import { useMcpServers } from '@/hooks/useMcpServers';
+import { McpServerList } from './McpServerList';
+import { McpServerDetail } from './McpServerDetail';
+import { McpAddForm } from './McpAddForm';
+
+interface Props {
+  onClose: () => void;
+}
+
+type View = { kind: 'list' } | { kind: 'detail'; name: string } | { kind: 'add' };
+
+export function McpModal(props: Props) {
+  const { onClose } = props;
+  const { servers, loading, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
+
+  const [view, setView] = useState<View>({ kind: 'list' });
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        if (view.kind !== 'list') {
+          setView({ kind: 'list' });
+        } else {
+          onClose();
+        }
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose, view]);
+
+  function handleSelect(nameOrSpecial: string): void {
+    if (nameOrSpecial === '__add__') {
+      setView({ kind: 'add' });
+    } else {
+      setView({ kind: 'detail', name: nameOrSpecial });
+    }
+  }
+
+  function getSelectedServer(): McpServer | null {
+    if (view.kind !== 'detail') return null;
+    return servers.find((s) => s.name === view.name) ?? null;
+  }
+
+  async function handleReconnect(name: string): Promise<void> {
+    await reconnect(name);
+    await fetch();
+  }
+
+  async function handleToggle(name: string, enabled: boolean): Promise<void> {
+    await setEnabled(name, enabled);
+    await fetch();
+  }
+
+  async function handleRemove(name: string, scope: string): Promise<void> {
+    await removeServer(name, scope);
+    setView({ kind: 'list' });
+    await fetch();
+  }
+
+  async function handleAdd(
+    name: string,
+    config: Record<string, unknown>,
+    scope: string,
+  ): Promise<void> {
+    await addServer(name, config, scope);
+    setView({ kind: 'list' });
+    await fetch();
+  }
+
+  const selectedServer = getSelectedServer();
+
+  return (
+    <Portal>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-scrim"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col"
+             style={{ maxHeight: '50rem', minHeight: '32rem' }}>
+          {/* Header */}
+          {view.kind !== 'add' && (
+            <div className="flex items-center justify-between px-4 pt-4 pb-2 flex-shrink-0">
+              <h2 className="text-lg font-semibold text-text-primary">MCP servers</h2>
+              
+              <div className="flex items-center gap-1">
+                {view.kind === 'list' && (
+                  <button
+                    onClick={() => setView({ kind: 'add' })}
+                    className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors"
+                    title="Add MCP server"
+                  >
+                    <PlusIcon className="w-5 h-5" />
+                  </button>
+                )}
+                <button
+                    onClick={onClose}
+                    className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors"
+                  >
+                  <XMarkIcon className="w-5 h-5" />
+                </button>
+              </div>
+            </div>
+          )}
+
+          {/* Body */}
+          <div className="flex-1 overflow-hidden flex flex-col">
+            {loading && (
+              <div className="flex-1 flex items-center justify-center text-md text-text-tertiary">
+                Checking MCP server health…
+              </div>
+            )}
+            {!loading && error && (
+              <div className="flex-1 flex items-center justify-center px-4">
+                <p className="text-sm text-state-error-fg text-center">{error}</p>
+              </div>
+            )}
+            {!loading && !error && view.kind === 'list' && (
+              <McpServerList servers={servers} onSelect={handleSelect} />
+            )}
+            {!loading && !error && view.kind === 'detail' && selectedServer && (
+              <McpServerDetail
+                server={selectedServer}
+                onBack={() => setView({ kind: 'list' })}
+                onReconnect={handleReconnect}
+                onAuthenticate={authenticate}
+                onClearAuth={clearAuth}
+                onToggleEnabled={handleToggle}
+                onRemove={handleRemove}
+              />
+            )}
+            {!loading && !error && view.kind === 'detail' && !selectedServer && (
+              <div className="flex-1 flex items-center justify-center text-md text-text-tertiary">
+                Server not found.
+              </div>
+            )}
+            {view.kind === 'add' && (
+              <McpAddForm
+                onAdd={handleAdd}
+                onCancel={() => setView({ kind: 'list' })}
+              />
+            )}
+          </div>
+
+          {/* Footer */}
+          <div className="px-4 py-5 border-t border-border-default">
+            <a
+              href="https://docs.anthropic.com/en/docs/claude-code/mcp"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm font-semibold text-text-tertiary hover:text-text-secondary underline underline-offset-2"
+            >
+              Learn more about MCP
+            </a>
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -1,21 +1,28 @@
 import { useEffect, useState } from 'react';
-import { XMarkIcon, PlusIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PlusIcon, ArrowPathIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
-import { McpServer } from '@/shared';
+import { McpServer, McpRegistryServer } from '@/shared';
+import { ParsedMcpServer } from '@/utils/parseMcpJson';
 import { useMcpServers } from '@/hooks/useMcpServers';
+import { registryServerToPrefill } from '@/hooks/useMcpRegistry';
 import { McpServerList } from './McpServerList';
 import { McpServerDetail } from './McpServerDetail';
 import { McpAddForm } from './McpAddForm';
+import { McpMarketplace } from './McpMarketplace';
 
 interface Props {
   onClose: () => void;
 }
 
-type View = { kind: 'list' } | { kind: 'detail'; name: string } | { kind: 'add' };
+type View =
+  | { kind: 'list' }
+  | { kind: 'detail'; name: string }
+  | { kind: 'add'; prefill?: { name: string; json: string } }
+  | { kind: 'marketplace' };
 
 export function McpModal(props: Props) {
   const { onClose } = props;
-  const { servers, loading, refreshing, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
+  const { servers, configPath, loading, refreshing, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
 
   const [view, setView] = useState<View>({ kind: 'list' });
 
@@ -63,17 +70,34 @@ export function McpModal(props: Props) {
     await fetch();
   }
 
-  async function handleAdd(
-    name: string,
-    config: Record<string, unknown>,
-    scope: string,
-  ): Promise<void> {
-    await addServer(name, config, scope);
-    setView({ kind: 'list' });
+  async function handleAdd(serversToAdd: ParsedMcpServer[], scope: string): Promise<void> {
+    const failures: string[] = [];
+    for (const s of serversToAdd) {
+      try {
+        await addServer(s.name, s.config, scope);
+      } catch (err) {
+        failures.push(`${s.name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
     await fetch();
+    if (failures.length > 0) {
+      // Some (or all) failed — keep the form open so the user can fix and retry.
+      // Servers that succeeded are already reflected by the refetch above.
+      throw new Error(
+        `${failures.length}/${serversToAdd.length} server(s) failed to add:\n${failures.join('\n')}`,
+      );
+    }
+    setView({ kind: 'list' });
+  }
+
+  function handlePick(server: McpRegistryServer): void {
+    // Marketplace → Add form: pre-fill name + config JSON, let the user fill any
+    // required env/secret values, then add via the same `claude mcp add-json` path.
+    setView({ kind: 'add', prefill: registryServerToPrefill(server) });
   }
 
   const selectedServer = getSelectedServer();
+  const ownHeaderView = view.kind === 'add' || view.kind === 'marketplace';
 
   return (
     <Portal>
@@ -86,10 +110,10 @@ export function McpModal(props: Props) {
         <div className="w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col"
              style={{ maxHeight: '50rem', minHeight: '32rem' }}>
           {/* Header */}
-          {view.kind !== 'add' && (
+          {!ownHeaderView && (
             <div className="flex items-center justify-between px-4 pt-4 pb-2 flex-shrink-0">
               <h2 className="text-lg font-semibold text-text-primary">MCP servers</h2>
-              
+
               <div className="flex items-center gap-1">
                 {view.kind === 'list' && (
                   <button
@@ -99,6 +123,15 @@ export function McpModal(props: Props) {
                     title="Refresh MCP servers"
                   >
                     <ArrowPathIcon className={`w-5 h-5 ${refreshing ? 'animate-spin' : ''}`} />
+                  </button>
+                )}
+                {view.kind === 'list' && (
+                  <button
+                    onClick={() => setView({ kind: 'marketplace' })}
+                    className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors"
+                    title="Browse MCP registry"
+                  >
+                    <MagnifyingGlassIcon className="w-5 h-5" />
                   </button>
                 )}
                 {view.kind === 'list' && (
@@ -122,18 +155,20 @@ export function McpModal(props: Props) {
 
           {/* Body */}
           <div className="flex-1 overflow-hidden flex flex-col">
-            {loading && (
+            {/* loading/error reflect the configured-servers list — not the
+                marketplace or add form, which manage their own state. */}
+            {!ownHeaderView && loading && (
               <div className="flex-1 flex items-center justify-center text-md text-text-tertiary">
                 Checking MCP server health…
               </div>
             )}
-            {!loading && error && (
+            {!ownHeaderView && !loading && error && (
               <div className="flex-1 flex items-center justify-center px-4">
                 <p className="text-sm text-state-error-fg text-center">{error}</p>
               </div>
             )}
             {!loading && !error && view.kind === 'list' && (
-              <McpServerList servers={servers} onSelect={handleSelect} />
+              <McpServerList servers={servers} configPath={configPath} onSelect={handleSelect} />
             )}
             {!loading && !error && view.kind === 'detail' && selectedServer && (
               <McpServerDetail
@@ -151,8 +186,14 @@ export function McpModal(props: Props) {
                 Server not found.
               </div>
             )}
+            {view.kind === 'marketplace' && (
+              <McpMarketplace onPick={handlePick} onBack={() => setView({ kind: 'list' })} />
+            )}
             {view.kind === 'add' && (
               <McpAddForm
+                key={view.prefill?.json ?? 'blank'}
+                initialName={view.prefill?.name}
+                initialJson={view.prefill?.json}
                 onAdd={handleAdd}
                 onCancel={() => setView({ kind: 'list' })}
               />

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -184,7 +184,7 @@ export function McpModal(props: Props) {
           )}
 
           {/* Body */}
-          <div className="flex-1 overflow-hidden flex flex-col">
+          <div className="flex-1 min-h-0 overflow-hidden flex flex-col">
             {/* loading/error reflect the configured-servers list — not the
                 marketplace or add form, which manage their own state. */}
             {!ownHeaderView && loading && (

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
 import { XMarkIcon, PlusIcon, ArrowPathIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
 import { McpServer, McpRegistryServer } from '@/shared';
@@ -18,6 +19,7 @@ type View =
   | { kind: 'list' }
   | { kind: 'detail'; name: string }
   | { kind: 'add'; prefill?: { name: string; json: string } }
+  | { kind: 'edit'; name: string }
   | { kind: 'marketplace' };
 
 export function McpModal(props: Props) {
@@ -25,6 +27,9 @@ export function McpModal(props: Props) {
   const { servers, configPath, loading, refreshing, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
 
   const [view, setView] = useState<View>({ kind: 'list' });
+  // While an add/edit submit is in flight, the whole modal is locked: no input
+  // edits, no closing, no other actions. The form reports its busy state here.
+  const [formBusy, setFormBusy] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
 
   // Focus trap for the lifetime of the modal. The chat input underneath runs
@@ -58,6 +63,7 @@ export function McpModal(props: Props) {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         e.preventDefault();
+        if (formBusy) return; // locked while a save is in flight
         if (view.kind !== 'list') {
           setView({ kind: 'list' });
         } else {
@@ -67,7 +73,7 @@ export function McpModal(props: Props) {
     };
     window.addEventListener('keydown', handleKey);
     return () => window.removeEventListener('keydown', handleKey);
-  }, [onClose, view]);
+  }, [onClose, view, formBusy]);
 
   function handleSelect(nameOrSpecial: string): void {
     if (nameOrSpecial === '__add__') {
@@ -98,6 +104,46 @@ export function McpModal(props: Props) {
     await fetch();
   }
 
+  /**
+   * Edit = replace an existing server. The CLI has no `mcp edit`, so the
+   * equivalent is `remove` then `add-json` (also how a CLI user would do it).
+   * Name and scope may change here too, which naturally covers rename / move.
+   * If the re-add fails, the original config is added back so a failed edit
+   * never leaves the user with a deleted server.
+   */
+  async function handleEdit(
+    original: McpServer,
+    serversFromForm: ParsedMcpServer[],
+    newScope: string,
+  ): Promise<void> {
+    if (serversFromForm.length !== 1) {
+      throw new Error('Editing replaces a single server — paste exactly one server config.');
+    }
+    const next = serversFromForm[0];
+    const oldName = original.name;
+    const oldScope = original.scope as string;
+    const oldConfig = original.config as unknown as Record<string, unknown> | null;
+
+    await removeServer(oldName, oldScope);
+    try {
+      await addServer(next.name, next.config, newScope);
+    } catch (err) {
+      // Roll back: re-add the original so the edit didn't destroy the server.
+      if (oldConfig) {
+        try {
+          await addServer(oldName, oldConfig, oldScope);
+        } catch {
+          /* best-effort restore; surface the original failure below */
+        }
+      }
+      await fetch();
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+    await fetch();
+    toast.success(`Saved ${next.name}`);
+    setView({ kind: 'list' });
+  }
+
   async function handleAdd(serversToAdd: ParsedMcpServer[], scope: string): Promise<void> {
     const failures: string[] = [];
     for (const s of serversToAdd) {
@@ -115,6 +161,7 @@ export function McpModal(props: Props) {
         `${failures.length}/${serversToAdd.length} server(s) failed to add:\n${failures.join('\n')}`,
       );
     }
+    serversToAdd.forEach((s) => toast.success(`Added ${s.name}`));
     setView({ kind: 'list' });
   }
 
@@ -125,19 +172,21 @@ export function McpModal(props: Props) {
   }
 
   const selectedServer = getSelectedServer();
-  const ownHeaderView = view.kind === 'add' || view.kind === 'marketplace';
+  const editServer = view.kind === 'edit' ? servers.find((s) => s.name === view.name) ?? null : null;
+  const ownHeaderView = view.kind === 'add' || view.kind === 'edit' || view.kind === 'marketplace';
 
   return (
     <Portal>
       <div
         className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-scrim"
         onClick={(e) => {
+          if (formBusy) return; // locked while a save is in flight
           if (e.target === e.currentTarget) onClose();
         }}
       >
         <div ref={dialogRef}
              tabIndex={-1}
-             className="w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col focus:outline-none"
+             className={`w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col focus:outline-none ${formBusy ? 'pointer-events-none' : ''}`}
              style={{ maxHeight: '50rem', minHeight: '32rem' }}>
           {/* Header */}
           {!ownHeaderView && (
@@ -204,6 +253,7 @@ export function McpModal(props: Props) {
               <McpServerDetail
                 server={selectedServer}
                 onBack={() => setView({ kind: 'list' })}
+                onEdit={(s) => setView({ kind: 'edit', name: s.name })}
                 onReconnect={handleReconnect}
                 onAuthenticate={authenticate}
                 onClearAuth={clearAuth}
@@ -226,7 +276,25 @@ export function McpModal(props: Props) {
                 initialJson={view.prefill?.json}
                 onAdd={handleAdd}
                 onCancel={() => setView({ kind: 'list' })}
+                onBusyChange={setFormBusy}
               />
+            )}
+            {view.kind === 'edit' && editServer && (
+              <McpAddForm
+                key={`edit-${editServer.name}`}
+                mode="edit"
+                initialName={editServer.name}
+                initialScope={editServer.scope as string}
+                initialJson={JSON.stringify(editServer.config, null, 2)}
+                onAdd={(parsed, scope) => handleEdit(editServer, parsed, scope)}
+                onCancel={() => setView({ kind: 'detail', name: editServer.name })}
+                onBusyChange={setFormBusy}
+              />
+            )}
+            {view.kind === 'edit' && !editServer && (
+              <div className="flex-1 flex items-center justify-center text-md text-text-tertiary">
+                Server not found.
+              </div>
             )}
           </div>
 

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { XMarkIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PlusIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
 import { McpServer } from '@/shared';
 import { useMcpServers } from '@/hooks/useMcpServers';
@@ -15,7 +15,7 @@ type View = { kind: 'list' } | { kind: 'detail'; name: string } | { kind: 'add' 
 
 export function McpModal(props: Props) {
   const { onClose } = props;
-  const { servers, loading, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
+  const { servers, loading, refreshing, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
 
   const [view, setView] = useState<View>({ kind: 'list' });
 
@@ -91,6 +91,16 @@ export function McpModal(props: Props) {
               <h2 className="text-lg font-semibold text-text-primary">MCP servers</h2>
               
               <div className="flex items-center gap-1">
+                {view.kind === 'list' && (
+                  <button
+                    onClick={() => void fetch()}
+                    disabled={refreshing}
+                    className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors disabled:hover:bg-transparent"
+                    title="Refresh MCP servers"
+                  >
+                    <ArrowPathIcon className={`w-5 h-5 ${refreshing ? 'animate-spin' : ''}`} />
+                  </button>
+                )}
                 {view.kind === 'list' && (
                   <button
                     onClick={() => setView({ kind: 'add' })}

--- a/webview/src/components/McpModal/index.tsx
+++ b/webview/src/components/McpModal/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { XMarkIcon, PlusIcon, ArrowPathIcon, MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
 import { McpServer, McpRegistryServer } from '@/shared';
@@ -25,6 +25,34 @@ export function McpModal(props: Props) {
   const { servers, configPath, loading, refreshing, error, fetch, reconnect, setEnabled, addServer, removeServer, authenticate, clearAuth } = useMcpServers();
 
   const [view, setView] = useState<View>({ kind: 'list' });
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Focus trap for the lifetime of the modal. The chat input underneath runs
+  // auto-focus timers (window focus, visibility change, …) that pull focus to
+  // its textarea whenever activeElement falls back to document.body — which
+  // happens the moment a non-focusable area inside this modal is clicked.
+  // Without a trap, clicking a result card or empty space yanks focus to the
+  // background composer. Mirrors ConfirmDialog: remember the opener, pull focus
+  // back if it escapes while open, and restore it on close.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+
+    const handleFocusIn = (e: FocusEvent) => {
+      const dialog = dialogRef.current;
+      if (dialog && e.target instanceof Node && !dialog.contains(e.target)) {
+        dialog.focus();
+      }
+    };
+    document.addEventListener('focusin', handleFocusIn);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -107,7 +135,9 @@ export function McpModal(props: Props) {
           if (e.target === e.currentTarget) onClose();
         }}
       >
-        <div className="w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col"
+        <div ref={dialogRef}
+             tabIndex={-1}
+             className="w-full max-w-lg bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col focus:outline-none"
              style={{ maxHeight: '50rem', minHeight: '32rem' }}>
           {/* Header */}
           {!ownHeaderView && (

--- a/webview/src/hooks/__tests__/registryServerToPrefill.test.ts
+++ b/webview/src/hooks/__tests__/registryServerToPrefill.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { registryServerToPrefill } from '../useMcpRegistry';
+import { McpTransportType, McpRegistryServer } from '@/shared';
+
+function makeServer(over: Partial<McpRegistryServer>): McpRegistryServer {
+  return {
+    name: 'io.github.acme/widget',
+    description: '',
+    version: '1.0.0',
+    repositoryUrl: null,
+    config: { type: McpTransportType.STDIO, command: 'npx', args: ['-y', 'widget-mcp'] },
+    requiredInputs: [],
+    ...over,
+  };
+}
+
+describe('registryServerToPrefill', () => {
+  it('shortens a reverse-DNS name to its last path segment', () => {
+    const { name } = registryServerToPrefill(makeServer({ name: 'io.github.acme/widget' }));
+    expect(name).toBe('widget');
+  });
+
+  it('keeps the name as-is when there is no slash', () => {
+    const { name } = registryServerToPrefill(makeServer({ name: 'plainname' }));
+    expect(name).toBe('plainname');
+  });
+
+  it('stringifies the config as pretty JSON the parser can read back', () => {
+    const { json } = registryServerToPrefill(makeServer({}));
+    expect(JSON.parse(json)).toEqual({
+      type: McpTransportType.STDIO,
+      command: 'npx',
+      args: ['-y', 'widget-mcp'],
+    });
+  });
+
+  it('returns empty json when the entry has no installable config', () => {
+    const { json } = registryServerToPrefill(makeServer({ config: null }));
+    expect(json).toBe('');
+  });
+});

--- a/webview/src/hooks/useMcpRegistry.ts
+++ b/webview/src/hooks/useMcpRegistry.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query';
+import { useBridge } from './useBridge';
+import { MessageType, McpRegistryServer } from '@/shared';
+
+export interface UseMcpRegistryReturn {
+  servers: McpRegistryServer[];
+  nextCursor: string | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Search the official MCP registry. Disabled until `query` is non-empty so an
+ * empty search box does not fire a request. Results are cached per query.
+ */
+export function useMcpRegistry(query: string): UseMcpRegistryReturn {
+  const { send } = useBridge();
+  const trimmed = query.trim();
+
+  const { data, isFetching, error: queryError } = useQuery({
+    queryKey: ['mcp-registry', trimmed],
+    queryFn: async () => {
+      const res = await send<{
+        status: string;
+        servers?: McpRegistryServer[];
+        nextCursor?: string | null;
+        error?: string;
+      }>(MessageType.SEARCH_MCP_REGISTRY, { query: trimmed });
+      if (res.status === 'ok') {
+        return { servers: res.servers ?? [], nextCursor: res.nextCursor ?? null };
+      }
+      throw new Error(res.error ?? 'Failed to search the MCP registry');
+    },
+    enabled: trimmed.length > 0,
+    staleTime: 60 * 1000,
+    retry: false,
+  });
+
+  const error =
+    queryError instanceof Error ? queryError.message : queryError != null ? String(queryError) : null;
+
+  return {
+    servers: data?.servers ?? [],
+    nextCursor: data?.nextCursor ?? null,
+    loading: isFetching,
+    error,
+  };
+}
+
+/**
+ * Convert a registry entry into pre-filled values for the Add form.
+ * The reverse-DNS name (e.g. "io.github.acme/widget") is shortened to its last
+ * path segment as a sensible default the user can edit; the config is stringified
+ * as the JSON the smart parser will read back.
+ */
+export function registryServerToPrefill(server: McpRegistryServer): { name: string; json: string } {
+  const name = server.name.split('/').pop() || server.name;
+  const json = server.config ? JSON.stringify(server.config, null, 2) : '';
+  return { name, json };
+}

--- a/webview/src/hooks/useMcpServerTools.ts
+++ b/webview/src/hooks/useMcpServerTools.ts
@@ -1,0 +1,37 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useBridge } from './useBridge';
+import { MessageType, McpServerConfig, McpServerTool } from '@/shared';
+
+/**
+ * Fetch one MCP server's tool list on demand (used by the server detail view).
+ *
+ * The backend connects to the server via the MCP SDK and runs the standard
+ * `tools/list` — there is no `claude` CLI command for this. We pass the server's
+ * `config` (already known from the list) so the backend doesn't re-run
+ * `claude mcp get`. Only enabled for connected, probeable servers.
+ */
+export function useMcpServerTools(
+  name: string,
+  config: McpServerConfig | null,
+  enabled: boolean,
+): UseQueryResult<McpServerTool[], Error> {
+  const { send } = useBridge();
+
+  return useQuery({
+    queryKey: ['mcp-tools', name],
+    enabled: enabled && config !== null,
+    queryFn: async () => {
+      const res = await send<{ status: string; tools?: McpServerTool[]; error?: string }>(
+        MessageType.GET_MCP_SERVER_TOOLS,
+        { name, config },
+      );
+      if (res.status === 'ok') return res.tools ?? [];
+      throw new Error(res.error ?? 'Failed to load tools');
+    },
+    // A server's tools rarely change between reconnects, so cache briefly to
+    // avoid re-connecting every time the user re-opens the same detail view.
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    retry: false,
+  });
+}

--- a/webview/src/hooks/useMcpServers.ts
+++ b/webview/src/hooks/useMcpServers.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useBridge } from './useBridge';
-import { MessageType, McpServer } from '@/shared';
+import { MessageType, McpServer, McpServerStatus } from '@/shared';
 
 export const MCP_SERVERS_QUERY_KEY = ['mcp-servers'] as const;
 
@@ -61,7 +61,29 @@ export function useMcpServers(): UseMcpServersReturn {
     mutationFn: async ({ name, enabled }: { name: string; enabled: boolean }) => {
       await send(MessageType.SET_MCP_SERVER_ENABLED, { name, enabled });
     },
-    onSuccess: () => { void invalidate(); },
+    // Optimistically reflect the toggle: a full refetch re-runs every server's
+    // health check (seconds), so without this the list/detail looks stale until
+    // it completes. onSettled re-syncs with the backend's real status.
+    onMutate: async ({ name, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: MCP_SERVERS_QUERY_KEY });
+      const previous = queryClient.getQueryData<McpServer[]>(MCP_SERVERS_QUERY_KEY);
+      queryClient.setQueryData<McpServer[]>(MCP_SERVERS_QUERY_KEY, (old) =>
+        (old ?? []).map((s) =>
+          s.name === name
+            ? {
+                ...s,
+                status: enabled ? McpServerStatus.PENDING : McpServerStatus.DISABLED,
+                error: enabled ? s.error : null,
+              }
+            : s,
+        ),
+      );
+      return { previous };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.previous) queryClient.setQueryData(MCP_SERVERS_QUERY_KEY, ctx.previous);
+    },
+    onSettled: () => { void invalidate(); },
   });
 
   const addServerMutation = useMutation({

--- a/webview/src/hooks/useMcpServers.ts
+++ b/webview/src/hooks/useMcpServers.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useBridge } from './useBridge';
+import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import { MessageType, McpServer, McpServerStatus } from '@/shared';
 
 export const MCP_SERVERS_QUERY_KEY = ['mcp-servers'] as const;
@@ -29,12 +30,20 @@ export interface UseMcpServersReturn {
 export function useMcpServers(): UseMcpServersReturn {
   const { send } = useBridge();
   const queryClient = useQueryClient();
+  // The CLI's project/local scope (.mcp.json) is cwd-relative, so every MCP
+  // command must run in the active workspace root — the same dir chat uses.
+  const { workingDirectory } = useWorkingDir();
+  const workingDir = workingDirectory ?? undefined;
+  // Key by workspace so switching projects refetches instead of showing stale
+  // project-scope servers. invalidate() below matches the prefix either way.
+  const mcpQueryKey = [...MCP_SERVERS_QUERY_KEY, workingDirectory] as const;
 
   const { data, isPending: loading, isFetching: refreshing, error: queryError } = useQuery({
-    queryKey: MCP_SERVERS_QUERY_KEY,
+    queryKey: mcpQueryKey,
     queryFn: async (): Promise<McpServersData> => {
       const res = await send<{ status: string; servers?: McpServer[]; configPath?: string; error?: string }>(
         MessageType.GET_MCP_SERVERS,
+        { workingDir },
       );
       if (res.status === 'ok' && res.servers) {
         return { servers: res.servers, configPath: res.configPath };
@@ -60,7 +69,7 @@ export function useMcpServers(): UseMcpServersReturn {
     mutationFn: async (name: string) => {
       const res = await send<{ status: string; server?: McpServer; error?: string }>(
         MessageType.RECONNECT_MCP_SERVER,
-        { name },
+        { name, workingDir },
       );
       return res.server ?? null;
     },
@@ -76,8 +85,8 @@ export function useMcpServers(): UseMcpServersReturn {
     // it completes. onSettled re-syncs with the backend's real status.
     onMutate: async ({ name, enabled }) => {
       await queryClient.cancelQueries({ queryKey: MCP_SERVERS_QUERY_KEY });
-      const previous = queryClient.getQueryData<McpServersData>(MCP_SERVERS_QUERY_KEY);
-      queryClient.setQueryData<McpServersData>(MCP_SERVERS_QUERY_KEY, (old) =>
+      const previous = queryClient.getQueryData<McpServersData>(mcpQueryKey);
+      queryClient.setQueryData<McpServersData>(mcpQueryKey, (old) =>
         old
           ? {
               ...old,
@@ -96,14 +105,14 @@ export function useMcpServers(): UseMcpServersReturn {
       return { previous };
     },
     onError: (_err, _vars, ctx) => {
-      if (ctx?.previous) queryClient.setQueryData(MCP_SERVERS_QUERY_KEY, ctx.previous);
+      if (ctx?.previous) queryClient.setQueryData(mcpQueryKey, ctx.previous);
     },
     onSettled: () => { void invalidate(); },
   });
 
   const addServerMutation = useMutation({
     mutationFn: async ({ name, config, scope }: { name: string; config: Record<string, unknown>; scope: string }) => {
-      const res = await send<{ status: string; error?: string }>(MessageType.ADD_MCP_SERVER, { name, config, scope });
+      const res = await send<{ status: string; error?: string }>(MessageType.ADD_MCP_SERVER, { name, config, scope, workingDir });
       if (res.status !== 'ok') throw new Error(res.error ?? 'Failed to add MCP server');
     },
     onSuccess: () => { void invalidate(); },
@@ -111,7 +120,7 @@ export function useMcpServers(): UseMcpServersReturn {
 
   const removeServerMutation = useMutation({
     mutationFn: async ({ name, scope }: { name: string; scope: string }) => {
-      const res = await send<{ status: string; error?: string }>(MessageType.REMOVE_MCP_SERVER, { name, scope });
+      const res = await send<{ status: string; error?: string }>(MessageType.REMOVE_MCP_SERVER, { name, scope, workingDir });
       if (res.status !== 'ok') throw new Error(res.error ?? 'Failed to remove MCP server');
     },
     onSuccess: () => { void invalidate(); },

--- a/webview/src/hooks/useMcpServers.ts
+++ b/webview/src/hooks/useMcpServers.ts
@@ -1,0 +1,109 @@
+import { useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useBridge } from './useBridge';
+import { MessageType, McpServer } from '@/shared';
+
+export const MCP_SERVERS_QUERY_KEY = ['mcp-servers'] as const;
+
+export interface UseMcpServersReturn {
+  servers: McpServer[];
+  loading: boolean;
+  error: string | null;
+  fetch: () => Promise<void>;
+  reconnect: (name: string) => Promise<McpServer | null>;
+  setEnabled: (name: string, enabled: boolean) => Promise<void>;
+  addServer: (name: string, config: Record<string, unknown>, scope: string) => Promise<void>;
+  removeServer: (name: string, scope: string) => Promise<void>;
+  authenticate: (name: string) => Promise<{ hint?: string }>;
+  clearAuth: (name: string) => Promise<{ hint?: string }>;
+}
+
+export function useMcpServers(): UseMcpServersReturn {
+  const { send } = useBridge();
+  const queryClient = useQueryClient();
+
+  const { data: servers = [], isPending: loading, error: queryError } = useQuery({
+    queryKey: MCP_SERVERS_QUERY_KEY,
+    queryFn: async () => {
+      const res = await send<{ status: string; servers?: McpServer[]; error?: string }>(
+        MessageType.GET_MCP_SERVERS,
+      );
+      if (res.status === 'ok' && res.servers) {
+        return res.servers;
+      }
+      throw new Error(res.error ?? 'Failed to load MCP servers');
+    },
+    // MCP 서버 상태는 런타임에 변경되므로 stale=0 — gcTime 내에선 캐시 즉시 표시 후 백그라운드 refresh
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    retry: false,
+  });
+
+  const error = queryError instanceof Error ? queryError.message : (queryError != null ? String(queryError) : null);
+
+  const invalidate = useCallback(
+    async () => { await queryClient.invalidateQueries({ queryKey: MCP_SERVERS_QUERY_KEY }); },
+    [queryClient],
+  );
+
+  const reconnectMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await send<{ status: string; server?: McpServer; error?: string }>(
+        MessageType.RECONNECT_MCP_SERVER,
+        { name },
+      );
+      return res.server ?? null;
+    },
+    onSuccess: () => { void invalidate(); },
+  });
+
+  const setEnabledMutation = useMutation({
+    mutationFn: async ({ name, enabled }: { name: string; enabled: boolean }) => {
+      await send(MessageType.SET_MCP_SERVER_ENABLED, { name, enabled });
+    },
+    onSuccess: () => { void invalidate(); },
+  });
+
+  const addServerMutation = useMutation({
+    mutationFn: async ({ name, config, scope }: { name: string; config: Record<string, unknown>; scope: string }) => {
+      const res = await send<{ status: string; error?: string }>(MessageType.ADD_MCP_SERVER, { name, config, scope });
+      if (res.status !== 'ok') throw new Error(res.error ?? 'Failed to add MCP server');
+    },
+    onSuccess: () => { void invalidate(); },
+  });
+
+  const removeServerMutation = useMutation({
+    mutationFn: async ({ name, scope }: { name: string; scope: string }) => {
+      const res = await send<{ status: string; error?: string }>(MessageType.REMOVE_MCP_SERVER, { name, scope });
+      if (res.status !== 'ok') throw new Error(res.error ?? 'Failed to remove MCP server');
+    },
+    onSuccess: () => { void invalidate(); },
+  });
+
+  const authenticateMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await send<{ status: string; hint?: string }>(MessageType.AUTHENTICATE_MCP_SERVER, { name });
+      return { hint: res.hint };
+    },
+  });
+
+  const clearAuthMutation = useMutation({
+    mutationFn: async (name: string) => {
+      const res = await send<{ status: string; hint?: string }>(MessageType.CLEAR_MCP_SERVER_AUTH, { name });
+      return { hint: res.hint };
+    },
+  });
+
+  return {
+    servers,
+    loading,
+    error,
+    fetch: invalidate,
+    reconnect: (name) => reconnectMutation.mutateAsync(name),
+    setEnabled: (name, enabled) => setEnabledMutation.mutateAsync({ name, enabled }),
+    addServer: (name, config, scope) => addServerMutation.mutateAsync({ name, config, scope }),
+    removeServer: (name, scope) => removeServerMutation.mutateAsync({ name, scope }),
+    authenticate: (name) => authenticateMutation.mutateAsync(name),
+    clearAuth: (name) => clearAuthMutation.mutateAsync(name),
+  };
+}

--- a/webview/src/hooks/useMcpServers.ts
+++ b/webview/src/hooks/useMcpServers.ts
@@ -8,6 +8,7 @@ export const MCP_SERVERS_QUERY_KEY = ['mcp-servers'] as const;
 export interface UseMcpServersReturn {
   servers: McpServer[];
   loading: boolean;
+  refreshing: boolean;
   error: string | null;
   fetch: () => Promise<void>;
   reconnect: (name: string) => Promise<McpServer | null>;
@@ -22,7 +23,7 @@ export function useMcpServers(): UseMcpServersReturn {
   const { send } = useBridge();
   const queryClient = useQueryClient();
 
-  const { data: servers = [], isPending: loading, error: queryError } = useQuery({
+  const { data: servers = [], isPending: loading, isFetching: refreshing, error: queryError } = useQuery({
     queryKey: MCP_SERVERS_QUERY_KEY,
     queryFn: async () => {
       const res = await send<{ status: string; servers?: McpServer[]; error?: string }>(
@@ -119,6 +120,7 @@ export function useMcpServers(): UseMcpServersReturn {
   return {
     servers,
     loading,
+    refreshing,
     error,
     fetch: invalidate,
     reconnect: (name) => reconnectMutation.mutateAsync(name),

--- a/webview/src/hooks/useMcpServers.ts
+++ b/webview/src/hooks/useMcpServers.ts
@@ -5,8 +5,15 @@ import { MessageType, McpServer, McpServerStatus } from '@/shared';
 
 export const MCP_SERVERS_QUERY_KEY = ['mcp-servers'] as const;
 
+interface McpServersData {
+  servers: McpServer[];
+  configPath?: string;
+}
+
 export interface UseMcpServersReturn {
   servers: McpServer[];
+  /** Display path of the global config file (~/.claude.json or $CLAUDE_CONFIG_DIR/.claude.json). */
+  configPath?: string;
   loading: boolean;
   refreshing: boolean;
   error: string | null;
@@ -23,14 +30,14 @@ export function useMcpServers(): UseMcpServersReturn {
   const { send } = useBridge();
   const queryClient = useQueryClient();
 
-  const { data: servers = [], isPending: loading, isFetching: refreshing, error: queryError } = useQuery({
+  const { data, isPending: loading, isFetching: refreshing, error: queryError } = useQuery({
     queryKey: MCP_SERVERS_QUERY_KEY,
-    queryFn: async () => {
-      const res = await send<{ status: string; servers?: McpServer[]; error?: string }>(
+    queryFn: async (): Promise<McpServersData> => {
+      const res = await send<{ status: string; servers?: McpServer[]; configPath?: string; error?: string }>(
         MessageType.GET_MCP_SERVERS,
       );
       if (res.status === 'ok' && res.servers) {
-        return res.servers;
+        return { servers: res.servers, configPath: res.configPath };
       }
       throw new Error(res.error ?? 'Failed to load MCP servers');
     },
@@ -40,6 +47,8 @@ export function useMcpServers(): UseMcpServersReturn {
     retry: false,
   });
 
+  const servers = data?.servers ?? [];
+  const configPath = data?.configPath;
   const error = queryError instanceof Error ? queryError.message : (queryError != null ? String(queryError) : null);
 
   const invalidate = useCallback(
@@ -67,17 +76,22 @@ export function useMcpServers(): UseMcpServersReturn {
     // it completes. onSettled re-syncs with the backend's real status.
     onMutate: async ({ name, enabled }) => {
       await queryClient.cancelQueries({ queryKey: MCP_SERVERS_QUERY_KEY });
-      const previous = queryClient.getQueryData<McpServer[]>(MCP_SERVERS_QUERY_KEY);
-      queryClient.setQueryData<McpServer[]>(MCP_SERVERS_QUERY_KEY, (old) =>
-        (old ?? []).map((s) =>
-          s.name === name
-            ? {
-                ...s,
-                status: enabled ? McpServerStatus.PENDING : McpServerStatus.DISABLED,
-                error: enabled ? s.error : null,
-              }
-            : s,
-        ),
+      const previous = queryClient.getQueryData<McpServersData>(MCP_SERVERS_QUERY_KEY);
+      queryClient.setQueryData<McpServersData>(MCP_SERVERS_QUERY_KEY, (old) =>
+        old
+          ? {
+              ...old,
+              servers: old.servers.map((s) =>
+                s.name === name
+                  ? {
+                      ...s,
+                      status: enabled ? McpServerStatus.PENDING : McpServerStatus.DISABLED,
+                      error: enabled ? s.error : null,
+                    }
+                  : s,
+              ),
+            }
+          : old,
       );
       return { previous };
     },
@@ -119,6 +133,7 @@ export function useMcpServers(): UseMcpServersReturn {
 
   return {
     servers,
+    configPath,
     loading,
     refreshing,
     error,

--- a/webview/src/pages/ChatPage/EmptyState.tsx
+++ b/webview/src/pages/ChatPage/EmptyState.tsx
@@ -18,7 +18,7 @@ export const EmptyState = () => {
       "Tired of repeating yourself? Tell Claude to remember what you've told it using CLAUDE.md.",
       <>Press <kbd className={kbdClass}>Shift</kbd> <kbd className={kbdClass}>Tab</kbd> to automatically approve code edits</>,
       <>Highlight any text and press <kbd className={kbdClass}>{isMac ? 'Option' : 'Alt'}</kbd> <kbd className={kbdClass}>K</kbd> to chat about it</>,
-      <>Type <kbd className={kbdClass}>/manage-mcp</kbd> to add, remove, and manage MCP servers right here.</>,
+      <>Type <kbd className={kbdClass}>/mcp</kbd> to add, remove, and manage MCP servers right here.</>,
       <>Use planning mode to talk through big changes before a commit. Press <kbd className={kbdClass}>Shift</kbd> <kbd className={kbdClass}>Tab</kbd> to cycle between modes.</>,
       'Type /model to pick the right tool for the job.',
       "You've come to the absolutely right place!",

--- a/webview/src/pages/ChatPage/EmptyState.tsx
+++ b/webview/src/pages/ChatPage/EmptyState.tsx
@@ -18,7 +18,7 @@ export const EmptyState = () => {
       "Tired of repeating yourself? Tell Claude to remember what you've told it using CLAUDE.md.",
       <>Press <kbd className={kbdClass}>Shift</kbd> <kbd className={kbdClass}>Tab</kbd> to automatically approve code edits</>,
       <>Highlight any text and press <kbd className={kbdClass}>{isMac ? 'Option' : 'Alt'}</kbd> <kbd className={kbdClass}>K</kbd> to chat about it</>,
-      "Use Claude Code in the terminal to configure MCP servers. They'll work here, too!",
+      <>Type <kbd className={kbdClass}>/manage-mcp</kbd> to add, remove, and manage MCP servers right here.</>,
       <>Use planning mode to talk through big changes before a commit. Press <kbd className={kbdClass}>Shift</kbd> <kbd className={kbdClass}>Tab</kbd> to cycle between modes.</>,
       'Type /model to pick the right tool for the job.',
       "You've come to the absolutely right place!",

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -11,6 +11,10 @@ import { UpdateBanner } from './UpdateBanner';
 import { ConnectionLostBanner } from './ConnectionLostBanner';
 import { BrowserPermissionBanner } from './BrowserPermissionBanner';
 import { BackgroundTasksPanel } from './BackgroundTasksPanel';
+import { McpModal } from '@/components/McpModal';
+import { OPEN_MCP_MODAL_EVENT } from '@/commandPalette/sections/customize/items';
+import { useMcpServers, MCP_SERVERS_QUERY_KEY } from '@/hooks/useMcpServers';
+import { useQueryClient } from '@tanstack/react-query';
 import { useChatInputFocus } from '../../contexts/ChatInputFocusContext';
 import { useChatStreamContext } from '../../contexts/ChatStreamContext';
 import { useSessionContext } from '../../contexts/SessionContext';
@@ -27,6 +31,22 @@ import { clampAutoScrollThreshold, nextAutoFollow, shouldShowScrollToBottom, AUT
 export function ChatPage() {
   // Redirect logged-out users to the login screen before they hit a failing chat.
   useLoginGate();
+
+  // pre-fetch: ChatPage 마운트 시 query를 활성화해 모달이 즉시 표시되도록
+  useMcpServers();
+  const queryClient = useQueryClient();
+  const [mcpModalOpen, setMcpModalOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = () => {
+      // 모달 오픈 시 캐시 invalidate → 최신 상태 보장
+      void queryClient.invalidateQueries({ queryKey: MCP_SERVERS_QUERY_KEY });
+      setMcpModalOpen(true);
+    };
+    window.addEventListener(OPEN_MCP_MODAL_EVENT, handler);
+    return () => window.removeEventListener(OPEN_MCP_MODAL_EVENT, handler);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const { textareaRef, focus: focusInput } = useChatInputFocus();
   const { currentSessionId, currentSession } = useSessionContext();
@@ -225,6 +245,7 @@ export function ChatPage() {
       )}
 
       <BackgroundTasksPanel />
+      {mcpModalOpen && <McpModal onClose={() => setMcpModalOpen(false)} />}
     </div>
   );
 }

--- a/webview/src/shared/index.ts
+++ b/webview/src/shared/index.ts
@@ -1,4 +1,5 @@
 export * from './account';
 export * from './client-env';
+export * from './mcp';
 export * from './message-type';
 export * from './workflow';

--- a/webview/src/shared/mcp.ts
+++ b/webview/src/shared/mcp.ts
@@ -1,0 +1,108 @@
+/**
+ * Shared MCP (Model Context Protocol) server management types.
+ *
+ * NOTE: This file is mirrored 1:1 in `webview/src/shared/mcp.ts`.
+ * Any edit here MUST be copied there (see `shared/CLAUDE.md`).
+ */
+
+/** Runtime connection status of an MCP server. Source: `claude mcp list/get` or control protocol. */
+export enum McpServerStatus {
+  CONNECTED = 'connected',
+  FAILED = 'failed',
+  /** Server requires authentication before it can connect. */
+  NEEDS_AUTH = 'needs-auth',
+  /** Connection attempt in progress. */
+  PENDING = 'pending',
+  /** Manually disabled by the user (disabledMcpServers list). Not reported by CLI — derived from config file. */
+  DISABLED = 'disabled',
+}
+
+/** Config scope the server belongs to. Used as the list grouping key. */
+export enum McpServerScope {
+  /** ~/.mcp.json or `.mcp.json` in the project root. */
+  PROJECT = 'project',
+  /** Local project-level config (settings.local.json or .clauderc). */
+  LOCAL = 'local',
+  /** User-level config in ~/.claude.json. */
+  USER = 'user',
+  /** Managed by claude.ai (connectors like Gmail, Calendar, Notion). */
+  CLAUDEAI = 'claudeai',
+  MANAGED = 'managed',
+  ENTERPRISE = 'enterprise',
+}
+
+/** Transport protocol of the MCP server. */
+export enum McpTransportType {
+  STDIO = 'stdio',
+  HTTP = 'http',
+  /** Server-Sent Events (legacy, deprecated upstream). */
+  SSE = 'sse',
+  WS = 'ws',
+  /** claude.ai managed connector (OAuth via claude.ai org URL, no Clear auth). */
+  CLAUDEAI_PROXY = 'claudeai-proxy',
+}
+
+export interface McpServerConfig {
+  type: McpTransportType;
+  /** stdio: the executable command. */
+  command?: string;
+  /** stdio: positional arguments to the command. */
+  args?: string[];
+  /** stdio: environment variable overrides passed to the server process. */
+  env?: Record<string, string>;
+  /** http / sse / ws: server endpoint URL. */
+  url?: string;
+  /** http: extra request headers. */
+  headers?: Record<string, string>;
+  /** claudeai-proxy: internal connector identifier. */
+  id?: string;
+  /** claudeai-proxy: human-readable connector display name. */
+  displayName?: string;
+  /** claudeai-proxy: connector icon URL. */
+  iconUrl?: string;
+}
+
+export interface McpServerTool {
+  name: string;
+  annotations?: {
+    /** Tool only reads data — no side effects. */
+    readOnly?: boolean;
+    /** Tool can perform irreversible destructive operations. */
+    destructive?: boolean;
+  };
+}
+
+export interface McpServer {
+  name: string;
+  status: McpServerStatus;
+  /** Grouping key for the list UI. Cast to McpServerScope when known; raw string otherwise. */
+  scope: McpServerScope | string;
+  /**
+   * Null when the CLI does not report transport details for this server
+   * (e.g. claude.ai connectors, or servers added without an explicit type).
+   * WebView: filter out "Add transport" prompts for null-config servers.
+   */
+  config: McpServerConfig | null;
+  /** Available tools reported by the server. Empty array when not yet fetched. */
+  tools: McpServerTool[];
+  /** Human-readable error message, populated when status === FAILED or NEEDS_AUTH. */
+  error: string | null;
+}
+
+/** Payload of GET_MCP_SERVERS ACK response. */
+export interface McpServersResult {
+  servers: McpServer[];
+}
+
+/**
+ * xme rule (from Cursor source analysis): only sse/http/claudeai-proxy servers
+ * expose authentication buttons. stdio servers have no auth flow.
+ */
+export function canAuthenticate(server: McpServer): boolean {
+  if (!server.config) return false;
+  return (
+    server.config.type === McpTransportType.SSE ||
+    server.config.type === McpTransportType.HTTP ||
+    server.config.type === McpTransportType.CLAUDEAI_PROXY
+  );
+}

--- a/webview/src/shared/mcp.ts
+++ b/webview/src/shared/mcp.ts
@@ -92,6 +92,43 @@ export interface McpServer {
 /** Payload of GET_MCP_SERVERS ACK response. */
 export interface McpServersResult {
   servers: McpServer[];
+  /**
+   * Display path of the global config file that backs the user/local scopes —
+   * `~/.claude.json`, or `$CLAUDE_CONFIG_DIR/.claude.json` when that env var is set.
+   * Used to label scope groups with their real source path.
+   */
+  configPath?: string;
+}
+
+/**
+ * A single MCP server entry from the official MCP Registry, normalised into a
+ * config ready for the Add form (`claude mcp add-json` shape).
+ *
+ * Source: https://registry.modelcontextprotocol.io/v0/servers (Generic MCP
+ * Registry API). The raw entry's packages[]/remotes[] are converted server-side
+ * into a single `config`; env vars / headers that need a user-supplied value are
+ * listed in `requiredInputs` so the UI can flag them.
+ */
+export interface McpRegistryServer {
+  /** Reverse-DNS identifier, e.g. "io.github.owner/server-name". */
+  name: string;
+  /** Short human-readable summary (may be empty). */
+  description: string;
+  /** Latest version string reported by the registry. */
+  version: string;
+  /** Source repository URL, or null when not reported. */
+  repositoryUrl: string | null;
+  /** Pre-built config for the Add form. Null when the entry has no installable package/remote. */
+  config: McpServerConfig | null;
+  /** Names of env vars / headers the user must fill in before the server will connect. */
+  requiredInputs: string[];
+}
+
+/** Payload of SEARCH_MCP_REGISTRY ACK response. */
+export interface McpRegistrySearchResult {
+  servers: McpRegistryServer[];
+  /** Opaque cursor for the next page, or null when there are no more results. */
+  nextCursor: string | null;
 }
 
 /**

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -163,6 +163,8 @@ export enum MessageType {
   ADD_MCP_SERVER = 'ADD_MCP_SERVER',
   /** Remove a named MCP server via `claude mcp remove`. inbound webview→backend */
   REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
+  /** Search the official MCP registry for installable servers. inbound webview→backend */
+  SEARCH_MCP_REGISTRY = 'SEARCH_MCP_REGISTRY',
 
   // -- Plugin updates --
   /** Check for available plugin updates. */

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -165,6 +165,8 @@ export enum MessageType {
   REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
   /** Search the official MCP registry for installable servers. inbound webview→backend */
   SEARCH_MCP_REGISTRY = 'SEARCH_MCP_REGISTRY',
+  /** Fetch the tool list of one MCP server by connecting to it (MCP tools/list). inbound webview→backend */
+  GET_MCP_SERVER_TOOLS = 'GET_MCP_SERVER_TOOLS',
 
   // -- Plugin updates --
   /** Check for available plugin updates. */

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -146,6 +146,24 @@ export enum MessageType {
   /** Detect the path to the `node` binary. */
   GET_DETECTED_NODE_PATH = 'GET_DETECTED_NODE_PATH',
 
+  // -- MCP server management --
+  /** List all MCP servers with status, scope, and config. inbound webview→backend */
+  GET_MCP_SERVERS = 'GET_MCP_SERVERS',
+  /** Reconnect (restart) a named MCP server. inbound webview→backend */
+  RECONNECT_MCP_SERVER = 'RECONNECT_MCP_SERVER',
+  /** Trigger the OAuth/auth flow for a named MCP server. inbound webview→backend */
+  AUTHENTICATE_MCP_SERVER = 'AUTHENTICATE_MCP_SERVER',
+  /** Clear saved authentication for a named MCP server. inbound webview→backend */
+  CLEAR_MCP_SERVER_AUTH = 'CLEAR_MCP_SERVER_AUTH',
+  /** Enable or disable a named MCP server (edits disabledMcpServers in config). inbound webview→backend */
+  SET_MCP_SERVER_ENABLED = 'SET_MCP_SERVER_ENABLED',
+  /** Submit a manual OAuth callback URL after a failed redirect. inbound webview→backend */
+  SUBMIT_MCP_OAUTH_CALLBACK_URL = 'SUBMIT_MCP_OAUTH_CALLBACK_URL',
+  /** Add a new MCP server via `claude mcp add-json`. inbound webview→backend */
+  ADD_MCP_SERVER = 'ADD_MCP_SERVER',
+  /** Remove a named MCP server via `claude mcp remove`. inbound webview→backend */
+  REMOVE_MCP_SERVER = 'REMOVE_MCP_SERVER',
+
   // -- Plugin updates --
   /** Check for available plugin updates. */
   GET_PLUGIN_UPDATES = 'GET_PLUGIN_UPDATES',

--- a/webview/src/utils/__tests__/parseMcpJson.test.ts
+++ b/webview/src/utils/__tests__/parseMcpJson.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import { parseMcpJson } from '../parseMcpJson';
+
+describe('parseMcpJson', () => {
+  describe('invalid input', () => {
+    it('rejects empty input', () => {
+      const r = parseMcpJson('', 'fallback');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects whitespace-only input', () => {
+      const r = parseMcpJson('   \n  ', 'fallback');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects malformed JSON', () => {
+      const r = parseMcpJson('{ not json', 'fallback');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.toLowerCase()).toContain('json');
+    });
+
+    it('rejects a JSON array at the top level', () => {
+      const r = parseMcpJson('[1, 2, 3]', 'fallback');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects a JSON primitive at the top level', () => {
+      const r = parseMcpJson('"hello"', 'fallback');
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe('mcpServers wrapper form', () => {
+    it('extracts a single stdio server from the wrapper, ignoring nameFallback', () => {
+      const input = JSON.stringify({
+        mcpServers: {
+          'my-server': { command: 'npx', args: ['-y', 'my-mcp-server'] },
+        },
+      });
+      const r = parseMcpJson(input, 'IGNORED');
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.servers).toHaveLength(1);
+        expect(r.servers[0].name).toBe('my-server');
+        expect(r.servers[0].config).toEqual({ command: 'npx', args: ['-y', 'my-mcp-server'] });
+      }
+    });
+
+    it('extracts multiple servers from the wrapper', () => {
+      const input = JSON.stringify({
+        mcpServers: {
+          a: { command: 'cmd-a' },
+          b: { type: 'http', url: 'https://example.com/mcp' },
+        },
+      });
+      const r = parseMcpJson(input, '');
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.servers).toHaveLength(2);
+        expect(r.servers.map((s) => s.name).sort()).toEqual(['a', 'b']);
+      }
+    });
+
+    it('preserves the original config verbatim (no key renaming or type injection)', () => {
+      const config = { command: 'npx', args: ['x'], env: { K: 'v' } };
+      const input = JSON.stringify({ mcpServers: { s: config } });
+      const r = parseMcpJson(input, '');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.servers[0].config).toEqual(config);
+    });
+
+    it('rejects an empty mcpServers object', () => {
+      const r = parseMcpJson(JSON.stringify({ mcpServers: {} }), 'fallback');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects a wrapper entry whose value is not an object', () => {
+      const r = parseMcpJson(JSON.stringify({ mcpServers: { s: 'oops' } }), '');
+      expect(r.ok).toBe(false);
+    });
+
+    it('rejects a wrapper entry with neither command nor url', () => {
+      const r = parseMcpJson(JSON.stringify({ mcpServers: { s: { args: ['x'] } } }), '');
+      expect(r.ok).toBe(false);
+    });
+  });
+
+  describe('inner config form (no wrapper)', () => {
+    it('uses nameFallback for a bare stdio config', () => {
+      const input = JSON.stringify({ command: 'npx', args: ['-y', 'pkg'] });
+      const r = parseMcpJson(input, 'my-name');
+      expect(r.ok).toBe(true);
+      if (r.ok) {
+        expect(r.servers).toHaveLength(1);
+        expect(r.servers[0].name).toBe('my-name');
+        expect(r.servers[0].config).toEqual({ command: 'npx', args: ['-y', 'pkg'] });
+      }
+    });
+
+    it('accepts a bare remote (url) config', () => {
+      const input = JSON.stringify({ type: 'http', url: 'https://example.com/mcp' });
+      const r = parseMcpJson(input, 'remote');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.servers[0].config).toEqual({ type: 'http', url: 'https://example.com/mcp' });
+    });
+
+    it('rejects a bare config when nameFallback is empty', () => {
+      const r = parseMcpJson(JSON.stringify({ command: 'npx' }), '');
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.error.toLowerCase()).toContain('name');
+    });
+
+    it('rejects a bare config when nameFallback is whitespace', () => {
+      const r = parseMcpJson(JSON.stringify({ command: 'npx' }), '   ');
+      expect(r.ok).toBe(false);
+    });
+
+    it('trims the fallback name', () => {
+      const r = parseMcpJson(JSON.stringify({ command: 'npx' }), '  spaced  ');
+      expect(r.ok).toBe(true);
+      if (r.ok) expect(r.servers[0].name).toBe('spaced');
+    });
+
+    it('rejects a bare config with neither command nor url', () => {
+      const r = parseMcpJson(JSON.stringify({ foo: 'bar' }), 'name');
+      expect(r.ok).toBe(false);
+    });
+  });
+});

--- a/webview/src/utils/parseMcpJson.ts
+++ b/webview/src/utils/parseMcpJson.ts
@@ -1,0 +1,86 @@
+/**
+ * Smart parser for the "Add MCP Server" paste box.
+ *
+ * Accepts the two JSON shapes users actually copy from the wild and normalises
+ * them into a list of { name, config } pairs ready for `claude mcp add-json`:
+ *
+ *   1. Wrapper form (`.mcp.json` / Claude Desktop config) — name lives in the key:
+ *        { "mcpServers": { "my-server": { "command": "npx", "args": [...] } } }
+ *      May hold several servers; each becomes its own entry. nameFallback is ignored.
+ *
+ *   2. Inner config form — a single server config with no wrapper:
+ *        { "command": "npx", "args": [...] }   or   { "type": "http", "url": "..." }
+ *      The name comes from nameFallback (the form's Name field), which is required here.
+ *
+ * Per the project's原본 보존 원칙, the config object is passed through VERBATIM —
+ * no key renaming, no `type` injection. Validation only checks that each config
+ * carries a `command` (stdio) or a `url` (remote); the CLI is the final arbiter.
+ */
+
+export interface ParsedMcpServer {
+  name: string;
+  config: Record<string, unknown>;
+}
+
+export type ParseMcpJsonResult =
+  | { ok: true; servers: ParsedMcpServer[] }
+  | { ok: false; error: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** A config is installable only if it has a stdio `command` or a remote `url`. */
+function hasInstallTarget(config: Record<string, unknown>): boolean {
+  const hasCommand = typeof config.command === 'string' && config.command.trim().length > 0;
+  const hasUrl = typeof config.url === 'string' && config.url.trim().length > 0;
+  return hasCommand || hasUrl;
+}
+
+export function parseMcpJson(rawText: string, nameFallback: string): ParseMcpJsonResult {
+  const text = rawText.trim();
+  if (!text) {
+    return { ok: false, error: 'Paste a JSON config to add a server.' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: `Invalid JSON: ${detail}` };
+  }
+
+  if (!isPlainObject(parsed)) {
+    return { ok: false, error: 'Expected a JSON object (an mcpServers wrapper or a single server config).' };
+  }
+
+  // Form 1: mcpServers wrapper.
+  if (isPlainObject(parsed.mcpServers)) {
+    const entries = Object.entries(parsed.mcpServers);
+    if (entries.length === 0) {
+      return { ok: false, error: 'The "mcpServers" object is empty — no servers to add.' };
+    }
+    const servers: ParsedMcpServer[] = [];
+    for (const [name, config] of entries) {
+      if (!isPlainObject(config)) {
+        return { ok: false, error: `Server "${name}" is not a JSON object.` };
+      }
+      if (!hasInstallTarget(config)) {
+        return { ok: false, error: `Server "${name}" needs a "command" (stdio) or "url" (remote).` };
+      }
+      servers.push({ name, config });
+    }
+    return { ok: true, servers };
+  }
+
+  // Form 2: bare inner config — name comes from the Name field.
+  const name = nameFallback.trim();
+  if (!name) {
+    return { ok: false, error: 'Name is required when pasting a single server config (no "mcpServers" wrapper).' };
+  }
+  if (!hasInstallTarget(parsed)) {
+    return { ok: false, error: 'Config needs a "command" (stdio) or "url" (remote).' };
+  }
+  return { ok: true, servers: [{ name, config: parsed }] };
+}


### PR DESCRIPTION
## Summary

- Add a GUI panel for viewing, adding, removing, enabling/disabling, and reconnecting MCP servers — no terminal required
- Access via \`/MCP Servers\` in the slash-command palette or the Customize section
- All data sourced from official CLI commands (\`claude mcp list / get / add-json / remove\`) — no undocumented internal protocols

## Features

### Server list
- Grouped by scope (Project → Local → User → claude.ai), alphabetically sorted within each group
- Status badges: Connected (green) / Failed (red) / Needs auth (yellow) / Disabled (grey text)
- React Query prefetch on chat page mount (\`staleTime: 0\`, \`gcTime: 5 min\`) — no loading spinner on first open

### Detail view
- Error box displayed above the server name when status is Failed or Needs auth
- **SSE/HTTP error enrichment**: backend probes the server URL with a 5-second \`fetch\` timeout and surfaces the real network error (ECONNREFUSED, ENOTFOUND, HTTP status, etc.) — uses \`cause.code\` since Node.js \`AggregateError\` has an empty \`cause.message\`
- **Reconnect UX**: \`busyAction: string | null\` state — active button shows "Reconnecting", all other buttons get \`pointer-events-none\`
- Action buttons (priority order): Authenticate (primary CTA) → Reconnect → Clear authentication → Enable/Disable
- Remove server (with confirmation)

### Add server
- Form: name, transport (stdio / http / sse), command / URL, optional args & env vars, scope (user / project / local) → submits via \`claude mcp add-json\`

### Other changes
- \`MessageType\` enum: 8 new MCP IPC types (\`GET_MCP_SERVERS\`, \`RECONNECT_MCP_SERVER\`, \`AUTHENTICATE_MCP_SERVER\`, \`CLEAR_MCP_SERVER_AUTH\`, \`SET_MCP_SERVER_ENABLED\`, \`SUBMIT_MCP_OAUTH_CALLBACK_URL\`, \`ADD_MCP_SERVER\`, \`REMOVE_MCP_SERVER\`)
- \`EmptyState\` hint updated to advertise \`/manage-mcp\` slash command
- Disabled servers sourced from \`~/.claude.json → disabledMcpServers\`
- \`CLAUDE.md\`: documented the CLI-parity & no-SDK-dependency core principles

## Documentation

- [\`docs/features/003-mcp_server_management/en.md\`](docs/features/003-mcp_server_management/en.md)
- [\`docs/features/003-mcp_server_management/ko.md\`](docs/features/003-mcp_server_management/ko.md)

## Test plan

- [ ] Open panel via \`/MCP Servers\` slash command
- [ ] Verify scope grouping and status badges in server list
- [ ] Click a failed SSE server → error box shows real network error (e.g. "connection refused")
- [ ] Click Reconnect → button shows "Reconnecting", other buttons disabled
- [ ] Toggle Enable / Disable, verify status reflects in list
- [ ] Add a stdio server via + button, verify it appears in list
- [ ] Remove server after confirmation
- [ ] Open modal immediately after chat page mount → list appears without loading spinner
