### PR TITLE
Show slash command descriptions and fix model-change/panel UX issues

### DIFF
--- a/webview/src/commandPalette/CommandPaletteProvider.tsx
+++ b/webview/src/commandPalette/CommandPaletteProvider.tsx
@@ -27,6 +27,7 @@ import {
   ClearCommand,
   UsageCommand,
   CliPassthroughCommand,
+  ModelSlashCommand,
   getContextItems,
   getModelItems,
   getCustomizeItems,
@@ -226,7 +227,14 @@ export function CommandPaletteProvider({ children }: CommandPaletteProviderProps
           seen.add(normalized);
           return true;
         })
-        .map((cmd, i) => new CliPassthroughCommand(cmd, 100 + i));
+        .map((cmd, i) => {
+          const normalized = cmd.name.startsWith('/') ? cmd.name : `/${cmd.name}`;
+          // "/model" can't run in stream-json mode, so intercept it and drive
+          // our own model switch instead of passing it to the CLI.
+          return normalized === '/model'
+            ? new ModelSlashCommand(cmd, 100 + i)
+            : new CliPassthroughCommand(cmd, 100 + i);
+        });
       const sortedCommands = [...localCommands, ...dynamicCommands]
         .sort((a, b) => a.label.localeCompare(b.label));
       sortedCommands.forEach((cmd, i) => { (cmd as { order: number }).order = i; });

--- a/webview/src/commandPalette/__tests__/highlightQuery.test.ts
+++ b/webview/src/commandPalette/__tests__/highlightQuery.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { highlightQuery } from '../highlightQuery';
+
+describe('highlightQuery', () => {
+  it('returns a single unmatched segment when the query is empty', () => {
+    expect(highlightQuery('Review PR', '')).toEqual([
+      { text: 'Review PR', matched: false },
+    ]);
+  });
+
+  it('returns a single unmatched segment when there is no match', () => {
+    expect(highlightQuery('Review PR', 'zzz')).toEqual([
+      { text: 'Review PR', matched: false },
+    ]);
+  });
+
+  it('splits around a case-insensitive match, preserving original casing', () => {
+    expect(highlightQuery('Review PR', 're')).toEqual([
+      { text: 'Re', matched: true },
+      { text: 'view PR', matched: false },
+    ]);
+  });
+
+  it('highlights every occurrence of the query', () => {
+    // "referee" -> re | fe | re | e
+    expect(highlightQuery('referee', 're')).toEqual([
+      { text: 're', matched: true },
+      { text: 'fe', matched: false },
+      { text: 're', matched: true },
+      { text: 'e', matched: false },
+    ]);
+  });
+
+  it('handles a match at the very end', () => {
+    expect(highlightQuery('code-review', 'review')).toEqual([
+      { text: 'code-', matched: false },
+      { text: 'review', matched: true },
+    ]);
+  });
+
+  it('handles the whole string matching', () => {
+    expect(highlightQuery('review', 'REVIEW')).toEqual([
+      { text: 'review', matched: true },
+    ]);
+  });
+});

--- a/webview/src/commandPalette/enKeyword.ts
+++ b/webview/src/commandPalette/enKeyword.ts
@@ -1,0 +1,13 @@
+import { i18n } from '@/i18n';
+
+/**
+ * The English text of an i18n key, for use as a search keyword. Built-in
+ * palette items are shown in the user's language, but users often search by
+ * the English spelling (matching the CLI). Adding the English label as a
+ * keyword lets e.g. "model" match the translated "모델 전환" item — without
+ * touching the displayed translation. English is always bundled (see
+ * i18n/config.ts), so this resolves regardless of the active locale.
+ */
+export function enKeyword(key: string): string {
+  return i18n.t(key, { lng: 'en' });
+}

--- a/webview/src/commandPalette/highlightQuery.ts
+++ b/webview/src/commandPalette/highlightQuery.ts
@@ -1,0 +1,35 @@
+export interface HighlightSegment {
+  text: string;
+  matched: boolean;
+}
+
+/**
+ * Split `text` into alternating matched/unmatched segments for every
+ * case-insensitive occurrence of `query`, preserving the original casing.
+ * Used to bold the matched portion of a slash command's name/description in
+ * the palette (issue #167), mirroring how the CLI highlights matches.
+ *
+ * An empty or unmatched query yields a single unmatched segment covering the
+ * whole string, so callers can render the result uniformly.
+ */
+export function highlightQuery(text: string, query: string): HighlightSegment[] {
+  if (!query) return [{ text, matched: false }];
+
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const segments: HighlightSegment[] = [];
+
+  let i = 0;
+  while (i < text.length) {
+    const idx = haystack.indexOf(needle, i);
+    if (idx === -1) {
+      segments.push({ text: text.slice(i), matched: false });
+      break;
+    }
+    if (idx > i) segments.push({ text: text.slice(i, idx), matched: false });
+    segments.push({ text: text.slice(idx, idx + needle.length), matched: true });
+    i = idx + needle.length;
+  }
+
+  return segments;
+}

--- a/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
+++ b/webview/src/commandPalette/hooks/__tests__/useCommandPalette.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useCommandPalette } from '../useCommandPalette';
 import { PanelItemType } from '@/types/commandPalette';
-import type { ActionItem, PanelSection } from '@/types/commandPalette';
+import type { ActionItem, CommandItem, PanelSection } from '@/types/commandPalette';
 import { PanelSectionId } from '@/types/commandPalette';
 
 // Mock useCommandPaletteRegistry so we don't need Provider context
@@ -10,7 +10,16 @@ vi.mock('../../CommandPaletteProvider', () => ({
   useCommandPaletteRegistry: vi.fn(),
 }));
 
+// Mock useCliConfig so the hook can trigger a refresh on panel open (issue #176)
+// without a real CliConfigProvider / React Query client.
+vi.mock('@/contexts/CliConfigContext', () => ({
+  useCliConfig: vi.fn(),
+}));
+
 import { useCommandPaletteRegistry } from '../../CommandPaletteProvider';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+
