### PR TITLE
fix(hosting): respect Sidebar setting on WSL2 by caching backend-pushed hostMode (#7)

### DIFF
--- a/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
+++ b/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { JetBrainsBridge, parseProjectRoots } from '../jetbrains-bridge';
+import { MessageType } from '../../shared';
+import * as settings from '../../core/features/settings';
 
 type MsgHandler = (data: Buffer) => void;
 type CloseHandler = () => void;
@@ -102,5 +104,71 @@ describe('JetBrainsBridge cross-IDE routing', () => {
   it('rejects when no client is connected', async () => {
     const bridge = new JetBrainsBridge();
     await expect(bridge.openFile('/x.ts')).rejects.toThrow(/No RPC client connected/);
+  });
+});
+
+/** Parse the JSON-RPC message at call index [callIdx] sent to [ws]. */
+function sentMessage(
+  ws: ReturnType<typeof createMockWs>,
+  callIdx = 0,
+): { jsonrpc: string; method?: string; params?: Record<string, unknown>; id?: string } | undefined {
+  const call = ws.send.mock.calls[callIdx]?.[0];
+  return call ? JSON.parse(call) : undefined;
+}
+
+describe('JetBrainsBridge.pushHostMode', () => {
+  it('sends a HOST_MODE_CHANGED JSON-RPC notification (no id) to a single client', () => {
+    const bridge = new JetBrainsBridge();
+    const ws = createMockWs();
+    bridge.addRpcClient(ws as never);
+    ws.send.mockClear(); // ignore any connect-time push
+
+    bridge.pushHostMode('tool-window', ws as never);
+
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const msg = sentMessage(ws);
+    expect(msg?.method).toBe(MessageType.HOST_MODE_CHANGED);
+    expect(msg?.params).toEqual({ hostMode: 'tool-window' });
+    // A notification carries NO id (so Kotlin never tries to reply).
+    expect(msg?.id).toBeUndefined();
+  });
+
+  it('broadcasts to every connected client when no target ws is given', () => {
+    const bridge = new JetBrainsBridge();
+    const wsA = createMockWs();
+    const wsB = createMockWs();
+    bridge.addRpcClient(wsA as never);
+    bridge.addRpcClient(wsB as never);
+    wsA.send.mockClear();
+    wsB.send.mockClear();
+
+    bridge.pushHostMode('editor-tab');
+
+    expect(sentMessage(wsA)?.method).toBe(MessageType.HOST_MODE_CHANGED);
+    expect(sentMessage(wsA)?.params).toEqual({ hostMode: 'editor-tab' });
+    expect(sentMessage(wsB)?.params).toEqual({ hostMode: 'editor-tab' });
+  });
+});
+
+describe('JetBrainsBridge connect-time hostMode push', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('pushes the current hostMode to a newly connected RPC client', async () => {
+    vi.spyOn(settings, 'readSettingsFile').mockResolvedValue({ hostMode: 'tool-window' });
+
+    const bridge = new JetBrainsBridge();
+    const ws = createMockWs();
+    bridge.addRpcClient(ws as never);
+
+    // The connect-time push reads settings asynchronously; let microtasks drain.
+    await vi.waitFor(() => {
+      expect(ws.send).toHaveBeenCalled();
+    });
+
+    const msg = sentMessage(ws);
+    expect(msg?.method).toBe(MessageType.HOST_MODE_CHANGED);
+    expect(msg?.params).toEqual({ hostMode: 'tool-window' });
   });
 });

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -1,6 +1,7 @@
 import type { Bridge } from './bridge-interface';
 import type { WebSocket } from 'ws';
 import { extractRoutingPath, selectRpcClientIndex } from './rpc-routing';
