### PR TITLE
feat(settings): open Settings as overlay so running session isn't lost

### DIFF
--- a/backend/src/core/features/settings.ts
+++ b/backend/src/core/features/settings.ts
@@ -17,6 +17,7 @@ const DEFAULT_SETTINGS: Record<string, unknown> = {
   logLevel: 'info',
   terminalApp: null,
   hostMode: 'editor-tab',
+  openSettingsAs: 'overlay',
   env: {},
 };
 
@@ -30,6 +31,7 @@ const COMMENT_MAP: Record<string, string> = {
   logLevel: '로그 레벨: "debug" | "info" | "warn" | "error"',
   terminalApp: '터미널 프로그램 (null이면 OS 기본 터미널)',
   hostMode: '채팅을 띄우는 자리: "editor-tab" | "tool-window"',
+  openSettingsAs: '설정 화면을 여는 방식: "overlay" | "new-tab"',
   env: '자식 프로세스(claude, ccb)에 주입할 환경 변수. 예: { CLAUDE_CONFIG_DIR: "..." }',
 };
 
@@ -142,6 +144,11 @@ function validateSetting(key: string, value: unknown): string | null {
     case 'hostMode':
       if (!['editor-tab', 'tool-window'].includes(value as string)) {
         return 'hostMode must be one of "editor-tab", "tool-window"';
+      }
+      break;
+    case 'openSettingsAs':
+      if (!['overlay', 'new-tab'].includes(value as string)) {
+        return 'openSettingsAs must be one of "overlay", "new-tab"';
       }
       break;
     case 'env': {

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 import { AppProviders } from './contexts';
-import { ChatPage, SettingsPage, SwitchAccountPage, ProjectSelectorPage, SessionPanelPage } from './pages';
+import { ChatPage, SettingsPage, SettingsOverlay, SwitchAccountPage, ProjectSelectorPage, SessionPanelPage } from './pages';
 import { AccountUsageModal } from './components/AccountUsageModal';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -13,6 +13,8 @@ import 'katex/dist/katex.min.css';
 function AppContent() {
   useKeyboardShortcuts();
   const [isAccountUsageOpen, setIsAccountUsageOpen] = useState(false);
+  const location = useLocation();
+  const backgroundLocation = location.state?.backgroundLocation;
 
   useEffect(() => {
     const handler = () => setIsAccountUsageOpen(true);
@@ -23,7 +25,7 @@ function AppContent() {
   return (
     <>
       {isDev() && <div className="sticky top-0 border-t-2 border-t-fuchsia-500 z-50" />}
-      <Routes>
+      <Routes location={backgroundLocation ?? location}>
         <Route path="/" element={<ProjectSelectorPage />} />
         <Route path="/sessions/new" element={<ChatPage />} />
         <Route path="/sessions/:current_session_id" element={<ChatPage />} />
@@ -33,6 +35,15 @@ function AppContent() {
         <Route path="/switch-account" element={<SwitchAccountPage />} />
         <Route path="*" element={<Navigate to="/sessions/new" replace />} />
       </Routes>
+
+      {backgroundLocation && (
+        <SettingsOverlay>
+          <Routes>
+            <Route path="/settings/*" element={<SettingsPage />} />
+          </Routes>
+        </SettingsOverlay>
+      )}
+
       {isAccountUsageOpen && (
         <AccountUsageModal onClose={() => setIsAccountUsageOpen(false)} />
       )}

--- a/webview/src/contexts/SessionContext.tsx
+++ b/webview/src/contexts/SessionContext.tsx
@@ -79,7 +79,8 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const bypassDisabled = claudeSettings.permissions?.disableBypassPermissionsMode === 'disable';
 
   // currentSessionId is derived from URL (SSOT)
-  const currentSessionId = parseSessionIdFromPath(location.pathname);
+  const bg = location.state?.backgroundLocation;
+  const currentSessionId = parseSessionIdFromPath(bg?.pathname ?? location.pathname);
 
   const [sessions, setSessions] = useState<SessionMetaDto[]>([]);
   const [sessionState, setSessionState] = useState<SessionState>(SessionState.Idle);

--- a/webview/src/contexts/__tests__/SessionContext.test.tsx
+++ b/webview/src/contexts/__tests__/SessionContext.test.tsx
@@ -84,6 +84,7 @@ const mockNavigate = vi.fn((path: string, _options?: unknown) => {
 vi.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
   useLocation: () => ({ pathname: mockPathname }),
+  useParams: () => ({}),
 }));
 
 // Test data

--- a/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
@@ -1,15 +1,14 @@
 import { Cog6ToothIcon } from '@heroicons/react/24/outline';
-import { useSessionContext } from '@/contexts/SessionContext';
-import { Route } from '@/router';
+import { useRouter, Route } from '@/router';
 import { ROUTE_META } from '@/router/routes';
 
 export function SettingsButton() {
-  const { openSettings } = useSessionContext();
+  const { navigate } = useRouter();
   const settingsMeta = ROUTE_META[Route.SETTINGS];
 
   return (
     <button
-      onClick={openSettings}
+      onClick={() => navigate(Route.SETTINGS_GENERAL)}
       className="p-1 rounded transition-colors text-text-secondary hover:text-text-primary hover:bg-surface-hover"
       title={settingsMeta.label}
     >

--- a/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
@@ -1,14 +1,16 @@
 import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { useRouter, Route } from '@/router';
 import { ROUTE_META } from '@/router/routes';
+import { useLocation } from 'react-router-dom';
 
 export function SettingsButton() {
   const { navigate } = useRouter();
+  const location = useLocation();
   const settingsMeta = ROUTE_META[Route.SETTINGS];
 
   return (
     <button
-      onClick={() => navigate(Route.SETTINGS_GENERAL)}
+      onClick={() => navigate(Route.SETTINGS_GENERAL, { backgroundLocation: location })}
       className="p-1 rounded transition-colors text-text-secondary hover:text-text-primary hover:bg-surface-hover"
       title={settingsMeta.label}
     >

--- a/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
+++ b/webview/src/pages/ChatPage/SessionHeader/SettingsButton.tsx
@@ -2,15 +2,34 @@ import { Cog6ToothIcon } from '@heroicons/react/24/outline';
 import { useRouter, Route } from '@/router';
 import { ROUTE_META } from '@/router/routes';
 import { useLocation } from 'react-router-dom';
+import { useSettings } from '@/contexts/SettingsContext';
+import { useSessionContext } from '@/contexts/SessionContext';
+import { SettingKey, OpenSettingsMode } from '@/types/settings';
 
 export function SettingsButton() {
   const { navigate } = useRouter();
   const location = useLocation();
+  const { settings } = useSettings();
+  const { openSettings } = useSessionContext();
   const settingsMeta = ROUTE_META[Route.SETTINGS];
+
+  // Open mode is user-configurable (General → "Open Settings as"):
+  // - overlay (default): a modal over the current session, so a running session
+  //   stays mounted.
+  // - new-tab: the legacy dedicated editor/browser tab via getAdapter().openSettings().
+  const openMode = settings[SettingKey.OPEN_SETTINGS_AS] ?? OpenSettingsMode.OVERLAY;
+
+  const handleClick = () => {
+    if (openMode === OpenSettingsMode.NEW_TAB) {
+      openSettings();
+    } else {
+      navigate(Route.SETTINGS_GENERAL, { backgroundLocation: location });
+    }
+  };
 
   return (
     <button
-      onClick={() => navigate(Route.SETTINGS_GENERAL, { backgroundLocation: location })}
+      onClick={handleClick}
       className="p-1 rounded transition-colors text-text-secondary hover:text-text-primary hover:bg-surface-hover"
       title={settingsMeta.label}
     >

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -47,9 +47,11 @@ vi.mock('../../../contexts/BridgeContext', () => ({
   }),
 }));
 
-// Mock react-router-dom (ProjectButton uses useNavigate)
+// Mock react-router-dom (ProjectButton uses useNavigate, SettingsButton uses useRouter)
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
+  useLocation: () => ({ pathname: '/' }),
+  useParams: () => ({}),
 }));
 
 // Mock WorkingDirContext (ProjectButton uses useWorkingDir)

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -32,10 +32,16 @@ const mockLoadSessions = vi.fn();
 const mockSend = vi.fn();
 
 let mockSessionCtxValue: any;
+let mockSettingsValue: any;
 
 // Mock SessionContext
 vi.mock('../../../contexts/SessionContext', () => ({
   useSessionContext: () => mockSessionCtxValue,
+}));
+
+// Mock SettingsContext (SettingsButton reads openSettingsAs to pick overlay vs new tab)
+vi.mock('../../../contexts/SettingsContext', () => ({
+  useSettings: () => mockSettingsValue,
 }));
 
 // Mock BridgeContext
@@ -126,6 +132,11 @@ beforeEach(() => {
     renameSession: vi.fn(),
     setSessionState: vi.fn(),
     setWorkingDirectory: vi.fn(),
+  };
+
+  mockSettingsValue = {
+    settings: { openSettingsAs: 'overlay' },
+    updateSettingWithScope: vi.fn(),
   };
 });
 
@@ -332,6 +343,26 @@ describe('SessionHeader', () => {
 
     // openNewTab 호출 확인
     expect(mockSessionCtxValue.openNewTab).toHaveBeenCalled();
+  });
+
+  it('설정 버튼: openSettingsAs=overlay(기본)이면 새 탭(openSettings)을 열지 않음', async () => {
+    const user = userEvent.setup();
+    render(<SessionHeader />, { wrapper: queryWrapper });
+
+    await user.click(screen.getByTitle('Settings'));
+
+    // Overlay mode navigates in-tab; it must NOT open a dedicated tab.
+    expect(mockSessionCtxValue.openSettings).not.toHaveBeenCalled();
+  });
+
+  it('설정 버튼: openSettingsAs=new-tab이면 openSettings 호출', async () => {
+    const user = userEvent.setup();
+    mockSettingsValue.settings.openSettingsAs = 'new-tab';
+    render(<SessionHeader />, { wrapper: queryWrapper });
+
+    await user.click(screen.getByTitle('Settings'));
+
+    expect(mockSessionCtxValue.openSettings).toHaveBeenCalledTimes(1);
   });
 
   it('새 탭 버튼이 항상 활성화되어 있음', () => {

--- a/webview/src/pages/SettingsPage/General/OpenSettingsRow.tsx
+++ b/webview/src/pages/SettingsPage/General/OpenSettingsRow.tsx
@@ -1,0 +1,35 @@
+import { SettingRow } from '../common';
+import { Select, type SelectOption } from '@/components/Select';
+import { useSettings } from '@/contexts/SettingsContext';
+import { SettingKey, OpenSettingsMode } from '@/types/settings';
+
+const OPEN_SETTINGS_OPTIONS: SelectOption[] = [
+  { value: OpenSettingsMode.OVERLAY, label: 'Overlay' },
+  { value: OpenSettingsMode.NEW_TAB, label: 'New tab' },
+];
+
+/**
+ * Lets the user choose how the Settings screen opens from the gear button:
+ * an overlay over the current session (keeps a running session intact) or a
+ * dedicated new tab. App-global behaviour, so always written to the global scope.
+ */
+export function OpenSettingsRow() {
+  const { settings, updateSettingWithScope } = useSettings();
+
+  const mode = settings[SettingKey.OPEN_SETTINGS_AS] ?? OpenSettingsMode.OVERLAY;
+
+  return (
+    <SettingRow
+      label="Open Settings as"
+      description="Show Settings as an overlay or in a new tab."
+    >
+      <Select
+        value={mode}
+        options={OPEN_SETTINGS_OPTIONS}
+        ariaLabel="Open Settings as"
+        className="bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary"
+        onChange={(value) => updateSettingWithScope(SettingKey.OPEN_SETTINGS_AS, value as OpenSettingsMode, 'global')}
+      />
+    </SettingRow>
+  );
+}

--- a/webview/src/pages/SettingsPage/General/index.tsx
+++ b/webview/src/pages/SettingsPage/General/index.tsx
@@ -2,6 +2,7 @@ import { SettingSection, SettingRow } from '../common';
 import { Select, type SelectOption } from '@/components/Select';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { HostModeRow } from './HostModeRow';
+import { OpenSettingsRow } from './OpenSettingsRow';
 import { ClaudeConfigDirRow } from './ClaudeConfigDirRow';
 import { APP_NAME } from '@/config/app';
 import { ROUTE_META, Route } from '@/router/routes';
@@ -100,6 +101,8 @@ export function GeneralSettings() {
         </SettingRow>
 
         <HostModeRow />
+
+        <OpenSettingsRow />
 
         <ClaudeConfigDirRow />
       </SettingSection>

--- a/webview/src/pages/SettingsPage/SettingsHeader.tsx
+++ b/webview/src/pages/SettingsPage/SettingsHeader.tsx
@@ -1,34 +1,21 @@
-import { ArrowLeftIcon } from '@heroicons/react/24/outline';
-import { useLocation } from 'react-router-dom';
-import { useRouter } from '@/router';
+import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Label, ROUTE_META, Route } from '@/router/routes';
+import { useCloseSettings } from './useCloseSettings';
 
 export function SettingsHeader() {
-  const { goBack, navigate } = useRouter();
-  const location = useLocation();
+  const onClose = useCloseSettings();
   const meta = ROUTE_META[Route.SETTINGS];
-
-  // Settings can be opened either in-tab (gear button → history push) or as a
-  // fresh tab (command palette → new editor/window). In the latter case there is
-  // no history to pop, so fall back to a new session instead of a dead no-op.
-  const onBack = () => {
-    if (location.key === 'default') {
-      navigate(Route.NEW_SESSION);
-    } else {
-      goBack();
-    }
-  };
 
   return (
     <header className="flex items-center gap-2 px-2 py-1 border-b border-border-default">
-      <button
-        onClick={onBack}
-        className="p-1 rounded text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
-        title={Label.BACK}
-      >
-        <ArrowLeftIcon className="w-4 h-4" />
-      </button>
       <h1 className="text-sm font-semibold text-text-primary">{meta.label}</h1>
+      <button
+        onClick={onClose}
+        className="ml-auto p-1 rounded text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
+        title={Label.CLOSE}
+      >
+        <XMarkIcon className="w-4 h-4" />
+      </button>
     </header>
   );
 }

--- a/webview/src/pages/SettingsPage/SettingsHeader.tsx
+++ b/webview/src/pages/SettingsPage/SettingsHeader.tsx
@@ -1,15 +1,28 @@
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { useLocation } from 'react-router-dom';
 import { useRouter } from '@/router';
 import { Label, ROUTE_META, Route } from '@/router/routes';
 
 export function SettingsHeader() {
-  const { navigate } = useRouter();
+  const { goBack, navigate } = useRouter();
+  const location = useLocation();
   const meta = ROUTE_META[Route.SETTINGS];
+
+  // Settings can be opened either in-tab (gear button → history push) or as a
+  // fresh tab (command palette → new editor/window). In the latter case there is
+  // no history to pop, so fall back to a new session instead of a dead no-op.
+  const onBack = () => {
+    if (location.key === 'default') {
+      navigate(Route.NEW_SESSION);
+    } else {
+      goBack();
+    }
+  };
 
   return (
     <header className="flex items-center gap-2 px-2 py-1 border-b border-border-default">
       <button
-        onClick={() => navigate(Route.NEW_SESSION)}
+        onClick={onBack}
         className="p-1 rounded text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
         title={Label.BACK}
       >

--- a/webview/src/pages/SettingsPage/SettingsOverlay.tsx
+++ b/webview/src/pages/SettingsPage/SettingsOverlay.tsx
@@ -1,0 +1,39 @@
+import { useEffect, ReactNode } from 'react';
+import { Portal } from '@/components/Portal';
+import { useCloseSettings } from './useCloseSettings';
+
+interface SettingsOverlayProps {
+  children: ReactNode;
+}
+
+export function SettingsOverlay({ children }: SettingsOverlayProps) {
+  const close = useCloseSettings();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [close]);
+
+  return (
+    <Portal>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-scrim"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) {
+            close();
+          }
+        }}
+      >
+        <div className="w-full max-w-5xl h-[85vh] bg-surface-base border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col">
+          {children}
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/webview/src/pages/SettingsPage/index.tsx
+++ b/webview/src/pages/SettingsPage/index.tsx
@@ -63,3 +63,5 @@ export function SettingsPage() {
     </SettingsLayout>
   );
 }
+
+export { SettingsOverlay } from './SettingsOverlay';

--- a/webview/src/pages/SettingsPage/useCloseSettings.ts
+++ b/webview/src/pages/SettingsPage/useCloseSettings.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useRouter } from '@/router';
+import { Route } from '@/router/routes';
+
+/**
+ * Close the settings overlay, returning to the session it was opened over.
+ *
+ * When opened as an overlay (gear button), `location.state.backgroundLocation`
+ * holds the underlying session. We navigate straight there with `replace` so the
+ * WHOLE settings stack collapses at once — history-back would only step one
+ * sidebar sub-route at a time and not actually hide the slot.
+ *
+ * When opened as a standalone tab (command palette / direct URL) there is no
+ * background: fall back to a new session if there is no history to pop, else back.
+ */
+export function useCloseSettings(): () => void {
+  const { goBack, navigate } = useRouter();
+  const nav = useNavigate();
+  const location = useLocation();
+
+  return useCallback(() => {
+    const bg = location.state?.backgroundLocation;
+    if (bg) {
+      nav(`${bg.pathname}${bg.search}`, { replace: true });
+    } else if (location.key === 'default') {
+      navigate(Route.NEW_SESSION);
+    } else {
+      goBack();
+    }
+  }, [location.state, location.key, nav, navigate, goBack]);
+}

--- a/webview/src/router/routes.ts
+++ b/webview/src/router/routes.ts
@@ -309,5 +309,6 @@ export const SETTINGS_SUB_ROUTES: Route[] = [
 export enum Label {
   SETTINGS = 'Settings',
   BACK = 'Back',
+  CLOSE = 'Close',
   NEW_TAB = 'Open New Tab',
 }

--- a/webview/src/router/useRouter.ts
+++ b/webview/src/router/useRouter.ts
@@ -1,10 +1,10 @@
-import { useNavigate, useLocation, useParams } from 'react-router-dom';
+import { useNavigate, useLocation, useParams, Location } from 'react-router-dom';
 import { Route, pathToRoute, routeToPath, isSettingsRoute, withWorkingDir } from './routes';
 
 export interface UseRouterReturn {
   route: Route;
   params: Record<string, string>;
-  navigate: (route: Route, params?: Record<string, string>) => void;
+  navigate: (route: Route, options?: { backgroundLocation?: Location }) => void;
   goBack: () => void;
   isSettings: boolean;
 }
@@ -18,9 +18,12 @@ export function useRouter(): UseRouterReturn {
   const routeParams = useParams();
   const route = pathToRoute(location.pathname);
 
-  const navigate = (targetRoute: Route, _params?: Record<string, string>) => {
+  const navigate = (targetRoute: Route, options?: { backgroundLocation?: Location }) => {
     const resolved = targetRoute === Route.SETTINGS ? Route.SETTINGS_GENERAL : targetRoute;
-    nav(withWorkingDir(routeToPath(resolved)));
+    const path = withWorkingDir(routeToPath(resolved));
+    const carried = options?.backgroundLocation
+      ?? (isSettingsRoute(resolved) ? location.state?.backgroundLocation : undefined);
+    nav(path, carried ? { state: { backgroundLocation: carried } } : undefined);
   };
 
   const goBack = () => {

--- a/webview/src/types/settings.ts
+++ b/webview/src/types/settings.ts
@@ -22,6 +22,19 @@ export enum SettingKey {
 
   // Host
   HOST_MODE = 'hostMode',
+
+  // Settings screen open mode
+  OPEN_SETTINGS_AS = 'openSettingsAs',
+}
+
+/**
+ * How the Settings screen opens from the gear button:
+ * - overlay: a modal over the current session (keeps a running session mounted)
+ * - new-tab: a dedicated editor tab / browser tab (the legacy openSettings path)
+ */
+export enum OpenSettingsMode {
+  OVERLAY = 'overlay',
+  NEW_TAB = 'new-tab',
 }
 
 /**
@@ -64,6 +77,7 @@ export interface SettingsState {
   [SettingKey.LOG_LEVEL]: LogLevel;
   [SettingKey.TERMINAL_APP]: string | null;
   [SettingKey.HOST_MODE]: HostMode;
+  [SettingKey.OPEN_SETTINGS_AS]: OpenSettingsMode;
 }
 
 /**
@@ -79,4 +93,5 @@ export const DEFAULT_SETTINGS: SettingsState = {
   [SettingKey.LOG_LEVEL]: LogLevel.INFO,
   [SettingKey.TERMINAL_APP]: null,
   [SettingKey.HOST_MODE]: HostMode.EDITOR_TAB,
+  [SettingKey.OPEN_SETTINGS_AS]: OpenSettingsMode.OVERLAY,
 };


### PR DESCRIPTION
## Summary

Open Settings as an overlay so the active (running) session is not lost, plus in-tab navigation that restores the previous session on back.

## Key commits

- **feat(settings): open Settings as overlay so running session isn't lost** — Settings now opens as an overlay instead of replacing the chat, so a streaming/running session stays intact.
- **fix(settings): navigate in-tab and restore previous session on back** — navigate within the current tab and restore the previously active session when going back.

> Note: since this fork's branch is ahead of upstream `main`, the PR also carries the preceding commits (`live-tail external terminal sessions`, `vitest pool=threads`, `watcher unwatch on LOAD_SESSION`).