+const mockRefresh = vi.fn();
 
 const mockSections: PanelSection[] = [
   {
@@ -45,6 +54,11 @@ describe('useCommandPalette', () => {
     onChange = vi.fn();
     textareaRef = { current: null };
     setupMockRegistry();
+    vi.mocked(useCliConfig).mockReturnValue({
+      controlResponse: null,
+      isLoading: false,
+      refresh: mockRefresh,
+    });
   });
 
   // ──────────────────────────────────────────────────────
@@ -428,6 +442,325 @@ describe('useCommandPalette', () => {
 
       const items = result.current.filteredSections.flatMap(s => s.items);
       expect(items.find(i => i.id === 'switch-account')).toBeUndefined();
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // description matching — slash commands surface on their description text,
+  // not just the command name (issue #167). The CLI ships a description for
+  // every command; the terminal matches on it, so the GUI must too.
+  // ──────────────────────────────────────────────────────
+
+  describe('description matching (command items)', () => {
+    const sectionsWithCommand: PanelSection[] = [
+      {
+        id: PanelSectionId.SlashCommands,
+        title: 'Slash Commands',
+        showDividerAbove: false,
+        items: [
+          {
+            id: 'cli-review',
+            label: '/review',
+            type: PanelItemType.Command,
+            name: '/review',
+            description: 'Review a GitHub pull request',
+            action: vi.fn(),
+          } as CommandItem,
+          {
+            id: 'cli-roadmap',
+            label: '/roadmap',
+            type: PanelItemType.Command,
+            name: '/roadmap',
+            description: 'Show the product roadmap',
+            action: vi.fn(),
+          } as CommandItem,
+        ],
+      },
+    ];
+
+    it('surfaces a command when the query matches its description but not the name', () => {
+      setupMockRegistry(sectionsWithCommand);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('github');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.find(i => i.id === 'cli-review')).toBeDefined();
+      // The other command's name and description both lack "github".
+      expect(items.find(i => i.id === 'cli-roadmap')).toBeUndefined();
+    });
+
+    it('still matches on the command name', () => {
+      setupMockRegistry(sectionsWithCommand);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('road');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.find(i => i.id === 'cli-roadmap')).toBeDefined();
+      expect(items.find(i => i.id === 'cli-review')).toBeUndefined();
+    });
+
+    it('hides commands when the query matches neither name nor description', () => {
+      setupMockRegistry(sectionsWithCommand);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('zzz');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items).toHaveLength(0);
+    });
+
+    it('ranks a name match above a description-only match', () => {
+      // "/model" matches its own name; "/claude-api" only matches via its
+      // description ("...model ids..."). The exact-name command must rank first
+      // even though it sorts later alphabetically (regression: /claude-api on top).
+      const sections: PanelSection[] = [
+        {
+          id: PanelSectionId.SlashCommands,
+          title: 'Slash Commands',
+          showDividerAbove: false,
+          items: [
+            {
+              id: 'cli-claude-api',
+              label: '/claude-api',
+              type: PanelItemType.Command,
+              name: '/claude-api',
+              description: 'Reference for the Claude API — model ids, pricing',
+              action: vi.fn(),
+            } as CommandItem,
+            {
+              id: 'cli-model',
+              label: '/model',
+              type: PanelItemType.Command,
+              name: '/model',
+              description: 'Set the AI model for Claude Code',
+              action: vi.fn(),
+            } as CommandItem,
+          ],
+        },
+      ];
+      setupMockRegistry(sections);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('model');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      expect(items.map(i => i.id)).toEqual(['cli-model', 'cli-claude-api']);
+    });
+
+    it('ranks an earlier (prefix) name match above a later substring match', () => {
+      const sections: PanelSection[] = [
+        {
+          id: PanelSectionId.SlashCommands,
+          title: 'Slash Commands',
+          showDividerAbove: false,
+          items: [
+            {
+              id: 'cli-remodel',
+              label: '/remodel',
+              type: PanelItemType.Command,
+              name: '/remodel',
+              description: '',
+              action: vi.fn(),
+            } as CommandItem,
+            {
+              id: 'cli-model',
+              label: '/model',
+              type: PanelItemType.Command,
+              name: '/model',
+              description: '',
+              action: vi.fn(),
+            } as CommandItem,
+          ],
+        },
+      ];
+      setupMockRegistry(sections);
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.setFilterQuery('model');
+      });
+
+      const items = result.current.filteredSections.flatMap(s => s.items);
+      // "/model" matches at index 1 (right after "/"), "/remodel" at index 3.
+      expect(items.map(i => i.id)).toEqual(['cli-model', 'cli-remodel']);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // panel-open refresh — reopening the panel refetches the CLI config so
+  // runtime-added skills/commands appear without a manual reload (issue #176).
+  // The cached list stays visible until the refetch resolves.
+  // ──────────────────────────────────────────────────────
+
+  describe('panel-open refresh (issue #176)', () => {
+    it('refreshes CLI config when the panel opens via the slash button', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      expect(mockRefresh).not.toHaveBeenCalled();
+
+      act(() => {
+        result.current.handleSlashButtonClick();
+      });
+
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes CLI config when the panel opens via typing "/"', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.detectSlashCommand('/');
+      });
+
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not refresh again while the panel stays open', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.detectSlashCommand('/');
+      });
+      // Typing more of the command keeps the panel open — no second refresh.
+      act(() => {
+        result.current.detectSlashCommand('/re');
+      });
+
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ──────────────────────────────────────────────────────
+  // detectSlashCommand with arguments — the panel must stay open while typing
+  // a command's arguments so "/model sonnet" keeps "/model" selected, instead
+  // of vanishing the moment a space is typed.
+  // ──────────────────────────────────────────────────────
+
+  describe('detectSlashCommand with arguments', () => {
+    it('keeps the panel open and filters by the command name when typing args', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.detectSlashCommand('/model sonnet');
+      });
+
+      expect(result.current.showSlashCommands).toBe(true);
+      // Filter by the first token ("/model") so the command still matches.
+      expect(result.current.filterQuery).toBe('model');
+    });
+
+    it('still opens the panel with no args', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.detectSlashCommand('/model');
+      });
+
+      expect(result.current.showSlashCommands).toBe(true);
+      expect(result.current.filterQuery).toBe('model');
+    });
+
+    it('hides the panel when the text does not start with a slash', () => {
+      const { result } = renderHook(() =>
+        useCommandPalette({ onChange, textareaRef }),
+      );
+
+      act(() => {
+        result.current.detectSlashCommand('hello world');
+      });
+
+      expect(result.current.showSlashCommands).toBe(false);
+    });
+
+    // Once an argument is being typed the command is settled, so the panel
+    // should narrow to the exact command — not keep showing other fuzzy
+    // (description) matches like /claude-api.
+    describe('narrows to the exact command in argument mode', () => {
+      const modelSections: PanelSection[] = [
+        {
+          id: PanelSectionId.SlashCommands,
+          title: 'Slash Commands',
+          showDividerAbove: false,
+          items: [
+            {
+              id: 'cli-model',
+              label: '/model',
+              type: PanelItemType.Command,
+              name: '/model',
+              description: 'Set the AI model for Claude Code',
+              action: vi.fn(),
+            } as CommandItem,
+            {
+              id: 'cli-claude-api',
+              label: '/claude-api',
+              type: PanelItemType.Command,
+              name: '/claude-api',
+              description: 'Reference for the Claude API — model ids',
+              action: vi.fn(),
+            } as CommandItem,
+          ],
+        },
+      ];
+
+      it('shows only the exact command once an argument is typed', () => {
+        setupMockRegistry(modelSections);
+        const { result } = renderHook(() =>
+          useCommandPalette({ onChange, textareaRef }),
+        );
+
+        act(() => {
+          result.current.detectSlashCommand('/model so');
+        });
+
+        const items = result.current.filteredSections.flatMap(s => s.items);
+        expect(items.map(i => i.id)).toEqual(['cli-model']);
+      });
+
+      it('still shows fuzzy matches while only the name is being typed', () => {
+        setupMockRegistry(modelSections);
+        const { result } = renderHook(() =>
+          useCommandPalette({ onChange, textareaRef }),
+        );
+
+        act(() => {
+          result.current.detectSlashCommand('/model');
+        });
+
+        const items = result.current.filteredSections.flatMap(s => s.items);
+        // description of /claude-api also mentions "model", so it stays visible.
+        expect(items.map(i => i.id)).toContain('cli-model');
+        expect(items.map(i => i.id)).toContain('cli-claude-api');
+      });
     });
   });
 });

--- a/webview/src/commandPalette/hooks/useCommandPalette.ts
+++ b/webview/src/commandPalette/hooks/useCommandPalette.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback, useMemo, KeyboardEvent, RefObject } from 'react';
+import { useState, useCallback, useEffect, useMemo, KeyboardEvent, RefObject } from 'react';
 import { PanelSection, PanelItemType, ActionItem, CommandItem, PanelItem } from '@/types/commandPalette';
 import { useCommandPaletteRegistry } from '../CommandPaletteProvider';