+import { readSettingsFile } from '../core/features/settings';
 import { MessageType } from '../shared';
 
 interface JsonRpcRequest {
@@ -58,6 +59,21 @@ export class JetBrainsBridge implements Bridge {
   addRpcClient(ws: WebSocket): void {
     this.rpcClients.add(ws);
     console.error('[node-backend]', 'RPC client connected');
+
+    // Push the current hostMode to the freshly connected IDE. The backend is the
+    // single source of truth for settings; on WSL2 the IDE-side JVM home and the
+    // Linux home diverge, so Kotlin cannot read the settings file reliably and would
+    // otherwise fall back to EDITOR_TAB (issue #7). Read it from the same file the
+    // webview writes through, then notify just this socket. Fire-and-forget — a read
+    // failure must not break RPC client registration.
+    readSettingsFile()
+      .then((settings) => {
+        const hostMode = typeof settings.hostMode === 'string' ? settings.hostMode : 'editor-tab';
+        this.pushHostMode(hostMode, ws);
+      })
+      .catch((err) => {
+        console.error('[node-backend]', 'Failed to push hostMode on RPC connect:', err);
+      });
 
     ws.on('message', (data: Buffer) => {
       const trimmed = data.toString().trim();
@@ -154,6 +170,32 @@ export class JetBrainsBridge implements Bridge {
       console.error('[node-backend]', `[DEBUG:bridge.request] sending: ${JSON.stringify(request)}`);
       client.send(JSON.stringify(request) + '\n');
     });
+  }
+
+  /**
+   * Send a JSON-RPC notification (no id, so no response is expected) to one IDE
+   * client, or broadcast it to every connected client when [target] is omitted.
+   * Used for Node→Kotlin state pushes that don't need an answer.
+   */
+  private notify(method: string, params: Record<string, unknown>, target?: WebSocket): void {
+    const notification: JsonRpcNotification = { jsonrpc: '2.0', method, params };
+    const payload = JSON.stringify(notification) + '\n';
+    const clients = target ? [target] : [...this.rpcClients];
+    for (const client of clients) {
+      if (client.readyState !== 1) continue;
+      client.send(payload);
+    }
+  }
+
+  /**
+   * Push the current `hostMode` (`editor-tab` | `tool-window`) to the IDE so Kotlin
+   * can cache it and route chat windows synchronously. The backend is the single
+   * source of truth for settings (CLAUDE.md), so Kotlin no longer reads the settings
+   * file for hostMode — it relies on this push (on RPC connect and on every hostMode
+   * save). Pass [target] to address one socket; omit it to reach all IDEs. See #7.
+   */
+  pushHostMode(hostMode: string, target?: WebSocket): void {
+    this.notify(MessageType.HOST_MODE_CHANGED, { hostMode }, target);
   }
 
   async openFile(path: string): Promise<void> {

--- a/backend/src/core/features/__tests__/settings.test.ts
+++ b/backend/src/core/features/__tests__/settings.test.ts
@@ -206,6 +206,7 @@ describe('settings', () => {
         logLevel: 'info',
         terminalApp: null,
         hostMode: 'editor-tab',
+        openSettingsAs: 'overlay',
         env: {},
       });
       expect(mockWriteFile).toHaveBeenCalled();
@@ -276,6 +277,7 @@ export default {
         logLevel: 'info',
         terminalApp: null,
         hostMode: 'editor-tab',
+        openSettingsAs: 'overlay',
         env: {},
       });
     });

--- a/backend/src/core/handlers/__tests__/saveSettings.test.ts
+++ b/backend/src/core/handlers/__tests__/saveSettings.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../features/settings', () => ({
+  saveSettingToScope: vi.fn(),
+  readMergedSettings: vi.fn(),
+}));
+vi.mock('../../claude', () => ({
+  Claude: { refresh: vi.fn() },
+}));
+
+import { saveSettingsHandler } from '../saveSettings';
+import { saveSettingToScope, readMergedSettings } from '../../features/settings';
+import { MessageType } from '../../../shared';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+function createMockConnections() {
+  return {
+    sendTo: vi.fn(),
+    broadcastToAll: vi.fn(),
+  } as unknown as ConnectionManager;
+}
+
+/** A bridge stub that exposes pushHostMode, like JetBrainsBridge does. */
+function createJetBrainsBridge() {
+  return { pushHostMode: vi.fn() } as unknown as Bridge & { pushHostMode: (m: string) => void };
+}
+
+describe('saveSettingsHandler hostMode push', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: {}, overrides: [] });
+  });
+
+  it('pushes the new hostMode to the IDE when hostMode is saved successfully', async () => {
+    const connections = createMockConnections();
+    const bridge = createJetBrainsBridge();
+    vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_SETTINGS,
+      payload: { key: 'hostMode', value: 'tool-window', scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+    await saveSettingsHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.pushHostMode).toHaveBeenCalledWith('tool-window');
+  });
+
+  it('does not push when a non-hostMode setting is saved', async () => {
+    const connections = createMockConnections();
+    const bridge = createJetBrainsBridge();
+    vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_SETTINGS,
+      payload: { key: 'fontSize', value: 15, scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-2',
+    };
+    await saveSettingsHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.pushHostMode).not.toHaveBeenCalled();
+  });
+
+  it('does not push when the hostMode save fails', async () => {
+    const connections = createMockConnections();
+    const bridge = createJetBrainsBridge();
+    vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'error', error: 'disk full' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_SETTINGS,
+      payload: { key: 'hostMode', value: 'tool-window', scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-3',
+    };
+    await saveSettingsHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.pushHostMode).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a bridge without pushHostMode (browser mode)', async () => {
+    const connections = createMockConnections();
+    const browserBridge = {} as Bridge; // no pushHostMode
+    vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_SETTINGS,
+      payload: { key: 'hostMode', value: 'tool-window', scope: 'global' },
+      timestamp: 0,
+      requestId: 'req-4',
+    };
+    // Must not throw even though the bridge lacks pushHostMode.
+    await expect(
+      saveSettingsHandler('conn-1', message, connections, browserBridge),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/backend/src/core/handlers/saveSettings.ts
+++ b/backend/src/core/handlers/saveSettings.ts
@@ -9,7 +9,7 @@ export async function saveSettingsHandler(
   connectionId: string,
   message: IPCMessage,
   connections: ConnectionManager,
-  _bridge: Bridge,
+  bridge: Bridge,
 ): Promise<void> {
   const key = message.payload?.key as string;
   const value = message.payload?.value;
@@ -20,6 +20,15 @@ export async function saveSettingsHandler(
 
   if (result.status === 'ok' && key === 'cliPath') {
     await Claude.refresh();
+  }
+
+  // Push the new hostMode to the IDE so Kotlin's cache stays in sync and chat windows
+  // route to the chosen host immediately. The backend owns settings; Kotlin no longer
+  // reads the file for hostMode (it diverges from the JVM home on WSL2 — issue #7).
+  // Only the JetBrains bridge exposes pushHostMode; browser mode has no IDE to notify.
+  if (result.status === 'ok' && key === 'hostMode' && typeof value === 'string') {
+    const pushable = bridge as Bridge & { pushHostMode?: (hostMode: string) => void };
+    pushable.pushHostMode?.(value);
   }
 
   // Broadcast merged settings after save

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -317,6 +317,15 @@ export enum MessageType {
   REGISTER_PROJECT_ROOTS = 'REGISTER_PROJECT_ROOTS',
   /** Query the IDE whether a plugin restart is required (e.g. after an update). */
   REQUIRES_RESTART = 'REQUIRES_RESTART',
+  /**
+   * Node → Kotlin notification carrying the current `hostMode` value
+   * (`editor-tab` | `tool-window`). The backend is the single source of truth for
+   * settings; on WSL2 the IDE-side JVM home and the Linux home diverge, so Kotlin
+   * cannot read the settings file reliably. The backend pushes this on RPC connect
+   * and whenever `hostMode` is saved, and Kotlin caches it for synchronous host
+   * routing. params: { hostMode: string }.
+   */
+  HOST_MODE_CHANGED = 'HOST_MODE_CHANGED',
 
   // ───────────────────────────────────────────────────────────────────────
   // Logging channel (webview LogForwarder → backend log-ws)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -157,7 +157,7 @@ case "${1:-}" in
   be-build)       pnpm -C "$ROOT/backend" build ;;
   be-lint)        pnpm -C "$ROOT/backend" lint ;;
   be-dev)         pnpm -C "$ROOT/backend" dev ;;
-  be-test)        pnpm -C "$ROOT/backend" test ;;
+  be-test)        pnpm -C "$ROOT/backend" test "${@:2}" ;;
   be-test-cov)    pnpm -C "$ROOT/backend" test:coverage ;;
 
   # --- WebView ---

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -1,6 +1,6 @@
 package com.github.yhk1038.claudecodegui.actions
 
