### PR TITLE
fix(#159): keep the MCP SDK off the backend boot path (lazy load + Web Streams polyfill)

### DIFF
--- a/backend/esbuild.mjs
+++ b/backend/esbuild.mjs
@@ -39,7 +39,23 @@ const common = {
     ...injectedDefine,
   },
   banner: {
-    js: `import { createRequire } from 'node:module';\nconst require = createRequire(import.meta.url);`,
+    // Prepended verbatim to the top of every bundle, so these run before any
+    // bundled module body (including the MCP SDK → eventsource-parser code below).
+    js: [
+      `import { createRequire } from 'node:module';`,
+      `const require = createRequire(import.meta.url);`,
+      // Web Streams globals (TransformStream/Readable/Writable) are only guaranteed
+      // on the global scope in newer Node runtimes; older or non-standard nodes that
+      // the plugin may end up launching expose them only on `node:stream/web`. The
+      // bundled MCP SDK pulls in eventsource-parser, whose `class extends
+      // TransformStream` is evaluated at module load — a missing global there kills
+      // the backend before it can even print its PORT line (#159). Pull them from
+      // the module and fill any gap so the bundle loads on any Node >= 16.5.
+      `import { TransformStream as __ccgTransformStream, ReadableStream as __ccgReadableStream, WritableStream as __ccgWritableStream } from 'node:stream/web';`,
+      `globalThis.TransformStream ??= __ccgTransformStream;`,
+      `globalThis.ReadableStream ??= __ccgReadableStream;`,
+      `globalThis.WritableStream ??= __ccgWritableStream;`,
+    ].join('\n'),
   },
 };
 