+import { useCliConfig } from '@/contexts/CliConfigContext';
 
 interface UseCommandPaletteOptions {
   onChange: (value: string) => void;
@@ -9,16 +10,39 @@ interface UseCommandPaletteOptions {
 
 export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOptions) {
   const { sections } = useCommandPaletteRegistry();
+  const { refresh: refreshCliConfig } = useCliConfig();
 
   // --- Panel state (from useSlashCommandPanel) ---
   const [filterQuery, setFilterQuery] = useState('');
   const [selectedSectionIndex, setSelectedSectionIndex] = useState(0);
   const [selectedItemIndex, setSelectedItemIndex] = useState(0);
   const [showSlashCommands, setShowSlashCommands] = useState(false);
+  // True once the user types a space after the command (i.e. arguments). The
+  // command is settled, so the panel narrows to the exact command instead of
+  // keeping fuzzy description matches around.
+  const [argMode, setArgMode] = useState(false);
+
+  // Refetch the CLI config each time the panel opens so runtime-added skills/
+  // commands (e.g. after /reload) show up without a manual reload. The cached
+  // list stays visible until the refetch resolves — no flicker (issue #176).
+  useEffect(() => {
+    if (showSlashCommands) void refreshCliConfig();
+  }, [showSlashCommands, refreshCliConfig]);
 
   const filteredSections = useMemo(() => {
     const query = filterQuery.toLowerCase();
     const hasQuery = query.length > 0;
+
+    // Rank a match so a name (label) hit beats a description-only hit, and an
+    // earlier name position (prefix) beats a later one — otherwise "/model"
+    // ranks below "/claude-api" just because its description mentions "model".
+    // Lower is better; items are already filtered so a match always exists.
+    const matchRank = (item: PanelItem): number => {
+      const labelIdx = item.label.toLowerCase().indexOf(query);
+      if (labelIdx !== -1) return labelIdx;
+      if (item.keywords?.some(k => k.toLowerCase().includes(query))) return 500;
+      return 1000; // description-only match
+    };
 
     return sections
       .map((section, index) => {
@@ -26,23 +50,38 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
           // searchOnly items stay hidden until the user types a matching query.
           if (item.searchOnly && !hasQuery) return false;
           if (hasQuery) {
+            // Argument mode: the command is settled ("/model sonnet"), so only
+            // the exact command name stays — no fuzzy/description matches.
+            if (argMode) {
+              return item.label.toLowerCase() === `/${query}`;
+            }
             const matchesLabel = item.label.toLowerCase().includes(query);
             const matchesKeyword = item.keywords?.some(keyword =>
               keyword.toLowerCase().includes(query),
             );
-            return matchesLabel || (matchesKeyword ?? false);
+            // Slash commands carry a CLI-provided description; match on it too
+            // so e.g. "/review" surfaces on "github pull request" (issue #167).
+            const matchesDescription =
+              item.type === PanelItemType.Command &&
+              (item as CommandItem).description.toLowerCase().includes(query);
+            return matchesLabel || (matchesKeyword ?? false) || matchesDescription;
           }
           return true;
         });
         if (filteredItems.length === 0) return null;
+        // Order by relevance when searching; keep the section's own order (e.g.
+        // alphabetical) otherwise. Sort is stable, so equal ranks keep it.
+        const orderedItems = hasQuery
+          ? [...filteredItems].sort((a, b) => matchRank(a) - matchRank(b))
+          : filteredItems;
         return {
           ...section,
           showDividerAbove: hasQuery ? index > 0 : section.showDividerAbove,
-          items: filteredItems,
+          items: orderedItems,
         };
       })
       .filter((section): section is PanelSection => section !== null);
-  }, [sections, filterQuery]);
+  }, [sections, filterQuery, argMode]);
 
   const selectItem = useCallback((sectionIndex: number, itemIndex: number) => {
     setSelectedSectionIndex(sectionIndex);
@@ -53,6 +92,7 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
     setSelectedSectionIndex(0);
     setSelectedItemIndex(0);
     setFilterQuery('');
+    setArgMode(false);
   }, []);
 
   const getTotalItemCount = useCallback(() => {
@@ -191,12 +231,16 @@ export function useCommandPalette({ onChange, textareaRef }: UseCommandPaletteOp
   }, [showSlashCommands, filteredSections, selectedSectionIndex, selectedItemIndex, executeSelectedItem, executeAndClear, closePanel, moveSelection, onChange]);
 
   const detectSlashCommand = useCallback((newValue: string) => {
-    // Show panel only while typing the command name itself. As soon as
-    // whitespace appears the user is typing arguments — keep the panel
-    // hidden so a stray match doesn't override what they typed.
-    if (newValue.startsWith('/') && !/\s/.test(newValue)) {
+    // Keep the panel open while typing a slash command AND its arguments, so
+    // "/model sonnet" still shows "/model" selected instead of the panel
+    // vanishing the moment a space is typed. Filter by the command name (the
+    // first whitespace-delimited token) rather than the whole input.
+    if (newValue.startsWith('/')) {
+      const commandToken = newValue.split(/\s/, 1)[0]; // "/model" from "/model sonnet"
       setShowSlashCommands(true);
-      setFilterQuery(newValue.substring(1));
+      setFilterQuery(commandToken.substring(1));
+      // A space means arguments are being typed — lock to the exact command.
+      setArgMode(/\s/.test(newValue));
       setSelectedSectionIndex(0);
       setSelectedItemIndex(0);
     } else {

--- a/webview/src/commandPalette/sections/context/items.ts
+++ b/webview/src/commandPalette/sections/context/items.ts
@@ -1,6 +1,7 @@
 import { IconType } from '@/types/commandPalette';
 import { i18n } from '@/i18n';
 import { StaticItem } from '../../types';
+import { enKeyword } from '../../enKeyword';
 
 /**
  * Fired when the user runs `/resume`. The session dropdown opens (browse/resume
@@ -15,6 +16,7 @@ export const OPEN_SESSION_DROPDOWN_EVENT = 'command-palette:open-session-dropdow
  */
 export const getContextItems = (): StaticItem[] => [
   new StaticItem('attach-file', i18n.t('commandPalette:context.attachFile'), {
+    keywords: [enKeyword('commandPalette:context.attachFile')],
     icon: IconType.File,
     disabled: false,
     action: async () => {
@@ -22,6 +24,7 @@ export const getContextItems = (): StaticItem[] => [
     },
   }),
   new StaticItem('mention-file', i18n.t('commandPalette:context.mentionFile'), {
+    keywords: [enKeyword('commandPalette:context.mentionFile')],
     icon: IconType.File,
     disabled: false,
     action: async () => {
@@ -29,6 +32,7 @@ export const getContextItems = (): StaticItem[] => [
     },
   }),
   new StaticItem('clear-conversation', i18n.t('commandPalette:context.clearConversation'), {
+    keywords: [enKeyword('commandPalette:context.clearConversation')],
     disabled: false,
     serviceAction: async (services) => {
       if (services.chatStream.isStreaming) services.chatStream.stop();
@@ -39,6 +43,7 @@ export const getContextItems = (): StaticItem[] => [
   // Search-only: surfaces when the user types `/resume`. Opens the session
   // dropdown so past conversations can be browsed and resumed (issue #28).
   new StaticItem('resume-conversation', i18n.t('commandPalette:context.resumeConversation'), {
+    keywords: [enKeyword('commandPalette:context.resumeConversation'), 'resume'],
     disabled: false,
     searchOnly: true,
     action: async () => {

--- a/webview/src/commandPalette/sections/customize/items.ts
+++ b/webview/src/commandPalette/sections/customize/items.ts
@@ -1,6 +1,7 @@
 import { IconType } from '@/types/commandPalette';
 import { i18n } from '@/i18n';
 import { StaticItem } from '../../types';
+import { enKeyword } from '../../enKeyword';
 
 export const OPEN_MCP_MODAL_EVENT = 'open-mcp-modal';
 
@@ -10,22 +11,35 @@ export const OPEN_MCP_MODAL_EVENT = 'open-mcp-modal';
  * the Customize section.
  */
 export const getCustomizeItems = (): StaticItem[] => [
-  new StaticItem('output-styles', i18n.t('commandPalette:customize.outputStyles')),
-  new StaticItem('agents', i18n.t('commandPalette:customize.agents')),
-  new StaticItem('hooks', i18n.t('commandPalette:customize.hooks')),
-  new StaticItem('memory', i18n.t('commandPalette:customize.memory')),
-  new StaticItem('permissions', i18n.t('commandPalette:customize.permissions')),
+  new StaticItem('output-styles', i18n.t('commandPalette:customize.outputStyles'), {
+    keywords: [enKeyword('commandPalette:customize.outputStyles')],
+  }),
+  new StaticItem('agents', i18n.t('commandPalette:customize.agents'), {
+    keywords: [enKeyword('commandPalette:customize.agents')],
+  }),
+  new StaticItem('hooks', i18n.t('commandPalette:customize.hooks'), {
+    keywords: [enKeyword('commandPalette:customize.hooks')],
+  }),
+  new StaticItem('memory', i18n.t('commandPalette:customize.memory'), {
+    keywords: [enKeyword('commandPalette:customize.memory')],
+  }),
+  new StaticItem('permissions', i18n.t('commandPalette:customize.permissions'), {
+    keywords: [enKeyword('commandPalette:customize.permissions')],
+  }),
   new StaticItem('manage-mcp', i18n.t('commandPalette:customize.mcpServers'), {
     disabled: false,
     // Label is "MCP Servers" (matches "/mcp"); these keywords also surface it
     // for "/manage-mcp" and the bare "/manage" query.
-    keywords: ['manage-mcp', 'mcp'],
+    keywords: ['manage-mcp', 'mcp', enKeyword('commandPalette:customize.mcpServers')],
     action: async () => {
       window.dispatchEvent(new CustomEvent(OPEN_MCP_MODAL_EVENT));
     },
   }),
-  new StaticItem('manage-plugins', i18n.t('commandPalette:customize.managePlugins')),
+  new StaticItem('manage-plugins', i18n.t('commandPalette:customize.managePlugins'), {
+    keywords: [enKeyword('commandPalette:customize.managePlugins')],
+  }),
   new StaticItem('open-terminal', i18n.t('commandPalette:customize.openInTerminal'), {
+    keywords: [enKeyword('commandPalette:customize.openInTerminal')],
     icon: IconType.Terminal,
     disabled: false,
     serviceAction: async (services) => {

--- a/webview/src/commandPalette/sections/index.ts
+++ b/webview/src/commandPalette/sections/index.ts
@@ -2,7 +2,7 @@
 export { ContextSection } from './context/ContextSection';
 export { ModelSection } from './model/ModelSection';
 export { CustomizeSection } from './customize/CustomizeSection';
-export { SlashCommandsSection, ClearCommand, UsageCommand, CliPassthroughCommand } from './slashCommands';
+export { SlashCommandsSection, ClearCommand, UsageCommand, CliPassthroughCommand, ModelSlashCommand } from './slashCommands';
 export { SettingsSection } from './settings/SettingsSection';
 export { SupportSection } from './support/SupportSection';
 

--- a/webview/src/commandPalette/sections/model/AccountUsageItem.tsx
+++ b/webview/src/commandPalette/sections/model/AccountUsageItem.tsx
@@ -1,10 +1,12 @@
 import { StaticItem } from '../../types';
 import { i18n } from '@/i18n';
+import { enKeyword } from '../../enKeyword';
 
 export const OPEN_ACCOUNT_USAGE_EVENT = 'open-account-usage';
 
 export const createAccountUsageItem = (): StaticItem =>
   new StaticItem('account-usage', i18n.t('commandPalette:model.accountUsage'), {
+    keywords: [enKeyword('commandPalette:model.accountUsage'), 'account', 'usage'],
     disabled: false,
     action: async () => {
       window.dispatchEvent(new CustomEvent(OPEN_ACCOUNT_USAGE_EVENT));

--- a/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
+++ b/webview/src/commandPalette/sections/model/SwitchModelItem.tsx
@@ -1,5 +1,6 @@
 import { StaticItem } from '../../types';
 import { i18n } from '@/i18n';
+import { enKeyword } from '../../enKeyword';
 import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { useCurrentModel } from '@/hooks/useCurrentModel';
@@ -22,6 +23,7 @@ const SwitchModelValue = () => {
 
 export const createSwitchModelItem = (): StaticItem =>
   new StaticItem('switch-model', i18n.t('commandPalette:model.switchModel'), {
+    keywords: [enKeyword('commandPalette:model.switchModel'), 'model'],
     disabled: false,
     valueComponent: () => <SwitchModelValue />,
     action: async () => {

--- a/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
+++ b/webview/src/commandPalette/sections/model/ToggleFastModeItem.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { StaticItem } from '../../types';
 import { i18n } from '@/i18n';
+import { enKeyword } from '../../enKeyword';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
@@ -33,6 +34,7 @@ function resolveActiveModel(
 // applyModelCapabilityFlags for the source of truth).
 export const createToggleFastModeItem = (): StaticItem =>
   new StaticItem('toggle-fast-mode', i18n.t('commandPalette:model.toggleFastMode'), {
+    keywords: [enKeyword('commandPalette:model.toggleFastMode'), 'fast mode'],
     disabled: false,
     keepOpen: true,
     valueComponent: () => <FastModeToggle />,

--- a/webview/src/commandPalette/sections/settings/items.ts
+++ b/webview/src/commandPalette/sections/settings/items.ts
@@ -1,6 +1,7 @@
 import { getAdapter } from '@/adapters';
 import { i18n } from '@/i18n';
 import { StaticItem } from '../../types';
+import { enKeyword } from '../../enKeyword';
 import { Route, routeToPath, withWorkingDir } from '@/router/routes';
 
 /** Navigate to the account switch page. Shared by "Switch account" and /login. */
@@ -27,11 +28,12 @@ export const getSettingsItems = (): StaticItem[] => [
   new StaticItem('switch-account', i18n.t('commandPalette:settings.switchAccount'), {
     disabled: false,
     // Also surfaces under the `/login` search, alongside the /login alias.
-    keywords: ['login'],
+    keywords: ['login', enKeyword('commandPalette:settings.switchAccount')],
     action: openSwitchAccount,
   }),
   new StaticItem('general-config', i18n.t('commandPalette:settings.generalConfig'), {
     disabled: false,
+    keywords: [enKeyword('commandPalette:settings.generalConfig')],
     action: async () => {
       await getAdapter().openSettings();
     },

--- a/webview/src/commandPalette/sections/slashCommands/ModelSlashCommand.ts
+++ b/webview/src/commandPalette/sections/slashCommands/ModelSlashCommand.ts
@@ -1,0 +1,46 @@
+import { SlashCommand } from '../../types';
+import type { SlashCommandInfo } from '@/types/slashCommand';
+import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
+
+/**
+ * The CLI advertises `/model` in its command list but rejects it in stream-json
+ * mode ("/model isn't available in this environment"), so passing it through
+ * like a normal command (CliPassthroughCommand) never switches the model.
+ * Instead we intercept it and drive our own model switch — the same set_model
+ * path the "Switch model" overlay uses — which honours CLI equivalence ("what
+ * the user does with /model in the CLI works in the GUI").
+ *
+ * - "/model"        → opens the model picker overlay.
+ * - "/model sonnet" → opens the overlay carrying "sonnet" as a query so it
+ *                     resolves the model and switches immediately.
+ */
+export class ModelSlashCommand extends SlashCommand {
+  readonly id: string;
+  readonly label: string;
+  readonly description: string;
+  readonly order: number;
+  readonly commandInfo: SlashCommandInfo;
+
+  constructor(commandInfo: SlashCommandInfo, order: number = 100) {
+    super();
+    const name = commandInfo.name;
+    const normalized = name.startsWith('/') ? name : `/${name}`;
+    this.id = `cli-${normalized.slice(1)}`;
+    this.label = normalized;
+    this.description = commandInfo.description || normalized;
+    this.order = order;
+    this.commandInfo = commandInfo;
+  }
+
+  async execute(): Promise<void> {
+    const { chatStream } = this.getServices();
+    const input = chatStream.input.trim();
+    // "/model sonnet" -> "sonnet"; "/model" (or palette click) -> undefined
+    const arg = input.startsWith(this.label)
+      ? input.slice(this.label.length).trim()
+      : '';
+    window.dispatchEvent(
+      new CustomEvent(SWITCH_MODEL_EVENT, { detail: { query: arg || undefined } }),
+    );
+  }
+}

--- a/webview/src/commandPalette/sections/slashCommands/__tests__/ModelSlashCommand.test.ts
+++ b/webview/src/commandPalette/sections/slashCommands/__tests__/ModelSlashCommand.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ModelSlashCommand } from '../ModelSlashCommand';
+import { SWITCH_MODEL_EVENT } from '@/pages/ChatPage/ModelSwitchOverlay';
+import { InputModeValues, type InputMode } from '@/types/chatInput';
+import { SessionState } from '@/types';
+import type { CommandPaletteServices } from '../../../types';
+
+function makeServices(input: string, inputMode: InputMode = InputModeValues.BYPASS): {
+  services: CommandPaletteServices;
+  sendMessage: ReturnType<typeof vi.fn>;
+} {
+  const sendMessage = vi.fn();
+  const services: CommandPaletteServices = {
+    chatStream: {
+      messages: [],
+      isStreaming: false,
+      input,
+      setInput: vi.fn(),
+      sendMessage,
+      stop: vi.fn(),
+      continue: vi.fn(),
+      clearMessages: vi.fn(),
+      resetStreamState: vi.fn(),
+      resetForSessionSwitch: vi.fn(),
+    },
+    session: {
+      currentSessionId: null,
+      sessionState: SessionState.Idle,
+      workingDirectory: '/tmp',
+      inputMode,
+      setSessionState: vi.fn(),
+      resetToNewSession: vi.fn(),
+    },
+    adapter: {
+      openNewTab: vi.fn().mockResolvedValue(undefined),
+      openSettings: vi.fn().mockResolvedValue(undefined),
+      openTerminal: vi.fn().mockResolvedValue(undefined),
+    },
+    ui: { confirm: vi.fn().mockResolvedValue(true) },
+    workflowState: { openPanel: vi.fn() },
+  };
+  return { services, sendMessage };
+}
+
+function makeCommand(services: CommandPaletteServices): ModelSlashCommand {
+  const cmd = new ModelSlashCommand({ name: 'model', description: 'Set the AI model', argumentHint: '' });
+  cmd._bind(() => services);
+  return cmd;
+}
+
+describe('ModelSlashCommand.execute', () => {
+  let dispatched: CustomEvent[];
+
+  beforeEach(() => {
+    dispatched = [];
+    vi.spyOn(window, 'dispatchEvent').mockImplementation((e: Event) => {
+      dispatched.push(e as CustomEvent);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens the model overlay carrying the parsed arg as query ("/model sonnet")', async () => {
+    const { services } = makeServices('/model sonnet');
+    await makeCommand(services).execute();
+
+    const evt = dispatched.find(e => e.type === SWITCH_MODEL_EVENT);
+    expect(evt).toBeDefined();
+    expect(evt!.detail).toEqual({ query: 'sonnet' });
+  });
+
+  it('opens the overlay with no query when there is no arg ("/model")', async () => {
+    const { services } = makeServices('/model');
+    await makeCommand(services).execute();
+
+    const evt = dispatched.find(e => e.type === SWITCH_MODEL_EVENT);
+    expect(evt).toBeDefined();
+    expect(evt!.detail).toEqual({ query: undefined });
+  });
+
+  it('does NOT pass /model through to the CLI as a chat message', async () => {
+    // The CLI rejects /model in stream-json mode ("isn't available in this
+    // environment"), so it must never be sent as a user message.
+    const { services, sendMessage } = makeServices('/model sonnet');
+    await makeCommand(services).execute();
+
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/commandPalette/sections/slashCommands/index.ts
+++ b/webview/src/commandPalette/sections/slashCommands/index.ts
@@ -2,3 +2,4 @@ export { SlashCommandsSection } from './SlashCommandsSection';
 export { ClearCommand } from './ClearCommand';
 export { UsageCommand } from './UsageCommand';
 export { CliPassthroughCommand } from './CliPassthroughCommand';
+export { ModelSlashCommand } from './ModelSlashCommand';

--- a/webview/src/commandPalette/sections/support/items.ts
+++ b/webview/src/commandPalette/sections/support/items.ts
@@ -1,6 +1,7 @@
 import { getAdapter } from '@/adapters';
 import { i18n } from '@/i18n';
 import { StaticItem } from '../../types';
+import { enKeyword } from '../../enKeyword';
 
 /**
  * Built on demand (not a module-eval constant) so the labels and confirm-dialog
@@ -10,12 +11,14 @@ import { StaticItem } from '../../types';
 export const getSupportItems = (): StaticItem[] => [
   new StaticItem('help-docs', i18n.t('commandPalette:support.viewHelpDocs'), {
     disabled: false,
+    keywords: [enKeyword('commandPalette:support.viewHelpDocs')],
     action: async () => {
       await getAdapter().openUrl('https://docs.anthropic.com/en/docs/claude-code/overview');
     },
   }),
   new StaticItem('restart-plugin', i18n.t('commandPalette:support.restartPlugin'), {
     disabled: false,
+    keywords: [enKeyword('commandPalette:support.restartPlugin')],
     serviceAction: async (services) => {
       const ok = await services.ui.confirm({
         title: i18n.t('commandPalette:support.restartConfirm.title'),

--- a/webview/src/commandPalette/ui/CommandPalettePanel.tsx
+++ b/webview/src/commandPalette/ui/CommandPalettePanel.tsx
@@ -1,8 +1,7 @@
-import React, { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { PanelSection, PanelItem } from '@/types/commandPalette';
 import { useVersionInfo } from '@/hooks/useVersionInfo';
-import { useCliConfig } from '@/contexts/CliConfigContext';
 import { APP_NAME } from '@/config/app';
 import { PanelSectionComponent } from './PanelSectionComponent';
 
@@ -10,6 +9,8 @@ interface CommandPalettePanelProps {
   sections: PanelSection[];
   selectedSectionIndex: number;
   selectedItemIndex: number;
+  /** Current slash-command filter text, forwarded so items can highlight matches. */
+  filterQuery?: string;
   onItemClick: (sectionIndex: number, itemIndex: number) => void;
   onItemExecute: (item: PanelItem) => void;
   onClose: () => void;
@@ -19,6 +20,7 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
   sections,
   selectedSectionIndex,
   selectedItemIndex,
+  filterQuery,
   onItemClick,
   onItemExecute,
   onClose,
@@ -27,20 +29,6 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
   const panelRef = useRef<HTMLDivElement>(null);
   const selectedItemRef = useRef<HTMLDivElement>(null);
   const { pluginVersion, cliVersion, refresh: refreshVersion, isLoading: versionRefreshing } = useVersionInfo();
-  const { refresh } = useCliConfig();
-  const [refreshing, setRefreshing] = useState(false);
-
-  const handleRefresh = async (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    e.stopPropagation();
-    if (refreshing) return;
-    setRefreshing(true);
-    try {
-      await refresh();
-    } finally {
-      setRefreshing(false);
-    }
-  };
 
   // Clicking the version text re-queries the CLI version — same action as the
   // Settings › About refresh button (both hit the shared [GET_VERSION] query).
@@ -101,6 +89,7 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
           selectedSectionIndex={selectedSectionIndex}
           selectedItemIndex={selectedItemIndex}
           selectedItemRef={selectedItemRef}
+          query={filterQuery}
           onItemClick={onItemClick}
           onItemExecute={onItemExecute}
         />
@@ -126,16 +115,7 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
           </div>
 
           <div className="flex items-center justify-between py-2">
-            <span className="text-text-secondary/80 hover:text-text-secondary hover:underline disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer leading-none">CCG v{pluginVersion}</span>
-
-            <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={refreshing}
-                className="text-text-tertiary underline hover:text-text-secondary disabled:opacity-60 disabled:cursor-not-allowed leading-none"
-            >
-              {refreshing ? t('panel.reloading') : t('panel.reloadCommands')}
-            </button>
+            <span className="text-text-secondary/80 leading-none">CCG v{pluginVersion}</span>
           </div>
         </div>
 
@@ -145,14 +125,6 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
             <a className="text-text-tertiary underline hover:text-text-secondary" href="https://github.com/anthropics/claude-code/issues" target="_blank">
               {t('panel.reportProblem')}
             </a>
-            <button
-                type="button"
-                onClick={handleRefresh}
-                disabled={refreshing}
-                className="text-text-tertiary underline hover:text-text-secondary disabled:opacity-60 disabled:cursor-not-allowed"
-            >
-              {refreshing ? t('panel.reloading') : t('panel.reloadCommands')}
-            </button>
           </div>
           <div className="text-text-secondary/80">
             {cliVersion ? (

--- a/webview/src/commandPalette/ui/HighlightedText.tsx
+++ b/webview/src/commandPalette/ui/HighlightedText.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { highlightQuery } from '../highlightQuery';
+
+interface Props {
+  text: string;
+  query: string;
+}
+
+/**
+ * Render `text` with the case-insensitive matches of `query` bolded, so the
+ * palette highlights why an item matched (issue #167). With an empty/unmatched
+ * query the whole string renders as plain text.
+ */
+export const HighlightedText: React.FC<Props> = ({ text, query }) => {
+  const segments = highlightQuery(text, query);
+  return (
+    <>
+      {segments.map((seg, i) =>
+        seg.matched ? (
+          <strong key={i} className="font-semibold">{seg.text}</strong>
+        ) : (
+          <React.Fragment key={i}>{seg.text}</React.Fragment>
+        ),
+      )}
+    </>
+  );
+};

--- a/webview/src/commandPalette/ui/PanelItemComponent.tsx
+++ b/webview/src/commandPalette/ui/PanelItemComponent.tsx
@@ -63,13 +63,15 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
       style={{ height: 'var(--item-height, 28px)' }}
     >
       {/* Left side: label (+ optional suffix, e.g. Effort's "(Extra high)").
-          For slash commands the label is a fixed-width name column and the
-          description fills the rest (issue #167), so it doesn't grow to push
-          the description off-screen. */}
+          For slash commands the label is a min-width name column so
+          descriptions line up across rows (issue #167). It never shrinks
+          (flex-shrink-0) or truncates — a long command name just takes more
+          space instead of being cut off, pushing that row's description
+          over. */}
       <div
         className={cn(
           'flex items-center gap-1.5',
-          isCommand ? 'flex-shrink-0 max-w-[55%]' : 'min-w-0 flex-1',
+          isCommand ? 'flex-shrink-0 min-w-[9rem]' : 'min-w-0 flex-1',
         )}
       >
         <span

--- a/webview/src/commandPalette/ui/PanelItemComponent.tsx
+++ b/webview/src/commandPalette/ui/PanelItemComponent.tsx
@@ -3,18 +3,22 @@ import { useTranslation } from 'react-i18next';
 import { PanelItem, PanelItemBase, ToggleItem, CommandItem, PanelItemType, IconType } from '@/types/commandPalette';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { TerminalIcon, LinkIcon } from './icons/PaletteIcons';
+import { HighlightedText } from './HighlightedText';
 import { cn } from '@/utils/cn';
 
 interface Props {
   item: PanelItem;
   isSelected: boolean;
+  /** Current slash-command filter text, used to highlight matches. */
+  query?: string;
   onClick: () => void;
   onExecute: () => void;
 }
 
 export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
-  const { item, isSelected, onClick, onExecute } = props;
+  const { item, isSelected, query = '', onClick, onExecute } = props;
   const { t } = useTranslation('commandPalette');
+  const isCommand = item.type === PanelItemType.Command;
 
   const handleClick = () => {
     if (item.disabled) {
@@ -58,8 +62,16 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
       )}
       style={{ height: 'var(--item-height, 28px)' }}
     >
-      {/* Left side: label (+ optional suffix, e.g. Effort's "(Extra high)") */}
-      <div className="flex min-w-0 flex-1 items-center gap-1.5">
+      {/* Left side: label (+ optional suffix, e.g. Effort's "(Extra high)").
+          For slash commands the label is a fixed-width name column and the
+          description fills the rest (issue #167), so it doesn't grow to push
+          the description off-screen. */}
+      <div
+        className={cn(
+          'flex items-center gap-1.5',
+          isCommand ? 'flex-shrink-0 max-w-[55%]' : 'min-w-0 flex-1',
+        )}
+      >
         <span
           className={cn(
             'overflow-hidden whitespace-nowrap text-ellipsis transition-colors duration-100',
@@ -73,7 +85,7 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
           )}
           style={{ fontSize: 'var(--item-size, 13px)' }}
         >
-          {item.label}
+          <HighlightedText text={item.label} query={query} />
         </span>
         {item.labelSuffix && (
           <span
@@ -84,6 +96,23 @@ export const PanelItemComponent = React.forwardRef<HTMLDivElement, Props>((props
           </span>
         )}
       </div>
+
+      {/* Slash command description column: the CLI-provided summary, matched
+          text bolded. Truncates so long descriptions never wrap. */}
+      {isCommand && (
+        <span
+          className={cn(
+            'ms-3 min-w-0 flex-1 overflow-hidden whitespace-nowrap text-ellipsis transition-colors duration-100',
+            isSelected
+              ? 'text-[var(--text-on-selected)]'
+              : 'text-[var(--secondary-text-color)]',
+            isClickable && 'group-hover:text-[var(--text-on-selected)]',
+          )}
+          style={{ fontSize: 'var(--item-size, 13px)' }}
+        >
+          <HighlightedText text={(item as CommandItem).description} query={query} />
+        </span>
+      )}
 
       {/* Right side: secondary label / toggle / icon */}
       <div className="flex flex-shrink-0 items-center gap-2">

--- a/webview/src/commandPalette/ui/PanelSectionComponent.tsx
+++ b/webview/src/commandPalette/ui/PanelSectionComponent.tsx
@@ -8,6 +8,7 @@ export const PanelSectionComponent: React.FC<{
   selectedSectionIndex: number;
   selectedItemIndex: number;
   selectedItemRef: React.RefObject<HTMLDivElement>;
+  query?: string;
   onItemClick: (sectionIndex: number, itemIndex: number) => void;
   onItemExecute: (item: PanelItem) => void;
 }> = ({
@@ -16,6 +17,7 @@ export const PanelSectionComponent: React.FC<{
   selectedSectionIndex,
   selectedItemIndex,
   selectedItemRef,
+  query,
   onItemClick,
   onItemExecute,
 }) => {
@@ -62,6 +64,7 @@ export const PanelSectionComponent: React.FC<{
               key={item.id}
               item={item}
               isSelected={isSelected}
+              query={query}
               ref={isSelected ? selectedItemRef : null}
               onClick={() => onItemClick(sectionIndex, itemIndex)}
               onExecute={() => onItemExecute(item)}

--- a/webview/src/commandPalette/ui/__tests__/PanelItemComponent.test.tsx
+++ b/webview/src/commandPalette/ui/__tests__/PanelItemComponent.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { PanelItemComponent } from '../PanelItemComponent';
+import { PanelItemType } from '@/types/commandPalette';
+import type { CommandItem, ActionItem, PanelItem } from '@/types/commandPalette';
+
+const commandItem: CommandItem = {
+  id: 'cli-code-review',
+  label: '/code-review',
+  type: PanelItemType.Command,
+  name: '/code-review',
+  description: 'Review a GitHub pull request',
+  action: vi.fn(),
+};
+
+function renderItem(item: PanelItem, query = '') {
+  return render(
+    <PanelItemComponent
+      item={item}
+      isSelected={false}
+      query={query}
+      onClick={vi.fn()}
+      onExecute={vi.fn()}
+    />,
+  );
+}
+
+describe('PanelItemComponent', () => {
+  it('renders a slash command description alongside its name (issue #167)', () => {
+    renderItem(commandItem);
+    expect(screen.getByText('/code-review')).toBeInTheDocument();
+    expect(screen.getByText('Review a GitHub pull request')).toBeInTheDocument();
+  });
+
+  it('does not render a description row for non-command items', () => {
+    const action: ActionItem = {
+      id: 'attach',
+      label: 'Attach file',
+      type: PanelItemType.Action,
+      action: vi.fn(),
+    };
+    renderItem(action);
+    expect(screen.getByText('Attach file')).toBeInTheDocument();
+    expect(
+      screen.queryByText('Review a GitHub pull request'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('bolds the matched portion of both the name and description', () => {
+    const { container } = renderItem(commandItem, 'review');
+    const strongs = Array.from(container.querySelectorAll('strong')).map(s =>
+      s.textContent?.toLowerCase(),
+    );
+    // "/code-review" -> "review"; "Review a GitHub..." -> "Review"
+    expect(strongs).toContain('review');
+    expect(strongs.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders the name as plain text when the query is empty', () => {
+    const { container } = renderItem(commandItem, '');
+    expect(container.querySelector('strong')).toBeNull();
+  });
+});

--- a/webview/src/contexts/CliConfigContext.tsx
+++ b/webview/src/contexts/CliConfigContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState, useEffect, useCallback, type ReactNode } from 'react';
+import { createContext, useContext, useCallback, type ReactNode } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useBridge } from '@/hooks/useBridge';
 import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import type { CliConfigControlResponse } from '@/types/slashCommand';
@@ -20,38 +21,45 @@ export function CliConfigProvider(props: Props) {
   const { children } = props;
   const { isConnected, send } = useBridge();
   const { workingDirectory } = useWorkingDir();
-  const [controlResponse, setControlResponse] = useState<CliConfigControlResponse | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const fetchCliConfig = useCallback(async (refresh = false) => {
-    if (!isConnected) return;
-
-    try {
+  // Key by workingDir so each project's commands/skills are cached separately
+  // (the backend is shared across IDE projects). `refresh: true` makes every
+  // fetch bypass the backend's per-workingDir cache and respawn the CLI, so a
+  // refetch always reflects runtime-added skills (issue #176).
+  const { data, isPending } = useQuery<CliConfigControlResponse | null>({
+    queryKey: [MessageType.GET_CLI_CONFIG, workingDirectory],
+    enabled: isConnected,
+    queryFn: async () => {
       const response = await send(MessageType.GET_CLI_CONFIG, {
         workingDir: workingDirectory ?? undefined,
-        refresh,
+        refresh: true,
       });
-      const cr = (response as Record<string, unknown>)?.controlResponse as CliConfigControlResponse | undefined;
-      if (cr) {
-        setControlResponse(cr);
-      } else {
+      const cr = (response as Record<string, unknown>)?.controlResponse as
+        | CliConfigControlResponse
+        | undefined;
+      if (!cr) {
         console.warn('[CliConfigContext] No controlResponse in response');
+        return null;
       }
-    } catch (err) {
-      console.error('[CliConfigContext] Failed to load CLI config:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isConnected, send, workingDirectory]);
+      return cr;
+    },
+    // Commands/skills change at runtime, so treat the data as always stale:
+    // reopening the panel refetches, while the cached list shows instantly and
+    // is quietly replaced when the refetch resolves (stale-while-revalidate).
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    retry: false,
+  });
 
-  useEffect(() => {
-    fetchCliConfig();
-  }, [fetchCliConfig]);
-
-  const refresh = useCallback(() => fetchCliConfig(true), [fetchCliConfig]);
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: [MessageType.GET_CLI_CONFIG] });
+  }, [queryClient]);
 
   return (
-    <CliConfigContext.Provider value={{ controlResponse, isLoading, refresh }}>
+    <CliConfigContext.Provider
+      value={{ controlResponse: data ?? null, isLoading: isPending, refresh }}
+    >
       {children}
     </CliConfigContext.Provider>
   );

--- a/webview/src/i18n/locales/ar/commandPalette.json
+++ b/webview/src/i18n/locales/ar/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "الإبلاغ عن مشكلة",
-    "reloading": "جارٍ إعادة التحميل…",
-    "reloadCommands": "إعادة تحميل الأوامر",
     "refreshVersion": "تحديث الإصدار",
     "comingSoon": "قريبًا"
   }

--- a/webview/src/i18n/locales/de/commandPalette.json
+++ b/webview/src/i18n/locales/de/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Problem melden",
-    "reloading": "Wird neu geladen…",
-    "reloadCommands": "Befehle neu laden",
     "refreshVersion": "Version aktualisieren",
     "comingSoon": "Demnächst verfügbar"
   }

--- a/webview/src/i18n/locales/en/commandPalette.json
+++ b/webview/src/i18n/locales/en/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Report a problem",
-    "reloading": "Reloading…",
-    "reloadCommands": "Reload commands",
     "refreshVersion": "Refresh version",
     "comingSoon": "Coming soon"
   }

--- a/webview/src/i18n/locales/es/commandPalette.json
+++ b/webview/src/i18n/locales/es/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Reportar un problema",
-    "reloading": "Recargando…",
-    "reloadCommands": "Recargar comandos",
     "refreshVersion": "Actualizar versión",
     "comingSoon": "Próximamente"
   }

--- a/webview/src/i18n/locales/fa/commandPalette.json
+++ b/webview/src/i18n/locales/fa/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "گزارش مشکل",
-    "reloading": "در حال بارگذاری مجدد…",
-    "reloadCommands": "بارگذاری مجدد دستورها",
     "refreshVersion": "تازه‌سازی نسخه",
     "comingSoon": "به‌زودی"
   }

--- a/webview/src/i18n/locales/fr/commandPalette.json
+++ b/webview/src/i18n/locales/fr/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Signaler un problème",
-    "reloading": "Rechargement…",
-    "reloadCommands": "Recharger les commandes",
     "refreshVersion": "Actualiser la version",
     "comingSoon": "Bientôt disponible"
   }

--- a/webview/src/i18n/locales/ja/commandPalette.json
+++ b/webview/src/i18n/locales/ja/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "問題を報告",
-    "reloading": "再読み込み中…",
-    "reloadCommands": "コマンドを再読み込み",
     "refreshVersion": "バージョンを更新",
     "comingSoon": "近日公開"
   }

--- a/webview/src/i18n/locales/ko/commandPalette.json
+++ b/webview/src/i18n/locales/ko/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "문제 신고",
-    "reloading": "다시 불러오는 중…",
-    "reloadCommands": "명령어 다시 불러오기",
     "refreshVersion": "버전 새로고침",
     "comingSoon": "출시 예정"
   }

--- a/webview/src/i18n/locales/pt/commandPalette.json
+++ b/webview/src/i18n/locales/pt/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Reportar um problema",
-    "reloading": "Recarregando…",
-    "reloadCommands": "Recarregar comandos",
     "refreshVersion": "Atualizar versão",
     "comingSoon": "Em breve"
   }

--- a/webview/src/i18n/locales/ru/commandPalette.json
+++ b/webview/src/i18n/locales/ru/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "Сообщить о проблеме",
-    "reloading": "Перезагрузка…",
-    "reloadCommands": "Перезагрузить команды",
     "refreshVersion": "Обновить версию",
     "comingSoon": "Скоро"
   }

--- a/webview/src/i18n/locales/zh-TW/commandPalette.json
+++ b/webview/src/i18n/locales/zh-TW/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "回報問題",
-    "reloading": "正在重新載入…",
-    "reloadCommands": "重新載入指令",
     "refreshVersion": "重新整理版本",
     "comingSoon": "即將推出"
   }

--- a/webview/src/i18n/locales/zh/commandPalette.json
+++ b/webview/src/i18n/locales/zh/commandPalette.json
@@ -52,8 +52,6 @@
   },
   "panel": {
     "reportProblem": "反馈问题",
-    "reloading": "正在重新加载…",
-    "reloadCommands": "重新加载命令",
     "refreshVersion": "刷新版本",
     "comingSoon": "即将推出"
   }

--- a/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/ModelTag.tsx
@@ -71,6 +71,7 @@ export function ModelTag() {
         uuid: crypto.randomUUID(),
         timestamp: new Date().toISOString(),
         summary: t('chatInput.modelTag.setModelNotification', { model: resolveModelLabel(next) }),
+        modelChangeValue: next.value,
       });
       if (currentSessionId) void send(MessageType.SET_MODEL, { model: next.value });
     };

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -89,6 +89,7 @@ export function ChatInput() {
   const lastMetaArrowTime = useRef<number>(0);
   const [showAttachMenu, setShowAttachMenu] = useState(false);
   const [showModelSwitch, setShowModelSwitch] = useState(false);
+  const [modelSwitchQuery, setModelSwitchQuery] = useState<string | null>(null);
   const [showModePanel, setShowModePanel] = useState(false);
   const modePanelRef = useRef<HTMLDivElement>(null);
 
@@ -194,9 +195,14 @@ export function ChatInput() {
     return () => window.removeEventListener(OPEN_SESSION_DROPDOWN_EVENT, handleResumeFromPalette);
   }, [onChange]);
 
-  // 커맨드 팔레트 "Switch model..." 항목 연동
+  // 커맨드 팔레트 "Switch model..." 항목 + "/model [name]" 슬래시 연동.
+  // "/model sonnet"은 detail.query로 이름을 실어 보내 오버레이가 즉시 전환한다.
   useEffect(() => {
-    const handler = () => setShowModelSwitch(true);
+    const handler = (e: Event) => {
+      const query = (e as CustomEvent<{ query?: string }>).detail?.query;
+      setModelSwitchQuery(typeof query === 'string' ? query : null);
+      setShowModelSwitch(true);
+    };
     window.addEventListener(SWITCH_MODEL_EVENT, handler);
     return () => window.removeEventListener(SWITCH_MODEL_EVENT, handler);
   }, []);
@@ -576,6 +582,7 @@ export function ChatInput() {
               sections={palette.filteredSections}
               selectedSectionIndex={palette.selectedSectionIndex}
               selectedItemIndex={palette.selectedItemIndex}
+              filterQuery={palette.filterQuery}
               onItemClick={palette.selectItem}
               onItemExecute={palette.handlePanelItemExecute}
               onClose={palette.closePanel}
@@ -585,7 +592,10 @@ export function ChatInput() {
 
         {/* Model switch panel */}
         {showModelSwitch && (
-          <ModelSwitchOverlay onClose={() => setShowModelSwitch(false)} />
+          <ModelSwitchOverlay
+            autoSelectQuery={modelSwitchQuery}
+            onClose={() => { setShowModelSwitch(false); setModelSwitchQuery(null); }}
+          />
         )}
 
         {/* 드래그 오버 오버레이 */}

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -76,6 +76,7 @@ export function ModelSwitchOverlay({ onClose, autoSelectQuery }: ModelSwitchOver
       uuid: crypto.randomUUID(),
       timestamp: new Date().toISOString(),
       summary: t('modelSwitch.setModelTo', { model: info ? resolveModelLabel(info) : value }),
+      modelChangeValue: value,
     });
 
     if (currentSessionId) {

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useBridge } from '@/hooks/useBridge';
@@ -8,6 +8,7 @@ import { useCurrentModel } from '@/hooks/useCurrentModel';
 import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { LoadedMessageType } from '@/types';
 import {
+  findModelForSelection,
   isFablePromoActive,
   resolveModelInfo,
   resolveModelLabel,
@@ -22,9 +23,12 @@ export const SWITCH_MODEL_EVENT = 'switch-model';
 
 interface ModelSwitchOverlayProps {
   onClose: () => void;
+  /** When set (e.g. from "/model sonnet"), resolve this to a model and switch
+   *  immediately; if it matches nothing, the picker just stays open. */
+  autoSelectQuery?: string | null;
 }
 
-export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
+export function ModelSwitchOverlay({ onClose, autoSelectQuery }: ModelSwitchOverlayProps) {
   const { t } = useTranslation('chat');
   const { setSessionModel, appendMessage } = useChatStreamContext();
   const { send } = useBridge();
@@ -60,7 +64,7 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
     };
   }, [onClose]);
 
-  const handleSelect = async (value: string) => {
+  const handleSelect = useCallback(async (value: string) => {
     setSessionModel(value);
 
     // Instant local feedback (same label & dedup behavior as the rotate path):
@@ -79,7 +83,21 @@ export function ModelSwitchOverlay({ onClose }: ModelSwitchOverlayProps) {
     }
 
     onClose();
-  };
+  }, [setSessionModel, models, appendMessage, t, currentSessionId, send, onClose]);
+
+  // "/model <name>": resolve the typed name to a model and switch immediately.
+  // Guarded to fire once per open; on no match the picker stays open so the
+  // user can choose manually.
+  const autoSelectedRef = useRef(false);
+  useEffect(() => {
+    if (autoSelectedRef.current) return;
+    if (!autoSelectQuery || models.length === 0) return;
+    autoSelectedRef.current = true;
+    // Exact/family match only (no default fallback): if the named model isn't
+    // available we leave the picker open instead of switching to Opus/default.
+    const info = findModelForSelection(models, autoSelectQuery);
+    if (info) void handleSelect(info.value);
+  }, [autoSelectQuery, models, handleSelect]);
 
   return (
     <div

--- a/webview/src/pages/ChatPage/message-renderers/NotificationMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/NotificationMessageRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LoadedMessageDto, LoadedMessageType, getTextContent } from '../../../types';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
-import { modelChangeLabel } from '@/types/models';
+import { modelChangeTarget } from '@/types/models';
 import { parseUserContent } from './utils/parseUserContent';
 import type { ModelInfo } from '@/types/slashCommand';
 
@@ -28,13 +28,18 @@ export const NotificationMessageRenderer: React.FC<NotificationMessageRendererPr
   // and that echo lands at the correct chronological position (and persists in
   // the session). Once the echo exists, hide this ephemeral notice so the two
   // converge to a single line whose position stays stable across reloads.
-  if (text.startsWith('Set model to ')) {
+  //
+  // Match by model identity (the notice's `modelChangeValue`), not by display
+  // text: the notice summary is localized while the echo is English, so string
+  // equality would never converge and both lines would linger.
+  const modelValue = message.modelChangeValue;
+  if (modelValue) {
     const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
     const echoArrived = messages.some((m) => {
       if (m.type !== LoadedMessageType.User) return false;
       const parsed = parseUserContent(getTextContent(m));
       if (!parsed.hasLocalCommandStdout && parsed.commandName !== 'model') return false;
-      return modelChangeLabel(parsed.text, models) === text;
+      return modelChangeTarget(parsed.text, models)?.value === modelValue;
     });
     if (echoArrived) return null;
   }

--- a/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
@@ -13,7 +13,7 @@ import { InterruptedMessageRenderer } from './InterruptedMessageRenderer';
 import { NotificationLine } from './NotificationMessageRenderer';
 import { MessageBox } from './components/MessageBox';
 import { useCliConfig } from '@/contexts/CliConfigContext';
-import { modelChangeLabel } from '@/types/models';
+import { modelChangeTarget } from '@/types/models';
 import type { ModelInfo } from '@/types/slashCommand';
 import { useTranslation } from '@/i18n';
 
@@ -68,13 +68,14 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   // and on reload.
   if (parsedContent.hasLocalCommandStdout || parsedContent.commandName === 'model') {
     const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
-    const label = modelChangeLabel(parsedContent.text, models);
-    // Always render the echo at its correct chronological position. The matching
-    // ephemeral local notification (added on model switch for instant feedback)
-    // hides itself once this echo exists — see NotificationMessageRenderer — so
-    // they converge to a single centered line at the right spot.
-    if (label) {
-      return <NotificationLine text={label} />;
+    const target = modelChangeTarget(parsedContent.text, models);
+    // Always render the echo at its correct chronological position, localized to
+    // the current locale (the CLI echo itself is English). The matching ephemeral
+    // local notification (added on model switch for instant feedback) hides
+    // itself once this echo exists — see NotificationMessageRenderer — so they
+    // converge to a single centered line at the right spot.
+    if (target) {
+      return <NotificationLine text={t('modelSwitch.setModelTo', { ns: 'chat', model: target.label })} />;
     }
     // A `/model` entry with no parseable model line carries no useful text —
     // drop the redundant bubble rather than show an empty notice.

--- a/webview/src/types/__tests__/models.test.ts
+++ b/webview/src/types/__tests__/models.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   toModelAlias,
   resolveModelInfo,
+  resolveModelLabel,
+  findModelForSelection,
   modelChangeLabel,
   isAutoModeAvailable,
   withFableFallback,
@@ -25,6 +27,43 @@ function model(value: string, displayName = value): ModelInfo {
 function modelWithAuto(value: string, supportsAutoMode: boolean): ModelInfo {
   return { value, displayName: value, description: `${value} desc`, supportsAutoMode };
 }
+
+describe('findModelForSelection', () => {
+  const models = [
+    model('default', 'Default'),
+    model('sonnet', 'Sonnet'),
+    model('haiku', 'Haiku'),
+    model('opus[1m]', 'Opus (1M)'),
+  ];
+
+  it('matches by exact value', () => {
+    expect(findModelForSelection(models, 'sonnet')?.value).toBe('sonnet');
+  });
+
+  it('matches by model family alias', () => {
+    expect(findModelForSelection(models, 'opus')?.value).toBe('opus[1m]');
+  });
+
+  it('returns null when the requested family is absent — does NOT fall back to default', () => {
+    // Regression: "/model fable" must NOT silently switch to Opus/default when
+    // Fable isn't in the list. autoSelect uses this instead of resolveModelInfo
+    // (which falls back to default for display).
+    expect(findModelForSelection(models, 'fable')).toBeNull();
+  });
+
+  it('matches fable when it is present', () => {
+    const withFable = [...models, model('fable', 'Fable')];
+    expect(findModelForSelection(withFable, 'fable')?.value).toBe('fable');
+  });
+
+  it('returns null for an unknown token', () => {
+    expect(findModelForSelection(models, 'zzz')).toBeNull();
+  });
+
+  it('matches an explicit "default" request', () => {
+    expect(findModelForSelection(models, 'default')?.value).toBe('default');
+  });
+});
 
 describe('isAutoModeAvailable', () => {
   const models = [
@@ -187,7 +226,10 @@ describe('withFableFallback', () => {
     expect(merged).toHaveLength(3);
     expect(merged[2]).toBe(FABLE_FALLBACK_MODEL);
     expect(merged[2].value).toBe('fable');
-    expect(merged[2].displayName).toBe('Fable 5');
+    // Verbatim CLI structure: short displayName + "Fable 5 · …" description so
+    // resolveModelLabel can extract "Fable 5" as the label.
+    expect(merged[2].displayName).toBe('Fable');
+    expect(resolveModelLabel(merged[2])).toBe('Fable 5');
   });
 
   it('does not append when a "fable" alias item is already present (dedup)', () => {

--- a/webview/src/types/__tests__/models.test.ts
+++ b/webview/src/types/__tests__/models.test.ts
@@ -4,7 +4,7 @@ import {
   resolveModelInfo,
   resolveModelLabel,
   findModelForSelection,
-  modelChangeLabel,
+  modelChangeTarget,
   isAutoModeAvailable,
   withFableFallback,
   isFablePromoActive,
@@ -169,7 +169,7 @@ describe('resolveModelInfo', () => {
   });
 });
 
-describe('modelChangeLabel', () => {
+describe('modelChangeTarget', () => {
   const models: ModelInfo[] = [
     { value: 'default', displayName: 'Default (recommended)', description: 'Opus 4.8 with 1M context · recommended' },
     { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · best for hard tasks' },
@@ -177,29 +177,38 @@ describe('modelChangeLabel', () => {
     { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
   ];
 
-  it('parses "Set model to <full id>" into a friendly label', () => {
+  it('resolves "Set model to <full id>" to the model value + friendly label', () => {
     // CLI echoes the bare id for the opus[1m] selection
-    expect(modelChangeLabel('Set model to claude-opus-4-8[1m]', models)).toBe('Set model to Opus 4.8');
+    expect(modelChangeTarget('Set model to claude-opus-4-8[1m]', models)).toEqual({
+      value: 'opus[1m]',
+      label: 'Opus 4.8',
+    });
   });
 
-  it('parses "Set model to <alias> (<id>)" by the alias before the paren', () => {
-    expect(modelChangeLabel('Set model to sonnet (claude-sonnet-4-6)', models)).toBe('Set model to Sonnet 4.6');
-    expect(modelChangeLabel('Set model to haiku (claude-haiku-4-5-20251001)', models)).toBe('Set model to Haiku 4.5');
+  it('resolves "Set model to <alias> (<id>)" by the alias before the paren', () => {
+    expect(modelChangeTarget('Set model to sonnet (claude-sonnet-4-6)', models)).toEqual({
+      value: 'sonnet',
+      label: 'Sonnet 4.6',
+    });
+    expect(modelChangeTarget('Set model to haiku (claude-haiku-4-5-20251001)', models)).toEqual({
+      value: 'haiku',
+      label: 'Haiku 4.5',
+    });
   });
 
   it('still parses when wrapped in a local-command-stdout tag', () => {
     expect(
-      modelChangeLabel('<local-command-stdout>Set model to claude-opus-4-8[1m]</local-command-stdout>', models),
-    ).toBe('Set model to Opus 4.8');
+      modelChangeTarget('<local-command-stdout>Set model to claude-opus-4-8[1m]</local-command-stdout>', models),
+    ).toEqual({ value: 'opus[1m]', label: 'Opus 4.8' });
   });
 
   it('returns null for text that is not a model-change line', () => {
-    expect(modelChangeLabel('hello world', models)).toBeNull();
-    expect(modelChangeLabel('', models)).toBeNull();
+    expect(modelChangeTarget('hello world', models)).toBeNull();
+    expect(modelChangeTarget('', models)).toBeNull();
   });
 
-  it('falls back to the raw token when the model is unknown', () => {
-    expect(modelChangeLabel('Set model to mystery', [])).toBe('Set model to mystery');
+  it('falls back to the raw token (value and label) when the model is unknown', () => {
+    expect(modelChangeTarget('Set model to mystery', [])).toEqual({ value: 'mystery', label: 'mystery' });
   });
 });
 

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -104,6 +104,11 @@ export class LoadedMessageDto {
   // UI-only fields (not in JSONL, set during streaming/local creation)
   isStreaming?: boolean;
   context?: Context[];
+
+  // UI-only: a locally-created model-change notice carries the target model's
+  // stable value so the CLI's `/model` echo can be deduped against it across
+  // locales (the summary text itself is localized). Not in JSONL.
+  modelChangeValue?: string;
 }
 
 /**

--- a/webview/src/types/models.ts
+++ b/webview/src/types/models.ts
@@ -227,17 +227,24 @@ export function isAutoModeAvailable(
 }
 
 /**
- * Turn a CLI `/model` echo line into a friendly notice label, or null if the
- * text isn't a model-change line. Accepts both "Set model to <id>" and
+ * Resolve the model a CLI `/model` echo line refers to, against the account
+ * catalog. Returns the model's stable `value` and a friendly `label`, or null
+ * if the text isn't a model-change line. Accepts both "Set model to <id>" and
  * "Set model to <alias> (<id>)" shapes (and ignores any surrounding tags by
  * matching only from "Set model to" up to the first "(" or a tag/end).
- * The resulting label matches the one our local notification uses, so the two
- * can be deduped by string equality.
+ *
+ * The `value` is locale-independent, so the CLI echo can be deduped against our
+ * local (localized) model-change notification by comparing model identity — not
+ * by display text, which differs per locale. When the token can't be resolved,
+ * both `value` and `label` fall back to the raw token.
  */
-export function modelChangeLabel(text: string, models: ModelInfo[]): string | null {
+export function modelChangeTarget(
+  text: string,
+  models: ModelInfo[],
+): { value: string; label: string } | null {
   const match = text.match(/Set model to (.+?)(?:\s*[(<]|$)/);
   if (!match) return null;
   const raw = match[1].trim();
   const info = resolveModelInfo(models, raw);
-  return `Set model to ${info ? resolveModelLabel(info) : raw}`;
+  return info ? { value: info.value, label: resolveModelLabel(info) } : { value: raw, label: raw };
 }

--- a/webview/src/types/models.ts
+++ b/webview/src/types/models.ts
@@ -70,12 +70,16 @@ export function isFableSupportedCli(cliVersion: string | null | undefined): bool
 /**
  * Hardcoded Fable item appended only when the CLI-provided catalog lacks Fable.
  * `value: 'fable'` matches the verified `--model fable` / `set_model` path.
- * `description` is the CLI's own Fable row text (kept verbatim, not invented).
+ * Structure mirrors the CLI's own rows verbatim — `displayName: 'Fable'` (the
+ * short name) and `description: 'Fable 5 · …'` (name+version, then blurb). The
+ * leading "Fable 5 ·" matters: `resolveModelLabel` reads the model label out of
+ * the description's first "·" segment, so without it the label degrades to the
+ * full blurb ("Most capable for your…") instead of "Fable 5".
  */
 export const FABLE_FALLBACK_MODEL: ModelInfo = {
   value: 'fable',
-  displayName: 'Fable 5',
-  description: 'Most capable for your hardest and longest-running tasks',
+  displayName: 'Fable',
+  description: 'Fable 5 · Most capable for your hardest and longest-running tasks',
 };
 
 /**
@@ -158,6 +162,30 @@ export function resolveModelLabel(info: ModelInfo): string {
  *  3. the `default` item — a sane visible fallback
  *  4. `null` — caller renders a raw label of last resort
  */
+/**
+ * Resolve a model the user *explicitly named* (e.g. "/model fable"), matching
+ * only by exact value or model family — with NO default fallback. Unlike
+ * `resolveModelInfo` (which always returns something so the indicator never
+ * blanks), this returns null when the requested model isn't available, so
+ * "/model fable" never silently switches to Opus/default when Fable is absent.
+ */
+export function findModelForSelection(
+  models: ModelInfo[],
+  query: string,
+): ModelInfo | null {
+  const exact = models.find((m) => m.value === query);
+  if (exact) return exact;
+
+  const alias = toModelAlias(query);
+  // toModelAlias returns DEFAULT_MODEL_ALIAS for anything it doesn't recognise;
+  // treat that as "no family match" (unless the user literally asked for the
+  // default) so an unknown token can't map onto the default model.
+  if (alias === DEFAULT_MODEL_ALIAS && query.toLowerCase() !== DEFAULT_MODEL_ALIAS) {
+    return null;
+  }
+  return models.find((m) => toModelAlias(m.value) === alias) ?? null;
+}
+
 export function resolveModelInfo(
   models: ModelInfo[],
   current: string | null | undefined,


### PR DESCRIPTION
## Summary

- Slash command panel now renders a two-column CLI-style layout (name + description), matches search queries against descriptions too (with matched text highlighted), and re-fetches CLI config each time it opens so skills/commands added at runtime (e.g. via /reload) show up without a manual reload.
- Intercept /model and route it through our own set_model control request, since the CLI rejects /model in stream-json mode - restores CLI equivalence for model switching.
- Rank matches so a label hit always beats a description-only hit; keep the panel open while typing command arguments (/model sonnet), narrowing to the exact command once a space is typed.
- Fix Fable's label parsing (fallback description format mismatch) and stop autoSelect from silently falling back to Opus/default when the requested model isn't in the account's catalog.

Found while manually testing the above:
- Model-change notice duplicated across locales. The instant local notice shown on model switch is localized, but the CLI's /model echo dedup compared against a hardcoded English string, so the two never matched outside English and both lines stuck around. Now deduped by the model's stable identity instead of display text, and the surviving echo line is localized too.
- Slash command panel column misalignment. The command-name column used max-w-[55%], which truncated long command names with an ellipsis and let each row's description start at a different x position. Switched to a min-width floor: short names share a common column width so descriptions line up, and long names grow past it in full rather than being cut off.

Closes #167, #176

## Test plan

- wv-test (1356 tests), wv-lint, be-lint, be-test (655 tests), full-build (incl. Kotlin test/koverVerify) all pass
- Manually verified in the dev webview: switching models produces exactly one localized notice line; slash command panel columns align, long command names are shown in full
