### PR TITLE
fix(account): hide delete on active account + reflect external account switches

### DIFF
--- a/webview/src/contexts/AuthContext.tsx
+++ b/webview/src/contexts/AuthContext.tsx
@@ -39,7 +39,13 @@ export function AuthProvider(props: AuthProviderProps) {
   const loggedIn: boolean | null = accountQuery.data ? accountQuery.data.loggedIn : null;
 
   const refetch = useCallback(async () => {
-    await queryClient.invalidateQueries({ queryKey: [MessageType.GET_ACCOUNT] });
+    // Invalidate both the single live-account query (login state, header avatar)
+    // and the saved-accounts list (active marker, switcher) so a login/switch made
+    // outside the GUI (e.g. in a terminal) is reflected on the next focus re-check.
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: [MessageType.GET_ACCOUNT] }),
+      queryClient.invalidateQueries({ queryKey: [MessageType.GET_ACCOUNTS] }),
+    ]);
   }, [queryClient]);
 
   useEffect(() => {

--- a/webview/src/hooks/queries/useAccountQuery.ts
+++ b/webview/src/hooks/queries/useAccountQuery.ts
@@ -52,6 +52,13 @@ export function useAccountQuery(): UseQueryResult<AccountQueryResult, Error> {
   return useQuery<AccountQueryResult, Error>({
     queryKey: [MessageType.GET_ACCOUNT, workingDirectory],
     enabled: isConnected,
+    // The live account can change OUTSIDE the GUI (e.g. `claude` login / account
+    // switch in a terminal), which emits no ACCOUNTS_CHANGED. Override the global
+    // staleTime:Infinity / refetchOnWindowFocus:false so returning to the IDE
+    // re-runs `claude auth status` and the GUI reflects the current account.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     queryFn: async () => {
       const result = (await send(MessageType.GET_ACCOUNT, {
         workingDir: workingDirectory ?? undefined,

--- a/webview/src/hooks/queries/useAccounts.ts
+++ b/webview/src/hooks/queries/useAccounts.ts
@@ -35,6 +35,12 @@ function useAccountsQuery(): UseQueryResult<AccountsResult, Error> {
   return useQuery<AccountsResult, Error>({
     queryKey: [MessageType.GET_ACCOUNTS],
     enabled: isConnected,
+    // External (terminal) account switches emit no ACCOUNTS_CHANGED, so override
+    // the global staleTime:Infinity / refetchOnWindowFocus:false: refetch the
+    // saved list + active marker when the IDE regains focus / reconnects.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
     queryFn: async () => {
       const result = (await send(MessageType.GET_ACCOUNTS)) as RawAccountsResponse;
       if (result?.status === 'ok') {

--- a/webview/src/pages/SettingsPage/Account/AccountList.tsx
+++ b/webview/src/pages/SettingsPage/Account/AccountList.tsx
@@ -8,10 +8,13 @@ import { AccountRow } from './AccountRow';
  * is not yet in the registry (covers accounts logged in outside the plugin).
  */
 export function AccountList() {
-  const { accounts, isLoading, error, save, switchTo, remove } = useAccounts();
+  const { accounts, activeEmail, isLoading, error, save, switchTo, remove } = useAccounts();
   const [busy, setBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
-  const autoSaveAttempted = useRef(false);
+  // The live account email we last auto-saved for. Keyed by email (not a one-shot
+  // boolean) so a NEW account logged in elsewhere (e.g. a terminal `claude` login)
+  // is captured too — not just the very first one seen on mount.
+  const autoSavedEmailRef = useRef<string | null>(null);
 
   const run = async (action: () => Promise<void>) => {
     if (busy) return;
@@ -27,15 +30,16 @@ export function AccountList() {
   };
 
   useEffect(() => {
-    if (isLoading || autoSaveAttempted.current) return;
-    const currentSaved = accounts.some((a) => a.active);
-    if (!currentSaved) {
-      autoSaveAttempted.current = true;
-      void run(save);
-    }
-    // run/save are recreated each render but autoSaveAttempted guards single execution
+    if (isLoading || !activeEmail) return;
+    // The live account is already saved (marked active) — nothing to capture.
+    if (accounts.some((a) => a.active)) return;
+    // Already attempted a save for this exact live account — don't loop on it.
+    if (autoSavedEmailRef.current === activeEmail) return;
+    autoSavedEmailRef.current = activeEmail;
+    void run(save);
+    // run/save are recreated each render; the per-email ref guards re-execution
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, accounts]);
+  }, [isLoading, accounts, activeEmail]);
 
   const handleDelete = (account: AccountListItem) => {
     void run(() => remove(account.id));

--- a/webview/src/pages/SettingsPage/Account/AccountRow.tsx
+++ b/webview/src/pages/SettingsPage/Account/AccountRow.tsx
@@ -107,7 +107,7 @@ export function AccountRow(props: AccountRowProps) {
       {/* Actions */}
       <div className="flex items-center gap-1.5 shrink-0">
         {account.active ? (
-          <span className="flex items-center gap-1 text-[0.8461rem] text-state-success-fg">
+          <span className="flex items-center gap-1 text-[0.8461rem] text-state-success-fg pr-4">
             <CheckBadgeIcon className="w-4 h-4" />
             In use
           </span>
@@ -120,14 +120,18 @@ export function AccountRow(props: AccountRowProps) {
             Switch
           </button>
         )}
-        <button
-          onClick={() => onDelete(account)}
-          disabled={busy}
-          title="Remove account"
-          className="p-1.5 rounded-md text-text-tertiary hover:text-state-error-fg hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-        >
-          <TrashIcon className="w-3.5 h-3.5" />
-        </button>
+        {/* The active account can't be deleted — removing it would orphan the live
+            CLI credential slot. Switch to another account first to delete this one. */}
+        {!account.active && (
+          <button
+            onClick={() => onDelete(account)}
+            disabled={busy}
+            title="Remove account"
+            className="p-1.5 rounded-md text-text-tertiary hover:text-state-error-fg hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <TrashIcon className="w-3.5 h-3.5" />
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Two related multi-account fixes in Settings → Account:

### 1. Hide the delete button on the active account
Deleting the **in-use** account removed its snapshot + registry entry but left the **live credential slot** (macOS Keychain / `.credentials.json`) untouched, so the account reappeared on the next `claude auth status` — i.e. you couldn't actually delete the current account without switching away first. The trash button is now rendered only for **non-active** accounts (switch to another account first to delete one). Also adds right padding to the "In use" badge so it aligns with the action column.

### 2. Reflect external (terminal) account switches
When a user logs in / switches account from a **terminal** (`claude`), no `ACCOUNTS_CHANGED` is broadcast, and the account queries inherited the global `staleTime: Infinity` / `refetchOnWindowFocus: false`, so the GUI kept showing the previous account.

- `GET_ACCOUNT` and `GET_ACCOUNTS` now `refetchOnWindowFocus` + `refetchOnReconnect` (with `staleTime: 0`), so returning to the IDE re-runs `claude auth status` and the header avatar / active marker update.
- `AuthContext`'s focus handler also invalidates `GET_ACCOUNTS` (not just `GET_ACCOUNT`).
- The Account page auto-save is keyed by the live email (not a one-shot flag), so a brand-new account added in a terminal is captured into the registry on return to the IDE.

> Note: on macOS the live credentials live in the Keychain (not a file), so this uses focus/reconnect refetch rather than a file watcher — covers the common "log in elsewhere, come back to the IDE" flow on all platforms without polling.

## Files
- `webview/src/pages/SettingsPage/Account/AccountRow.tsx`
- `webview/src/hooks/queries/useAccountQuery.ts`
- `webview/src/hooks/queries/useAccounts.ts`
- `webview/src/contexts/AuthContext.tsx`
- `webview/src/pages/SettingsPage/Account/AccountList.tsx`

## Verification
- `wv-lint` (tsc) passes.
- Manually verified in the standalone webview: active account shows no trash button; "In use" badge padded; account list + header reflect the live account after returning focus to the IDE.