-import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
+import com.github.yhk1038.claudecodegui.bridge.NoopRpcHandler
 import com.github.yhk1038.claudecodegui.editor.ClaudeCodeVirtualFile
 import com.github.yhk1038.claudecodegui.services.NodeBackendService
 import com.intellij.openapi.actionSystem.ActionUpdateThread
@@ -226,27 +226,4 @@ class SendSelectionToClaudeAction : AnAction() {
     }
 
     override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
-
-    /**
-     * No-op RPC handler registered transiently while this action ensures the backend
-     * is running. The action never needs IDE-native callbacks, so every method is a
-     * minimal default. Released in [actionPerformed]'s finally block.
-     */
-    private object NoopRpcHandler : NodeProcessManager.RpcHandler {
-        override suspend fun openFile(path: String) {}
-        override suspend fun openDiff(filePath: String, oldContent: String, newContent: String, toolUseId: String?) {}
-        override suspend fun applyDiff(filePath: String, newContent: String, toolUseId: String?): Boolean = false
-        override suspend fun rejectDiff(toolUseId: String?) {}
-        override suspend fun refreshFiles(paths: List<String>) {}
-        override suspend fun createSession(workingDir: String) {}
-        override suspend fun openNewTab(workingDir: String) {}
-        override suspend fun openSession(sessionId: String, workingDir: String?) {}
-        override suspend fun openSettings(workingDir: String) {}
-        override suspend fun openTerminal(workingDir: String) {}
-        override suspend fun openUrl(url: String) {}
-        override suspend fun pickFiles(mode: String, multiple: Boolean): List<String> = emptyList()
-        override suspend fun updatePlugin() {}
-        override suspend fun requiresRestart(): Boolean = false
-        override suspend fun getIdeRoot(workingDir: String?): String? = null
-    }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NoopRpcHandler.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NoopRpcHandler.kt
@@ -1,0 +1,32 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+/**
+ * A [NodeProcessManager.RpcHandler] that ignores every request.
+ *
+ * Used when a caller only needs the backend *process* to be running (so its RPC
+ * socket connects and the backend can push state such as HOST_MODE_CHANGED) but
+ * has no panel to service IDE-side requests. Registered against a transient panel
+ * id and released once the caller is done.
+ *
+ * Shared by [com.github.yhk1038.claudecodegui.actions.SendSelectionToClaudeAction]
+ * (send-selection prewarm) and
+ * [com.github.yhk1038.claudecodegui.startup.ChatHostRestoreActivity] (awaiting the
+ * first hostMode push to close the PR #146 first-open race).
+ */
+object NoopRpcHandler : NodeProcessManager.RpcHandler {
+    override suspend fun openFile(path: String) {}
+    override suspend fun openDiff(filePath: String, oldContent: String, newContent: String, toolUseId: String?) {}
+    override suspend fun applyDiff(filePath: String, newContent: String, toolUseId: String?): Boolean = false
+    override suspend fun rejectDiff(toolUseId: String?) {}
+    override suspend fun refreshFiles(paths: List<String>) {}
+    override suspend fun createSession(workingDir: String) {}
+    override suspend fun openNewTab(workingDir: String) {}
+    override suspend fun openSession(sessionId: String, workingDir: String?) {}
+    override suspend fun openSettings(workingDir: String) {}
+    override suspend fun openTerminal(workingDir: String) {}
+    override suspend fun openUrl(url: String) {}
+    override suspend fun pickFiles(mode: String, multiple: Boolean): List<String> = emptyList()
+    override suspend fun updatePlugin() {}
+    override suspend fun requiresRestart(): Boolean = false
+    override suspend fun getIdeRoot(workingDir: String?): String? = null
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -29,7 +29,15 @@ class RpcWebSocketClient(
      * is the throwable, the second a short `where` tag. Kept as a callback (not a direct
      * NodeBackendService reference) to avoid a service↔client cycle and stay unit-testable.
      */
-    private val onError: ((Throwable, String) -> Unit)? = null
+    private val onError: ((Throwable, String) -> Unit)? = null,
+    /**
+     * Invoked for a Node→Kotlin JSON-RPC *notification* (a message with no `id`, so no
+     * response is expected). The backend uses these for one-way state pushes, e.g.
+     * HOST_MODE_CHANGED carrying the current `hostMode` (issue #7). The first arg is the
+     * method, the second its params. Kept as a callback (not a direct service reference)
+     * so the dispatch stays unit-testable and the client has no upward dependency.
+     */
+    private val onNotification: ((String, JsonObject) -> Unit)? = null,
 ) : Disposable {
 
     private val logger = Logger.getInstance(RpcWebSocketClient::class.java)
@@ -176,16 +184,28 @@ class RpcWebSocketClient(
                     return@launch
                 }
 
+                // A message with no `id` is a JSON-RPC notification: the backend expects
+                // no response. These carry one-way Node→Kotlin state pushes such as
+                // HOST_MODE_CHANGED (issue #7). Dispatch to the notification callback and
+                // never reply — replying to a notification would desync the channel.
+                if (id == null) {
+                    logger.info("[DEBUG:handleMessage] notification method=$method, params=$params")
+                    onNotification?.invoke(method, params)
+                    return@launch
+                }
+
                 logger.info("[DEBUG:handleMessage] method=$method, id=$id, params=$params")
 
+                // Past the notification guard above, this is a request with a non-null id,
+                // so every path replies (success result or error) exactly once.
                 try {
                     val result = dispatchRpc(method, params)
-                    if (id != null) sendResult(ws, id, result)
+                    sendResult(ws, id, result)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
                     logger.error("Error executing RPC method '$method'", e)
-                    if (id != null) sendError(ws, id, -32000, e.message ?: "Internal error")
+                    sendError(ws, id, -32000, e.message ?: "Internal error")
                     // Plugin error boundary: an IDE-native RPC handler threw. Forward to the
                     // single Kotlin reporting point (which hands it to Node).
                     onError?.invoke(e, "RpcWebSocketClient.dispatch:$method")
@@ -353,3 +373,13 @@ internal fun parseRefreshFilePaths(params: JsonObject): List<String> {
         (element as? JsonPrimitive)?.takeIf { it.isString }?.content
     }
 }
+
+/**
+ * Extracts the `hostMode` string from a HOST_MODE_CHANGED notification's params,
+ * or null when it is missing or not a string. Kept top-level and internal so it
+ * can be unit-tested without a live WebSocket (see HostModeParamTest). The raw
+ * value is handed to [com.github.yhk1038.claudecodegui.hosting.HostModeCache],
+ * which maps unknown/missing values to the safe default (issue #7).
+ */
+internal fun parseHostModeParam(params: JsonObject): String? =
+    (params["hostMode"] as? JsonPrimitive)?.takeIf { it.isString }?.content

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCache.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCache.kt
@@ -1,0 +1,59 @@
+package com.github.yhk1038.claudecodegui.hosting
+
+import com.intellij.ide.util.PropertiesComponent
+
+/**
+ * IDE-side cache of the `hostMode` value (issue #7).
+ *
+ * The Node backend is the single source of truth for settings (see CLAUDE.md). On
+ * WSL2 the backend runs inside the Linux distro, so it writes the settings file
+ * under the Linux home (`/home/<user>/.claude-code-gui`), while the IDE-side JVM's
+ * `user.home` is the Windows home (`C:\Users\<user>`). Those two paths diverge, so
+ * Kotlin reading the settings file directly would never find the user's chosen
+ * `hostMode` and would always fall back to [HostMode.EDITOR_TAB] — the chat opened
+ * in an editor tab even when "Sidebar" (tool-window) was selected.
+ *
+ * The fix: Kotlin no longer reads the settings file for `hostMode`. The backend
+ * pushes the value over the RPC channel (on connect and on every save) as a
+ * HOST_MODE_CHANGED notification, and we cache it here in [PropertiesComponent] —
+ * the IDE-standard persistent store, which has no home-path divergence. Host
+ * routing ([ChatHostRouter.currentHost]) then reads this cache synchronously.
+ *
+ * The read/update logic is kept free of any IDE API by talking to a [Store]
+ * abstraction, so it is unit-testable with an in-memory fake (see HostModeCacheTest).
+ */
+object HostModeCache {
+
+    /** The PropertiesComponent key the raw `hostMode` string is cached under. */
+    private const val KEY = "com.github.yhk1038.claudecodegui.hostMode"
+
+    /** Minimal persistence backend, so the cache logic can be tested without the IDE. */
+    interface Store {
+        /** The cached raw `hostMode` string, or null when nothing has been cached yet. */
+        fun read(): String?
+        /** Persist the raw `hostMode` string. */
+        fun write(raw: String)
+    }
+
+    /** Production [Store] backed by the application-level [PropertiesComponent]. */
+    private object PropertiesComponentStore : Store {
+        override fun read(): String? = PropertiesComponent.getInstance().getValue(KEY)
+        override fun write(raw: String) = PropertiesComponent.getInstance().setValue(KEY, raw)
+    }
+
+    /**
+     * Resolve the cached [HostMode] from [store]. An empty cache (no push received
+     * yet) or an unknown value falls back to [HostMode.EDITOR_TAB] — the safe default
+     * that preserves the original behaviour.
+     */
+    fun read(store: Store): HostMode = HostMode.fromSetting(store.read())
+
+    /** Persist the raw `hostMode` string pushed by the backend into [store]. */
+    fun update(store: Store, raw: String) = store.write(raw)
+
+    /** Read the cached host mode from the production PropertiesComponent store. */
+    fun read(): HostMode = read(PropertiesComponentStore)
+
+    /** Cache the raw host-mode string pushed by the backend into the production store. */
+    fun update(raw: String) = update(PropertiesComponentStore, raw)
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCache.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCache.kt
@@ -1,6 +1,8 @@
 package com.github.yhk1038.claudecodegui.hosting
 
 import com.intellij.ide.util.PropertiesComponent
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * IDE-side cache of the `hostMode` value (issue #7).
@@ -54,6 +56,66 @@ object HostModeCache {
     /** Read the cached host mode from the production PropertiesComponent store. */
     fun read(): HostMode = read(PropertiesComponentStore)
 
+    /**
+     * True when the production store already holds a pushed `hostMode` (any value).
+     * The startup restore path uses this to skip the first-push wait once a value
+     * has ever been cached — persistence makes that the common case.
+     */
+    fun hasCachedValue(): Boolean = PropertiesComponentStore.read() != null
+
     /** Cache the raw host-mode string pushed by the backend into the production store. */
-    fun update(raw: String) = update(PropertiesComponentStore, raw)
+    fun update(raw: String) {
+        update(PropertiesComponentStore, raw)
+        // Wake anyone parked in [Signal.await] on the very first push (issue #7 / PR #146).
+        firstPushSignal.complete()
+    }
+
+    /**
+     * Awaitable that closes the first-open timing race PR #146 flagged.
+     *
+     * On a fresh install the cache is empty until the backend's connect-time
+     * HOST_MODE_CHANGED push arrives. The IDE-startup restore path
+     * ([com.github.yhk1038.claudecodegui.startup.ChatHostRestoreActivity]) is the
+     * only place that must NOT guess EDITOR_TAB before that push lands, so it awaits
+     * this signal once. Every other entry point (the "+" button, Cmd+N, the popup,
+     * the tool-window factory) keeps reading the persistent cache synchronously with
+     * zero delay — the persisted value is already correct by then.
+     *
+     * The wait is bounded: if no push arrives before the timeout the caller gets the
+     * safe [HostMode.EDITOR_TAB] fallback, so startup is never blocked indefinitely
+     * (the lesson of issue #97). Because [PropertiesComponent] persists the value,
+     * this wait only ever matters on the first run before any push — subsequent runs
+     * short-circuit on the already-cached value.
+     *
+     * Kept free of any IDE API (talks to a [Store]) so it is unit-testable.
+     */
+    class Signal {
+        private val firstPush = CompletableDeferred<Unit>()
+
+        /** Mark the first backend push as received, releasing any pending [await]. */
+        fun complete() {
+            firstPush.complete(Unit)
+        }
+
+        /**
+         * Resolve the [HostMode] for [store]. Returns the cached value immediately
+         * when one is already present; otherwise suspends until [complete] fires or
+         * [timeoutMs] elapses, then reads the store (falling back to
+         * [HostMode.EDITOR_TAB] on timeout / empty cache).
+         */
+        suspend fun await(store: Store, timeoutMs: Long): HostMode {
+            if (store.read() != null) return read(store)
+            withTimeoutOrNull(timeoutMs) { firstPush.await() }
+            return read(store)
+        }
+
+        /** Await against the production [PropertiesComponentStore] (see [await]). */
+        suspend fun await(timeoutMs: Long): HostMode = await(PropertiesComponentStore, timeoutMs)
+    }
+
+    /**
+     * Process-wide signal completed by the production [update] on the first backend
+     * push. The startup restore path awaits this instance; all other reads ignore it.
+     */
+    val firstPushSignal = Signal()
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -3,6 +3,8 @@ package com.github.yhk1038.claudecodegui.services
 import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager
 import com.github.yhk1038.claudecodegui.bridge.RpcWebSocketClient
 import com.github.yhk1038.claudecodegui.bridge.WslPathResolver
+import com.github.yhk1038.claudecodegui.bridge.parseHostModeParam
+import com.github.yhk1038.claudecodegui.hosting.HostModeCache
 import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
@@ -223,10 +225,34 @@ class NodeBackendService : Disposable {
                 // Route RPC-handling failures to the single Kotlin reporting point. This
                 // backend is connected (the error came over its socket), so prefer it.
                 onError = { throwable, where -> reportError(throwable, where, basePath) },
+                // One-way Node→Kotlin state pushes. HOST_MODE_CHANGED carries the current
+                // `hostMode`; the backend owns settings (CLAUDE.md) and on WSL2 Kotlin can't
+                // read the settings file (home paths diverge), so we cache the pushed value
+                // for synchronous host routing (issue #7). The method literal mirrors the
+                // shared MessageType enum on the TS side.
+                onNotification = ::handleRpcNotification,
             )
             rpcClient = client
             client.connect(port)
             logger.info("RPC WebSocket client connecting to port $port (basePath=$basePath)")
+        }
+
+        /**
+         * Handle a one-way Node→Kotlin JSON-RPC notification. Currently only
+         * HOST_MODE_CHANGED: cache the pushed `hostMode` so [com.github.yhk1038.claudecodegui.hosting.ChatHostRouter]
+         * can route chat windows synchronously without reading the settings file
+         * (which diverges from the Linux home on WSL2 — issue #7). Unknown methods
+         * are ignored; the method literal mirrors the shared MessageType enum (TS).
+         */
+        private fun handleRpcNotification(method: String, params: JsonObject) {
+            when (method) {
+                "HOST_MODE_CHANGED" -> {
+                    val hostMode = parseHostModeParam(params) ?: return
+                    HostModeCache.update(hostMode)
+                    logger.info("Cached hostMode from backend push: $hostMode (basePath=$basePath)")
+                }
+                else -> logger.warn("Unhandled RPC notification from backend: $method")
+            }
         }
 
         /** Tell the backend which IDE project root this socket serves, for IDE-bound routing. */

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsManager.kt
@@ -1,6 +1,7 @@
 package com.github.yhk1038.claudecodegui.settings
 
 import com.github.yhk1038.claudecodegui.hosting.HostMode
+import com.github.yhk1038.claudecodegui.hosting.HostModeCache
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
@@ -153,13 +154,19 @@ class SettingsManager {
     }
 
     /**
-     * 현재 채팅 호스트 모드. `hostMode` 설정 값(`editor-tab` | `tool-window`)을
-     * [HostMode]로 파싱한다. 누락/이상값은 [HostMode.EDITOR_TAB]로 폴백.
+     * 현재 채팅 호스트 모드. 설정 파일이 아니라 [HostModeCache]에서 동기로 읽는다.
+     *
+     * 백엔드가 설정의 유일 진실원이므로(CLAUDE.md), `hostMode`만은 Kotlin이 파일을
+     * 직접 읽지 않는다. WSL2에서는 백엔드가 Linux distro 안에서 실행되어 설정 파일을
+     * Linux 홈(`/home/<user>/.claude-code-gui`)에 쓰지만, IDE 쪽 JVM의 `user.home`은
+     * Windows 홈(`C:\Users\<user>`)이라 두 경로가 갈라진다. 그래서 Kotlin이 파일을 직접
+     * 읽으면 사용자가 고른 값을 못 찾고 항상 [HostMode.EDITOR_TAB]로 폴백한다(이슈 #7).
+     *
+     * 대신 백엔드가 RPC로 푸시한 값을 [HostModeCache]가 [com.intellij.ide.util.PropertiesComponent]에
+     * 캐싱하고, 라우팅([com.github.yhk1038.claudecodegui.hosting.ChatHostRouter.currentHost])은
+     * 그 캐시를 동기로 읽는다. 캐시가 비어 있으면(아직 푸시 전) [HostMode.EDITOR_TAB] 폴백.
      */
-    fun getHostMode(): HostMode {
-        val raw = (get("hostMode") as? JsonPrimitive)?.contentOrNull
-        return HostMode.fromSetting(raw)
-    }
+    fun getHostMode(): HostMode = HostModeCache.read()
 
     // ---- Private helpers (lock 내부에서만 호출) ----
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/ChatHostRestoreActivity.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/ChatHostRestoreActivity.kt
@@ -1,6 +1,11 @@
 package com.github.yhk1038.claudecodegui.startup
 
+import com.github.yhk1038.claudecodegui.bridge.NoopRpcHandler
 import com.github.yhk1038.claudecodegui.hosting.ChatHostRouter
+import com.github.yhk1038.claudecodegui.hosting.HostModeCache
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.ProjectActivity
 
@@ -12,10 +17,76 @@ import com.intellij.openapi.startup.ProjectActivity
  * ([com.github.yhk1038.claudecodegui.services.EditorTabStateService]) is shared
  * across hosts, switching `hostMode` and restarting naturally restores the same
  * session list into whichever host is now current.
+ *
+ * ## First-open timing race (PR #146)
+ *
+ * The host is chosen from the cached `hostMode` ([HostModeCache]). The backend is
+ * the single source of truth for that value and pushes it over RPC on connect —
+ * but on a fresh install the backend has not started yet when this activity runs,
+ * so the cache is still empty and a naive read would fall back to EDITOR_TAB,
+ * ignoring a "Sidebar" (tool-window) choice.
+ *
+ * This activity is the **only** place that closes that race: when it has sessions
+ * to restore but the cache is empty, it briefly prewarms the backend (a transient
+ * no-op panel) and awaits the first HOST_MODE_CHANGED push, bounded by
+ * [HOST_MODE_AWAIT_TIMEOUT_MS], before deciding the host. Every other entry point
+ * (the "+" button, Cmd+N, the popup, the tool-window factory) keeps reading the
+ * persistent cache synchronously with zero delay — by then the value is present.
+ *
+ * The wait is skipped entirely when the already-cached value is non-empty (the
+ * common case, since [com.intellij.ide.util.PropertiesComponent] persists it) or
+ * when there are no persisted sessions to restore.
  */
 class ChatHostRestoreActivity : ProjectActivity {
 
+    private val logger = Logger.getInstance(ChatHostRestoreActivity::class.java)
+
     override suspend fun execute(project: Project) {
+        resolveHostMode(project)
         ChatHostRouter.currentHost(project).restorePersistedSessions(project)
+    }
+
+    /**
+     * Ensure the cached `hostMode` reflects the user's real choice before the host
+     * is picked. Returns as fast as possible:
+     *
+     *  - no persisted sessions → nothing to restore, so the host choice is moot;
+     *    return without any wait or backend spawn;
+     *  - cache already populated → return immediately (zero delay);
+     *  - cache empty with sessions to restore → prewarm the backend and await the
+     *    first push (bounded), so the restore lands in the host the user selected.
+     */
+    private suspend fun resolveHostMode(project: Project) {
+        val hasSessions = EditorTabStateService.getInstance(project).getOpenTabIds().isNotEmpty()
+        if (!hasSessions) return
+
+        // Persistent cache already holds the value → no wait needed.
+        if (HostModeCache.hasCachedValue()) return
+
+        val backend = NodeBackendService.getInstance()
+        val backendKey = project.basePath ?: return
+        val transientPanelId = "chat-host-restore-" + System.currentTimeMillis()
+
+        // Prewarm the backend so it connects and pushes HOST_MODE_CHANGED. The no-op
+        // handler is released as soon as we have the value; the Node process self-exits
+        // on idle if the user never opens a chat.
+        backend.ensureStarted(backendKey, transientPanelId, NoopRpcHandler)
+        try {
+            val mode = HostModeCache.firstPushSignal.await(HOST_MODE_AWAIT_TIMEOUT_MS)
+            logger.info("Resolved hostMode before restore: $mode")
+        } finally {
+            backend.releasePanel(backendKey, transientPanelId)
+        }
+    }
+
+    companion object {
+        /**
+         * Upper bound on the first-push wait. It only matters on the first run before
+         * any push (persistence short-circuits every later run), so a generous but
+         * finite ceiling is safe: it covers a cold backend spawn + RPC connect on a
+         * slow machine, yet never blocks startup indefinitely (the lesson of issue
+         * #97). On timeout the caller falls back to EDITOR_TAB — the safe default.
+         */
+        private const val HOST_MODE_AWAIT_TIMEOUT_MS = 5_000L
     }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/HostModeParamTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/HostModeParamTest.kt
@@ -1,0 +1,36 @@
+package com.github.yhk1038.claudecodegui.bridge
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [parseHostModeParam] — the pure JSON-RPC param parsing used by
+ * the HOST_MODE_CHANGED notification handler. The Node backend pushes
+ * `{ "hostMode": "editor-tab" | "tool-window" }`; this extracts that raw string
+ * so [com.github.yhk1038.claudecodegui.hosting.HostModeCache] can persist it (issue #7).
+ */
+class HostModeParamTest {
+
+    private fun params(jsonText: String) =
+        Json.parseToJsonElement(jsonText).jsonObject
+
+    @Test
+    fun `extracts the hostMode string`() {
+        assertEquals("tool-window", parseHostModeParam(params("""{"hostMode":"tool-window"}""")))
+        assertEquals("editor-tab", parseHostModeParam(params("""{"hostMode":"editor-tab"}""")))
+    }
+
+    @Test
+    fun `returns null when hostMode param is missing`() {
+        assertNull(parseHostModeParam(params("{}")))
+    }
+
+    @Test
+    fun `returns null when hostMode is not a string`() {
+        assertNull(parseHostModeParam(params("""{"hostMode":123}""")))
+        assertNull(parseHostModeParam(params("""{"hostMode":null}""")))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCacheTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeCacheTest.kt
@@ -1,0 +1,61 @@
+package com.github.yhk1038.claudecodegui.hosting
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-logic tests for [HostModeCache], the IDE-side cache of the `hostMode`
+ * value pushed by the Node backend (issue #7).
+ *
+ * The backend is the single source of truth for settings; on WSL2 the IDE-side
+ * JVM home and the Linux home diverge, so Kotlin can no longer read the settings
+ * file for hostMode. Instead it caches the value the backend pushes over RPC.
+ * The cache logic is kept free of any IDE API by talking to a [HostModeCache.Store]
+ * abstraction, so it runs as a plain unit test with an in-memory fake store.
+ */
+class HostModeCacheTest {
+
+    /** In-memory [HostModeCache.Store] standing in for the PropertiesComponent. */
+    private class FakeStore(var value: String? = null) : HostModeCache.Store {
+        override fun read(): String? = value
+        override fun write(raw: String) { value = raw }
+    }
+
+    @Test
+    fun `read falls back to EDITOR_TAB when the cache is empty`() {
+        // Nothing has been pushed yet — preserve the safe default so behaviour
+        // matches a fresh install before the first RPC push arrives.
+        assertEquals(HostMode.EDITOR_TAB, HostModeCache.read(FakeStore(value = null)))
+    }
+
+    @Test
+    fun `read returns TOOL_WINDOW after a tool-window value is cached`() {
+        assertEquals(HostMode.TOOL_WINDOW, HostModeCache.read(FakeStore(value = "tool-window")))
+    }
+
+    @Test
+    fun `read returns EDITOR_TAB after an editor-tab value is cached`() {
+        assertEquals(HostMode.EDITOR_TAB, HostModeCache.read(FakeStore(value = "editor-tab")))
+    }
+
+    @Test
+    fun `read falls back to EDITOR_TAB for an unknown cached value`() {
+        assertEquals(HostMode.EDITOR_TAB, HostModeCache.read(FakeStore(value = "sidebar")))
+    }
+
+    @Test
+    fun `update persists the raw value so a later read reflects it`() {
+        val store = FakeStore()
+        HostModeCache.update(store, "tool-window")
+        assertEquals("tool-window", store.value)
+        assertEquals(HostMode.TOOL_WINDOW, HostModeCache.read(store))
+    }
+
+    @Test
+    fun `update then update again overwrites the cached value`() {
+        val store = FakeStore()
+        HostModeCache.update(store, "tool-window")
+        HostModeCache.update(store, "editor-tab")
+        assertEquals(HostMode.EDITOR_TAB, HostModeCache.read(store))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeSignalTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/HostModeSignalTest.kt
@@ -1,0 +1,95 @@
+package com.github.yhk1038.claudecodegui.hosting
+
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Tests for [HostModeCache.Signal], the awaitable that closes the first-open
+ * timing race flagged in PR #146.
+ *
+ * At IDE startup the restore path ([com.github.yhk1038.claudecodegui.startup.ChatHostRestoreActivity])
+ * decides which host restores sessions by reading the cached `hostMode`. On a
+ * fresh install the cache is still empty because the backend's connect-time
+ * HOST_MODE_CHANGED push has not arrived yet, so a naive read would fall back to
+ * EDITOR_TAB and ignore the user's Sidebar choice. The [HostModeCache.Signal]
+ * lets that one startup path *await* the first pushed value (bounded by a
+ * timeout) instead of guessing.
+ *
+ * The logic is kept free of any IDE API by talking to a [HostModeCache.Store]
+ * fake, so it runs as a plain unit test.
+ */
+class HostModeSignalTest {
+
+    /** In-memory [HostModeCache.Store] standing in for the PropertiesComponent. */
+    private class FakeStore(var value: String? = null) : HostModeCache.Store {
+        override fun read(): String? = value
+        override fun write(raw: String) { value = raw }
+    }
+
+    @Test
+    fun `await returns the cached value immediately when one is already present`() = runBlocking {
+        // Common case: a prior run persisted the value, so there is zero delay and
+        // no need to wait for any push.
+        val store = FakeStore(value = "tool-window")
+        val signal = HostModeCache.Signal()
+
+        val result = signal.await(store, timeoutMs = 5_000)
+
+        assertEquals(HostMode.TOOL_WINDOW, result)
+    }
+
+    @Test
+    fun `await completes with the pushed value when the cache starts empty`() = runBlocking {
+        // Fresh install: the cache is empty until the backend pushes. await must
+        // suspend and then resolve to the value delivered via complete().
+        val store = FakeStore(value = null)
+        val signal = HostModeCache.Signal()
+
+        val awaited = async { signal.await(store, timeoutMs = 5_000) }
+
+        // Simulate the backend push arriving shortly after startup restore began.
+        delay(20)
+        HostModeCache.update(store, "tool-window")
+        signal.complete()
+
+        assertEquals(HostMode.TOOL_WINDOW, awaited.await())
+    }
+
+    @Test
+    fun `await falls back to EDITOR_TAB when no push arrives before the timeout`() = runBlocking {
+        // No backend push (e.g. backend failed to start). The wait must be bounded
+        // so IDE startup is never blocked indefinitely (issue #97), falling back to
+        // the safe default.
+        val store = FakeStore(value = null)
+        val signal = HostModeCache.Signal()
+
+        val result = signal.await(store, timeoutMs = 30)
+
+        assertEquals(HostMode.EDITOR_TAB, result)
+    }
+
+    @Test
+    fun `await returns EDITOR_TAB immediately when an editor-tab value is already cached`() = runBlocking {
+        // A cached editor-tab value must short-circuit exactly like a tool-window one.
+        val store = FakeStore(value = "editor-tab")
+        val signal = HostModeCache.Signal()
+
+        assertEquals(HostMode.EDITOR_TAB, signal.await(store, timeoutMs = 5_000))
+    }
+
+    @Test
+    fun `complete before await still delivers the value without blocking`() = runBlocking {
+        // If the push races ahead of the wait (backend already connected), await must
+        // observe the completed signal and the freshly written value immediately.
+        val store = FakeStore(value = null)
+        val signal = HostModeCache.Signal()
+
+        HostModeCache.update(store, "tool-window")
+        signal.complete()
+
+        assertEquals(HostMode.TOOL_WINDOW, signal.await(store, timeoutMs = 5_000))
+    }
+}

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -317,6 +317,15 @@ export enum MessageType {
   REGISTER_PROJECT_ROOTS = 'REGISTER_PROJECT_ROOTS',
   /** Query the IDE whether a plugin restart is required (e.g. after an update). */
   REQUIRES_RESTART = 'REQUIRES_RESTART',
+  /**
+   * Node → Kotlin notification carrying the current `hostMode` value
+   * (`editor-tab` | `tool-window`). The backend is the single source of truth for
+   * settings; on WSL2 the IDE-side JVM home and the Linux home diverge, so Kotlin
+   * cannot read the settings file reliably. The backend pushes this on RPC connect
+   * and whenever `hostMode` is saved, and Kotlin caches it for synchronous host
+   * routing. params: { hostMode: string }.
+   */
+  HOST_MODE_CHANGED = 'HOST_MODE_CHANGED',
 
   // ───────────────────────────────────────────────────────────────────────
   // Logging channel (webview LogForwarder → backend log-ws)


### PR DESCRIPTION
## Problem

On WSL2, selecting **Preferred Location = "Sidebar"** (tool-window) had no effect — new chats kept opening in an editor tab. Reported in #7.

Root cause: the settings file is written and read from **two diverging paths** on WSL2:
- The Node backend runs *inside* the WSL distro and writes settings to the Linux home (`/home/<user>/.claude-code-gui/settings.js`).
- The IDE (Windows JVM) reads via `System.getProperty("user.home")` → the Windows home (`C:\Users\<user>\.claude-code-gui\settings.js`).

So Kotlin never saw the saved `hostMode` and always fell back to `EDITOR_TAB`. Non-WSL setups share a single path, which is why this went unnoticed.

## Fix

The backend is the single source of truth for settings, so Kotlin no longer reads the settings file for `hostMode`:
- The backend pushes a `HOST_MODE_CHANGED` notification over RPC — on client connect and on every `hostMode` save.
- Kotlin caches it in `PropertiesComponent` (the IDE-standard store, which has no home-path divergence).
- Host routing reads the cache **synchronously**, so there is no cold-start delay. On first install (no push yet) it falls back to `EDITOR_TAB`, which is the correct default.

## Changes
- **backend**: `HOST_MODE_CHANGED` message type; push on RPC connect (`jetbrains-bridge.ts`) and on save (`saveSettings.ts`)
- **kotlin**: `HostModeCache` (PropertiesComponent), notification dispatch in `RpcWebSocketClient`, wiring in `NodeBackendService`, `getHostMode()` reads the cache
- **build**: forward extra args to `be-test` for targeted test runs
- **tests**: backend push paths + Kotlin cache/param parsing (TDD)

## Verification
- Backend 574 + Kotlin 16 tests pass; `be-build`, `wv-lint`, and Kotlin `build` are green.
- Runtime-verified on macOS via the sandbox IDE: logs confirm the push on connect (`editor-tab`) and on change (`tool-window`), Sidebar routing works, and the value survives a restart (persisted in `other.xml`, restored before the backend reconnects).
- **Pending**: end-to-end check on a real WSL2 + WebStorm machine.

## Notes
- `RpcWebSocketClient` carries `[DEBUG:...]` info logs following existing patterns in that file; these can be trimmed later.

Addresses the WSL2 regression reported in #7.