--- a/backend/src/core/features/__tests__/mcp-tools.test.ts
+++ b/backend/src/core/features/__tests__/mcp-tools.test.ts
@@ -34,33 +34,33 @@ describe('mapMcpTool', () => {
 });
 
 describe('buildTransport', () => {
-  it('returns a transport for a stdio server with a command', () => {
+  it('returns a transport for a stdio server with a command', async () => {
     const config: McpServerConfig = {
       type: McpTransportType.STDIO,
       command: 'npx',
       args: ['@executeautomation/playwright-mcp-server'],
     };
-    expect(buildTransport(config)).not.toBeNull();
+    expect(await buildTransport(config)).not.toBeNull();
   });
 
-  it('returns null for a stdio server without a command', () => {
-    expect(buildTransport({ type: McpTransportType.STDIO })).toBeNull();
+  it('returns null for a stdio server without a command', async () => {
+    expect(await buildTransport({ type: McpTransportType.STDIO })).toBeNull();
   });
 
-  it('returns a transport for an http server with a url', () => {
-    expect(buildTransport({ type: McpTransportType.HTTP, url: 'http://localhost:8000/mcp' })).not.toBeNull();
+  it('returns a transport for an http server with a url', async () => {
+    expect(await buildTransport({ type: McpTransportType.HTTP, url: 'http://localhost:8000/mcp' })).not.toBeNull();
   });
 
-  it('returns a transport for an sse server with a url', () => {
-    expect(buildTransport({ type: McpTransportType.SSE, url: 'http://localhost:64342/sse' })).not.toBeNull();
+  it('returns a transport for an sse server with a url', async () => {
+    expect(await buildTransport({ type: McpTransportType.SSE, url: 'http://localhost:64342/sse' })).not.toBeNull();
   });
 
-  it('returns null for http/sse without a url', () => {
-    expect(buildTransport({ type: McpTransportType.HTTP })).toBeNull();
-    expect(buildTransport({ type: McpTransportType.SSE })).toBeNull();
+  it('returns null for http/sse without a url', async () => {
+    expect(await buildTransport({ type: McpTransportType.HTTP })).toBeNull();
+    expect(await buildTransport({ type: McpTransportType.SSE })).toBeNull();
   });
 
-  it('returns null for claudeai-proxy (needs OAuth, not directly probeable)', () => {
-    expect(buildTransport({ type: McpTransportType.CLAUDEAI_PROXY, url: 'https://example' })).toBeNull();
+  it('returns null for claudeai-proxy (needs OAuth, not directly probeable)', async () => {
+    expect(await buildTransport({ type: McpTransportType.CLAUDEAI_PROXY, url: 'https://example' })).toBeNull();
   });
 });

--- a/backend/src/core/features/mcp-tools.ts
+++ b/backend/src/core/features/mcp-tools.ts
@@ -10,10 +10,15 @@
  * standard — it does NOT route through Claude's API/account/policy, so this
  * stays within the "no Claude-SDK / no undocumented protocol" rule in CLAUDE.md.
  */
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+// The SDK is imported *dynamically* inside the functions that actually connect to
+// a server (buildTransport/fetchServerTools) rather than at module top-level. The
+// SDK transitively pulls in eventsource-parser, whose `class extends TransformStream`
+// is evaluated on load; a static import here would drag that into the backend boot
+// path (handlers/index → this module), crashing startup on Node runtimes without the
+// Web Streams globals before the backend can even report its port (#159). MCP is only
+// needed when the user actually inspects a server's tools, so this defers the whole
+// SDK — and its Web Streams dependency — until that first use. Only the type is safe
+// to import statically (erased at build time, no runtime load).
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { McpTransportType } from '../../shared';
 import type { McpServerTool, McpServerConfig } from '../../shared';
@@ -50,10 +55,11 @@ export function mapMcpTool(tool: RawMcpTool): McpServerTool {
  * Build the SDK transport for a server config, or null when the transport can't
  * be probed directly (claudeai-proxy needs OAuth; ws is rare; missing url/cmd).
  */
-export function buildTransport(config: McpServerConfig): Transport | null {
+export async function buildTransport(config: McpServerConfig): Promise<Transport | null> {
   switch (config.type) {
-    case McpTransportType.STDIO:
+    case McpTransportType.STDIO: {
       if (!config.command) return null;
+      const { StdioClientTransport } = await import('@modelcontextprotocol/sdk/client/stdio.js');
       return new StdioClientTransport({
         command: config.command,
         args: config.args ?? [],
@@ -62,16 +68,21 @@ export function buildTransport(config: McpServerConfig): Transport | null {
         // the server's own env overrides on top.
         env: stdioEnv(config.env),
       });
-    case McpTransportType.HTTP:
+    }
+    case McpTransportType.HTTP: {
       if (!config.url) return null;
+      const { StreamableHTTPClientTransport } = await import('@modelcontextprotocol/sdk/client/streamableHttp.js');
       return new StreamableHTTPClientTransport(new URL(config.url), {
         requestInit: config.headers ? { headers: config.headers } : undefined,
       });
-    case McpTransportType.SSE:
+    }
+    case McpTransportType.SSE: {
       if (!config.url) return null;
+      const { SSEClientTransport } = await import('@modelcontextprotocol/sdk/client/sse.js');
       return new SSEClientTransport(new URL(config.url), {
         requestInit: config.headers ? { headers: config.headers } : undefined,
       });
+    }
     default:
       return null;
   }
@@ -104,9 +115,10 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
  */
 export async function fetchServerTools(config: McpServerConfig | null): Promise<McpServerTool[]> {
   if (!config) return [];
-  const transport = buildTransport(config);
+  const transport = await buildTransport(config);
   if (!transport) return [];
 
+  const { Client } = await import('@modelcontextprotocol/sdk/client/index.js');
   const client = new Client({ name: 'claude-code-gui', version: '1.0.0' });
   try {
     await withTimeout(client.connect(transport), TOOLS_TIMEOUT_MS, 'MCP connect');


### PR DESCRIPTION
## Summary
Fixes #159 — on some setups the plugin fails to start with `Node.js process exited before printing PORT (exit code: 1)`.

## Root cause
The backend bundle includes the MCP SDK, which transitively pulls in `eventsource-parser`, whose top-level `class extends TransformStream` is evaluated the moment the module loads. `handlers/index` statically imports the MCP handlers → `mcp-tools` → the SDK, so the SDK was dragged onto the **backend boot path**: merely starting the backend loaded it. On a Node runtime that doesn't expose the Web Streams API on the global scope, this throws `ReferenceError: TransformStream is not defined` before the backend can print its `PORT:` line — the exact failure in the #159 screenshot.

This isn't a source regression: the same import existed in v0.22.1. The trigger is *which node gets launched* — a GUI-launched IDE has a minimal PATH, so node discovery can pick a different/older node than the user's shell (nvm) one.

## Fix (two layers)
1. **Lazy load (root fix)** — MCP is only needed when the user inspects a server's tools, so `buildTransport`/`fetchServerTools` now `await import(...)` the SDK submodules instead of importing them at module top-level. This removes the SDK from the boot path entirely: users who never touch MCP can't hit this on any node, and the backend boots lighter. `buildTransport` becomes async (its only callers already await it).
2. **Web Streams polyfill (safety net)** — an esbuild banner pulls `TransformStream`/`ReadableStream`/`WritableStream` from `node:stream/web` and fills any missing global (`??=`), so even when MCP *is* used the SDK loads fine on any Node ≥ 16.5. Applies to both `backend.mjs` and `account-cli.mjs` (shared banner).

## Verification
- Before the fix, loading the bundle with the Web Streams globals removed → crash (reproduces #159).
- With **lazy loading and no polyfill**, the backend boots on a runtime with those globals removed → proves the SDK is off the boot path.
- With both layers, boot succeeds on both the crippled and a normal node (`PORT:` printed, server listening).
- `be lint` (tsc) passes; `mcp-tools` tests pass 11/11.