### PR TITLE
fix: keep env-provided ANTHROPIC_API_KEY when spawning the Claude CLI

### DIFF
--- a/backend/src/core/features/__tests__/getStrippableAuthEnvKeys.test.ts
+++ b/backend/src/core/features/__tests__/getStrippableAuthEnvKeys.test.ts
@@ -41,7 +41,7 @@ describe('getStrippableAuthEnvKeys()', () => {
     vi.clearAllMocks();
   });
 
-  it('returns ALL OAuth-related env keys when no settings file specifies any of them', async () => {
+  it('strips the OAuth token keys — but NOT ANTHROPIC_API_KEY — when no settings specify any', async () => {
     mockSettingsByPath({
       [HOME_SETTINGS]: { env: {} },
       [HOME_SETTINGS_LOCAL]: {},
@@ -49,61 +49,69 @@ describe('getStrippableAuthEnvKeys()', () => {
     const keys = await getStrippableAuthEnvKeys();
     expect(keys).toEqual(
       expect.arrayContaining([
-        'ANTHROPIC_API_KEY',
         'CLAUDE_CODE_OAUTH_TOKEN',
         'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
       ]),
     );
-    expect(keys).toHaveLength(3);
+    expect(keys).toHaveLength(2);
   });
 
-  it('returns ALL keys when settings files do not exist at all', async () => {
+  it('strips only the OAuth token keys when settings files do not exist at all', async () => {
     mockReadFile.mockRejectedValue(new Error('ENOENT'));
     const keys = await getStrippableAuthEnvKeys();
     expect(keys).toEqual(
       expect.arrayContaining([
-        'ANTHROPIC_API_KEY',
         'CLAUDE_CODE_OAUTH_TOKEN',
         'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
       ]),
     );
-    expect(keys).toHaveLength(3);
+    expect(keys).toHaveLength(2);
   });
 
-  it('excludes a key when user explicitly sets it in global settings.json env', async () => {
+  // Regression for marketplace review #140950: a user who authenticates by exporting
+  // ANTHROPIC_API_KEY (shell env / Windows `setx`) without pinning it in settings.json must
+  // NOT have it stripped — the CLI reads that env var directly, and stripping it left the
+  // plugin "Not logged in" / unable to prompt. The API key never expires, so it is never a
+  // strip target regardless of settings.
+  it('never strips ANTHROPIC_API_KEY even when it is not pinned in any settings file', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+    const keys = await getStrippableAuthEnvKeys();
+    expect(keys).not.toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('excludes an OAuth token key when user explicitly sets it in global settings.json env', async () => {
     mockSettingsByPath({
-      [HOME_SETTINGS]: { env: { ANTHROPIC_API_KEY: 'sk-ant-user-pinned' } },
+      [HOME_SETTINGS]: { env: { CLAUDE_CODE_OAUTH_TOKEN: 'token-user-pinned' } },
       [HOME_SETTINGS_LOCAL]: {},
     });
     const keys = await getStrippableAuthEnvKeys();
-    expect(keys).not.toContain('ANTHROPIC_API_KEY');
-    expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(keys).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
     expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR');
   });
 
-  it('excludes a key when user explicitly sets it in settings.local.json env', async () => {
+  it('excludes an OAuth token key when user explicitly sets it in settings.local.json env', async () => {
     mockSettingsByPath({
       [HOME_SETTINGS]: {},
       [HOME_SETTINGS_LOCAL]: { env: { CLAUDE_CODE_OAUTH_TOKEN: 'token-from-local' } },
     });
     const keys = await getStrippableAuthEnvKeys();
     expect(keys).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
-    expect(keys).toContain('ANTHROPIC_API_KEY');
+    expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR');
   });
 
-  it('excludes a key when user explicitly sets it in project settings.json env', async () => {
+  it('excludes an OAuth token key when user explicitly sets it in project settings.json env', async () => {
     mockSettingsByPath({
       [HOME_SETTINGS]: {},
       [HOME_SETTINGS_LOCAL]: {},
-      [PROJECT_SETTINGS]: { env: { ANTHROPIC_API_KEY: 'project-api-key' } },
+      [PROJECT_SETTINGS]: { env: { CLAUDE_CODE_OAUTH_TOKEN: 'project-token' } },
       [PROJECT_SETTINGS_LOCAL]: {},
     });
     const keys = await getStrippableAuthEnvKeys(PROJECT_DIR);
-    expect(keys).not.toContain('ANTHROPIC_API_KEY');
-    expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(keys).not.toContain('CLAUDE_CODE_OAUTH_TOKEN');
+    expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR');
   });
 
-  it('excludes a key when user explicitly sets it in project settings.local.json env', async () => {
+  it('excludes an OAuth token key when user explicitly sets it in project settings.local.json env', async () => {
     mockSettingsByPath({
       [HOME_SETTINGS]: {},
       [HOME_SETTINGS_LOCAL]: {},
@@ -112,7 +120,6 @@ describe('getStrippableAuthEnvKeys()', () => {
     });
     const keys = await getStrippableAuthEnvKeys(PROJECT_DIR);
     expect(keys).not.toContain('CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR');
-    expect(keys).toContain('ANTHROPIC_API_KEY');
     expect(keys).toContain('CLAUDE_CODE_OAUTH_TOKEN');
   });
 
@@ -122,15 +129,15 @@ describe('getStrippableAuthEnvKeys()', () => {
       [HOME_SETTINGS_LOCAL]: {},
     });
     const keys = await getStrippableAuthEnvKeys();
-    expect(keys).toHaveLength(3);
+    expect(keys).toHaveLength(2);
   });
 
-  it('honors precedence: project explicit overrides global, but global explicit alone is enough', async () => {
-    // ANTHROPIC_API_KEY explicit only in project; CLAUDE_CODE_OAUTH_TOKEN explicit only in global
+  it('honors precedence: a project-explicit OAuth key overrides, leaving only the unspecified one', async () => {
+    // CLAUDE_CODE_OAUTH_TOKEN explicit only in global; nothing pins FILE_DESCRIPTOR anywhere.
     mockSettingsByPath({
       [HOME_SETTINGS]: { env: { CLAUDE_CODE_OAUTH_TOKEN: 'g' } },
       [HOME_SETTINGS_LOCAL]: {},
-      [PROJECT_SETTINGS]: { env: { ANTHROPIC_API_KEY: 'p' } },
+      [PROJECT_SETTINGS]: {},
       [PROJECT_SETTINGS_LOCAL]: {},
     });
     const keys = await getStrippableAuthEnvKeys(PROJECT_DIR);

--- a/backend/src/core/features/claude-settings.ts
+++ b/backend/src/core/features/claude-settings.ts
@@ -203,13 +203,21 @@ const API_KEY_PATTERNS = [
   /AUTH_TOKEN$/i,
 ];
 
-// OAuth/API credential env keys that the Claude CLI consults BEFORE the keychain.
-// If these are inherited from a parent process (e.g. Claude Desktop spawning Claude Code,
-// IDE-integrated terminals, or stale env in the user's shell), the CLI will use them as-is
-// and never trigger its keychain-based refresh_token flow — so once the inherited token
-// expires, every call returns 401 indefinitely.
+// OAuth *token* env keys that the Claude CLI consults BEFORE the keychain. When these are
+// inherited from a parent process (e.g. Claude Desktop spawning Claude Code, IDE-integrated
+// terminals, or stale env in the user's shell), the CLI uses them as-is and never triggers
+// its keychain-based refresh_token flow — so once the inherited token EXPIRES, every call
+// returns 401 indefinitely. Stripping them lets the CLI fall back to its refreshable keychain
+// auth.
+//
+// ANTHROPIC_API_KEY is intentionally NOT in this list. An API key does not expire and has no
+// refresh flow, so it never causes the 401 loop above — the only reason the OAuth tokens are
+// stripped. Stripping it only broke users who authenticate by exporting ANTHROPIC_API_KEY
+// (shell env / Windows `setx`) rather than pinning it in settings.json: the `claude` CLI
+// honors that env var directly, so the GUI must too (CLI parity). See marketplace review
+// #140950 — the plugin showed "Not logged in" / prompts failed on Windows precisely because
+// this strip removed the user's env-provided API key before spawning the CLI.
 const STRIPPABLE_AUTH_ENV_KEYS = [
-  'ANTHROPIC_API_KEY',
   'CLAUDE_CODE_OAUTH_TOKEN',
   'CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR',
 ] as const;


### PR DESCRIPTION
## Summary

JetBrains Marketplace review [#140950](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui/reviews) (Rider, Windows 11) reported the plugin stuck on **"Not logged in · Please run /login"** even though `ANTHROPIC_API_KEY` was set as a Windows user env var (`setx`) and the same key worked fine in the IDE's integrated terminal. The user could browse conversations but every prompt failed.

## Root cause

The auth-env strip introduced in `dcb0d53` removes `ANTHROPIC_API_KEY` from the env handed to the spawned `claude` process unless the user pinned it in `settings.json`.

That strip is meant for inherited **OAuth tokens**: the CLI prefers env-based credentials over its keychain and never refreshes them, so an expired inherited token 401s forever. An **API key**, however, never expires and has no refresh flow — it was never a cause of that loop; it was bundled into the strip list only by key name.

The side effect: users who authenticate the way the CLI itself supports — exporting `ANTHROPIC_API_KEY` via shell env / `setx` instead of `settings.json` — had their key silently removed before `claude -p` spawned, so prompts failed with "Not logged in". This is a CLI-parity break: the `claude` CLI honors that env var directly, so the GUI must too.

## Change

- Remove `ANTHROPIC_API_KEY` from `STRIPPABLE_AUTH_ENV_KEYS`; keep the two OAuth token keys (`CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR`) — the real, expiring targets.
- Regression test: the API key is never stripped even when absent from every settings file.

## Ruled out (investigated, not the cause)

- `ProcessBuilder.environment().clear()` in the Kotlin backend spawn, a Windows registry re-read, and `EnvironmentUtil` snapshot staleness were all investigated and rejected. The backend→CLI chain already inherits `process.env` in full; the only place the key was lost was this explicit strip.
- OAuth-token strip is intentionally left intact — removing it risks regressing the 401-loop fix from `dcb0d53`.

## Testing

- `be-test`: `getStrippableAuthEnvKeys` suite green. (The `loadCliConfig.test.ts` failures are a pre-existing 15s-timer teardown flake, reproduced identically on clean `main` — unrelated to this change.)
- `be-build`: bundles clean.

## Note

The actual Windows path cannot be exercised on the dev host (macOS); this fix is verified by unit test + code-path analysis. Final confirmation is best done by the reporter.

Fixes JetBrains Marketplace review #140950.