### PR TITLE
refactor: unify auth-env strip across all Claude CLI invocations

### DIFF
--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -2,7 +2,6 @@ import type { ConnectionManager } from '../ws/connection-manager';
 import type { Bridge } from '../bridge/bridge-interface';
 import { Claude } from './claude';
 import { diagnoseAuthError } from './features/auth-diagnosis';
-import { getStrippableAuthEnvKeys } from './features/claude-settings';
 import { EditedFileTracker } from './features/editedFileTracker';
 import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
@@ -165,25 +164,16 @@ export async function ensureClaudeProcess(
   // spawning, so the CLI resolves the right Claude data dir for THIS workingDir. (#123)
   await Claude.applyConfigDir(workingDir);
 
-  // Strip OAuth env inherited from parent (e.g. Claude Desktop spawning the IDE) so the
-  // CLI falls through to its keychain-based auth, which can refresh expired tokens.
-  // User-pinned keys in Claude settings are preserved by getStrippableAuthEnvKeys().
-  const stripKeys = await getStrippableAuthEnvKeys(workingDir);
-  if (stripKeys.length > 0) {
-    console.error('[node-backend]', `Stripping inherited auth env from CLI spawn: ${stripKeys.join(', ')}`);
-  }
-  const stripEnv: Record<string, undefined> = Object.fromEntries(
-    stripKeys.map((k) => [k, undefined]),
-  );
-
-  const proc = Claude.spawn(args, {
+  // spawnAuthed strips inherited OAuth tokens (e.g. from Claude Desktop spawning the IDE) so
+  // the CLI falls through to its refreshable keychain auth. Centralized in Claude so chat and
+  // `auth status` strip identically; user-pinned / ANTHROPIC_API_KEY env is preserved there.
+  const proc = await Claude.spawnAuthed(args, workingDir, {
     cwd: workingDir,
     stdio: ['pipe', 'pipe', 'pipe'],
     env: {
       TERM: 'dumb',
       CI: 'true',
       CLAUDECODE: undefined,
-      ...stripEnv,
     },
   });
 

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -7,6 +7,7 @@ import {
   type ExecFileOptions,
 } from 'child_process';
 import { readSettingsFile, resolveClaudeConfigDirOverride } from './features/settings';
+import { getStrippableAuthEnvKeys } from './features/claude-settings';
 import { augmentedPath } from './augmented-path';
 import { isWslUncPath, toWslPath } from './wsl-path';
 import { execViaCmdArgv } from './win-exec';
@@ -101,6 +102,52 @@ export class Claude {
         ...options?.env,
       },
     });
+  }
+
+  /**
+   * The env overrides that strip inherited OAuth *tokens* before handing the env to a
+   * spawned CLI child, given the merged Claude settings for [workingDir]. Centralizes the
+   * strip policy (see {@link getStrippableAuthEnvKeys}) so every auth-bearing CLI invocation
+   * — chat AND `auth status` — sees the SAME credentials. Previously only the chat spawn
+   * stripped, so `auth status` could report a "logged in" state the chat then didn't use.
+   * Returns `{ KEY: undefined }` pairs; child_process omits undefined-valued keys from the
+   * spawned env. ANTHROPIC_API_KEY is never stripped — see getStrippableAuthEnvKeys.
+   */
+  private static async authStripEnv(workingDir?: string): Promise<Record<string, undefined>> {
+    const keys = await getStrippableAuthEnvKeys(workingDir);
+    if (keys.length > 0) {
+      console.error('[node-backend]', `Stripping inherited auth env from CLI: ${keys.join(', ')}`);
+    }
+    return Object.fromEntries(keys.map((k) => [k, undefined]));
+  }
+
+  /**
+   * {@link spawn} for auth-bearing CLI calls (chat `-p`, `/usage`): identical to spawn but
+   * also strips inherited OAuth tokens for [workingDir] so the child authenticates the same
+   * way `auth status` reports. Use this instead of spawn for anything whose result depends on
+   * the active credentials. Do NOT use it for `auth login` (it intentionally re-authenticates).
+   */
+  static async spawnAuthed(
+    args: string[],
+    workingDir?: string,
+    options?: SpawnOptions,
+  ): Promise<ChildProcess> {
+    const stripEnv = await Claude.authStripEnv(workingDir);
+    return Claude.spawn(args, { ...options, env: { ...options?.env, ...stripEnv } });
+  }
+
+  /**
+   * {@link exec} for auth-bearing CLI calls (`auth status`): identical to exec but also strips
+   * inherited OAuth tokens for [workingDir], so the login state it reports matches what the
+   * chat spawn actually uses.
+   */
+  static async execAuthed(
+    args: string[],
+    workingDir?: string,
+    options?: ExecFileOptions,
+  ): Promise<{ stdout: string; stderr: string }> {
+    const stripEnv = await Claude.authStripEnv(workingDir);
+    return Claude.exec(args, { ...options, env: { ...options?.env, ...stripEnv } });
   }
 
   /**

--- a/backend/src/core/features/__tests__/account-manager.test.ts
+++ b/backend/src/core/features/__tests__/account-manager.test.ts
@@ -18,7 +18,7 @@ vi.mock('../account-store', () => ({
   deleteAccountFiles: vi.fn(),
   newAccountId: vi.fn(() => 'acc-new'),
 }));
-vi.mock('../../claude', () => ({ Claude: { exec: vi.fn() } }));
+vi.mock('../../claude', () => ({ Claude: { execAuthed: vi.fn() } }));
 
 import {
   readLiveCredentials,
@@ -48,7 +48,7 @@ const mockReadSnapshot = vi.mocked(readSnapshot);
 const mockUpsert = vi.mocked(upsertAccount);
 const mockSetCurrent = vi.mocked(setCurrentAccount);
 const mockDeleteFiles = vi.mocked(deleteAccountFiles);
-const mockExec = vi.mocked(Claude.exec);
+const mockExec = vi.mocked(Claude.execAuthed);
 
 function authStatus(obj: Record<string, unknown>): void {
   mockExec.mockResolvedValue({ stdout: JSON.stringify(obj), stderr: '' });

--- a/backend/src/core/features/__tests__/loadCliConfig.test.ts
+++ b/backend/src/core/features/__tests__/loadCliConfig.test.ts
@@ -5,7 +5,11 @@ import type { ChildProcess } from 'child_process';
 
 vi.mock('../../claude', () => ({
   Claude: {
-    spawn: vi.fn(),
+    // loadCliConfig now goes through spawnAuthed (auth-env strip centralized in Claude).
+    // killTree is mocked too so the 15s safety-timeout callback — which can fire after a
+    // fast test has torn down — doesn't throw "Claude.killTree is not a function".
+    spawnAuthed: vi.fn(),
+    killTree: vi.fn(),
   },
 }));
 
@@ -51,14 +55,13 @@ function controlResponse(commandName: string): string {
 describe('loadCliConfig', () => {
   beforeEach(() => {
     _resetCliConfigCache();
-    vi.mocked(Claude.spawn).mockReset();
+    vi.mocked(Claude.spawnAuthed).mockReset();
   });
 
   describe('cache', () => {
     it('caches per workingDir — different projects get different configs', async () => {
-      vi.mocked(Claude.spawn).mockImplementation((_args, options) => {
-        const cwd = options?.cwd as string;
-        const cmdName = cwd === '/project/a' ? 'skill-a' : 'skill-b';
+      vi.mocked(Claude.spawnAuthed).mockImplementation(async (_args, workingDir) => {
+        const cmdName = workingDir === '/project/a' ? 'skill-a' : 'skill-b';
         return makeFakeProc(controlResponse(cmdName));
       });
 
@@ -70,24 +73,24 @@ describe('loadCliConfig', () => {
     });
 
     it('returns the cached config for the same workingDir without respawning', async () => {
-      vi.mocked(Claude.spawn).mockImplementation(() => makeFakeProc(controlResponse('skill-a')));
+      vi.mocked(Claude.spawnAuthed).mockImplementation(async () => makeFakeProc(controlResponse('skill-a')));
 
       await loadCliConfig('/project/a');
       await loadCliConfig('/project/a');
 
-      expect(vi.mocked(Claude.spawn)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(Claude.spawnAuthed)).toHaveBeenCalledTimes(1);
     });
 
     it('refresh:true bypasses the cache and re-spawns', async () => {
-      vi.mocked(Claude.spawn).mockImplementationOnce(() => makeFakeProc(controlResponse('first')));
+      vi.mocked(Claude.spawnAuthed).mockImplementationOnce(async () => makeFakeProc(controlResponse('first')));
       const first = await loadCliConfig('/project/a');
 
-      vi.mocked(Claude.spawn).mockImplementationOnce(() => makeFakeProc(controlResponse('second')));
+      vi.mocked(Claude.spawnAuthed).mockImplementationOnce(async () => makeFakeProc(controlResponse('second')));
       const second = await loadCliConfig('/project/a', { refresh: true });
 
       expect(first?.response.response.commands[0].name).toBe('first');
       expect(second?.response.response.commands[0].name).toBe('second');
-      expect(vi.mocked(Claude.spawn)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(Claude.spawnAuthed)).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/backend/src/core/features/account-manager.ts
+++ b/backend/src/core/features/account-manager.ts
@@ -37,7 +37,9 @@ interface ClaudeAuthStatus {
 /** Run `claude auth status` for the live account. Null when it fails / not JSON. */
 async function runAuthStatus(): Promise<ClaudeAuthStatus | null> {
   try {
-    const { stdout } = await Claude.exec(['auth', 'status', '--json'], { timeout: 8000 });
+    // execAuthed (global context — account management is not project-scoped) so the live
+    // account matches what the chat spawn authenticates as; env-provided API keys are kept.
+    const { stdout } = await Claude.execAuthed(['auth', 'status', '--json'], undefined, { timeout: 8000 });
     // Extract the JSON object from stdout to guard against shell banner noise
     // (e.g. Windows Console banners, .bashrc printf sequences) that can prefix
     // or suffix the actual JSON output.

--- a/backend/src/core/features/loadCliConfig.ts
+++ b/backend/src/core/features/loadCliConfig.ts
@@ -129,7 +129,29 @@ export function _resetCliConfigCache(): void {
   pendingByWorkingDir.clear();
 }
 
-function loadCliConfigInternal(workingDir: string): Promise<CliConfigControlResponse | null> {
+async function loadCliConfigInternal(workingDir: string): Promise<CliConfigControlResponse | null> {
+  const args = [
+    '-p',
+    '--no-session-persistence',
+    '--output-format', 'stream-json',
+    '--input-format', 'stream-json',
+    '--verbose',
+    '--permission-mode', 'default',
+  ];
+
+  // spawnAuthed: the config probe runs as the same authenticated identity as chat
+  // (inherited OAuth tokens stripped identically); env-provided API keys are kept. Awaited
+  // before wiring handlers — the 'spawn' event fires only after this sync block registers it.
+  const proc = await Claude.spawnAuthed(args, workingDir, {
+    cwd: workingDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      TERM: 'dumb',
+      CI: 'true',
+      CLAUDECODE: undefined,
+    },
+  });
+
   return new Promise((resolve) => {
     let resolved = false;
     const safeResolve = (value: CliConfigControlResponse | null): void => {
@@ -137,24 +159,6 @@ function loadCliConfigInternal(workingDir: string): Promise<CliConfigControlResp
       resolved = true;
       resolve(value);
     };
-    const args = [
-      '-p',
-      '--no-session-persistence',
-      '--output-format', 'stream-json',
-      '--input-format', 'stream-json',
-      '--verbose',
-      '--permission-mode', 'default',
-    ];
-
-    const proc = Claude.spawn(args, {
-      cwd: workingDir,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: {
-        TERM: 'dumb',
-        CI: 'true',
-        CLAUDECODE: undefined,
-      },
-    });
 
     let stdout = '';
 

--- a/backend/src/core/handlers/__tests__/getAccount.test.ts
+++ b/backend/src/core/handlers/__tests__/getAccount.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock BEFORE import
 vi.mock('../../claude', () => ({
   Claude: {
-    exec: vi.fn(),
+    execAuthed: vi.fn(),
   },
 }));
 
@@ -14,7 +14,7 @@ import type { Bridge } from '../../../bridge/bridge-interface';
 import type { IPCMessage } from '../../types';
 import { MessageType } from '../../../shared';
 
-const mockExec = vi.mocked(Claude.exec);
+const mockExec = vi.mocked(Claude.execAuthed);
 
 function createMockConnections() {
   return {
@@ -75,7 +75,7 @@ describe('getAccountHandler', () => {
     }));
   });
 
-  it('should send ACK with status error when Claude.exec throws', async () => {
+  it('should send ACK with status error when Claude.execAuthed throws', async () => {
     const connections = createMockConnections();
     const message: IPCMessage = { type: MessageType.GET_ACCOUNT, payload: {}, timestamp: 0, requestId: 'req-1' };
 
@@ -90,7 +90,7 @@ describe('getAccountHandler', () => {
     }));
   });
 
-  it('should call Claude.exec with auth status args and timeout 8000', async () => {
+  it('should call Claude.execAuthed with auth status args, workingDir, and timeout 8000', async () => {
     const connections = createMockConnections();
     const message: IPCMessage = { type: MessageType.GET_ACCOUNT, payload: {}, timestamp: 0, requestId: 'req-1' };
 
@@ -101,6 +101,7 @@ describe('getAccountHandler', () => {
 
     await getAccountHandler('conn-1', message, connections, mockBridge);
 
-    expect(mockExec).toHaveBeenCalledWith(['auth', 'status'], { timeout: 8000 });
+    // execAuthed(args, workingDir, options) — no workingDir in this payload → undefined.
+    expect(mockExec).toHaveBeenCalledWith(['auth', 'status'], undefined, { timeout: 8000 });
   });
 });

--- a/backend/src/core/handlers/__tests__/getAllUsage.test.ts
+++ b/backend/src/core/handlers/__tests__/getAllUsage.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Mock BEFORE imports
 vi.mock('../../claude', () => ({
   Claude: {
-    exec: vi.fn(),
+    execAuthed: vi.fn(),
     applyConfigDir: vi.fn(),
   },
 }));
@@ -26,7 +26,7 @@ import type { Bridge } from '../../../bridge/bridge-interface';
 import type { IPCMessage } from '../../types';
 import { MessageType } from '../../../shared';
 
-const mockExec = vi.mocked(Claude.exec);
+const mockExec = vi.mocked(Claude.execAuthed);
 const mockReadRegistry = vi.mocked(readRegistry);
 const mockRunCcbUsage = vi.mocked(runCcbUsage);
 

--- a/backend/src/core/handlers/getAccount.ts
+++ b/backend/src/core/handlers/getAccount.ts
@@ -13,9 +13,11 @@ interface ClaudeAuthStatus {
   orgName?: string | null;
 }
 
-async function runClaudeAuthStatus(): Promise<ClaudeAuthStatus | null> {
+async function runClaudeAuthStatus(workingDir?: string): Promise<ClaudeAuthStatus | null> {
   try {
-    const { stdout } = await Claude.exec(['auth', 'status'], { timeout: 8000 });
+    // execAuthed so the reported login state reflects the same credentials the chat spawn
+    // uses (inherited OAuth tokens stripped identically); env-provided API keys are kept.
+    const { stdout } = await Claude.execAuthed(['auth', 'status'], workingDir, { timeout: 8000 });
     if (!stdout.trim()) return null;
     return JSON.parse(stdout.trim()) as ClaudeAuthStatus;
   } catch {
@@ -35,7 +37,7 @@ export async function getAccountHandler(
   const workingDir = (message.payload as { workingDir?: string })?.workingDir;
   if (workingDir) await Claude.applyConfigDir(workingDir);
 
-  const authStatus = await runClaudeAuthStatus();
+  const authStatus = await runClaudeAuthStatus(workingDir);
 
   if (!authStatus) {
     connections.sendTo(connectionId, MessageType.ACK, {

--- a/backend/src/core/handlers/getAllUsage.ts
+++ b/backend/src/core/handlers/getAllUsage.ts
@@ -43,7 +43,9 @@ export async function getAllUsageHandler(
     // Resolve active email
     let liveEmail: string | null = null;
     try {
-      const { stdout } = await Claude.exec(['auth', 'status', '--json'], { timeout: 8000 });
+      // execAuthed so the resolved active account matches the chat spawn's credentials
+      // (inherited OAuth tokens stripped identically); env-provided API keys are kept.
+      const { stdout } = await Claude.execAuthed(['auth', 'status', '--json'], workingDir, { timeout: 8000 });
       // Extract the JSON object to guard against shell banner noise on Windows/Linux
       // that can prefix or suffix the actual JSON output.
       const match = stdout.match(/\{[\s\S]*\}/);

--- a/backend/src/core/handlers/getUsageReport.ts
+++ b/backend/src/core/handlers/getUsageReport.ts
@@ -25,14 +25,17 @@ export function resetUsageReportCache(): void {
  * `/usage` in the terminal, so it stays aligned with the CLI and depends on no
  * SDK or undocumented protocol.
  */
-export function runUsageReport(workingDir?: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const proc = Claude.spawn(['-p', '/usage', '--no-session-persistence'], {
-      cwd: workingDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: { TERM: 'dumb', CI: 'true', CLAUDECODE: undefined },
-    });
+export async function runUsageReport(workingDir?: string): Promise<string> {
+  // spawnAuthed: /usage runs as the same authenticated identity as chat (inherited OAuth
+  // tokens stripped identically); env-provided API keys are kept. Must await before wiring
+  // the stream handlers, so the spawn happens outside the result Promise's executor.
+  const proc = await Claude.spawnAuthed(['-p', '/usage', '--no-session-persistence'], workingDir, {
+    cwd: workingDir,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { TERM: 'dumb', CI: 'true', CLAUDECODE: undefined },
+  });
 
+  return new Promise((resolve, reject) => {
     let stdout = '';
     let stderr = '';
     let settled = false;


### PR DESCRIPTION
## Summary

Follow-up to #163. The OAuth-token strip that keeps the CLI on its refreshable keychain auth lived **only on the chat spawn** (`claude -p`). Every other CLI call — including the `auth status` reads that decide what the UI shows as the login state — ran **without** the strip.

That's an inconsistency: an inherited OAuth token could make `auth status` report "logged in" while the chat spawn stripped it and fell back to the keychain. **The login state the UI showed could differ from the credentials a prompt actually ran with.**

## Change

Centralize the strip policy in `Claude`:

- Add `Claude.spawnAuthed` / `Claude.execAuthed`, which apply `getStrippableAuthEnvKeys()` before delegating to `spawn` / `exec`.
- Route every **auth-bearing** call through them:
  - chat — `claude-process.ts` (removes its inline strip block)
  - `/usage` — `getUsageReport.ts`
  - CLI config probe — `loadCliConfig.ts`
  - `auth status` readers — `getAccount.ts`, `account-manager.ts`, `getAllUsage.ts`
- `auth login` intentionally keeps plain `spawn` (it re-authenticates).
- Non-auth calls (`--version`, `mcp …`, `update`) are unchanged.

Now the login state a user sees and the credentials a prompt runs with are always the same. `ANTHROPIC_API_KEY` stays preserved everywhere (the #163 policy is centralized, not changed).

## Bonus: fixes a pre-existing test flake

`loadCliConfig.test.ts`'s `Claude` mock lacked `killTree`, so the 15s safety-timer callback threw `Claude.killTree is not a function` after a fast test tore down (the failures seen on clean `main` during #163). The mock now provides `killTree` (and `spawnAuthed`).

## Testing

- `be-test`: **60 files / 653 tests all green** (previously 3 files / 8 failing, including the loadCliConfig flake).
- `tsc --noEmit`: clean.
- `be-build`: bundles clean.

## Note

`auth status` now runs with the OAuth-token strip applied, so it reports the same identity chat uses. The inherited-stale-token case is hard to reproduce on a dev host, so this is verified by unit tests + code-path analysis.