### PR TITLE
fix(model controls): effort slider matching, fast mode toggle stability, Fable CLI gate

### DIFF
--- a/docs/features/006-effort_and_fast_mode/en.md
+++ b/docs/features/006-effort_and_fast_mode/en.md
@@ -1,0 +1,63 @@
+# Effort & Fast Mode
+
+> Languages: **English** · [한국어](./ko.md)
+>
+> Related: [#121](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/121), [#152](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/152)
+
+Two of the controls in the **Model** section let you trade speed for depth on a per-model basis: **Effort** and **Fast mode**. Both mirror what the Claude Code CLI already lets you set, surfaced as inline controls so you never have to leave the chat.
+
+## Effort
+
+**Effort** is how hard Claude works on a response — its reasoning budget. Higher effort means more thorough thinking (slower, more tokens); lower effort means quicker, cheaper replies. It's the same setting the CLI exposes per model.
+
+### The slider
+
+Effort is a **slider**, not a list. Each notch is one level the current model supports:
+
+| Level | Label |
+|-------|-------|
+| `low` | Low |
+| `medium` | Medium |
+| `high` | High |
+| `xhigh` | Extra high |
+| `max` | Max |
+
+- **Auto** is not a notch — it's the label shown while you haven't picked a level, meaning "use the CLI's default." As soon as you pick a level the slider stays within the real levels.
+- **Click or drag** the slider to jump to a level. **Clicking the row** (or pressing Enter on it) cycles to the next level, wrapping back to the first.
+
+### Ultracode (the top step)
+
+When a model supports the `xhigh` level, the slider gains one extra step past Max, rendered in **purple**: **Ultracode**. Landing on it engages `xhigh` effort **plus** standing workflow orchestration — the maximum-capability setting. It's only offered when the model supports `xhigh` and Workflows aren't disabled.
+
+### Where to find it
+
+- **Slash command panel** (type `/`) → **Model** section → the **Effort** row, with the current level shown next to the label (e.g. *Effort (Extra high)*).
+- **Modes popup** (**Shift + Tab**) → the effort slider sits at the bottom.
+
+## Fast mode
+
+**Fast mode** prioritizes faster output. It's available on **Opus** models only. You'll find it in the **Model** section as the **Toggle fast mode** switch.
+
+## Model support at a glance
+
+Which controls apply depends on the model you're using — the CLI reports each model's capabilities, and the GUI follows them exactly:
+
+| Model | Effort | Levels | Ultracode | Fast mode |
+|-------|:---:|---|:---:|:---:|
+| **Opus** | ✅ | Low · Medium · High · Extra high · Max | ✅ | ✅ |
+| **Sonnet** | ✅ | Low · Medium · High · Max *(no Extra high)* | ❌ | ❌ |
+| **Haiku** | ❌ | — | ❌ | ❌ |
+
+A couple of consequences worth knowing:
+
+- **Sonnet has no Extra high**, so it also has **no Ultracode step** — that's a model capability, not a bug.
+- **Fast mode is Opus-only**, so on Sonnet and Haiku the toggle is inactive.
+
+## What happens on models that don't support a control
+
+Rather than hiding a control on models that don't support it, the row stays visible but **disabled (greyed out)**, and hovering it shows a short tooltip explaining why — for example *"This model doesn't support effort levels"* or *"Fast mode is only available on Opus models"*. This keeps the Model section consistent no matter which model you're on, so a missing control never looks like something broke ([#152](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/152)).
+
+## Notes
+
+- These controls reflect the **currently running session model** — switch models and the available effort levels, Ultracode step, and Fast mode availability update to match.
+- Everything here maps to what the CLI already supports; the GUI just makes it a click instead of a flag.

--- a/docs/features/006-effort_and_fast_mode/ko.md
+++ b/docs/features/006-effort_and_fast_mode/ko.md
@@ -1,0 +1,63 @@
+# Effort & Fast Mode
+
+> 언어: [English](./en.md) · **한국어**
+>
+> 관련: [#121](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/121), [#152](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/152)
+
+**Model** 섹션의 두 컨트롤 **Effort**와 **Fast mode**는 모델별로 속도와 깊이를 조절하게 해줍니다. 둘 다 Claude Code CLI에서 이미 설정할 수 있는 것을, 채팅을 벗어나지 않고 바로 조작할 수 있도록 인라인 컨트롤로 꺼내온 것입니다.
+
+## Effort
+
+**Effort**는 Claude가 응답에 얼마나 공을 들이는지 — 추론에 쓰는 예산 — 를 뜻합니다. 높을수록 더 깊이 생각하고(느리고 토큰을 더 씀), 낮을수록 더 빠르고 저렴하게 답합니다. CLI가 모델별로 노출하는 바로 그 설정입니다.
+
+### 슬라이더
+
+Effort는 목록이 아니라 **슬라이더**입니다. 각 눈금은 현재 모델이 지원하는 단계 하나입니다:
+
+| 단계 | 표시 |
+|------|------|
+| `low` | Low |
+| `medium` | Medium |
+| `high` | High |
+| `xhigh` | Extra high |
+| `max` | Max |
+
+- **Auto**는 눈금이 아닙니다. 아직 단계를 고르지 않았을 때 표시되는 라벨로, "CLI 기본값을 사용"한다는 뜻입니다. 단계를 하나라도 고르면 슬라이더는 실제 단계 안에서만 움직입니다.
+- 슬라이더를 **클릭하거나 드래그**하면 해당 단계로 이동합니다. **행을 클릭**(또는 Enter)하면 다음 단계로 순환하며, 마지막에서 첫 단계로 돌아옵니다.
+
+### Ultracode (최상단 스텝)
+
+모델이 `xhigh` 단계를 지원하면, 슬라이더에 Max를 지나 한 칸이 더 생기고 **보라색**으로 표시됩니다 — **Ultracode**입니다. 여기에 놓으면 `xhigh` effort에 더해 상시 워크플로우 오케스트레이션까지 켜지는, 최대 성능 설정이 됩니다. 모델이 `xhigh`를 지원하고 Workflows가 비활성이 아닐 때만 제공됩니다.
+
+### 어디서 찾나요
+
+- **슬래시 커맨드 패널**(`/` 입력) → **Model** 섹션 → **Effort** 행. 라벨 옆에 현재 단계가 표시됩니다(예: *Effort (Extra high)*).
+- **모드 팝업**(**Shift + Tab**) → 하단에 effort 슬라이더가 있습니다.
+
+## Fast mode
+
+**Fast mode**는 더 빠른 출력을 우선합니다. **Opus** 모델에서만 사용할 수 있으며, **Model** 섹션의 **Toggle fast mode** 스위치에서 켤 수 있습니다.
+
+## 모델별 지원 한눈에 보기
+
+어떤 컨트롤이 적용되는지는 사용 중인 모델에 따라 다릅니다. CLI가 각 모델의 지원 여부를 알려주고, GUI는 그것을 그대로 따릅니다:
+
+| 모델 | Effort | 단계 | Ultracode | Fast mode |
+|------|:---:|---|:---:|:---:|
+| **Opus** | ✅ | Low · Medium · High · Extra high · Max | ✅ | ✅ |
+| **Sonnet** | ✅ | Low · Medium · High · Max *(Extra high 없음)* | ❌ | ❌ |
+| **Haiku** | ❌ | — | ❌ | ❌ |
+
+알아두면 좋은 점 두 가지:
+
+- **Sonnet에는 Extra high가 없어서** **Ultracode 스텝도 없습니다** — 버그가 아니라 모델의 지원 범위입니다.
+- **Fast mode는 Opus 전용**이라, Sonnet과 Haiku에서는 토글이 비활성입니다.
+
+## 지원하지 않는 모델에서의 동작
+
+지원하지 않는 모델에서 컨트롤을 아예 숨기는 대신, 행은 그대로 보이되 **비활성(회색)** 으로 표시되고, 마우스를 올리면 이유를 짧은 툴팁으로 알려줍니다 — 예를 들어 *"This model doesn't support effort levels"* 또는 *"Fast mode is only available on Opus models"*. 이렇게 하면 어떤 모델에서든 Model 섹션이 일관되게 보여서, 컨트롤이 없어졌다고 고장으로 오해하지 않게 됩니다 ([#152](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/152)).
+
+## 참고
+
+- 이 컨트롤들은 **현재 실행 중인 세션 모델**을 반영합니다 — 모델을 바꾸면 사용 가능한 effort 단계, Ultracode 스텝, Fast mode 지원 여부가 그에 맞춰 갱신됩니다.
+- 여기 있는 모든 것은 CLI가 이미 지원하는 것과 대응됩니다. GUI는 그저 플래그 대신 클릭으로 바꿔줄 뿐입니다.

--- a/docs/features/CLAUDE.md
+++ b/docs/features/CLAUDE.md
@@ -11,3 +11,4 @@
 - [MCP Server Management](./003-mcp_server_management/en.md) — GUI에서 MCP 서버를 조회·추가·편집·제거·활성화·재연결하는 MCP 서버 관리 패널 ([#136](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/136))
 - [Settings Overlay](./004-settings_overlay/en.md) — 설정을 현재 채팅 위 오버레이로 열어 진행 중인 세션을 잃지 않게 하고, 여는 방식(오버레이/새 탭)을 선택할 수 있는 기능 ([#137](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/137))
 - [Claude Code CLI Version & Update](./005-cli_version_update/en.md) — 설치된 CLI 버전을 확인하고, 설치 방식(npm/pnpm/yarn/volta/native/homebrew/winget)에 맞는 공식 명령으로 GUI에서 바로 업데이트하는 기능 ([#150](https://github.com/yhk1038/claude-code-gui-jetbrains/pull/150))
+- [Effort & Fast Mode](./006-effort_and_fast_mode/en.md) — 모델별로 추론 깊이(Effort 슬라이더·Ultracode)와 빠른 출력(Fast mode)을 조절하는 Model 섹션 컨트롤. 지원하지 않는 모델에서는 숨기지 않고 비활성+툴팁으로 안내 ([#121](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/121), [#152](https://github.com/yhk1038/claude-code-gui-jetbrains/issues/152))

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -3,7 +3,7 @@ import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useChatInputState } from '@/contexts/ChatInputStateContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
-import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
+import { useCurrentModel } from '@/hooks/useCurrentModel';
 import { getModelEffortConfig } from '@/types/effort';
 import { getAdapter } from '@/adapters';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
@@ -56,15 +56,15 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
   const chatInputState = useChatInputState();
   const session = useSessionContext();
   const { controlResponse } = useCliConfig();
-  const { settings } = useClaudeSettings();
   const { confirmDialog, confirm } = useConfirmDialog();
   const workflowState = useWorkflowState();
+  const currentModel = useCurrentModel();
 
   // The Effort row only makes sense on models that support effort. On others
   // (e.g. Haiku) it would render an empty, unresponsive row — the same
   // "nothing happens" symptom as issue #121 — so we drop it, matching the
   // Cursor extension (which unregisters the effort action for such models).
-  const supportsEffort = getModelEffortConfig(controlResponse, settings.model).supportsEffort;
+  const supportsEffort = getModelEffortConfig(controlResponse, currentModel).supportsEffort;
 
   // Services ref - always points to current React state
   const servicesRef = useRef<CommandPaletteServices>({

--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -5,6 +5,7 @@ import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { useCurrentModel } from '@/hooks/useCurrentModel';
 import { getModelEffortConfig } from '@/types/effort';
+import { resolveModelInfo } from '@/types/models';
 import { getAdapter } from '@/adapters';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
 import { useWorkflowState } from '@/contexts/WorkflowStateContext';
@@ -15,6 +16,7 @@ import type { SlashCommandInfo } from '@/types/slashCommand';
 import { CommandPaletteServices } from './types';
 import { CommandPaletteRegistry } from './CommandPaletteRegistry';
 import { KeyboardRegistry } from './KeyboardRegistry';
+import { applyModelCapabilityFlags } from './applyModelCapabilityFlags';
 import {
   ContextSection,
   ModelSection,
@@ -60,11 +62,15 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
   const workflowState = useWorkflowState();
   const currentModel = useCurrentModel();
 
-  // The Effort row only makes sense on models that support effort. On others
-  // (e.g. Haiku) it would render an empty, unresponsive row — the same
-  // "nothing happens" symptom as issue #121 — so we drop it, matching the
-  // Cursor extension (which unregisters the effort action for such models).
+  // The Effort and fast-mode rows only make sense on models that support
+  // them. Rather than hiding them on unsupported models (e.g. Haiku), we
+  // keep them visible but disabled with a hover tooltip explaining why —
+  // matching the pattern already used for other disabled rows in the panel.
+  // See applyModelCapabilityFlags for where this is applied to the built
+  // sections.
   const supportsEffort = getModelEffortConfig(controlResponse, currentModel).supportsEffort;
+  const models = controlResponse?.response?.response?.models ?? [];
+  const supportsFastMode = resolveModelInfo(models, currentModel)?.supportsFastMode ?? false;
 
   // Services ref - always points to current React state
   const servicesRef = useRef<CommandPaletteServices>({
@@ -226,13 +232,8 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
       registry.registerSection(new SlashCommandsSection(), sortedCommands);
     }
     const built = registry.buildSections();
-    if (supportsEffort) return built;
-    // Hide the Effort row on effort-unsupported models (see note above).
-    return built.map((s) => ({
-      ...s,
-      items: s.items.filter((it) => it.id !== 'effort'),
-    }));
-  }, [registry, commands, supportsEffort]);
+    return built.map((s) => applyModelCapabilityFlags(s, { supportsEffort, supportsFastMode }));
+  }, [registry, commands, supportsEffort, supportsFastMode]);
 
   const contextValue = useMemo<CommandPaletteRegistryContextValue>(
     () => ({ registry, keyboardRegistry, sections }),

--- a/webview/src/commandPalette/__tests__/applyModelCapabilityFlags.test.ts
+++ b/webview/src/commandPalette/__tests__/applyModelCapabilityFlags.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { applyModelCapabilityFlags } from '../applyModelCapabilityFlags';
+import { EFFORT_UNSUPPORTED_REASON } from '../sections/model/EffortItem';
+import { FAST_MODE_UNSUPPORTED_REASON } from '../sections/model/ToggleFastModeItem';
+import { PanelSection, PanelSectionId, PanelItem, PanelItemType } from '@/types/commandPalette';
+
+function makeItem(id: string, overrides: Partial<PanelItem> = {}): PanelItem {
+  return {
+    id,
+    label: id,
+    type: PanelItemType.Action,
+    disabled: false,
+    valueComponent: () => null,
+    action: async () => {},
+    ...overrides,
+  } as PanelItem;
+}
+
+function makeSection(id: PanelSectionId, items: PanelItem[]): PanelSection {
+  return {
+    id,
+    title: id,
+    items,
+    showDividerAbove: false,
+  };
+}
+
+describe('applyModelCapabilityFlags', () => {
+  it('disables the effort item with EFFORT_UNSUPPORTED_REASON when supportsEffort is false', () => {
+    const section = makeSection(PanelSectionId.Model, [makeItem('effort')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: false, supportsFastMode: true });
+    const effort = result.items.find((it) => it.id === 'effort')!;
+    expect(effort.disabled).toBe(true);
+    expect(effort.disabledReason).toBe(EFFORT_UNSUPPORTED_REASON);
+  });
+
+  it('enables the effort item with no disabledReason when supportsEffort is true', () => {
+    const section = makeSection(PanelSectionId.Model, [makeItem('effort')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: true, supportsFastMode: true });
+    const effort = result.items.find((it) => it.id === 'effort')!;
+    expect(effort.disabled).toBe(false);
+    expect(effort.disabledReason).toBeUndefined();
+  });
+
+  it('disables the toggle-fast-mode item with FAST_MODE_UNSUPPORTED_REASON when supportsFastMode is false', () => {
+    const section = makeSection(PanelSectionId.Model, [makeItem('toggle-fast-mode')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: true, supportsFastMode: false });
+    const fastMode = result.items.find((it) => it.id === 'toggle-fast-mode')!;
+    expect(fastMode.disabled).toBe(true);
+    expect(fastMode.disabledReason).toBe(FAST_MODE_UNSUPPORTED_REASON);
+  });
+
+  it('enables the toggle-fast-mode item with no disabledReason when supportsFastMode is true', () => {
+    const section = makeSection(PanelSectionId.Model, [makeItem('toggle-fast-mode')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: true, supportsFastMode: true });
+    const fastMode = result.items.find((it) => it.id === 'toggle-fast-mode')!;
+    expect(fastMode.disabled).toBe(false);
+    expect(fastMode.disabledReason).toBeUndefined();
+  });
+
+  it('returns non-Model sections unchanged', () => {
+    const section = makeSection(PanelSectionId.Settings, [makeItem('some-setting')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: false, supportsFastMode: false });
+    expect(result).toBe(section);
+  });
+
+  it('leaves other Model items untouched', () => {
+    const section = makeSection(PanelSectionId.Model, [makeItem('thinking')]);
+    const result = applyModelCapabilityFlags(section, { supportsEffort: false, supportsFastMode: false });
+    const thinking = result.items.find((it) => it.id === 'thinking')!;
+    expect(thinking.disabled).toBe(false);
+    expect(thinking.disabledReason).toBeUndefined();
+  });
+
+  it('does not mutate the original section or its items', () => {
+    const original = makeSection(PanelSectionId.Model, [makeItem('effort'), makeItem('toggle-fast-mode')]);
+    const originalItemsSnapshot = original.items.map((it) => ({ ...it }));
+
+    applyModelCapabilityFlags(original, { supportsEffort: false, supportsFastMode: false });
+
+    expect(original.items.map((it) => ({ ...it }))).toEqual(originalItemsSnapshot);
+  });
+});

--- a/webview/src/commandPalette/applyModelCapabilityFlags.ts
+++ b/webview/src/commandPalette/applyModelCapabilityFlags.ts
@@ -1,0 +1,43 @@
+import { PanelSection, PanelSectionId } from '@/types/commandPalette';
+import { EFFORT_UNSUPPORTED_REASON } from './sections/model/EffortItem';
+import { FAST_MODE_UNSUPPORTED_REASON } from './sections/model/ToggleFastModeItem';
+
+export interface ModelCapabilityFlags {
+  supportsEffort: boolean;
+  supportsFastMode: boolean;
+}
+
+/**
+ * Inject disabled/disabledReason into the Model section's effort and
+ * toggle-fast-mode items based on the current model's capabilities. Rows for
+ * unsupported capabilities stay visible but disabled (with a hover tooltip
+ * explaining why), instead of being hidden from the panel. Pure function —
+ * returns a new section object (and never mutates the input) so it's safe to
+ * call from a `useMemo` derivation.
+ */
+export function applyModelCapabilityFlags(
+  section: PanelSection,
+  flags: ModelCapabilityFlags,
+): PanelSection {
+  if (section.id !== PanelSectionId.Model) return section;
+  return {
+    ...section,
+    items: section.items.map((it) => {
+      if (it.id === 'effort') {
+        return {
+          ...it,
+          disabled: !flags.supportsEffort,
+          disabledReason: flags.supportsEffort ? undefined : EFFORT_UNSUPPORTED_REASON,
+        };
+      }
+      if (it.id === 'toggle-fast-mode') {
+        return {
+          ...it,
+          disabled: !flags.supportsFastMode,
+          disabledReason: flags.supportsFastMode ? undefined : FAST_MODE_UNSUPPORTED_REASON,
+        };
+      }
+      return it;
+    }),
+  };
+}

--- a/webview/src/commandPalette/sections/model/EffortItem.tsx
+++ b/webview/src/commandPalette/sections/model/EffortItem.tsx
@@ -4,6 +4,9 @@ import { EffortSlider } from '@/components/EffortSlider';
 
 export const EFFORT_CYCLE_EVENT = 'effort-cycle';
 
+/** Reason shown as a hover tooltip when the row is disabled (model doesn't support effort levels). */
+export const EFFORT_UNSUPPORTED_REASON = "This model doesn't support effort levels";
+
 // Shown right after the "Effort" label, e.g. "(Extra high)" — matches the
 // Cursor extension's labelSuffix. Hidden when the model has no effort support.
 const EffortLabelSuffix = () => {

--- a/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
+++ b/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
@@ -2,12 +2,14 @@ import { StaticItem } from '../../types';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { useCurrentModel } from '@/hooks/useCurrentModel';
+import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { resolveModelInfo, withFableFallback } from '@/types/models';
 
 const SwitchModelValue = () => {
   const { controlResponse } = useCliConfig();
   const currentModel = useCurrentModel();
-  const models = withFableFallback(controlResponse?.response?.response?.models ?? [], new Date());
+  const { cliVersion } = useVersionInfo();
+  const models = withFableFallback(controlResponse?.response?.response?.models ?? [], new Date(), cliVersion);
   const info = resolveModelInfo(models, currentModel);
   const text = info?.displayName ?? currentModel;
   return (

--- a/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
+++ b/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
@@ -9,6 +9,9 @@ import { ToggleSwitch } from '@/components/ToggleSwitch';
 
 export const FAST_MODE_TOGGLE_EVENT = 'fast-mode-toggle';
 
+/** Reason shown as a hover tooltip when the row is disabled (model doesn't support fast mode). */
+export const FAST_MODE_UNSUPPORTED_REASON = 'Fast mode is only available on Opus models';
+
 function resolveActiveModel(
   models: ModelInfo[],
   sessionModel: string | null,
@@ -17,9 +20,12 @@ function resolveActiveModel(
   return resolveModelInfo(models, sessionModel ?? settingsModel);
 }
 
-// disabled를 런타임에 동적으로 변경할 수 있도록 backing field + getter/setter 설정
-let _disabled = false;
-const _toggleFastModeItem = new StaticItem('toggle-fast-mode', 'Toggle fast mode', {
+// Actual disabled state is injected by CommandPaletteProvider (via
+// applyModelCapabilityFlags) based on the current model's capability, not
+// mutated here. Mutating module-level state from a render function is a
+// React anti-pattern that caused stale/flickering disabled state (see
+// applyModelCapabilityFlags for the source of truth).
+export const toggleFastModeItem = new StaticItem('toggle-fast-mode', 'Toggle fast mode', {
   disabled: false,
   keepOpen: true,
   valueComponent: () => <FastModeToggle />,
@@ -27,13 +33,6 @@ const _toggleFastModeItem = new StaticItem('toggle-fast-mode', 'Toggle fast mode
     window.dispatchEvent(new CustomEvent(FAST_MODE_TOGGLE_EVENT));
   },
 });
-Object.defineProperty(_toggleFastModeItem, 'disabled', {
-  get: () => _disabled,
-  set: (v: boolean) => { _disabled = v; },
-  enumerable: true,
-  configurable: true,
-});
-export const toggleFastModeItem = _toggleFastModeItem;
 
 const FastModeToggle = () => {
   const { settings, updateSetting } = useClaudeSettings();
@@ -43,9 +42,6 @@ const FastModeToggle = () => {
   const activeModel = resolveActiveModel(models, sessionModel, settings.model);
   const supportsFastMode = activeModel?.supportsFastMode ?? false;
   const enabled = settings.preferFastMode ?? false;
-
-  // 행(row) disabled 상태를 supportsFastMode에 따라 동적으로 갱신
-  (toggleFastModeItem as unknown as { disabled: boolean }).disabled = !supportsFastMode;
 
   // 행(row) 클릭 시 발생하는 이벤트 처리 (지원되는 모델일 때만 토글)
   useEffect(() => {

--- a/webview/src/commandPalette/ui/PanelItemComponent.tsx
+++ b/webview/src/commandPalette/ui/PanelItemComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PanelItem, ToggleItem, CommandItem, PanelItemType, IconType } from '@/types/commandPalette';
+import { PanelItem, PanelItemBase, ToggleItem, CommandItem, PanelItemType, IconType } from '@/types/commandPalette';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { TerminalIcon, LinkIcon } from './icons/PaletteIcons';
 import { cn } from '@/utils/cn';
@@ -34,7 +34,7 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
   const isClickable = item.type !== PanelItemType.Info && !item.disabled;
   const hasRightTerminalIcon = item.icon === IconType.Terminal && item.type === PanelItemType.Action;
   const title = item.disabled
-    ? 'Coming soon'
+    ? ((item as PanelItemBase).disabledReason ?? 'Coming soon')
     : item.type === PanelItemType.Command
       ? (item as CommandItem).description
       : undefined;

--- a/webview/src/hooks/__tests__/useFableNotice.test.ts
+++ b/webview/src/hooks/__tests__/useFableNotice.test.ts
@@ -1,6 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
-import { useFableNotice, FABLE_NOTICE_DISMISSED_KEY } from '../useFableNotice';
+import {
+  useFableNotice,
+  FABLE_NOTICE_DISMISSED_KEY,
+  FABLE_UPDATE_NOTICE_DISMISSED_KEY,
+} from '../useFableNotice';
+
+// CLI versions on either side of the Fable minimum (2.1.170), used to drive the
+// 'available' vs 'update-required' variant.
+const SUPPORTED_CLI = '2.1.170';
+const OLD_CLI = '2.1.169';
 
 describe('useFableNotice', () => {
   beforeEach(() => {
@@ -13,19 +22,19 @@ describe('useFableNotice', () => {
 
   it('is visible during the promo window when not dismissed', () => {
     vi.setSystemTime(new Date('2026-07-03T00:00:00Z'));
-    const { result } = renderHook(() => useFableNotice());
+    const { result } = renderHook(() => useFableNotice(SUPPORTED_CLI));
     expect(result.current.visible).toBe(true);
   });
 
   it('is hidden after the promo window ends', () => {
     vi.setSystemTime(new Date('2026-07-08T00:00:00Z'));
-    const { result } = renderHook(() => useFableNotice());
+    const { result } = renderHook(() => useFableNotice(SUPPORTED_CLI));
     expect(result.current.visible).toBe(false);
   });
 
   it('hides and persists the dismissal once dismissed', () => {
     vi.setSystemTime(new Date('2026-07-03T00:00:00Z'));
-    const { result } = renderHook(() => useFableNotice());
+    const { result } = renderHook(() => useFableNotice(SUPPORTED_CLI));
     act(() => result.current.dismiss());
     expect(result.current.visible).toBe(false);
     expect(localStorage.getItem(FABLE_NOTICE_DISMISSED_KEY)).toBe('1');
@@ -34,7 +43,63 @@ describe('useFableNotice', () => {
   it('stays hidden on remount when previously dismissed', () => {
     vi.setSystemTime(new Date('2026-07-03T00:00:00Z'));
     localStorage.setItem(FABLE_NOTICE_DISMISSED_KEY, '1');
-    const { result } = renderHook(() => useFableNotice());
+    const { result } = renderHook(() => useFableNotice(SUPPORTED_CLI));
     expect(result.current.visible).toBe(false);
+  });
+
+  describe('variant', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('2026-07-03T00:00:00Z'));
+    });
+
+    it("is 'available' when the CLI is new enough to select Fable", () => {
+      const { result } = renderHook(() => useFableNotice(SUPPORTED_CLI));
+      expect(result.current.variant).toBe('available');
+    });
+
+    it("is 'update-required' when the CLI is too old", () => {
+      const { result } = renderHook(() => useFableNotice(OLD_CLI));
+      expect(result.current.variant).toBe('update-required');
+    });
+
+    it("is 'update-required' when the CLI version is unknown (null)", () => {
+      const { result } = renderHook(() => useFableNotice(null));
+      expect(result.current.variant).toBe('update-required');
+    });
+  });
+
+  describe('per-variant dismissal', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('2026-07-03T00:00:00Z'));
+    });
+
+    it('dismissing the update nudge writes only its own key', () => {
+      const { result } = renderHook(() => useFableNotice(OLD_CLI));
+      act(() => result.current.dismiss());
+      expect(localStorage.getItem(FABLE_UPDATE_NOTICE_DISMISSED_KEY)).toBe('1');
+      expect(localStorage.getItem(FABLE_NOTICE_DISMISSED_KEY)).toBeNull();
+    });
+
+    it('shows the available card after a CLI update even if the update nudge was dismissed', () => {
+      // User on an old CLI dismisses the update nudge...
+      const oldCli = renderHook(() => useFableNotice(OLD_CLI));
+      act(() => oldCli.result.current.dismiss());
+      expect(oldCli.result.current.visible).toBe(false);
+
+      // ...then updates their CLI: the 'available' card has never been dismissed,
+      // so it surfaces (independent keys).
+      const newCli = renderHook(() => useFableNotice(SUPPORTED_CLI));
+      expect(newCli.result.current.variant).toBe('available');
+      expect(newCli.result.current.visible).toBe(true);
+    });
+
+    it('keeps the update nudge dismissed independently of the available card', () => {
+      // Dismiss the available card first.
+      localStorage.setItem(FABLE_NOTICE_DISMISSED_KEY, '1');
+      const oldCli = renderHook(() => useFableNotice(OLD_CLI));
+      // The update nudge is a different key, so it is still visible.
+      expect(oldCli.result.current.variant).toBe('update-required');
+      expect(oldCli.result.current.visible).toBe(true);
+    });
   });
 });

--- a/webview/src/hooks/useEffort.ts
+++ b/webview/src/hooks/useEffort.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
+import { useCurrentModel } from '@/hooks/useCurrentModel';
 import {
   EFFORT_AUTO,
   EffortLevelDef,
@@ -48,8 +49,9 @@ export interface UseEffortReturn {
 export function useEffort(): UseEffortReturn {
   const { settings, updateSetting } = useClaudeSettings();
   const { controlResponse } = useCliConfig();
+  const currentModel = useCurrentModel();
 
-  const { supportsEffort, levels } = getModelEffortConfig(controlResponse, settings.model);
+  const { supportsEffort, levels } = getModelEffortConfig(controlResponse, currentModel);
   const current = parseEffortLevel(settings.effortLevel, levels);
 
   const ultracodeAvailable =

--- a/webview/src/hooks/useFableNotice.ts
+++ b/webview/src/hooks/useFableNotice.ts
@@ -1,50 +1,87 @@
 import { useState, useCallback } from 'react';
-import { isFablePromoActive } from '@/types/models';
+import { isFablePromoActive, isFableSupportedCli } from '@/types/models';
 
 /**
- * localStorage key for the dismissed state of the Fable promo notice. Mirrors
- * the key claude.ai's web bundle uses for the same notice (issue #153 appendix),
- * so the two stay conceptually aligned.
+ * Which flavour of the Fable notice to show:
+ *  - 'available': the running CLI can select Fable — the original promo card.
+ *  - 'update-required': the CLI is too old (< 2.1.170) to know `--model fable`,
+ *    so we nudge the user to update instead of offering a model they can't pick.
+ */
+export type FableNoticeVariant = 'available' | 'update-required';
+
+/**
+ * localStorage key for the dismissed state of the 'available' Fable promo notice.
+ * Mirrors the key claude.ai's web bundle uses for the same notice (issue #153
+ * appendix), so the two stay conceptually aligned. Kept unchanged for backward
+ * compatibility with users who already dismissed it.
  */
 export const FABLE_NOTICE_DISMISSED_KEY = 'fable-usage-notice-dismissed';
 
-function getDismissed(): boolean {
+/**
+ * localStorage key for the dismissed state of the 'update-required' notice. Kept
+ * separate from the 'available' key so that, once the user updates their CLI,
+ * the (previously unseen) 'available' notice can still surface even if they had
+ * dismissed the update nudge.
+ */
+export const FABLE_UPDATE_NOTICE_DISMISSED_KEY = 'fable-update-notice-dismissed';
+
+function dismissKeyFor(variant: FableNoticeVariant): string {
+  return variant === 'available' ? FABLE_NOTICE_DISMISSED_KEY : FABLE_UPDATE_NOTICE_DISMISSED_KEY;
+}
+
+function getDismissed(variant: FableNoticeVariant): boolean {
   try {
-    return localStorage.getItem(FABLE_NOTICE_DISMISSED_KEY) === '1';
+    return localStorage.getItem(dismissKeyFor(variant)) === '1';
   } catch {
     return false;
   }
 }
 
-function persistDismissed(): void {
+function persistDismissed(variant: FableNoticeVariant): void {
   try {
-    localStorage.setItem(FABLE_NOTICE_DISMISSED_KEY, '1');
+    localStorage.setItem(dismissKeyFor(variant), '1');
   } catch {
     // ignore — a failed persist just means the notice may reappear next load.
   }
 }
 
 interface UseFableNoticeReturn {
-  /** Whether the Fable promo notice should be shown right now. */
+  /** Whether the Fable notice should be shown right now. */
   visible: boolean;
-  /** Dismiss the notice permanently (persisted to localStorage). */
+  /** Which flavour of notice to render (drives copy in FableNoticeBanner). */
+  variant: FableNoticeVariant;
+  /** Dismiss the current variant's notice permanently (persisted to localStorage). */
   dismiss: () => void;
 }
 
 /**
- * Controls the one-time Fable 5 promo notice (issue #153). Shown while the promo
- * window is open (`isFablePromoActive`) and the user hasn't dismissed it; once
- * dismissed it stays hidden across reloads. Past the promo window it never
- * shows, so no cleanup is needed when Fable's launch period ends.
+ * Controls the one-time Fable 5 notice (issue #153). Shown while the promo window
+ * is open (`isFablePromoActive`) and the user hasn't dismissed the variant that
+ * currently applies.
+ *
+ * The variant depends on the running CLI version (`cliVersion`): a CLI new enough
+ * to select Fable (>= 2.1.170) gets the 'available' promo card; an older CLI gets
+ * the 'update-required' nudge instead. Each variant tracks its own dismissed
+ * state, so a user who dismissed the update nudge and then updates their CLI
+ * still sees the 'available' card once (they've never seen it before).
+ *
+ * Past the promo window it never shows, so no cleanup is needed when Fable's
+ * launch period ends.
  */
-export function useFableNotice(): UseFableNoticeReturn {
-  const [dismissed, setDismissed] = useState(getDismissed);
+export function useFableNotice(cliVersion: string | null | undefined): UseFableNoticeReturn {
+  const variant: FableNoticeVariant = isFableSupportedCli(cliVersion) ? 'available' : 'update-required';
+  // Re-read the (variant-specific) dismissed flag on every render rather than
+  // snapshotting once: the variant can flip when the user updates their CLI, and
+  // each variant has its own key. `bump` re-renders after a dismiss so the fresh
+  // localStorage value is picked up without a manual `dismissed` mirror.
+  const [, bump] = useState(0);
+  const dismissed = getDismissed(variant);
   const visible = isFablePromoActive(new Date()) && !dismissed;
 
   const dismiss = useCallback(() => {
-    persistDismissed();
-    setDismissed(true);
-  }, []);
+    persistDismissed(variant);
+    bump((n) => n + 1);
+  }, [variant]);
 
-  return { visible, dismiss };
+  return { visible, variant, dismiss };
 }

--- a/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
@@ -7,6 +7,7 @@ import { useBridge } from '@/hooks/useBridge';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { DEFAULT_MODEL_ALIAS, resolveModelInfo, resolveModelLabel, toModelAlias, withFableFallback } from '@/types/models';
 import { useCurrentModel } from '@/hooks/useCurrentModel';
+import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { LoadedMessageType } from '@/types';
 import type { ModelInfo } from '@/types/slashCommand';
 import { MessageType } from '@/shared';
@@ -41,12 +42,13 @@ export function ModelTag() {
   const { currentSessionId } = useSessionContext();
   const { send } = useBridge();
   const currentModel = useCurrentModel();
+  const { cliVersion } = useVersionInfo();
 
   // Memoized on the CLI response so the fallback-augmented array keeps a stable
   // reference across renders (the rotate effect below depends on `models`).
   const models: ModelInfo[] = useMemo(
-    () => withFableFallback(controlResponse?.response?.response?.models ?? [], new Date()),
-    [controlResponse],
+    () => withFableFallback(controlResponse?.response?.response?.models ?? [], new Date(), cliVersion),
+    [controlResponse, cliVersion],
   );
 
   useEffect(() => {

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -39,6 +39,7 @@ import { InputBanner } from '../InputBanner';
 import { FableNoticeBanner } from '../FableNoticeBanner';
 import { useTelemetryConsent, ConsentStatus, ConsentSource } from '@/hooks/useTelemetryConsent';
 import { useFableNotice } from '@/hooks/useFableNotice';
+import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { getCaretOffset, setCaretOffset, getSelectionRange } from '@/utils/domSelection';
 import { MessageType } from '@/shared';
 
@@ -111,7 +112,9 @@ export function ChatInput() {
   // 숨기고(consentDismissed), 새 세션 전환 시 다시 노출한다. 수락/거절하면 status가 바뀌어 영영 숨는다.
   const { status: consentStatus, accept: acceptConsent, deny: denyConsent } = useTelemetryConsent();
   const [consentDismissed, setConsentDismissed] = useState(false);
-  const fableNotice = useFableNotice();
+  // Fable notice variant depends on the running CLI version (Fable needs 2.1.170+).
+  const { cliVersion } = useVersionInfo();
+  const fableNotice = useFableNotice(cliVersion);
 
   // Native (IDE/Swing) drag-and-drop bridge: Kotlin → Node backend → IPC NATIVE_DROP_ENTRIES.
   // Currently unused (CefDragHandler forwards drops to the page as HTML5 events instead),
@@ -535,7 +538,7 @@ export function ChatInput() {
         />
       )}
       {/* Fable 5 프로모션 공지: 프로모션 기간(~2026-07-07)이고 아직 닫지 않았을 때만 (issue #153) */}
-      {fableNotice.visible && <FableNoticeBanner onClose={fableNotice.dismiss} />}
+      {fableNotice.visible && <FableNoticeBanner variant={fableNotice.variant} onClose={fableNotice.dismiss} />}
       {/* Auto mode 강등 안내: auto를 요청했으나 CLI가 이 환경에서 미지원이라 기본 모드로 적용한 경우 */}
       {autoFallbackNotice && (
         <InputBanner

--- a/webview/src/pages/ChatPage/FableNoticeBanner.tsx
+++ b/webview/src/pages/ChatPage/FableNoticeBanner.tsx
@@ -1,5 +1,6 @@
 import { SparklesIcon } from '@heroicons/react/24/outline';
 import { InputBanner } from './InputBanner';
+import type { FableNoticeVariant } from '@/hooks/useFableNotice';
 
 /**
  * "Learn more" target. claude.ai's web bundle actually references this news
@@ -9,32 +10,56 @@ import { InputBanner } from './InputBanner';
 const FABLE_LEARN_MORE_URL = 'https://www.anthropic.com/news/fable-mythos-access';
 
 interface Props {
+  /**
+   * Which notice to render: 'available' (CLI can select Fable) shows the promo
+   * card; 'update-required' (CLI < 2.1.170) nudges the user to update instead.
+   */
+  variant: FableNoticeVariant;
   /** X(닫기) 클릭 — 공지를 영구히 숨긴다(useFableNotice가 영속화). */
   onClose: () => void;
 }
 
 /**
- * Fable 5 promo notice (issue #153), styled after Cursor's "Auto mode is
- * enabled" card: an icon + bold title, a muted body paragraph, and a trailing
+ * Fable 5 notice (issue #153), styled after Cursor's "Auto mode is enabled"
+ * card: an icon + bold title, a muted body paragraph, and a trailing
  * "Learn more" link, sitting just above the composer as an InputBanner.
  *
- * The title is ours (there is no official Fable "now available" card — claude.ai
- * only surfaces Fable as a usage notice); the body is the CLI's own Fable usage
- * copy, kept verbatim rather than invented.
+ * Two variants:
+ *  - 'available': the CLI can select Fable — the promo card. Title is ours
+ *    (there is no official Fable "now available" card — claude.ai only surfaces
+ *    Fable as a usage notice); the body is the CLI's own Fable usage copy, kept
+ *    verbatim rather than invented.
+ *  - 'update-required': the CLI is too old to know `--model fable`, so we point
+ *    the user at the CLI updater in Settings → About instead of offering a model
+ *    they can't select.
  */
 export function FableNoticeBanner(props: Props) {
-  const { onClose } = props;
+  const { variant, onClose } = props;
+
+  const title = variant === 'available' ? 'Fable is now available' : 'Update to use Fable 5';
+  const body =
+    variant === 'available' ? (
+      <>
+        You can use up to 50% of your plan limits on Fable 5 through July 7. After
+        that, switch to usage credits to continue using it.
+      </>
+    ) : (
+      <>
+        Fable 5 requires Claude Code CLI v2.1.170 or newer. Update your CLI in
+        Settings → About to select it.
+      </>
+    );
+
   return (
     <InputBanner
       message={
         <div className="flex flex-col gap-0.5">
           <span className="flex items-center gap-1.5 font-medium text-[0.9230rem]">
             <SparklesIcon className="h-4 w-4 flex-shrink-0" />
-            Fable is now available
+            {title}
           </span>
           <span className="text-text-tertiary text-[0.8461rem]">
-            You can use up to 50% of your plan limits on Fable 5 through July 7. After
-            that, switch to usage credits to continue using it.{' '}
+            {body}{' '}
             <a
               href={FABLE_LEARN_MORE_URL}
               target="_blank"

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -5,6 +5,7 @@ import { useBridge } from '@/hooks/useBridge';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { useCurrentModel } from '@/hooks/useCurrentModel';
+import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { LoadedMessageType } from '@/types';
 import {
   FABLE_PROMO_BADGE,
@@ -29,10 +30,11 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
   const { currentSessionId } = useSessionContext();
   const { controlResponse } = useCliConfig();
   const currentModel = useCurrentModel();
+  const { cliVersion } = useVersionInfo();
   const panelRef = useRef<HTMLDivElement>(null);
 
   const now = new Date();
-  const models: ModelInfo[] = withFableFallback(controlResponse?.response?.response?.models ?? [], now);
+  const models: ModelInfo[] = withFableFallback(controlResponse?.response?.response?.models ?? [], now, cliVersion);
   const currentInfo = resolveModelInfo(models, currentModel);
   const isMac = navigator.platform.toUpperCase().includes('MAC');
   const promoActive = isFablePromoActive(now);

--- a/webview/src/pages/ChatPage/__tests__/FableNoticeBanner.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/FableNoticeBanner.test.tsx
@@ -3,8 +3,8 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { FableNoticeBanner } from '../FableNoticeBanner';
 
 describe('FableNoticeBanner', () => {
-  it('renders the title, usage copy, and a Learn more link', () => {
-    render(<FableNoticeBanner onClose={() => {}} />);
+  it('renders the available title, usage copy, and a Learn more link', () => {
+    render(<FableNoticeBanner variant="available" onClose={() => {}} />);
     expect(screen.getByText('Fable is now available')).toBeInTheDocument();
     expect(screen.getByText(/50% of your plan limits on Fable 5 through July 7/)).toBeInTheDocument();
     const link = screen.getByRole('link', { name: /learn more/i });
@@ -12,9 +12,22 @@ describe('FableNoticeBanner', () => {
     expect(link).toHaveAttribute('target', '_blank');
   });
 
+  it('renders the update-required title and CLI version copy', () => {
+    render(<FableNoticeBanner variant="update-required" onClose={() => {}} />);
+    expect(screen.getByText('Update to use Fable 5')).toBeInTheDocument();
+    expect(screen.getByText(/requires Claude Code CLI v2\.1\.170 or newer/)).toBeInTheDocument();
+    // The promo usage copy must NOT appear in the update-required variant.
+    expect(screen.queryByText(/50% of your plan limits/)).not.toBeInTheDocument();
+    // Learn more link is reused across variants.
+    expect(screen.getByRole('link', { name: /learn more/i })).toHaveAttribute(
+      'href',
+      'https://www.anthropic.com/news/fable-mythos-access',
+    );
+  });
+
   it('calls onClose when the close button is clicked', () => {
     const onClose = vi.fn();
-    render(<FableNoticeBanner onClose={onClose} />);
+    render(<FableNoticeBanner variant="available" onClose={onClose} />);
     fireEvent.click(screen.getByRole('button', { name: '닫기' }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/webview/src/pages/SettingsPage/About/CliUpdateControl.tsx
+++ b/webview/src/pages/SettingsPage/About/CliUpdateControl.tsx
@@ -11,25 +11,12 @@ import {
 import { UpdateMode } from '@/shared';
 import { useCliUpdate } from '@/hooks/queries/useCliUpdate';
 import { useConfirmDialog } from '@/components/ConfirmDialog/useConfirmDialog';
+import { compareVersions } from '@/utils/compareVersions';
 
 const BUTTON_CLASS =
   'flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded ' +
   'bg-accent-primary-hover hover:bg-accent-primary text-text-primary ' +
   'disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
-
-/** Sign of a - b by semver components (>0 a newer, 0 equal, <0 a older). */
-function compareVersions(a: string, b: string): number {
-  const pa = a.split('.').map((n) => parseInt(n, 10));
-  const pb = b.split('.').map((n) => parseInt(n, 10));
-  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-    const x = pa[i] ?? 0;
-    const y = pb[i] ?? 0;
-    if (Number.isNaN(x) || Number.isNaN(y)) return 0;
-    if (x > y) return 1;
-    if (x < y) return -1;
-  }
-  return 0;
-}
 
 /**
  * One channel row in the dropdown. Its state is relative to the installed version:

--- a/webview/src/types/__tests__/effort.test.ts
+++ b/webview/src/types/__tests__/effort.test.ts
@@ -3,11 +3,13 @@ import {
   EFFORT_AUTO,
   buildEffortLevels,
   getEffortDef,
+  getModelEffortConfig,
   nextEffortLevel,
   parseEffortLevel,
   isUltracodeAvailable,
   nextEffortStep,
 } from '../effort';
+import type { CliConfigControlResponse, ModelInfo } from '../slashCommand';
 
 // Mirrors the Claude Code CLI: effort levels are low/medium/high/xhigh (+max
 // when a model reports it). "Auto" is not a level — it's the unset state. The
@@ -112,5 +114,106 @@ describe('nextEffortStep', () => {
 
   it('advances ultracode → first level (wraps back into the level set)', () => {
     expect(nextEffortStep('xhigh', true, SUPPORTED, true)).toEqual({ kind: 'level', key: 'low' });
+  });
+});
+
+function controlResponseWithModels(models: ModelInfo[]): CliConfigControlResponse {
+  return {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'req-1',
+      response: {
+        commands: [],
+        agents: [],
+        output_style: 'default',
+        available_output_styles: [],
+        models,
+        account: { email: 'test@example.com' },
+        pid: 1,
+      },
+    },
+  } as unknown as CliConfigControlResponse;
+}
+
+describe('getModelEffortConfig', () => {
+  // Regression test for the bug where the effort slider vanished on Opus 1M
+  // context: the CLI's `value` for that model is the suffixed `opus[1m]`, not
+  // the bare `opus` alias, so an exact-match lookup missed it entirely.
+  it('matches an opus[1m] entry even when currentModel is the suffixed value', () => {
+    const models: ModelInfo[] = [
+      {
+        value: 'opus[1m]',
+        displayName: 'Opus',
+        description: 'Opus 4.8 with 1M context · Best for everyday tasks',
+        supportsEffort: true,
+        supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      },
+    ];
+    const controlResponse = controlResponseWithModels(models);
+    expect(getModelEffortConfig(controlResponse, 'opus[1m]')).toEqual({
+      supportsEffort: true,
+      levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    });
+  });
+
+  it('matches an opus[1m] entry when currentModel is the bare alias form', () => {
+    const models: ModelInfo[] = [
+      {
+        value: 'opus[1m]',
+        displayName: 'Opus',
+        description: 'Opus 4.8 with 1M context · Best for everyday tasks',
+        supportsEffort: true,
+        supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      },
+    ];
+    const controlResponse = controlResponseWithModels(models);
+    expect(getModelEffortConfig(controlResponse, 'opus')).toEqual({
+      supportsEffort: true,
+      levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+    });
+  });
+
+  it('matches sonnet by exact alias and by a full model id', () => {
+    const models: ModelInfo[] = [
+      {
+        value: 'sonnet',
+        displayName: 'Sonnet',
+        description: 'Sonnet 5 · Great for everyday coding',
+        supportsEffort: true,
+        supportedEffortLevels: ['low', 'medium', 'high'],
+      },
+    ];
+    const controlResponse = controlResponseWithModels(models);
+    expect(getModelEffortConfig(controlResponse, 'sonnet')).toEqual({
+      supportsEffort: true,
+      levels: ['low', 'medium', 'high'],
+    });
+    expect(getModelEffortConfig(controlResponse, 'claude-sonnet-5')).toEqual({
+      supportsEffort: true,
+      levels: ['low', 'medium', 'high'],
+    });
+  });
+
+  it('returns unsupported for a model without effort support (e.g. Haiku)', () => {
+    const models: ModelInfo[] = [
+      {
+        value: 'haiku',
+        displayName: 'Haiku',
+        description: 'Haiku 5 · Fastest for everyday tasks',
+      },
+    ];
+    const controlResponse = controlResponseWithModels(models);
+    expect(getModelEffortConfig(controlResponse, 'haiku')).toEqual({
+      supportsEffort: false,
+      levels: [],
+    });
+  });
+
+  it('returns unsupported when controlResponse is null', () => {
+    expect(getModelEffortConfig(null, 'opus')).toEqual({
+      supportsEffort: false,
+      levels: [],
+    });
   });
 });

--- a/webview/src/types/__tests__/models.test.ts
+++ b/webview/src/types/__tests__/models.test.ts
@@ -176,9 +176,12 @@ describe('isFablePromoActive', () => {
 describe('withFableFallback', () => {
   const def = model('default', 'Default (recommended)');
   const opus = model('opus', 'Opus');
+  // A CLI version new enough to select Fable (>= 2.1.170), used wherever the
+  // pre-existing expectation is that the fallback gets appended.
+  const SUPPORTED_CLI = '2.1.170';
 
   it('appends the hardcoded Fable item when the list has no Fable model', () => {
-    const merged = withFableFallback([def, opus], DURING_PROMO);
+    const merged = withFableFallback([def, opus], DURING_PROMO, SUPPORTED_CLI);
     expect(merged).toHaveLength(3);
     expect(merged[2]).toBe(FABLE_FALLBACK_MODEL);
     expect(merged[2].value).toBe('fable');
@@ -187,14 +190,14 @@ describe('withFableFallback', () => {
 
   it('does not append when a "fable" alias item is already present (dedup)', () => {
     const cliFable = model('fable', 'Fable 5');
-    const merged = withFableFallback([def, cliFable], DURING_PROMO);
+    const merged = withFableFallback([def, cliFable], DURING_PROMO, SUPPORTED_CLI);
     expect(merged).toHaveLength(2);
     expect(merged).toEqual([def, cliFable]);
   });
 
   it('dedups against a full Fable model id the CLI may hand back', () => {
     const cliFable = model('claude-fable-5', 'Fable 5');
-    const merged = withFableFallback([def, cliFable], DURING_PROMO);
+    const merged = withFableFallback([def, cliFable], DURING_PROMO, SUPPORTED_CLI);
     expect(merged).toHaveLength(2);
     expect(merged.some((m) => m === FABLE_FALLBACK_MODEL)).toBe(false);
   });
@@ -203,12 +206,12 @@ describe('withFableFallback', () => {
     // An empty list means the CLI config has not arrived yet; consumers treat
     // length 0 as "loading" (hide the tag / show a spinner). Injecting Fable
     // there would break that, so the fallback only augments a loaded list.
-    expect(withFableFallback([], DURING_PROMO)).toEqual([]);
+    expect(withFableFallback([], DURING_PROMO, SUPPORTED_CLI)).toEqual([]);
   });
 
   it('does not inject the fallback after the promo window ends', () => {
     // Past the promo the hardcoded fallback is dropped — nothing to select.
-    const merged = withFableFallback([def, opus], AFTER_PROMO);
+    const merged = withFableFallback([def, opus], AFTER_PROMO, SUPPORTED_CLI);
     expect(merged).toEqual([def, opus]);
   });
 
@@ -216,7 +219,36 @@ describe('withFableFallback', () => {
     // If the account's catalog carries Fable, it stays regardless of our promo
     // window — the server, not us, decides post-promo availability.
     const cliFable = model('fable', 'Fable 5');
-    const merged = withFableFallback([def, cliFable], AFTER_PROMO);
+    const merged = withFableFallback([def, cliFable], AFTER_PROMO, SUPPORTED_CLI);
+    expect(merged).toEqual([def, cliFable]);
+  });
+
+  it('does not append the fallback when the CLI is too old to select Fable', () => {
+    // CLI 2.1.169 < 2.1.170: it doesn't know `--model fable`, so offering the
+    // hardcoded fallback would surface a model the user can't actually select.
+    const merged = withFableFallback([def, opus], DURING_PROMO, '2.1.169');
+    expect(merged).toEqual([def, opus]);
+    expect(merged.some((m) => toModelAlias(m.value) === 'fable')).toBe(false);
+  });
+
+  it('does not append the fallback when the CLI version is unknown (null)', () => {
+    // A null version means we can't confirm Fable support; stay conservative.
+    const merged = withFableFallback([def, opus], DURING_PROMO, null);
+    expect(merged).toEqual([def, opus]);
+  });
+
+  it('appends the fallback when the CLI is exactly at the minimum version', () => {
+    // 2.1.170 is the first CLI that knows Fable — inclusive threshold.
+    const merged = withFableFallback([def, opus], DURING_PROMO, '2.1.170');
+    expect(merged).toHaveLength(3);
+    expect(merged[2]).toBe(FABLE_FALLBACK_MODEL);
+  });
+
+  it('keeps a CLI-served Fable even on an old CLI (dedup wins over version gate)', () => {
+    // If the catalog already carries Fable, that dynamic entry is trusted
+    // regardless of the parsed version — the dedup check runs first.
+    const cliFable = model('fable', 'Fable 5');
+    const merged = withFableFallback([def, cliFable], DURING_PROMO, '2.1.100');
     expect(merged).toEqual([def, cliFable]);
   });
 });

--- a/webview/src/types/claude-settings.ts
+++ b/webview/src/types/claude-settings.ts
@@ -27,7 +27,7 @@ export interface ClaudeSettingsState {
   ultracode?: boolean | null; // xhigh effort + standing workflow orchestration; the slider's top step (null = off/cleared)
   disableWorkflows?: boolean; // CLI-owned: when true, the Workflows feature (and ultracode) is unavailable
   alwaysThinkingEnabled: boolean; // extended thinking always on
-  preferFastMode: boolean; // fast output mode (Opus 4.6 only)
+  preferFastMode: boolean; // fast output mode (Opus models only)
   useCtrlEnterToSend: boolean; // when true, Ctrl/Cmd+Enter sends; plain Enter inserts a newline
   focusInputOnEditorContext: boolean; // when true, move focus to chat input after inserting file path via Alt+K
   respectGitignoreForContext: boolean; // when true, exclude body of .gitignore'd files from editor context (path only)

--- a/webview/src/types/commandPalette.ts
+++ b/webview/src/types/commandPalette.ts
@@ -41,6 +41,8 @@ export interface PanelItemBase {
   /** Rendered right after the label (secondary color), e.g. Effort's "(Extra high)". */
   labelSuffix?: () => React.ReactNode;
   disabled?: boolean;
+  /** Hover tooltip shown on a disabled row explaining why it's unavailable (e.g. model capability gating). */
+  disabledReason?: string;
   keepOpen?: boolean;
   /** Hidden from the panel by default; only surfaced when the filter query matches its label. */
   searchOnly?: boolean;

--- a/webview/src/types/effort.ts
+++ b/webview/src/types/effort.ts
@@ -13,7 +13,7 @@
  * model's `supportedEffortLevels` (low/medium/high/xhigh/max), and `auto` is
  * only the label shown while the level is unset.
  */
-import { toModelAlias, DEFAULT_MODEL_ALIAS } from './models';
+import { resolveModelInfo } from './models';
 import type { CliConfigControlResponse, ModelInfo } from './slashCommand';
 
 export const EFFORT_AUTO = 'auto';
@@ -139,16 +139,23 @@ export interface ModelEffortConfig {
 
 /**
  * Resolve the current model's effort configuration from the CLI control
- * response. The CLI keys models by short `value` (`default`, `sonnet`,
- * `haiku`); `settings.model` is either a full CLI model ID or `null`.
+ * response. `currentModel` may be a precise list value (e.g. `opus[1m]`), a
+ * coarse alias (`opus`), or a raw full model id — the same granularity mix
+ * `resolveModelInfo` already handles for the model indicator, so this reuses
+ * it rather than doing its own exact-only lookup.
+ *
+ * This matters in practice: the CLI's `value` for Opus with the 1M context
+ * window is the suffixed `opus[1m]`, not the bare `opus` alias. An exact-match
+ * lookup against that suffixed value missed it whenever `currentModel` was the
+ * bare alias, silently reporting `supportsEffort: false` and hiding the effort
+ * slider. `resolveModelInfo`'s alias-equivalence fallback fixes that.
  */
 export function getModelEffortConfig(
   controlResponse: CliConfigControlResponse | null,
-  settingsModel: string | null | undefined,
+  currentModel: string | null | undefined,
 ): ModelEffortConfig {
   const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
-  const alias = settingsModel ? toModelAlias(settingsModel) : DEFAULT_MODEL_ALIAS;
-  const info = models.find((m) => m.value === alias);
+  const info = resolveModelInfo(models, currentModel);
   if (!info?.supportsEffort) return { supportsEffort: false, levels: [] };
   return { supportsEffort: true, levels: info.supportedEffortLevels ?? [] };
 }

--- a/webview/src/types/models.ts
+++ b/webview/src/types/models.ts
@@ -1,4 +1,5 @@
 import type { ModelInfo } from './slashCommand';
+import { isAtLeastVersion } from '@/utils/compareVersions';
 
 /**
  * CLI model alias ("default", "opus", "sonnet", "haiku", "fable") used by the
@@ -55,6 +56,18 @@ export function isFablePromoActive(now: Date): boolean {
 }
 
 /**
+ * Minimum Claude Code CLI version that knows the Fable model (`--model fable`).
+ * Fable landed in CLI 2.1.170; older CLIs don't recognise it, so we must not
+ * surface a fallback they can't select.
+ */
+export const FABLE_MIN_CLI_VERSION = '2.1.170';
+
+/** Whether the running CLI is new enough to select Fable. */
+export function isFableSupportedCli(cliVersion: string | null | undefined): boolean {
+  return isAtLeastVersion(cliVersion, FABLE_MIN_CLI_VERSION);
+}
+
+/**
  * Hardcoded Fable item appended only when the CLI-provided catalog lacks Fable.
  * `value: 'fable'` matches the verified `--model fable` / `set_model` path.
  * `description` is the CLI's own Fable row text (kept verbatim, not invented).
@@ -74,14 +87,27 @@ export const FABLE_FALLBACK_MODEL: ModelInfo = {
  * not us, decides post-promo availability; only our hardcoded fallback is
  * gated on the promo still being active (`now`).
  *
+ * The hardcoded fallback is additionally gated on the CLI version: Fable landed
+ * in CLI 2.1.170 (`FABLE_MIN_CLI_VERSION`), and older CLIs don't recognise
+ * `--model fable`, so offering the fallback to them would surface a model the
+ * user can't actually select. The "CLI already serves it" dedup check runs
+ * BEFORE the version gate on purpose: an entitled account whose catalog carries
+ * Fable is necessarily on a CLI new enough to serve it, so we always trust that
+ * dynamic entry regardless of the parsed version string.
+ *
  * An empty list is left untouched: length 0 means the CLI config hasn't loaded
  * yet, and consumers treat that as "loading" (hide the tag / show a spinner).
  * Injecting Fable there would defeat that, so only a loaded list is augmented.
  */
-export function withFableFallback(models: ModelInfo[], now: Date): ModelInfo[] {
+export function withFableFallback(
+  models: ModelInfo[],
+  now: Date,
+  cliVersion: string | null | undefined,
+): ModelInfo[] {
   if (models.length === 0) return models;
-  if (models.some((m) => toModelAlias(m.value) === 'fable')) return models;
+  if (models.some((m) => toModelAlias(m.value) === 'fable')) return models; // CLI already serves it — always trust, regardless of version
   if (!isFablePromoActive(now)) return models;
+  if (!isFableSupportedCli(cliVersion)) return models; // an old CLI can't select Fable, so don't offer the fallback
   return [...models, FABLE_FALLBACK_MODEL];
 }
 

--- a/webview/src/utils/__tests__/compareVersions.test.ts
+++ b/webview/src/utils/__tests__/compareVersions.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { compareVersions, isAtLeastVersion } from '../compareVersions';
+
+describe('compareVersions', () => {
+  it('returns 0 for equal versions', () => {
+    expect(compareVersions('2.1.170', '2.1.170')).toBe(0);
+    expect(compareVersions('1.0.0', '1.0.0')).toBe(0);
+  });
+
+  it('returns a negative number when a is older', () => {
+    expect(compareVersions('2.1.169', '2.1.170')).toBeLessThan(0);
+    expect(compareVersions('1.9.9', '2.0.0')).toBeLessThan(0);
+  });
+
+  it('returns a positive number when a is newer', () => {
+    expect(compareVersions('2.1.171', '2.1.170')).toBeGreaterThan(0);
+    expect(compareVersions('2.2.0', '2.1.170')).toBeGreaterThan(0);
+  });
+
+  it('handles differing component counts (missing treated as 0)', () => {
+    // '2.1' === '2.1.0' which is older than '2.1.170'
+    expect(compareVersions('2.1', '2.1.170')).toBeLessThan(0);
+    expect(compareVersions('2.1.170', '2.1')).toBeGreaterThan(0);
+    expect(compareVersions('2.1', '2.1.0')).toBe(0);
+  });
+
+  it('treats NaN / empty components as 0', () => {
+    // '' → NaN → 0, so equal to '0.0.0'
+    expect(compareVersions('', '0.0.0')).toBe(0);
+    expect(compareVersions('2.x.1', '2.0.1')).toBe(0);
+    expect(compareVersions('', '1.0.0')).toBeLessThan(0);
+  });
+});
+
+describe('isAtLeastVersion', () => {
+  it('returns false for a null / undefined version (undetected CLI)', () => {
+    expect(isAtLeastVersion(null, '2.1.170')).toBe(false);
+    expect(isAtLeastVersion(undefined, '2.1.170')).toBe(false);
+  });
+
+  it('returns true when the version exactly meets the minimum', () => {
+    expect(isAtLeastVersion('2.1.170', '2.1.170')).toBe(true);
+  });
+
+  it('returns true when the version exceeds the minimum', () => {
+    expect(isAtLeastVersion('2.1.198', '2.1.170')).toBe(true);
+    expect(isAtLeastVersion('2.2.0', '2.1.170')).toBe(true);
+  });
+
+  it('returns false when the version is below the minimum', () => {
+    expect(isAtLeastVersion('2.1.169', '2.1.170')).toBe(false);
+  });
+});

--- a/webview/src/utils/compareVersions.ts
+++ b/webview/src/utils/compareVersions.ts
@@ -1,0 +1,18 @@
+/** Sign of a - b by dotted numeric version components (>0 a is newer, 0 equal, <0 a older). Missing/NaN components are treated as 0. */
+export function compareVersions(a: string, b: string): number {
+  const pa = a.split('.').map((n) => parseInt(n, 10));
+  const pb = b.split('.').map((n) => parseInt(n, 10));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = Number.isNaN(pa[i]) ? 0 : (pa[i] ?? 0);
+    const y = Number.isNaN(pb[i]) ? 0 : (pb[i] ?? 0);
+    if (x > y) return 1;
+    if (x < y) return -1;
+  }
+  return 0;
+}
+
+/** True when `version` is present and >= `min`. A null/undefined version (undetected CLI) is treated as NOT meeting the minimum (conservative: don't surface features we can't confirm are supported). */
+export function isAtLeastVersion(version: string | null | undefined, min: string): boolean {
+  if (!version) return false;
+  return compareVersions(version, min) >= 0;
+}


### PR DESCRIPTION
## Summary

Fixes and hardens the **Model-section controls** (Effort, Fast mode, model list) in the slash-command / modes popups. Four related changes:

### 1. Effort slider missing on `opus[1m]` — `closes #152`
`getModelEffortConfig` applied `toModelAlias` only to the settings model, then exact-matched it against the raw CLI model `value`. The CLI reports Opus 1M as `opus[1m]`, so alias `opus` never matched → `supportsEffort: false` → the slider vanished on Opus (and any suffixed value), in all three call sites. Now reuses `resolveModelInfo` (alias-equivalence + default fallback, the same resolution fast mode / Switch model already use) and keys on the current session model.

### 2. Fast mode toggle instability
The toggle flickered ("worked, then didn't") and looked translucent-yet-clickable on Opus. Root cause: `ToggleFastModeItem` mutated a module-level singleton's `disabled` from inside its render function, and `commandToItem` proxies `disabled` through a live getter — so the write leaked into the row a beat late, and StrictMode's double render made it nondeterministic. The render-time global mutation is removed; disabled state is now injected purely in `CommandPaletteProvider`'s `sections` memo via a new pure helper `applyModelCapabilityFlags`.

### 3. Capability rows: disabled + tooltip instead of hiding
Unsupported controls (Effort on Haiku, Fast mode on Sonnet/Haiku) used to be **hidden**. They now stay visible but **disabled with a hover tooltip** explaining why — consistent Model section regardless of model, so a missing control never reads as a bug.

### 4. Fable fallback gated on CLI version (>= 2.1.170) — follow-up to #153
The hardcoded Fable fallback was surfaced purely on the promo window, ignoring CLI version. Fable landed in CLI **2.1.170**; older CLIs don't know `--model fable`, so the fallback offered a model the user could select but never use. Now gated on `cliVersion` (via `useVersionInfo` → `GET_VERSION`): below 2.1.170 (or undetected) the fallback is withheld and an **"update-required"** input-banner variant tells the user which version to update to; once updated, Fable appears automatically. A CLI that already serves Fable in its catalog still wins regardless of version.

Plus: `compareVersions` extracted into a shared util (dropping a duplicate copy), and a user-facing **Effort & Fast Mode** feature guide (en/ko) under `docs/features/006`.

## Test plan

- **Unit**: `wv-test` — 1117 passed (new: `getModelEffortConfig` `opus[1m]` regression, `applyModelCapabilityFlags`, `compareVersions`, Fable version-gate cases incl. 2.1.169→hidden / null→hidden / 2.1.170→shown). `wv-lint` — 0 TS errors.
- **Browser (standalone)** — Opus/Sonnet/Haiku switching: effort slider shows/greys correctly, fast mode toggle stable, tooltips correct.
- **Fable gate, both directions (real CLI)**: downgraded the running `claude` to **2.1.169** → Fable hidden + "Update to use Fable 5" banner; restored to **2.1.198** → Fable listed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
