### PR TITLE
fix(backend): hard-bind Claude CLI lifetime to backend lifetime (orphaned CLI processes)

### DIFF
--- a/backend/src/core/__tests__/cli-registry.test.ts
+++ b/backend/src/core/__tests__/cli-registry.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+// The registry lives under homedir()/.claude-code-gui — point homedir at a scratch
+// dir so tests never touch the real user registry.
+let fakeHome: string;
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => fakeHome };
+});
+
+import {
+  registerCliProcess,
+  unregisterCliProcess,
+  findLiveCliForSession,
+  killRegisteredCli,
+  sweepOrphanCliProcesses,
+  type CliRegistryEntry,
+} from '../cli-registry';
+
+// Real-process tests (like kill-tree.integration.test.ts): identity checks shell
+// out to `ps` and kills are real group signals — mocks cannot prove either.
+const isPosix = process.platform !== 'win32';
+
+const registryDir = () => join(fakeHome, '.claude-code-gui', 'cli-registry');
+const entryPath = (pid: number) => join(registryDir(), `${pid}.json`);
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('condition not met within timeout');
+}
+
+/** A dead-but-real pid: spawn `true` and wait for it to exit. */
+function deadPid(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('true');
+    proc.on('error', reject);
+    proc.on('exit', () => resolve(proc.pid as number));
+  });
+}
+
+/**
+ * Spawn a CLI stand-in whose argv carries [marker] (the `sh -c` $0 slot), the
+ * way the real chat spawn carries `--session-id <id>` — that argv marker is what
+ * the registry's identity check reads back via `ps`. The script must be a
+ * multi-command one: for a single command `sh -c` exec-optimizes itself away and
+ * the marker-bearing shell argv disappears from `ps`.
+ */
+function spawnMarked(marker: string, script = 'sleep 30; true'): ChildProcess {
+  return spawn('sh', ['-c', script, marker], { detached: true, stdio: 'ignore' });
+}
+
+function tamperOwner(pid: number, owner: { pid: number; argv1: string }): void {
+  const entry = JSON.parse(readFileSync(entryPath(pid), 'utf8')) as CliRegistryEntry;
+  entry.owner = owner;
+  writeFileSync(entryPath(pid), JSON.stringify(entry));
+}
+
+describe.skipIf(!isPosix)('cli-registry (POSIX, real processes)', () => {
+  const spawned: ChildProcess[] = [];
+
+  beforeEach(() => {
+    fakeHome = mkdtempSync(join(process.env.TMPDIR ?? '/tmp', 'cli-registry-test-'));
+  });
+
+  afterEach(() => {
+    for (const proc of spawned) {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, 'SIGKILL');
+        } catch {
+          // Not a leader or already gone
+        }
+      }
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+    spawned.length = 0;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it('register writes an entry file, unregister removes it', () => {
+    const proc = spawnMarked('sess-lifecycle');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-lifecycle', '/tmp/proj');
+
+    expect(existsSync(entryPath(proc.pid as number))).toBe(true);
+    const entry = JSON.parse(readFileSync(entryPath(proc.pid as number), 'utf8')) as CliRegistryEntry;
+    expect(entry.sessionId).toBe('sess-lifecycle');
+    expect(entry.owner.pid).toBe(process.pid);
+
+    unregisterCliProcess(proc.pid);
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('finds a live orphan (dead owner) for its session', async () => {
+    const proc = spawnMarked('sess-orphan');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-orphan', '/tmp/proj');
+    tamperOwner(proc.pid as number, { pid: await deadPid(), argv1: 'node' });
+
+    const conflict = findLiveCliForSession('sess-orphan');
+    expect(conflict?.entry.pid).toBe(proc.pid);
+    expect(conflict?.ownerAlive).toBe(false);
+  });
+
+  it('reports ownerAlive for an entry owned by a live process', () => {
+    const proc = spawnMarked('sess-owned');
+    spawned.push(proc);
+    const owner = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(owner);
+    registerCliProcess(proc, 'sess-owned', '/tmp/proj');
+    tamperOwner(proc.pid as number, { pid: owner.pid as number, argv1: '/usr/bin/sleep' });
+
+    const conflict = findLiveCliForSession('sess-owned');
+    expect(conflict?.ownerAlive).toBe(true);
+  });
+
+  it('treats a pid whose argv lost the sessionId as dead (pid reuse) and GCs the entry', () => {
+    // The live process argv carries a DIFFERENT marker than the registered session.
+    const proc = spawnMarked('some-other-marker');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-reused', '/tmp/proj');
+
+    expect(findLiveCliForSession('sess-reused')).toBeNull();
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('killRegisteredCli escalates to SIGKILL when SIGTERM is ignored', async () => {
+    const proc = spawnMarked('sess-stubborn', 'trap "" TERM; sleep 30 & wait');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-stubborn', '/tmp/proj');
+    const entry = JSON.parse(readFileSync(entryPath(proc.pid as number), 'utf8')) as CliRegistryEntry;
+
+    await killRegisteredCli(entry, 500);
+
+    await waitUntil(() => !pidAlive(proc.pid as number));
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('sweep kills orphans, skips live-owner entries, and GCs dead ones', async () => {
+    const orphan = spawnMarked('sess-sweep-orphan');
+    spawned.push(orphan);
+    registerCliProcess(orphan, 'sess-sweep-orphan', '/tmp/proj');
+    tamperOwner(orphan.pid as number, { pid: await deadPid(), argv1: 'node' });
+
+    const owned = spawnMarked('sess-sweep-owned');
+    spawned.push(owned);
+    const owner = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(owner);
+    registerCliProcess(owned, 'sess-sweep-owned', '/tmp/proj');
+    tamperOwner(owned.pid as number, { pid: owner.pid as number, argv1: '/usr/bin/sleep' });
+
+    const gone = spawnMarked('sess-sweep-dead');
+    registerCliProcess(gone, 'sess-sweep-dead', '/tmp/proj');
+    process.kill(-(gone.pid as number), 'SIGKILL');
+    await waitUntil(() => !pidAlive(gone.pid as number));
+
+    const result = await sweepOrphanCliProcesses();
+
+    expect(result).toEqual({ killed: 1, skipped: 1 });
+    await waitUntil(() => !pidAlive(orphan.pid as number));
+    expect(pidAlive(owned.pid as number)).toBe(true);
+    expect(existsSync(entryPath(orphan.pid as number))).toBe(false);
+    expect(existsSync(entryPath(gone.pid as number))).toBe(false);
+    expect(existsSync(entryPath(owned.pid as number))).toBe(true);
+  });
+});

--- a/backend/src/core/__tests__/cli-registry.test.ts
+++ b/backend/src/core/__tests__/cli-registry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { spawn, type ChildProcess } from 'child_process';
+import { spawn, execFileSync, type ChildProcess } from 'child_process';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
@@ -45,10 +45,10 @@ async function waitUntil(cond: () => boolean, timeoutMs = 5_000): Promise<void> 
   throw new Error('condition not met within timeout');
 }
 
-/** A dead-but-real pid: spawn `true` and wait for it to exit. */
+/** A dead-but-real pid: spawn a no-op child and wait for it to exit. */
 function deadPid(): Promise<number> {
   return new Promise((resolve, reject) => {
-    const proc = spawn('true');
+    const proc = isPosix ? spawn('true') : spawn(process.execPath, ['-e', '']);
     proc.on('error', reject);
     proc.on('exit', () => resolve(proc.pid as number));
   });
@@ -212,4 +212,164 @@ describe.skipIf(!isPosix)('cli-registry (POSIX, real processes)', () => {
     expect(existsSync(entryPath(gone.pid as number))).toBe(false);
     expect(existsSync(entryPath(owned.pid as number))).toBe(true);
   });
+});
+
+// ── win32 (real processes) ───────────────────────────────────────────────────
+// The POSIX suite proves identity/kill via `ps` + group signals; neither exists
+// on win32. Here identity shells out to CIM (Win32_Process.CommandLine) and kills
+// go through `taskkill /F /T` — the exact paths cli-registry takes on win32, so
+// mocks could not prove them. CIM spins up powershell per query, so these are slow;
+// each test carries a generous timeout.
+const WIN_TIMEOUT = 30_000;
+
+/**
+ * A live CLI stand-in whose argv carries [marker] the way the real chat spawn
+ * carries `--session-id <id>`. node stays alive on setInterval; the marker rides
+ * AFTER `--` so node won't parse it as an option, and CIM's CommandLine reads it
+ * back — the token the registry's identity check matches on.
+ */
+function spawnMarkedWin(marker: string): ChildProcess {
+  return spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)', '--', '--session-id', marker], {
+    stdio: 'ignore',
+  });
+}
+
+function taskkillTree(pid: number | undefined): void {
+  if (!pid) return;
+  try {
+    execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { windowsHide: true });
+  } catch {
+    // Already gone
+  }
+}
+
+describe.skipIf(isPosix)('cli-registry (win32, real processes)', () => {
+  const spawned: ChildProcess[] = [];
+
+  beforeEach(() => {
+    fakeHome = mkdtempSync(join(process.env.TEMP ?? process.env.TMPDIR ?? '.', 'cli-registry-test-'));
+  });
+
+  afterEach(() => {
+    for (const proc of spawned) taskkillTree(proc.pid);
+    spawned.length = 0;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it(
+    'finds a live orphan (dead owner) for its session via CIM identity',
+    async () => {
+      const proc = spawnMarkedWin('sess-orphan-win');
+      spawned.push(proc);
+      registerCliProcess(proc, 'sess-orphan-win', 'C:/tmp/proj');
+      tamperOwner(proc.pid as number, { pid: await deadPid(), argv1: 'node.exe' });
+
+      const conflict = findLiveCliForSession('sess-orphan-win');
+      expect(conflict?.entry.pid).toBe(proc.pid);
+      expect(conflict?.ownerAlive).toBe(false);
+    },
+    WIN_TIMEOUT,
+  );
+
+  it(
+    'reports ownerAlive for an entry owned by a live process',
+    () => {
+      const proc = spawnMarkedWin('sess-owned-win');
+      spawned.push(proc);
+      const owner = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      spawned.push(owner);
+      registerCliProcess(proc, 'sess-owned-win', 'C:/tmp/proj');
+      tamperOwner(proc.pid as number, { pid: owner.pid as number, argv1: process.execPath });
+
+      const conflict = findLiveCliForSession('sess-owned-win');
+      expect(conflict?.ownerAlive).toBe(true);
+    },
+    WIN_TIMEOUT,
+  );
+
+  it(
+    'treats a pid whose argv lost the sessionId as dead (pid reuse) and GCs the entry',
+    () => {
+      const proc = spawnMarkedWin('some-other-marker-win');
+      spawned.push(proc);
+      registerCliProcess(proc, 'sess-reused-win', 'C:/tmp/proj');
+
+      expect(findLiveCliForSession('sess-reused-win')).toBeNull();
+      expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+    },
+    WIN_TIMEOUT,
+  );
+
+  it(
+    'killRegisteredCli tears down the orphan tree via taskkill',
+    async () => {
+      const proc = spawnMarkedWin('sess-kill-win');
+      spawned.push(proc);
+      registerCliProcess(proc, 'sess-kill-win', 'C:/tmp/proj');
+      const entry = JSON.parse(readFileSync(entryPath(proc.pid as number), 'utf8')) as CliRegistryEntry;
+
+      await killRegisteredCli(entry, 3_000);
+
+      await waitUntil(() => !pidAlive(proc.pid as number), 10_000);
+      expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+    },
+    WIN_TIMEOUT,
+  );
+
+  it(
+    'drops a registry entry with a bogus pid (<= 1) without ever killing',
+    async () => {
+      mkdirSync(registryDir(), { recursive: true });
+      const bogus = join(registryDir(), '0.json');
+      writeFileSync(
+        bogus,
+        JSON.stringify({
+          pid: 0,
+          sessionId: 'sess-bogus-win',
+          workingDir: 'C:/tmp/proj',
+          startedAt: new Date().toISOString(),
+          owner: { pid: 999999, argv1: 'node.exe' },
+        }),
+      );
+
+      const result = await sweepOrphanCliProcesses();
+
+      // readEntries rejects pid <= 1 up front: never swept, GC'd instead.
+      expect(result).toEqual({ killed: 0, skipped: 0 });
+      expect(existsSync(bogus)).toBe(false);
+    },
+    WIN_TIMEOUT,
+  );
+
+  it(
+    'sweep kills orphans, skips live-owner entries, and GCs dead ones',
+    async () => {
+      const orphan = spawnMarkedWin('sess-sweep-orphan-win');
+      spawned.push(orphan);
+      registerCliProcess(orphan, 'sess-sweep-orphan-win', 'C:/tmp/proj');
+      tamperOwner(orphan.pid as number, { pid: await deadPid(), argv1: 'node.exe' });
+
+      const owned = spawnMarkedWin('sess-sweep-owned-win');
+      spawned.push(owned);
+      const owner = spawn(process.execPath, ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'ignore' });
+      spawned.push(owner);
+      registerCliProcess(owned, 'sess-sweep-owned-win', 'C:/tmp/proj');
+      tamperOwner(owned.pid as number, { pid: owner.pid as number, argv1: process.execPath });
+
+      const gone = spawnMarkedWin('sess-sweep-dead-win');
+      registerCliProcess(gone, 'sess-sweep-dead-win', 'C:/tmp/proj');
+      taskkillTree(gone.pid);
+      await waitUntil(() => !pidAlive(gone.pid as number), 10_000);
+
+      const result = await sweepOrphanCliProcesses();
+
+      expect(result).toEqual({ killed: 1, skipped: 1 });
+      await waitUntil(() => !pidAlive(orphan.pid as number), 10_000);
+      expect(pidAlive(owned.pid as number)).toBe(true);
+      expect(existsSync(entryPath(orphan.pid as number))).toBe(false);
+      expect(existsSync(entryPath(gone.pid as number))).toBe(false);
+      expect(existsSync(entryPath(owned.pid as number))).toBe(true);
+    },
+    WIN_TIMEOUT,
+  );
 });

--- a/backend/src/core/__tests__/cli-registry.test.ts
+++ b/backend/src/core/__tests__/cli-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { spawn, type ChildProcess } from 'child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
 // The registry lives under homedir()/.claude-code-gui — point homedir at a scratch
@@ -154,6 +154,35 @@ describe.skipIf(!isPosix)('cli-registry (POSIX, real processes)', () => {
 
     await waitUntil(() => !pidAlive(proc.pid as number));
     expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('drops a registry entry with a bogus pid (<= 1) without ever signalling', async () => {
+    // Defence in depth: a corrupt/bogus pid must never reach the group kill.
+    // process.kill(-0) signals our OWN process group and process.kill(-1) every
+    // group we may signal — in JetBrains mode that can include the IDE JVM.
+    mkdirSync(registryDir(), { recursive: true });
+    const bogus = join(registryDir(), '0.json');
+    writeFileSync(
+      bogus,
+      JSON.stringify({
+        pid: 0,
+        sessionId: 'sess-bogus',
+        workingDir: '/tmp/proj',
+        startedAt: new Date().toISOString(),
+        owner: { pid: 999999, argv1: 'node' },
+      }),
+    );
+
+    const killSpy = vi.spyOn(process, 'kill');
+    const result = await sweepOrphanCliProcesses();
+    const groupSignals = killSpy.mock.calls.filter(([p]) => typeof p === 'number' && p <= 0);
+    killSpy.mockRestore();
+
+    // readEntries rejects pid <= 1 up front, so the sweep never sees it, never
+    // signals a group, and GCs the corrupt file.
+    expect(groupSignals).toEqual([]);
+    expect(result).toEqual({ killed: 0, skipped: 0 });
+    expect(existsSync(bogus)).toBe(false);
   });
 
   it('sweep kills orphans, skips live-owner entries, and GCs dead ones', async () => {

--- a/backend/src/core/__tests__/cli-registry.test.ts
+++ b/backend/src/core/__tests__/cli-registry.test.ts
@@ -17,6 +17,7 @@ import {
   findLiveCliForSession,
   killRegisteredCli,
   sweepOrphanCliProcesses,
+  isValidSessionId,
   type CliRegistryEntry,
 } from '../cli-registry';
 
@@ -70,6 +71,44 @@ function tamperOwner(pid: number, owner: { pid: number; argv1: string }): void {
   entry.owner = owner;
   writeFileSync(entryPath(pid), JSON.stringify(entry));
 }
+
+// ── isValidSessionId (platform-agnostic) ─────────────────────────────────────
+// The win32 orphan kill interpolates the sessionId into a CIM `-like '*<id>*'`
+// match. An empty or wildcard/quote-bearing id widens that match (worst case
+// `-like '*'` → every process) and turns the orphan kill into a machine-wide
+// taskkill, or lets a crafted id inject PowerShell. The guard rejects anything
+// outside a simple token so a malformed id matches nothing. Pure and runs
+// everywhere — no processes, no platform skip.
+describe('isValidSessionId', () => {
+  it('rejects an empty string (would widen the CIM match to every process)', () => {
+    expect(isValidSessionId('')).toBe(false);
+  });
+
+  it('rejects whitespace-only ids', () => {
+    expect(isValidSessionId('   ')).toBe(false);
+  });
+
+  it('rejects ids carrying a quote and whitespace (PowerShell injection shape)', () => {
+    expect(isValidSessionId("abc'; Stop-Process")).toBe(false);
+  });
+
+  it('rejects a bare wildcard and wildcard-bearing ids', () => {
+    expect(isValidSessionId('*')).toBe(false);
+    expect(isValidSessionId('abc*')).toBe(false);
+  });
+
+  it('rejects an id with a wildcard character class bracket', () => {
+    expect(isValidSessionId('a[bc')).toBe(false);
+  });
+
+  it('accepts the sess-* fixture form used across the suite', () => {
+    expect(isValidSessionId('sess-lifecycle')).toBe(true);
+  });
+
+  it('accepts a real uuid session id', () => {
+    expect(isValidSessionId('9f8b1c2d-4e5a-6789-abcd-0123456789ef')).toBe(true);
+  });
+});
 
 describe.skipIf(!isPosix)('cli-registry (POSIX, real processes)', () => {
   const spawned: ChildProcess[] = [];

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { Claude } from '../claude';
+import { ConnectionManager } from '../../ws/connection-manager';
+
+// Real-process integration tests reproducing the orphaned-CLI bug.
+// claude.test.ts mocks child_process entirely; the process-group kill semantics
+// verified here are exactly what mocks cannot prove. POSIX-only: the win32 branch
+// shells out to taskkill, which needs Windows (untested locally).
+
+const isPosix = process.platform !== 'win32';
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('condition not met within timeout');
+}
+
+/** First stdout line of [proc] — the fixtures echo their grandchild PID there. */
+function firstStdoutLine(proc: ChildProcess): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    proc.stdout?.on('data', (data: Buffer) => {
+      buf += data.toString();
+      const nl = buf.indexOf('\n');
+      if (nl >= 0) resolve(buf.slice(0, nl).trim());
+    });
+    proc.on('error', reject);
+    proc.on('exit', () => reject(new Error(`exited before printing a line: "${buf}"`)));
+  });
+}
+
+/**
+ * Spawn a fixture shaped like the chat CLI spawn (claude-process.ts): detached ⇒
+ * own process group, with a background grandchild whose PID it echoes — the
+ * stand-in for subagent shells / background tasks under a real CLI.
+ */
+function spawnDetachedTree(shellScript = 'sleep 30 & echo $!; wait'): ChildProcess {
+  return spawn('sh', ['-c', shellScript], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
+  const spawned: ChildProcess[] = [];
+  afterEach(() => {
+    for (const proc of spawned) {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, 'SIGKILL');
+        } catch {
+          // Not a group leader or already gone
+        }
+      }
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+    spawned.length = 0;
+  });
+
+  it('kills the whole tree of a detached child — grandchild included', async () => {
+    const proc = spawnDetachedTree();
+    spawned.push(proc);
+    const grandchildPid = parseInt(await firstStdoutLine(proc), 10);
+    expect(Number.isFinite(grandchildPid)).toBe(true);
+    expect(pidAlive(grandchildPid)).toBe(true);
+
+    Claude.killTree(proc);
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    await waitUntil(() => !pidAlive(grandchildPid));
+  });
+
+  it('falls back to a plain signal for a non-detached (non-leader) child', async () => {
+    const proc = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(proc);
+
+    Claude.killTree(proc);
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    expect(proc.signalCode).toBe('SIGTERM');
+  });
+});
+
+describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
+  it('kill-sweeps every registered session tree', async () => {
+    const connections = new ConnectionManager();
+    const procs = [
+      spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+      spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    ];
+    try {
+      const grandchildren = await Promise.all(
+        procs.map(async (proc) => parseInt(await firstStdoutLine(proc), 10)),
+      );
+      connections.getOrCreateSession('session-a');
+      connections.setProcess('session-a', procs[0]);
+      connections.getOrCreateSession('session-b');
+      connections.setProcess('session-b', procs[1]);
+
+      connections.shutdownAll();
+
+      await waitUntil(() => procs.every((p) => p.exitCode !== null || p.signalCode !== null));
+      await waitUntil(() => grandchildren.every((pid) => !pidAlive(pid)));
+    } finally {
+      for (const proc of procs) {
+        if (proc.pid) {
+          try {
+            process.kill(-proc.pid, 'SIGKILL');
+          } catch {
+            // Already gone
+          }
+        }
+      }
+    }
+  });
+});

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { spawn, type ChildProcess } from 'child_process';
 import { Claude } from '../claude';
 import { ConnectionManager } from '../../ws/connection-manager';
@@ -108,6 +108,25 @@ describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
 
     await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
     expect(proc.signalCode).toBe('SIGTERM');
+  });
+
+  it('does not raw-group-signal a reaped child (stale pid may be reused)', async () => {
+    // Regression: a stale killTree (e.g. an uncleared safety timeout) firing after
+    // the child closed must not signal -proc.pid — that pid may now belong to an
+    // unrelated reused process group. proc.kill() would no-op, but process.kill(-pid)
+    // is not liveness-aware, so killTree must bail on a reaped child.
+    const proc = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(proc);
+    proc.kill('SIGKILL');
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+
+    const killSpy = vi.spyOn(process, 'kill');
+    try {
+      Claude.killTree(proc, 'SIGTERM');
+      expect(killSpy).not.toHaveBeenCalled();
+    } finally {
+      killSpy.mockRestore();
+    }
   });
 });
 

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import { Claude } from '../claude';
 import { ConnectionManager } from '../../ws/connection-manager';
 
-// Real-process integration tests reproducing the orphaned-CLI bug.
+// Real-process integration tests for the orphaned-CLI hard-binding.
 // claude.test.ts mocks child_process entirely; the process-group kill semantics
 // verified here are exactly what mocks cannot prove. POSIX-only: the win32 branch
 // shells out to taskkill, which needs Windows (untested locally).
@@ -111,8 +111,8 @@ describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
   });
 });
 
-describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
-  it('kill-sweeps every registered session tree', async () => {
+describe.skipIf(!isPosix)('ConnectionManager.killAllSessionProcesses', () => {
+  it('kill-sweeps every registered session tree and reports the count', async () => {
     const connections = new ConnectionManager();
     const procs = [
       spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
@@ -133,8 +133,9 @@ describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
       connections.getOrCreateSession('session-b');
       connections.setProcess('session-b', procs[1]);
 
-      connections.shutdownAll();
+      const killed = connections.killAllSessionProcesses('SIGKILL');
 
+      expect(killed).toBe(2);
       await waitUntil(() => procs.every((p) => p.exitCode !== null || p.signalCode !== null));
       await waitUntil(() => grandchildren.every((pid) => !pidAlive(pid)));
     } finally {

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -87,6 +87,19 @@ describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
     await waitUntil(() => !pidAlive(grandchildPid));
   });
 
+  it('supports SIGKILL (the exit-sweep signal) through the same path', async () => {
+    // The fixture shell ignores SIGTERM to prove the sweep's SIGKILL is what lands.
+    const proc = spawnDetachedTree('trap "" TERM; sleep 30 & echo $!; wait');
+    spawned.push(proc);
+    const grandchildPid = parseInt(await firstStdoutLine(proc), 10);
+    expect(pidAlive(grandchildPid)).toBe(true);
+
+    Claude.killTree(proc, 'SIGKILL');
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    await waitUntil(() => !pidAlive(grandchildPid));
+  });
+
   it('falls back to a plain signal for a non-detached (non-leader) child', async () => {
     const proc = spawn('sleep', ['30'], { stdio: 'ignore' });
     spawned.push(proc);

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -7,6 +7,7 @@ import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
 import { reportBackendError } from './features/telemetry';
 import { restoreSchedulesForSession } from './features/scheduled-messages';
+import { findLiveCliForSession, killRegisteredCli, registerCliProcess, unregisterCliProcess } from './cli-registry';
 import { MessageType } from '../shared';
 
 // Tracks files Claude edits so the IDE can be told to reload them once the
@@ -150,6 +151,37 @@ export async function ensureClaudeProcess(
     return;
   }
 
+  // Liveness guard before spawning: a live, identity-checked CLI may
+  // already be writing this session's JSONL — an orphan left by a hard-killed
+  // backend, or a session legitimately open under another live backend. Spawning
+  // a second CLI would mean two writers on one JSONL (branched history,
+  // false task verdicts, interleaved GUI) — so kill the orphan / refuse the takeover.
+  const conflict = findLiveCliForSession(targetSessionId);
+  if (conflict) {
+    if (conflict.ownerAlive) {
+      const reason =
+        `Session ${targetSessionId} is already active under another backend ` +
+        `(CLI PID ${conflict.entry.pid}, backend PID ${conflict.entry.owner.pid}). ` +
+        'Refusing to start a second writer on the same session.';
+      console.error('[node-backend]', reason);
+      connections.broadcastToSession(targetSessionId, MessageType.SERVICE_ERROR, {
+        type: MessageType.SPAWN_ERROR,
+        reason,
+        error: reason,
+      });
+      connections.broadcastToSession(targetSessionId, MessageType.STREAM_END);
+      return;
+    }
+    console.error(
+      '[node-backend]',
+      `Killing orphaned CLI ${conflict.entry.pid} before respawning session ${targetSessionId}`,
+    );
+    await killRegisteredCli(conflict.entry);
+    // The orphan proves this session already ran — resume it instead of passing
+    // --session-id, which would fail with "already in use".
+    spawnedSessions.add(targetSessionId);
+  }
+
   const useResume = spawnedSessions.has(targetSessionId);
   const sessionFlag = useResume ? '--resume' : '--session-id';
 
@@ -228,6 +260,11 @@ export async function ensureClaudeProcess(
   // reservation can deliver to this fresh process. Idempotent (already-armed
   // timers are skipped) and fire-and-forget so it never blocks the stream start.
   void restoreSchedulesForSession(targetSessionId, connections);
+
+  // Record the live CLI in the on-disk registry: lets a FUTURE backend detect this
+  // process as an orphan (startup sweep) or as a conflicting writer (resume guard)
+  // if we die hard before the 'close' handler unregisters it.
+  registerCliProcess(proc, targetSessionId, workingDir);
 
   // 모든 구독자에게 스트림 시작 알림
   connections.broadcastToSession(targetSessionId, MessageType.STREAM_START);
@@ -317,6 +354,9 @@ export async function ensureClaudeProcess(
 
       // 프로세스 참조만 해제 (세션 레코드는 유지 — 구독자가 아직 있을 수 있음)
       connections.setProcess(targetSessionId, null);
+      // Clean CLI exit — drop its registry entry (hard backend deaths skip this;
+      // that is exactly what the startup orphan sweep is for).
+      unregisterCliProcess(proc.pid);
     } catch (err) {
       reportBackendError(err instanceof Error ? err : new Error(String(err)), {
         layer: 'claude_stream',

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -171,6 +171,13 @@ export async function ensureClaudeProcess(
   const proc = await Claude.spawnAuthed(args, workingDir, {
     cwd: workingDir,
     stdio: ['pipe', 'pipe', 'pipe'],
+    // POSIX: detach the CLI into its own process group so every kill path can take
+    // down the WHOLE tree at once (Claude.killTree signals -pid: the CLI plus its
+    // subagent shells and background tasks). Trade-off: a detached CLI no longer
+    // shares the terminal's process group, so it stops receiving the terminal's
+    // SIGHUP alongside the backend — server.ts compensates with its own SIGHUP
+    // handler (graceful shutdownAll). Keep those two in sync.
+    detached: process.platform !== 'win32',
     env: {
       TERM: 'dumb',
       CI: 'true',

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -162,6 +162,12 @@ export class Claude {
    */
   static killTree(proc: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
     if (!proc.pid) return;
+    // Once the child has been reaped, proc.pid is a stale number the OS may have
+    // reused. Signalling -proc.pid (or taskkill /T) then hits an unrelated process
+    // group/tree. proc.kill() would be a no-op here, but the raw group signal is
+    // not liveness-aware — bail before issuing it. (Guards e.g. an uncleared
+    // safety-timeout killTree firing after the process already closed.)
+    if (proc.exitCode !== null || proc.signalCode !== null) return;
     if (process.platform === 'win32') {
       try {
         execFileSync('taskkill', ['/F', '/T', '/PID', String(proc.pid)]);

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -153,10 +153,14 @@ export class Claude {
    * Terminate a process spawned via {@link spawn} AND its children. On win32
    * spawn() runs through a shell, so the real `claude` is a grandchild of
    * cmd.exe — a plain SIGTERM to `proc` leaves it orphaned. `taskkill /T` tears
-   * down the whole tree; macOS/Linux run the launcher directly, so SIGTERM
-   * suffices there. Used by every place that time-limits a spawned CLI child.
+   * down the whole tree. On macOS/Linux, chat CLIs are spawned detached (see
+   * claude-process.ts) so they lead their own process group and signalling
+   * `-pid` reaches the CLI plus every descendant (subagent shells, background
+   * tasks); for non-detached children the group signal fails with ESRCH and we
+   * fall back to a plain signal, which is the pre-existing behavior. Used by
+   * every kill path for a spawned CLI child.
    */
-  static killTree(proc: ChildProcess): void {
+  static killTree(proc: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
     if (!proc.pid) return;
     if (process.platform === 'win32') {
       try {
@@ -165,7 +169,12 @@ export class Claude {
         proc.kill();
       }
     } else {
-      proc.kill('SIGTERM');
+      try {
+        process.kill(-proc.pid, signal);
+      } catch {
+        // Not a process-group leader (or already gone) — plain signal as before.
+        proc.kill(signal);
+      }
     }
   }
 

--- a/backend/src/core/cli-registry.ts
+++ b/backend/src/core/cli-registry.ts
@@ -59,6 +59,10 @@ function pidAlive(pid: number): boolean {
 
 /** Group signal with plain-signal fallback — pid-based twin of Claude.killTree. */
 function killPidTree(pid: number, signal: NodeJS.Signals): void {
+  // process.kill(-0)/process.kill(-1) would signal our own (or every) process
+  // group — in JetBrains mode that can include the IDE JVM. Never let a corrupt
+  // or bogus registry pid reach the group signal.
+  if (!Number.isInteger(pid) || pid <= 1) return;
   try {
     process.kill(-pid, signal);
   } catch {
@@ -110,7 +114,7 @@ function readEntries(): CliRegistryEntry[] {
   for (const file of files) {
     try {
       const parsed = JSON.parse(readFileSync(join(registryDir(), file), 'utf8')) as CliRegistryEntry;
-      if (typeof parsed.pid === 'number' && typeof parsed.sessionId === 'string' && parsed.owner) {
+      if (Number.isInteger(parsed.pid) && parsed.pid > 1 && typeof parsed.sessionId === 'string' && parsed.owner) {
         entries.push(parsed);
       } else {
         rmSync(join(registryDir(), file), { force: true });

--- a/backend/src/core/cli-registry.ts
+++ b/backend/src/core/cli-registry.ts
@@ -1,0 +1,234 @@
+import { execFileSync, type ChildProcess } from 'child_process';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { basename, join } from 'path';
+
+/**
+ * On-disk registry of live chat CLI processes.
+ *
+ * The process-group hard-binding covers every backend death that still runs
+ * JS, but a hard SIGKILL of the backend bypasses all of it — the CLI survives as
+ * an orphan, invisible to any later backend. This registry closes that loop: every chat CLI spawn writes a small
+ * entry file, every clean CLI exit removes it, and a fresh backend can then
+ * (a) sweep orphans at startup and (b) refuse/kill a conflicting live writer
+ * before `--resume` (two CLIs appending to one session JSONL branch its history
+ * and emit false task verdicts).
+ *
+ * Layout: one JSON file per CLI pid under ~/.claude-code-gui/cli-registry/.
+ * Per-entry files avoid read-modify-write races between concurrently running
+ * backends (JetBrains mode legitimately runs one backend per project).
+ *
+ * PID reuse safety: a pid alone is not an identity. Before acting on an entry we
+ * re-read the live process argv (`ps -o args=`) and require it to still contain
+ * the entry's sessionId (the chat spawn always passes `--session-id <id>` or
+ * `--resume <id>`). win32 has no `ps`; identity is unknown there, so detection is
+ * log-only and nothing is auto-killed (an honest, documented gap).
+ */
+
+export interface CliRegistryEntry {
+  pid: number;
+  sessionId: string;
+  workingDir: string;
+  startedAt: string;
+  /** The backend that spawned the CLI; argv1 lets liveness checks survive pid reuse. */
+  owner: { pid: number; argv1: string };
+}
+
+function registryDir(): string {
+  return join(homedir(), '.claude-code-gui', 'cli-registry');
+}
+
+/** Live argv of [pid] as one string, or null when unknown (dead pid / win32). */
+function processArgs(pid: number): string | null {
+  if (process.platform === 'win32') return null;
+  try {
+    return execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf8' }).trim();
+  } catch {
+    return null; // ps exits non-zero for a dead pid
+  }
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Group signal with plain-signal fallback — pid-based twin of Claude.killTree. */
+function killPidTree(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone
+    }
+  }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export function registerCliProcess(proc: ChildProcess, sessionId: string, workingDir: string): void {
+  if (!proc.pid) return;
+  const entry: CliRegistryEntry = {
+    pid: proc.pid,
+    sessionId,
+    workingDir,
+    startedAt: new Date().toISOString(),
+    owner: { pid: process.pid, argv1: process.argv[1] ?? '' },
+  };
+  try {
+    mkdirSync(registryDir(), { recursive: true });
+    writeFileSync(join(registryDir(), `${proc.pid}.json`), JSON.stringify(entry, null, 2) + '\n');
+  } catch (err) {
+    // Best-effort: a failed registry write must never block the chat itself.
+    console.error('[node-backend]', 'CLI registry write failed:', err);
+  }
+}
+
+export function unregisterCliProcess(pid: number | undefined): void {
+  if (!pid) return;
+  try {
+    rmSync(join(registryDir(), `${pid}.json`), { force: true });
+  } catch (err) {
+    console.error('[node-backend]', 'CLI registry remove failed:', err);
+  }
+}
+
+function readEntries(): CliRegistryEntry[] {
+  let files: string[];
+  try {
+    files = readdirSync(registryDir()).filter((f) => f.endsWith('.json'));
+  } catch {
+    return []; // No registry dir yet — clean world
+  }
+  const entries: CliRegistryEntry[] = [];
+  for (const file of files) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(registryDir(), file), 'utf8')) as CliRegistryEntry;
+      if (typeof parsed.pid === 'number' && typeof parsed.sessionId === 'string' && parsed.owner) {
+        entries.push(parsed);
+      } else {
+        rmSync(join(registryDir(), file), { force: true });
+      }
+    } catch {
+      rmSync(join(registryDir(), file), { force: true }); // Corrupt entry — drop it
+    }
+  }
+  return entries;
+}
+
+/**
+ * Identity-checked liveness of an entry's CLI:
+ * 'live' — pid alive and argv still carries the sessionId;
+ * 'dead' — pid gone, or pid reused by an unrelated process (argv mismatch);
+ * 'unknown' — pid alive but argv unreadable (win32) — do NOT auto-kill.
+ */
+function cliState(entry: CliRegistryEntry): 'live' | 'dead' | 'unknown' {
+  if (!pidAlive(entry.pid)) return 'dead';
+  const args = processArgs(entry.pid);
+  if (args === null) return process.platform === 'win32' ? 'unknown' : 'dead';
+  return args.includes(entry.sessionId) ? 'live' : 'dead';
+}
+
+/**
+ * Is the backend that spawned this CLI still alive (and not us)? Conservative on
+ * ambiguity: when the owner pid is alive but its argv is unreadable, assume alive
+ * — never kill a CLI that might belong to a living backend.
+ */
+function ownerAlive(entry: CliRegistryEntry): boolean {
+  if (entry.owner.pid === process.pid) return false; // our own stale record
+  if (!pidAlive(entry.owner.pid)) return false;
+  const args = processArgs(entry.owner.pid);
+  if (args === null) return true;
+  const hint = basename(entry.owner.argv1 || '');
+  return hint === '' || args.includes(hint);
+}
+
+export interface CliConflict {
+  entry: CliRegistryEntry;
+  ownerAlive: boolean;
+}
+
+/**
+ * A live, identity-checked CLI already attached to [sessionId], if any.
+ * Cleans up dead entries it encounters along the way.
+ */
+export function findLiveCliForSession(sessionId: string): CliConflict | null {
+  for (const entry of readEntries()) {
+    if (entry.sessionId !== sessionId) continue;
+    const state = cliState(entry);
+    if (state === 'dead') {
+      unregisterCliProcess(entry.pid);
+      continue;
+    }
+    if (state === 'unknown') {
+      // win32: cannot verify identity — report nothing rather than risk acting
+      // on a reused pid.
+      console.error(
+        '[node-backend]',
+        `CLI registry: pid ${entry.pid} for session ${sessionId} is alive but unverifiable on this platform — ignoring`,
+      );
+      continue;
+    }
+    return { entry, ownerAlive: ownerAlive(entry) };
+  }
+  return null;
+}
+
+/** SIGTERM the entry's process group, escalate to SIGKILL after [graceMs]. */
+export async function killRegisteredCli(entry: CliRegistryEntry, graceMs = 3_000): Promise<void> {
+  killPidTree(entry.pid, 'SIGTERM');
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline && cliState(entry) === 'live') {
+    await delay(100);
+  }
+  if (cliState(entry) === 'live') {
+    console.error('[node-backend]', `Orphaned CLI ${entry.pid} ignored SIGTERM — escalating to SIGKILL`);
+    killPidTree(entry.pid, 'SIGKILL');
+  }
+  unregisterCliProcess(entry.pid);
+}
+
+/**
+ * Startup orphan sweep: kill every registered CLI whose owning backend is gone.
+ * Entries owned by other LIVE backends are left alone (multi-backend setups are
+ * legitimate); dead/reused entries are garbage-collected.
+ */
+export async function sweepOrphanCliProcesses(): Promise<{ killed: number; skipped: number }> {
+  let killed = 0;
+  let skipped = 0;
+  for (const entry of readEntries()) {
+    const state = cliState(entry);
+    if (state === 'dead') {
+      unregisterCliProcess(entry.pid);
+      continue;
+    }
+    if (state === 'unknown') {
+      console.error(
+        '[node-backend]',
+        `Orphan sweep: pid ${entry.pid} (session ${entry.sessionId}) alive but unverifiable on this platform — left running`,
+      );
+      skipped++;
+      continue;
+    }
+    if (ownerAlive(entry)) {
+      skipped++;
+      continue;
+    }
+    console.error(
+      '[node-backend]',
+      `Orphan sweep: killing orphaned CLI ${entry.pid} (session ${entry.sessionId}, dead owner ${entry.owner.pid})`,
+    );
+    await killRegisteredCli(entry);
+    killed++;
+  }
+  if (killed > 0 || skipped > 0) {
+    console.error('[node-backend]', `Orphan sweep done: killed ${killed}, skipped ${skipped}`);
+  }
+  return { killed, skipped };
+}

--- a/backend/src/core/cli-registry.ts
+++ b/backend/src/core/cli-registry.ts
@@ -19,10 +19,11 @@ import { basename, join } from 'path';
  * backends (JetBrains mode legitimately runs one backend per project).
  *
  * PID reuse safety: a pid alone is not an identity. Before acting on an entry we
- * re-read the live process argv (`ps -o args=`) and require it to still contain
- * the entry's sessionId (the chat spawn always passes `--session-id <id>` or
- * `--resume <id>`). win32 has no `ps`; identity is unknown there, so detection is
- * log-only and nothing is auto-killed (an honest, documented gap).
+ * re-read the live process argv (`ps -o args=` on POSIX, the CIM `Win32_Process`
+ * CommandLine on win32) and require it to still contain the entry's sessionId (the
+ * chat spawn always passes `--session-id <id>` or `--resume <id>`). If the argv is
+ * unreadable (e.g. a transient CIM failure) identity stays unknown and nothing is
+ * auto-killed — the conservative fallback, never a reused pid casualty.
  */
 
 export interface CliRegistryEntry {
@@ -38,9 +39,30 @@ function registryDir(): string {
   return join(homedir(), '.claude-code-gui', 'cli-registry');
 }
 
-/** Live argv of [pid] as one string, or null when unknown (dead pid / win32). */
+/** Live argv of [pid] as one string, or null when unknown (dead pid / unreadable). */
 function processArgs(pid: number): string | null {
-  if (process.platform === 'win32') return null;
+  if (!Number.isInteger(pid) || pid <= 1) return null;
+  if (process.platform === 'win32') {
+    try {
+      // Win32_Process.CommandLine is the full argv (incl. --session-id / --resume),
+      // the identity token our PID-reuse guard needs. `tasklist` only yields the
+      // image name, so it cannot verify identity. CIM is the portable, non-deprecated
+      // path (wmic is being removed from Windows). Empty output = pid gone / no argv.
+      const out = execFileSync(
+        'powershell.exe',
+        [
+          '-NoProfile',
+          '-NonInteractive',
+          '-Command',
+          `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}").CommandLine`,
+        ],
+        { encoding: 'utf8', windowsHide: true },
+      ).trim();
+      return out.length > 0 ? out : null;
+    } catch {
+      return null; // CIM query failed — treat identity as unknown
+    }
+  }
   try {
     return execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf8' }).trim();
   } catch {
@@ -57,12 +79,26 @@ function pidAlive(pid: number): boolean {
   }
 }
 
-/** Group signal with plain-signal fallback — pid-based twin of Claude.killTree. */
+/** Tree kill with plain-signal fallback — pid-based twin of Claude.killTree. */
 function killPidTree(pid: number, signal: NodeJS.Signals): void {
   // process.kill(-0)/process.kill(-1) would signal our own (or every) process
   // group — in JetBrains mode that can include the IDE JVM. Never let a corrupt
   // or bogus registry pid reach the group signal.
   if (!Number.isInteger(pid) || pid <= 1) return;
+  if (process.platform === 'win32') {
+    // No process groups on win32; `taskkill /T` walks the child tree, `/F` forces.
+    // `signal` is irrelevant here (taskkill always terminates) — both the SIGTERM
+    // and the escalated SIGKILL caller in killRegisteredCli map to the same tree
+    // kill. That collapses the grace ladder to an immediate hard kill, which is
+    // correct for an orphan (its owning backend is already gone). taskkill on an
+    // already-dead pid exits non-zero and is swallowed by the catch.
+    try {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)], { windowsHide: true });
+    } catch {
+      // Already gone or not killable — ignore
+    }
+    return;
+  }
   try {
     process.kill(-pid, signal);
   } catch {
@@ -71,6 +107,39 @@ function killPidTree(pid: number, signal: NodeJS.Signals): void {
     } catch {
       // Already gone
     }
+  }
+}
+
+/**
+ * win32 only: pids of every LIVE process whose argv carries [sessionId]. The chat
+ * spawn wraps `claude` in a cmd.exe shell (win32 needs a shell to resolve the
+ * `.cmd`/`.ps1` launcher), so the pid the registry stored is the SHELL. When the
+ * backend dies the shell drops with the broken stdio pipe, but the real `claude`
+ * grandchild keeps running — a working orphan the stored pid can no longer reach.
+ * The session id rides in `--session-id`/`--resume`, which BOTH the shell and the
+ * grandchild carry in their CommandLine, so matching on it finds the survivor.
+ * Excludes our own CIM query (its command text contains the id too).
+ */
+function liveSessionProcs(sessionId: string): number[] {
+  if (process.platform !== 'win32') return [];
+  try {
+    const out = execFileSync(
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `Get-CimInstance Win32_Process | Where-Object { $_.CommandLine -like '*${sessionId}*' -and $_.CommandLine -notlike '*Get-CimInstance*' } | ForEach-Object { $_.ProcessId }`,
+      ],
+      { encoding: 'utf8', windowsHide: true },
+    ).trim();
+    if (!out) return [];
+    return out
+      .split(/\r?\n/)
+      .map((s) => Number.parseInt(s.trim(), 10))
+      .filter((n) => Number.isInteger(n) && n > 1);
+  } catch {
+    return [];
   }
 }
 
@@ -128,14 +197,23 @@ function readEntries(): CliRegistryEntry[] {
 
 /**
  * Identity-checked liveness of an entry's CLI:
- * 'live' — pid alive and argv still carries the sessionId;
- * 'dead' — pid gone, or pid reused by an unrelated process (argv mismatch);
- * 'unknown' — pid alive but argv unreadable (win32) — do NOT auto-kill.
+ * 'live' — a live process still carries the sessionId;
+ * 'dead' — no live carrier, or the stored pid was reused by an unrelated process.
+ *
+ * win32 keys on the session id across ALL live processes, not the stored pid: that
+ * pid is the cmd.exe shell, which dies with the backend while the real `claude`
+ * grandchild orphans on. Keying on the shell pid alone would declare a live orphan
+ * 'dead' and leak it. POSIX spawns the CLI directly (no shell) and detached, so the
+ * stored pid IS the CLI — argv identity on that pid is exact. A transient argv-read
+ * failure resolves to 'dead' (GC the record) rather than risk killing a reused pid.
  */
-function cliState(entry: CliRegistryEntry): 'live' | 'dead' | 'unknown' {
+function cliState(entry: CliRegistryEntry): 'live' | 'dead' {
+  if (process.platform === 'win32') {
+    return liveSessionProcs(entry.sessionId).length > 0 ? 'live' : 'dead';
+  }
   if (!pidAlive(entry.pid)) return 'dead';
   const args = processArgs(entry.pid);
-  if (args === null) return process.platform === 'win32' ? 'unknown' : 'dead';
+  if (args === null) return 'dead';
   return args.includes(entry.sessionId) ? 'live' : 'dead';
 }
 
@@ -170,15 +248,6 @@ export function findLiveCliForSession(sessionId: string): CliConflict | null {
       unregisterCliProcess(entry.pid);
       continue;
     }
-    if (state === 'unknown') {
-      // win32: cannot verify identity — report nothing rather than risk acting
-      // on a reused pid.
-      console.error(
-        '[node-backend]',
-        `CLI registry: pid ${entry.pid} for session ${sessionId} is alive but unverifiable on this platform — ignoring`,
-      );
-      continue;
-    }
     return { entry, ownerAlive: ownerAlive(entry) };
   }
   return null;
@@ -186,6 +255,15 @@ export function findLiveCliForSession(sessionId: string): CliConflict | null {
 
 /** SIGTERM the entry's process group, escalate to SIGKILL after [graceMs]. */
 export async function killRegisteredCli(entry: CliRegistryEntry, graceMs = 3_000): Promise<void> {
+  if (process.platform === 'win32') {
+    // Kill by session id, not the stored shell pid: `taskkill /F /T` every live
+    // carrier — the orphaned `claude` grandchild (and any of its own children).
+    // No grace ladder; the owning backend is already gone, so there is nothing to
+    // shut down gracefully.
+    for (const pid of liveSessionProcs(entry.sessionId)) killPidTree(pid, 'SIGKILL');
+    unregisterCliProcess(entry.pid);
+    return;
+  }
   killPidTree(entry.pid, 'SIGTERM');
   const deadline = Date.now() + graceMs;
   while (Date.now() < deadline && cliState(entry) === 'live') {
@@ -210,14 +288,6 @@ export async function sweepOrphanCliProcesses(): Promise<{ killed: number; skipp
     const state = cliState(entry);
     if (state === 'dead') {
       unregisterCliProcess(entry.pid);
-      continue;
-    }
-    if (state === 'unknown') {
-      console.error(
-        '[node-backend]',
-        `Orphan sweep: pid ${entry.pid} (session ${entry.sessionId}) alive but unverifiable on this platform — left running`,
-      );
-      skipped++;
       continue;
     }
     if (ownerAlive(entry)) {

--- a/backend/src/core/cli-registry.ts
+++ b/backend/src/core/cli-registry.ts
@@ -39,6 +39,18 @@ function registryDir(): string {
   return join(homedir(), '.claude-code-gui', 'cli-registry');
 }
 
+/**
+ * A sessionId is safe to interpolate into the win32 CIM `-like` match only when
+ * it is non-empty and contains no PowerShell wildcard/quote/whitespace metacharacters.
+ * An empty or wildcard-bearing id would broaden `-like '*<id>*'` into a mass match
+ * (worst case `-like '*'` → every process), turning the orphan kill into a machine-wide taskkill.
+ * Claude session ids are simple tokens (uuid-like, and the test fixtures use `sess-*`),
+ * so restrict to [A-Za-z0-9._-]. Reject everything else — a malformed id means "match nothing".
+ */
+export function isValidSessionId(sessionId: string): boolean {
+  return /^[A-Za-z0-9._-]+$/.test(sessionId);
+}
+
 /** Live argv of [pid] as one string, or null when unknown (dead pid / unreadable). */
 function processArgs(pid: number): string | null {
   if (!Number.isInteger(pid) || pid <= 1) return null;
@@ -122,6 +134,10 @@ function killPidTree(pid: number, signal: NodeJS.Signals): void {
  */
 function liveSessionProcs(sessionId: string): number[] {
   if (process.platform !== 'win32') return [];
+  // A malformed id (empty or metacharacter-bearing) must match NOTHING: an empty
+  // id makes `-like '*<id>*'` collapse to `-like '*'` (every process → machine-wide
+  // taskkill) and quotes/wildcards let a crafted id inject or over-broaden the match.
+  if (!isValidSessionId(sessionId)) return [];
   try {
     const out = execFileSync(
       'powershell.exe',
@@ -208,6 +224,10 @@ function readEntries(): CliRegistryEntry[] {
  * failure resolves to 'dead' (GC the record) rather than risk killing a reused pid.
  */
 function cliState(entry: CliRegistryEntry): 'live' | 'dead' {
+  // A malformed sessionId can never identify a live CLI: on POSIX an empty id makes
+  // `args.includes('')` always true, mis-declaring an unrelated pid 'live'. Treat any
+  // invalid entry as dead so it gets garbage-collected instead of falsely resurrected.
+  if (!isValidSessionId(entry.sessionId)) return 'dead';
   if (process.platform === 'win32') {
     return liveSessionProcs(entry.sessionId).length > 0 ? 'live' : 'dead';
   }

--- a/backend/src/core/features/loadCliConfig.ts
+++ b/backend/src/core/features/loadCliConfig.ts
@@ -154,9 +154,13 @@ async function loadCliConfigInternal(workingDir: string): Promise<CliConfigContr
 
   return new Promise((resolve) => {
     let resolved = false;
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
     const safeResolve = (value: CliConfigControlResponse | null): void => {
       if (resolved) return;
       resolved = true;
+      // Clear the safety timeout so it cannot fire a stale killTree after the
+      // probe process has already closed and its pid may have been reused.
+      if (timeoutHandle) clearTimeout(timeoutHandle);
       resolve(value);
     };
 
@@ -200,7 +204,7 @@ async function loadCliConfigInternal(workingDir: string): Promise<CliConfigContr
     });
 
     // Safety timeout — kill process but let close event handle resolve
-    setTimeout(() => {
+    timeoutHandle = setTimeout(() => {
       console.error('[loadCliConfig] timeout — killing process');
       Claude.killTree(proc);
     }, 15000);

--- a/backend/src/core/handlers/reclaimSession.ts
+++ b/backend/src/core/handlers/reclaimSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { markSessionAsSpawned } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 import { loadAndSendSession } from './loadAndSendSession';
 
@@ -34,7 +35,7 @@ export async function reclaimSessionHandler(
   const session = connections.getSession(sessionId);
   if (session?.process) {
     console.error('[node-backend]', `Killing internal process for session ${sessionId}`);
-    session.process.kill('SIGTERM');
+    Claude.killTree(session.process);
     connections.setProcess(sessionId, null);
     await new Promise(resolve => setTimeout(resolve, 500));
   }

--- a/backend/src/core/handlers/stopGeneration.ts
+++ b/backend/src/core/handlers/stopGeneration.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 export function stopGenerationHandler(
@@ -19,7 +20,7 @@ export function stopGenerationHandler(
       const sent = sendInterruptToProcess(connections, sessionId);
       if (!sent) {
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
-        session.process.kill('SIGTERM');
+        Claude.killTree(session.process);
       }
       // Settle any background workflows the interrupt just cancelled so the panel
       // doesn't leave them hanging on "running".

--- a/backend/src/core/handlers/stopSession.ts
+++ b/backend/src/core/handlers/stopSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 export function stopSessionHandler(
@@ -22,7 +23,7 @@ export function stopSessionHandler(
       if (!sent) {
         // stdin이 이미 닫혀있으면 fallback으로 SIGTERM
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
-        session.process.kill('SIGTERM');
+        Claude.killTree(session.process);
       }
       // Settle any background workflows the stop just cancelled so the panel
       // doesn't leave them hanging on "running".

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -39,10 +39,16 @@ import type { NativeDropEntry } from './core/types';
  * 5. Kotlin이 http://localhost:{port} 로 JCEF 로드 → /ws WebSocket 연결
  */
 
-function killProcessOnPort(port: number): void {
+const GRACEFUL_RECLAIM_MS = 2_500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function listeningPidsOnPort(port: number): number[] {
   // CRITICAL: only ever target processes *LISTENING* on the port. A plain
   // `lsof -ti :PORT` also returns processes merely connected to it — including the
-  // IDE JVM's RPC WebSocket — and SIGKILLing those kills the entire IDE (exit 137).
+  // IDE JVM's RPC WebSocket — and killing those kills the entire IDE (exit 137).
   // Restricting to LISTEN sockets + filtering our own PID (selectKillablePids)
   // ensures we only reclaim the port from a stale backend, never the IDE.
   if (process.platform === 'win32') {
@@ -50,38 +56,54 @@ function killProcessOnPort(port: number): void {
       const output = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, {
         encoding: 'utf8',
       }).trim();
-      if (!output) return;
+      if (!output) return [];
       // Last column of each netstat row is the PID.
       const rawPids = output
         .split('\n')
         .map((line) => line.trim().split(/\s+/).pop() ?? '')
         .join('\n');
-      selectKillablePids(rawPids, process.pid).forEach((pid) => {
-        try {
-          execFileSync('taskkill', ['/F', '/PID', String(pid)]);
-          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
-        } catch {
-          // Process may have already exited — ignore
-        }
-      });
+      return selectKillablePids(rawPids, process.pid);
     } catch {
       // netstat/findstr returns non-zero when no match — ignore
+      return [];
     }
-  } else {
-    try {
-      // -sTCP:LISTEN restricts the query to listening sockets only.
-      const raw = execFileSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' });
-      selectKillablePids(raw, process.pid).forEach((pid) => {
-        try {
-          process.kill(pid, 'SIGKILL');
-          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
-        } catch {
-          // Process may have already exited — ignore
-        }
-      });
-    } catch {
-      // lsof returns non-zero when no process found — ignore
+  }
+  try {
+    // -sTCP:LISTEN restricts the query to listening sockets only.
+    const raw = execFileSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' });
+    return selectKillablePids(raw, process.pid);
+  } catch {
+    // lsof returns non-zero when no process found — ignore
+    return [];
+  }
+}
+
+/**
+ * Direct children of a stale backend, captured BEFORE it is killed. If the
+ * graceful phase fails and we SIGKILL the backend, it can no longer clean its
+ * CLI children up itself — we sweep the survivors from here instead. POSIX only
+ * (win32 uses taskkill /T, which tears the whole tree down by itself).
+ */
+function childPidsOf(pid: number): number[] {
+  try {
+    const raw = execFileSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' });
+    return selectKillablePids(raw, process.pid);
+  } catch {
+    // pgrep returns non-zero when there are no children — ignore
+    return [];
+  }
+}
+
+function sigkillPid(pid: number): void {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)]);
+    } else {
+      process.kill(pid, 'SIGKILL');
     }
+    console.error('[node-backend]', `SIGKILLed stale process ${pid}`);
+  } catch {
+    // Process may have already exited — ignore
   }
 }
 
@@ -89,18 +111,71 @@ async function startServerWithRetry(
   bridges: BridgeMap,
   logWs?: LogWebSocketServer,
 ): Promise<Awaited<ReturnType<typeof startWebSocketServer>>> {
+  const start = () =>
+    startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
   try {
-    return await startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
+    return await start();
   } catch (err: unknown) {
-    const nodeErr = err as NodeJS.ErrnoException;
-    if (nodeErr.code !== 'EADDRINUSE') throw err;
+    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
 
-    console.error('[node-backend]', `Port ${serverPort} already in use. Killing existing process and retrying...`);
-    killProcessOnPort(serverPort);
+    const stalePids = listeningPidsOnPort(serverPort);
+    console.error(
+      '[node-backend]',
+      `Port ${serverPort} already in use by PID(s) ${stalePids.join(', ') || '?'}. Reclaiming...`,
+    );
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    if (process.platform === 'win32') {
+      // Node emulates SIGTERM with TerminateProcess on Windows, so there is no
+      // graceful phase to offer — go straight to the tree kill (taskkill /T takes
+      // the stale backend's CLI children down with it).
+      stalePids.forEach(sigkillPid);
+      await delay(200);
+      return await start();
+    }
 
-    return await startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
+    // Ask the stale backend to shut down FIRST: its SIGTERM handler runs
+    // shutdownAll(), which kills its CLI children. The previous straight-SIGKILL
+    // behavior orphaned them (measured with a real orphan: it kept making API
+    // calls for ~5 more minutes). Children are captured up front so that if we
+    // do have to escalate, we can sweep the CLI trees the SIGKILL leaves behind.
+    const staleChildren = stalePids.flatMap(childPidsOf);
+    stalePids.forEach((pid) => {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // Process may have already exited — ignore
+      }
+    });
+
+    // The dying backend frees the port at close() almost immediately; it may then
+    // linger flushing logs, which is fine — we only need the LISTEN socket.
+    const deadline = Date.now() + GRACEFUL_RECLAIM_MS;
+    while (Date.now() < deadline) {
+      await delay(250);
+      try {
+        return await start();
+      } catch (retryErr: unknown) {
+        if ((retryErr as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw retryErr;
+      }
+    }
+
+    console.error('[node-backend]', 'Graceful port reclaim timed out — escalating to SIGKILL');
+    stalePids.forEach(sigkillPid);
+    for (const child of staleChildren) {
+      // Group signal first: post-fix backends spawn chat CLIs as process-group
+      // leaders, so -pid takes the whole CLI tree; plain kill covers pre-fix ones.
+      try {
+        process.kill(-child, 'SIGKILL');
+      } catch {
+        try {
+          process.kill(child, 'SIGKILL');
+        } catch {
+          // Already gone — ignore
+        }
+      }
+    }
+    await delay(200);
+    return await start();
   }
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -277,6 +277,11 @@ async function main() {
 
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
+  // SIGHUP (terminal window closed): MANDATORY now that chat CLIs run in their own
+  // process groups — they no longer receive the terminal's SIGHUP alongside the
+  // backend (pre-fix they died with us for free). Without
+  // this handler the process-group isolation itself would mint a new orphan class.
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
 }
 
 main().catch((err) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -16,6 +16,7 @@ import { isJetBrainsMode, serverPort, serverHost, webviewDir } from './config/en
 import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
 import { Claude } from './core/claude';
+import { sweepOrphanCliProcesses } from './core/cli-registry';
 import { ClientEnv } from './shared';
 import type { NativeDropEntry } from './core/types';
 
@@ -243,6 +244,12 @@ async function main() {
 
   // Load CLI path from settings before any handler can spawn claude
   await Claude.refresh();
+
+  // Orphan sweep: a backend that died hard (SIGKILL bypasses every
+  // JS-level guard from the process-group hard-binding) leaves its CLI children running
+  // headless. The registry written at spawn time lets this fresh backend find
+  // and kill them before it starts serving.
+  await sweepOrphanCliProcesses();
 
   const bridges: BridgeMap = {
     [ClientEnv.BROWSER]: new BrowserBridge(),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -188,6 +188,21 @@ async function main() {
   // installs the quota-check hook the engine calls before delivering a reservation.
   registerAutoResumeHook(connections);
 
+  // Last-resort orphan guard: tie CLI lifetime to backend lifetime. Every soft
+  // cleanup path (grace timers, shutdownAll) needs a LIVE backend; this hook
+  // covers every death that still runs 'exit' hooks (process.exit, fatal
+  // main().catch, handled signals). uncaughtException/unhandledRejection above
+  // deliberately do NOT exit (survival style), so they reach this hook only if
+  // the process really dies. A hard SIGKILL bypasses JS entirely — that residual
+  // gap is narrowed by the graceful port reclaim (startServerWithRetry) and,
+  // later, orphan detection at startup.
+  process.on('exit', () => {
+    const killed = connections.killAllSessionProcesses('SIGKILL');
+    if (killed > 0) {
+      console.error('[node-backend]', `Exit sweep: SIGKILLed ${killed} CLI process tree(s)`);
+    }
+  });
+
   // Stash native drop paths on drag-enter; the webview will flush them on its drop event.
   // The page's HTML5 `dataTransfer` doesn't expose absolute paths (browser security), so
   // Kotlin sends the paths it received from CefDragHandler over /rpc, and we hold them

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConnectionManager } from '../connection-manager';
 import { ClientEnv } from '../../shared';
 import { MessageType } from '../../shared';
+import { Claude } from '../../core/claude';
+
+// connection-manager delegates process kills to Claude.killTree (process-group
+// kill). Mock it here: unit tests use fake PIDs, and a real group
+// signal aimed at a fake PID could hit an unrelated live process group on the
+// test machine. Real-process coverage lives in kill-tree.integration.test.ts.
+vi.mock('../../core/claude', () => ({
+  Claude: { killTree: vi.fn() },
+}));
 
 function createMockWs(readyState = 1) {
   return {
@@ -121,12 +130,12 @@ describe('ConnectionManager', () => {
     it('should kill all session processes and close all connections', () => {
       const ws = createMockWs();
       cm.addConnection(ws);
-      const mockProcess = { kill: vi.fn() } as unknown as import('child_process').ChildProcess;
+      const mockProcess = { pid: 4242, kill: vi.fn() } as unknown as import('child_process').ChildProcess;
       cm.setProcess('sess-1', mockProcess);
 
       cm.shutdownAll();
 
-      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(Claude.killTree).toHaveBeenCalledWith(mockProcess, 'SIGTERM');
       expect(ws.close).toHaveBeenCalled();
     });
   });

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from 'child_process';
 import type { IPCMessage, NativeDropEntry } from '../core/types';
 import { ClientEnv, MessageType } from '../shared';
 import { disableIdleShutdown } from '../config/environment';
+import { Claude } from '../core/claude';
 
 const SESSION_CLEANUP_GRACE_MS = 30_000;
 const IDLE_SHUTDOWN_GRACE_MS = 60_000;
@@ -536,6 +537,23 @@ export class ConnectionManager {
 
   // ─── Internal ───────────────────────────────────────────────────────────────
 
+  /**
+   * Kill-sweep over every live session CLI tree. shutdownAll uses it with
+   * SIGTERM (graceful path); the process 'exit' hook in server.ts uses it with
+   * SIGKILL as the last-resort orphan guard, so it must stay synchronous —
+   * 'exit' handlers cannot await.
+   */
+  killAllSessionProcesses(signal: NodeJS.Signals): number {
+    let killed = 0;
+    for (const session of this.sessionRegistry.values()) {
+      if (session.process) {
+        Claude.killTree(session.process, signal);
+        killed++;
+      }
+    }
+    return killed;
+  }
+
   shutdownAll(): void {
     // Clear all pending cleanup timers
     for (const timer of this.cleanupTimers.values()) {
@@ -545,15 +563,8 @@ export class ConnectionManager {
 
     this.cancelIdleShutdown();
 
-    let killedSessions = 0;
+    const killedSessions = this.killAllSessionProcesses('SIGTERM');
     let closedConnections = 0;
-
-    for (const session of this.sessionRegistry.values()) {
-      if (session.process) {
-        session.process.kill('SIGTERM');
-        killedSessions++;
-      }
-    }
 
     for (const ws of this.connectionMap.values()) {
       ws.close();
@@ -606,7 +617,7 @@ export class ConnectionManager {
         '[node-backend]',
         `Killing process for session ${sessionId} (PID: ${session.process.pid})`,
       );
-      session.process.kill('SIGTERM');
+      Claude.killTree(session.process);
       session.process = null;
     }
 

--- a/backend/test-harness/cli-pid-registry.verify.mjs
+++ b/backend/test-harness/cli-pid-registry.verify.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Pid-registry verification: startup orphan sweep and the
+ * pre-`--resume` liveness guard. Scripted, NO token burn — same fake-CLI
+ * approach as cli-process-tree.verify.mjs (worst-case CLI ignoring stdin EOF), isolated
+ * $HOME, scratch ports 19838/19839 (never the real 19836).
+ *
+ * Scenarios:
+ *   S1 startup sweep — SIGKILL a backend with a live CLI (the SIGKILL residual
+ *      gap), start a fresh backend on the same port: its startup sweep must
+ *      find the orphan via the registry and kill the whole tree.
+ *   S2 resume guard (orphan) — plant a live orphan registered for a session,
+ *      then send a prompt for that session: the backend must kill the orphan
+ *      BEFORE spawning its own CLI (no dual writer on one JSONL).
+ *   S3 resume guard (live owner) — the same session driven through a SECOND
+ *      backend on another port must be REFUSED (SERVICE_ERROR), and the first
+ *      backend's CLI must stay untouched.
+ *
+ * Usage: node backend/test-harness/cli-pid-registry.verify.mjs
+ * Artifacts land in $TMPDIR/cli-pid-registry-verify/.
+ */
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(new URL('../package.json', import.meta.url));
+const WebSocket = require('ws');
+
+const PORT_A = Number(process.env.PID_REGISTRY_PORT ?? 19838);
+const PORT_B = PORT_A + 1;
+const ROOT = join(process.env.TMPDIR || os.tmpdir(), 'cli-pid-registry-verify');
+const HOME = join(ROOT, 'home');
+const PROJ = join(ROOT, 'proj');
+const CLI_LOG = join(ROOT, 'fake-cli.log');
+const REGISTRY = join(HOME, '.claude-code-gui', 'cli-registry');
+const BACKEND = fileURLToPath(new URL('../dist/backend.mjs', import.meta.url));
+
+const results = [];
+let failed = false;
+
+function report(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) failed = true;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return true;
+    await delay(100);
+  }
+  throw new Error(`timeout waiting for: ${what}`);
+}
+
+// ── Fixtures (same fake CLI as cli-process-tree.verify) ──────────────────────────────────
+
+function setupFixtures() {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(join(HOME, '.claude-code-gui'), { recursive: true });
+  mkdirSync(join(ROOT, 'bin'), { recursive: true });
+  mkdirSync(PROJ, { recursive: true });
+
+  const fakeCli = join(ROOT, 'bin', 'claude');
+  writeFileSync(fakeCli, `#!/bin/bash
+log="\${FAKE_CLI_LOG:?}"
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+echo "started pid=$$ pgid=$pgid args=$*" >> "$log"
+sleep 600 &
+child=$!
+echo "child pid=$$ childpid=$child" >> "$log"
+trap 'echo "SIGTERM pid=$$" >> "$log"; kill $child 2>/dev/null; exit 0' TERM
+trap 'echo "SIGHUP pid=$$" >> "$log"' HUP
+while true; do sleep 1; done
+`);
+  chmodSync(fakeCli, 0o755);
+
+  writeFileSync(
+    join(HOME, '.claude-code-gui', 'settings.js'),
+    `export default {\n  cliPath: ${JSON.stringify(fakeCli)},\n};\n`,
+  );
+}
+
+// ── Backend + ws driving ─────────────────────────────────────────────────────
+
+const backends = [];
+
+function startBackend(label, port) {
+  const proc = spawn(process.execPath, [BACKEND], {
+    env: { ...process.env, HOME, PORT: String(port), FAKE_CLI_LOG: CLI_LOG, JETBRAINS_MODE: '' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const record = { label, port, proc, stdout: '', stderr: '', exited: false };
+  proc.stdout.on('data', (d) => (record.stdout += d.toString()));
+  proc.stderr.on('data', (d) => (record.stderr += d.toString()));
+  proc.on('exit', () => (record.exited = true));
+  backends.push(record);
+  return record;
+}
+
+async function waitForPortLine(backend) {
+  await waitUntil(
+    () => backend.stdout.includes(`PORT:${backend.port}`),
+    15_000,
+    `${backend.label} PORT line`,
+  );
+}
+
+/** Connect, SEND_MESSAGE, collect pushed messages; resolve on ACK. */
+function drive(port, sessionId) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const messages = [];
+    const timer = setTimeout(() => reject(new Error(`ws drive timeout (session ${sessionId})`)), 15_000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'SEND_MESSAGE',
+          requestId: `harness-${sessionId}`,
+          timestamp: Date.now(),
+          payload: {
+            content: 'lifecycle probe',
+            workingDir: PROJ,
+            sessionId,
+            isNewSession: true,
+            inputMode: 'text',
+          },
+        }),
+      );
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      messages.push(msg);
+      if (msg.type === 'ACK') {
+        clearTimeout(timer);
+        resolve({ ws, messages });
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** n-th (0-based) fake-CLI instance recorded in the log. */
+function cliFromLog(index) {
+  let content;
+  try {
+    content = readFileSync(CLI_LOG, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines = content.trim().split('\n');
+  const started = lines.filter((l) => l.startsWith('started'))[index];
+  if (!started) return null;
+  const pid = Number(/pid=(\d+)/.exec(started)[1]);
+  const childLine = lines.filter((l) => l.startsWith(`child pid=${pid}`)).pop();
+  if (!childLine) return null;
+  return { pid, child: Number(/childpid=(\d+)/.exec(childLine)[1]) };
+}
+
+async function waitForCli(index, what) {
+  await waitUntil(() => cliFromLog(index) !== null, 10_000, what);
+  return cliFromLog(index);
+}
+
+/** A dead-but-real pid for crafting orphan entries. */
+function deadPid() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('true');
+    proc.on('error', reject);
+    proc.on('exit', () => resolve(proc.pid));
+  });
+}
+
+/**
+ * Plant a fake orphan: a live marked process + a registry entry with a dead
+ * owner, exactly what a hard-killed backend leaves behind. The marker script is
+ * multi-command so `sh -c` does not exec-optimize the marker out of its argv.
+ */
+async function plantOrphan(sessionId) {
+  const proc = spawn('sh', ['-c', 'sleep 600; true', sessionId], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  await waitUntil(() => proc.pid !== undefined, 5_000, 'orphan spawn');
+  mkdirSync(REGISTRY, { recursive: true });
+  writeFileSync(
+    join(REGISTRY, `${proc.pid}.json`),
+    JSON.stringify({
+      pid: proc.pid,
+      sessionId,
+      workingDir: PROJ,
+      startedAt: new Date().toISOString(),
+      owner: { pid: await deadPid(), argv1: 'backend.mjs' },
+    }),
+  );
+  return proc;
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function main() {
+  setupFixtures();
+
+  // S1: startup orphan sweep after a SIGKILLed backend (the SIGKILL residual gap).
+  const a = startBackend('backend-A', PORT_A);
+  await waitForPortLine(a);
+  const driveA = await drive(PORT_A, 'harness-session-1');
+  const cliA = await waitForCli(0, 'fake CLI under backend-A');
+  process.kill(a.proc.pid, 'SIGKILL');
+  await waitUntil(() => a.exited, 5_000, 'backend-A SIGKILLed');
+  await delay(500);
+  report('S1 orphan exists after backend SIGKILL', pidAlive(cliA.pid) && pidAlive(cliA.child));
+  report('S1 registry entry survived the hard death',
+    readdirSync(REGISTRY).includes(`${cliA.pid}.json`));
+
+  const b = startBackend('backend-B', PORT_A);
+  await waitForPortLine(b);
+  await waitUntil(() => !pidAlive(cliA.pid) && !pidAlive(cliA.child), 10_000, 'S1 orphan killed by sweep');
+  report('S1 startup sweep killed the orphan tree',
+    !pidAlive(cliA.pid) && !pidAlive(cliA.child));
+  report('S1 sweep logged its kill', b.stderr.includes('Orphan sweep: killing orphaned CLI'));
+  try {
+    driveA.ws.terminate();
+  } catch {
+    // Died with backend-A
+  }
+
+  // S2: resume guard — planted live orphan for the session must die BEFORE spawn.
+  const orphan = await plantOrphan('harness-session-2');
+  const driveB = await drive(PORT_A, 'harness-session-2');
+  await waitUntil(() => !pidAlive(orphan.pid), 10_000, 'S2 orphan killed by resume guard');
+  const cliB = await waitForCli(1, 'fake CLI spawned after the guard');
+  report('S2 resume guard killed the live orphan first', !pidAlive(orphan.pid));
+  report('S2 guard logged the kill', b.stderr.includes('Killing orphaned CLI'));
+  report('S2 fresh CLI runs for the session afterwards', pidAlive(cliB.pid));
+  report('S2 respawn switched to --resume (session already ran)',
+    b.stderr.includes('--resume') && b.stderr.includes('harness-session-2'));
+
+  // S3: resume guard — same session via a SECOND backend must be refused.
+  const c = startBackend('backend-C', PORT_B);
+  await waitForPortLine(c);
+  const driveC = await drive(PORT_B, 'harness-session-2');
+  const refusal = driveC.messages.find(
+    (m) => m.type === 'SERVICE_ERROR' && String(m.payload?.reason ?? '').includes('already active under another backend'),
+  );
+  report('S3 second backend refused the takeover (SERVICE_ERROR)', Boolean(refusal));
+  report('S3 first backend CLI untouched', pidAlive(cliB.pid) && pidAlive(cliB.child));
+  report('S3 no second fake CLI was spawned', cliFromLog(2) === null);
+  try {
+    driveB.ws.terminate();
+    driveC.ws.terminate();
+  } catch {
+    // Already closed
+  }
+
+  console.log('\nArtifacts in', ROOT);
+  console.log(failed ? 'RESULT: FAIL' : 'RESULT: ALL PASS');
+  process.exitCode = failed ? 1 : 0;
+}
+
+main()
+  .catch((err) => {
+    console.error('VERIFY ERROR:', err);
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    for (const backend of backends) {
+      if (!backend.exited) {
+        try {
+          backend.proc.kill('SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    }
+    for (let i = 0; ; i++) {
+      const cli = cliFromLog(i);
+      if (!cli) break;
+      try {
+        process.kill(-cli.pid, 'SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+  });

--- a/backend/test-harness/cli-process-tree.verify.mjs
+++ b/backend/test-harness/cli-process-tree.verify.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Orphaned-CLI hard-binding verification: scripted, NO token burn.
+ *
+ * Drives the BUILT backend (backend/dist/backend.mjs) with a fake `claude` binary
+ * (bash fixture that never exits on stdin EOF — the worst-case mid-turn CLI) under
+ * an isolated $HOME, on a scratch port (19837, NOT the real 19836), and asserts:
+ *
+ *   1. spawn shape: the chat CLI runs detached — pgid == pid (own process group);
+ *   2. double-start: a second backend reclaims the port with
+ *      SIGTERM first → the stale backend's shutdownAll() kills the whole CLI
+ *      tree (fake CLI + its background child) — NO orphan;
+ *   3. SIGHUP: terminal-close signal on the backend still takes
+ *      the CLI tree down, now via the explicit SIGHUP handler (mandatory since
+ *      process-group isolation detached the CLI from the terminal's group);
+ *   4. residual gap (documented, not fixed here): SIGKILL of the backend
+ *      still orphans the CLI — recorded honestly for the issue write-up.
+ *
+ * Usage: node backend/test-harness/cli-process-tree.verify.mjs
+ * Artifacts (backend logs, fake-CLI log) land in $TMPDIR/cli-process-tree-verify/.
+ */
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(new URL('../package.json', import.meta.url));
+const WebSocket = require('ws');
+
+const PORT = Number(process.env.CLI_TREE_PORT ?? 19837);
+const ROOT = join(process.env.TMPDIR || os.tmpdir(), 'cli-process-tree-verify');
+const HOME = join(ROOT, 'home');
+const PROJ = join(ROOT, 'proj');
+const CLI_LOG = join(ROOT, 'fake-cli.log');
+const BACKEND = fileURLToPath(new URL('../dist/backend.mjs', import.meta.url));
+
+const results = [];
+let failed = false;
+
+function report(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) failed = true;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return true;
+    await delay(100);
+  }
+  throw new Error(`timeout waiting for: ${what}`);
+}
+
+// ── Fixture setup ────────────────────────────────────────────────────────────
+
+function setupFixtures() {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(join(HOME, '.claude-code-gui'), { recursive: true });
+  mkdirSync(join(ROOT, 'bin'), { recursive: true });
+  mkdirSync(PROJ, { recursive: true });
+
+  const fakeCli = join(ROOT, 'bin', 'claude');
+  // Worst-case CLI: ignores stdin EOF entirely, keeps a background child (the
+  // stand-in for subagent shells / background tasks), exits cleanly on SIGTERM.
+  writeFileSync(fakeCli, `#!/bin/bash
+log="\${FAKE_CLI_LOG:?}"
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+echo "started pid=$$ pgid=$pgid ppid=$PPID" >> "$log"
+sleep 600 &
+child=$!
+echo "child pid=$$ childpid=$child" >> "$log"
+trap 'echo "SIGTERM pid=$$" >> "$log"; kill $child 2>/dev/null; exit 0' TERM
+trap 'echo "SIGHUP pid=$$" >> "$log"' HUP
+while true; do sleep 1; done
+`);
+  chmodSync(fakeCli, 0o755);
+
+  writeFileSync(
+    join(HOME, '.claude-code-gui', 'settings.js'),
+    `export default {\n  cliPath: ${JSON.stringify(fakeCli)},\n};\n`,
+  );
+}
+
+// ── Backend + ws driving ─────────────────────────────────────────────────────
+
+const backends = [];
+
+function startBackend(label) {
+  const proc = spawn(process.execPath, [BACKEND], {
+    env: {
+      ...process.env,
+      HOME,
+      PORT: String(PORT),
+      FAKE_CLI_LOG: CLI_LOG,
+      JETBRAINS_MODE: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const record = { label, proc, stdout: '', stderr: '', exited: false };
+  proc.stdout.on('data', (d) => (record.stdout += d.toString()));
+  proc.stderr.on('data', (d) => (record.stderr += d.toString()));
+  proc.on('exit', () => (record.exited = true));
+  backends.push(record);
+  return record;
+}
+
+async function waitForPortLine(backend) {
+  await waitUntil(() => backend.stdout.includes(`PORT:${PORT}`), 15_000, `${backend.label} PORT line`);
+}
+
+/** Connect to /ws and SEND_MESSAGE; resolves with the open socket after ACK. */
+function driveSession(sessionId) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+    const timer = setTimeout(() => reject(new Error('ws drive timeout')), 10_000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'SEND_MESSAGE',
+          requestId: `harness-${sessionId}`,
+          timestamp: Date.now(),
+          payload: {
+            content: 'lifecycle probe',
+            workingDir: PROJ,
+            sessionId,
+            isNewSession: true,
+            inputMode: 'text',
+          },
+        }),
+      );
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'ACK' || msg.type === 'STREAM_START') {
+        clearTimeout(timer);
+        resolve(ws);
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** n-th (0-based) fake-CLI instance recorded in the log: { pid, pgid, child }. */
+function cliFromLog(index) {
+  const lines = readFileSync(CLI_LOG, 'utf8').trim().split('\n');
+  const started = lines.filter((l) => l.startsWith('started'))[index];
+  if (!started) return null;
+  const pid = Number(/pid=(\d+)/.exec(started)[1]);
+  const pgid = Number(/pgid=(\d+)/.exec(started)[1]);
+  const childLine = lines.filter((l) => l.startsWith(`child pid=${pid}`)).pop();
+  if (!childLine) return null; // start recorded, child not yet — treat as incomplete
+  return { pid, pgid, child: Number(/childpid=(\d+)/.exec(childLine)[1]) };
+}
+
+/** Wait until the n-th fake CLI has fully registered (started + child lines). */
+async function waitForCli(index, what) {
+  await waitUntil(() => {
+    try {
+      return cliFromLog(index) !== null;
+    } catch {
+      return false;
+    }
+  }, 10_000, what);
+  return cliFromLog(index);
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function main() {
+  setupFixtures();
+
+  // Scenario 1: spawn shape — detached chat CLI leads its own process group.
+  const a = startBackend('backend-A');
+  await waitForPortLine(a);
+  const wsA = await driveSession('harness-session-1');
+  const cliA = await waitForCli(0, 'fake CLI started under backend-A');
+  report('S1 fake CLI spawned', pidAlive(cliA.pid) && pidAlive(cliA.child));
+  report('S1 CLI is a process-group leader (pgid == pid)', cliA.pgid === cliA.pid,
+    `pid=${cliA.pid} pgid=${cliA.pgid}`);
+
+  // Scenario 2: double-start on the same port.
+  const b = startBackend('backend-B');
+  await waitForPortLine(b);
+  await waitUntil(() => a.exited, 10_000, 'backend-A exit after SIGTERM reclaim');
+  await waitUntil(() => !pidAlive(cliA.pid) && !pidAlive(cliA.child), 10_000, 'CLI tree of A dead');
+  report('S2 second backend reclaimed the port gracefully',
+    b.stderr.includes('already in use') && a.stderr.includes('SIGTERM received'));
+  report('S2 stale backend CLI tree died with it (no orphan)',
+    !pidAlive(cliA.pid) && !pidAlive(cliA.child));
+  report('S2 fake CLI observed SIGTERM (graceful, not SIGKILL)',
+    readFileSync(CLI_LOG, 'utf8').includes(`SIGTERM pid=${cliA.pid}`));
+  try {
+    wsA.terminate();
+  } catch {
+    // Socket already died with backend-A
+  }
+
+  // Scenario 3: SIGHUP on the backend (terminal close analog).
+  const wsB = await driveSession('harness-session-2');
+  const cliB = await waitForCli(1, 'fake CLI started under backend-B');
+  report('S3 fake CLI spawned under backend-B', pidAlive(cliB.pid) && pidAlive(cliB.child));
+  process.kill(b.proc.pid, 'SIGHUP');
+  await waitUntil(() => b.exited, 10_000, 'backend-B exit on SIGHUP');
+  await waitUntil(() => !pidAlive(cliB.pid) && !pidAlive(cliB.child), 10_000, 'CLI tree of B dead');
+  report('S3 SIGHUP handler shut the backend down', b.stderr.includes('SIGHUP received'));
+  report('S3 CLI tree died on SIGHUP (no orphan)', !pidAlive(cliB.pid) && !pidAlive(cliB.child));
+  try {
+    wsB.terminate();
+  } catch {
+    // Socket already died with backend-B
+  }
+
+  // Scenario 4: residual gap — SIGKILL of the backend still orphans the CLI.
+  const c = startBackend('backend-C');
+  await waitForPortLine(c);
+  const wsC = await driveSession('harness-session-3');
+  const cliC = await waitForCli(2, 'fake CLI started under backend-C');
+  report('S4 fake CLI spawned under backend-C', pidAlive(cliC.pid) && pidAlive(cliC.child));
+  process.kill(c.proc.pid, 'SIGKILL');
+  await waitUntil(() => c.exited, 5_000, 'backend-C SIGKILLed');
+  await delay(1_500);
+  report('S4 residual gap confirmed: SIGKILL of backend orphans the CLI (pid-registry territory)',
+    pidAlive(cliC.pid) && pidAlive(cliC.child));
+  try {
+    wsC.terminate();
+  } catch {
+    // Socket died with backend-C
+  }
+  // Manual cleanup of the intentional orphan.
+  try {
+    process.kill(-cliC.pid, 'SIGKILL');
+  } catch {
+    // Already gone
+  }
+
+  console.log('\nArtifacts in', ROOT);
+  console.log(failed ? 'RESULT: FAIL' : 'RESULT: ALL PASS');
+  process.exitCode = failed ? 1 : 0;
+}
+
+main()
+  .catch((err) => {
+    console.error('VERIFY ERROR:', err);
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    for (const backend of backends) {
+      if (!backend.exited) {
+        try {
+          backend.proc.kill('SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    }
+    try {
+      for (let i = 0; ; i++) {
+        const cli = cliFromLog(i);
+        if (!cli) break;
+        try {
+          process.kill(-cli.pid, 'SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    } catch {
+      // No CLI ever started
+    }
+  });


### PR DESCRIPTION
Fixes #186.

## What this fixes

The backend had no hard binding between its own lifetime and the lifetime of the
Claude CLI processes it spawns — a hard backend death (SIGKILL, crash, port
takeover) left running CLIs working headless in the background, spending the
user's tokens with no GUI attached (measured orphans of 5–9.5 minutes, one of them
making 5 extra API calls and hashing 214 GiB of data; details and repro in
#186).

## How (four mechanisms, one commit each)

1. **Own process group + group kill**
   ([ee32d36](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/ee32d367caf486120db4ef525aa38e4723a9f469)):
   on POSIX the chat CLI is spawned `detached` so it leads its own process group,
   and `Claude.killTree` signals the whole group (`-pid`, configurable signal, plain
   fallback for non-leaders); win32 keeps `taskkill /F /T`. Mandatory companion in
   the same commit: a SIGHUP handler in `server.ts` — a detached CLI no longer dies
   with the terminal for free, so without the handler the isolation itself would
   mint a new orphan class.
2. **Every kill path goes through `killTree` + a process-exit sweep**
   ([1b52a93](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/1b52a935cda812f16c9eea564fdd72da7d0fea4d)):
   all five kill paths (`shutdownAll`, `cleanupSession`, `stopSession`,
   `stopGeneration`, `reclaimSession`) now take the whole tree down; a new
   synchronous `killAllSessionProcesses` sweep hangs off `process.on('exit')` as
   the last-resort guard (SIGKILL) for every death that still runs exit hooks.
3. **Graceful port reclaim**
   ([612c22d](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/612c22de409c1922e81b42a688641514e1907736)):
   on `EADDRINUSE` the stale backend gets SIGTERM first (so its own `shutdownAll`
   kills its CLI children), binding is retried for ~2.5 s, and only then SIGKILL —
   sweeping the stale backend's child process groups captured up front. Directly
   fixes the standalone double-start orphan.
4. **On-disk CLI pid-registry + startup orphan sweep + resume liveness guard**
   ([b80550c](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/b80550cbb440b337071eeeccc2c70ce95853d8e4)):
   one JSON entry per CLI pid under `~/.claude-code-gui/cli-registry/`, written at
   spawn, removed on clean exit. A fresh backend kills identity-checked orphans
   whose owning backend is gone (PID-reuse safe: the live process argv must still
   carry the sessionId). A liveness guard before every session spawn kills a live
   orphan first (switching the spawn to `--resume`) and refuses — with a visible
   SERVICE_ERROR — a session already active under another live backend, instead of
   silently creating a second writer on one session JSONL.

Mechanisms 1–3 close every death the backend can still react to; mechanism 4 covers
the one it cannot (its own SIGKILL): the orphan is killed at the next backend start
instead of living invisibly forever.

## Test strategy

- The first commit
  ([7035cec](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/7035cec1731794a114bba7878ba4e4adb6fa991e))
  adds **red tests on real processes** demonstrating the bug (2 failed / 1 passed
  on purpose); the fix commits turn them green mechanism by mechanism, and the full
  suite is green from commit 3 on.
- The second commit
  ([d0d384a](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/d0d384ac8943e04b886eb4c9e79bbf5ce8007c90))
  adds two **scripted real-process harnesses** (`node
  backend/test-harness/cli-process-tree.verify.mjs` /
  `cli-pid-registry.verify.mjs`): they drive the *built* backend with a fake
  `claude` binary under an isolated `$HOME` on scratch ports — zero token burn —
  and cover what mocks cannot prove (real port contention between two backends,
  real signal delivery across process groups, real detachment from a dying
  parent). Like the vitest reds, they assert the FIXED behavior: red on their own
  commit, green at the tip (10 + 11 scenarios).
- Plus unit tests per mechanism (see the commit messages).

## Platform note — win32

**Update (maintainer, yhk1038):** the win32 orphan-kill path is now **verified**;
the "log-only, never auto-kills" note below is superseded by commit c439d00.

Verifying on a real Windows machine surfaced a deeper cause: on win32 the chat
CLI is spawned through a `cmd.exe` shell, so the pid the registry stores is the
SHELL, not `claude`. On a hard backend kill the shell drops with the broken stdio
pipe while the real `claude.exe` grandchild orphans on — and a sweep keyed on the
dead shell pid GC'd the record and leaked the working orphan. The fix keys on the
session id instead:

- identity: read argv via CIM (`Win32_Process.CommandLine`) so pid-reuse
  verification works **without `ps`**;
- liveness/kill: `cliState`/`killRegisteredCli` scan every live process carrying
  the session id and `taskkill /F /T` each carrier, reaching the grandchild the
  stored pid can no longer reach.

Verified end-to-end on Windows with a **real** `claude`: a mid-turn backend
SIGKILL orphans `claude.exe`, and a fresh backend's startup sweep removes it
(killed 1, no survivors). Adds 6 win32 real-process registry tests (the suite was
POSIX-only and skipped entirely on win32).

**Still open on win32:** the `isValidSessionId` guard added on top (commit
452848f — rejecting empty / metacharacter session ids before the CIM `-like`
match, which would otherwise broaden into a machine-wide `taskkill`) is covered by
platform-agnostic unit tests but **not yet re-verified on Windows with a real
`claude`**.

## Remaining follow-ups (out of scope here)

- Immediate orphan kill without waiting for the next backend start would need a
  parent-death signal (`prctl(PR_SET_PDEATHSIG)` wrapper on Linux, Job Objects on
  Windows) or a supervisor-side watchdog.
- Re-test of the "prompt sent to a dead session's GUI tab is silently lost"
  scenario from #186 — **re-verified (maintainer)**: on backend death the webview
  shows an explicit "reconnecting" banner (not a silent loss), and after the
  backend restarts the dead session **resumes cleanly** — a prompt sent to that
  tab reaches a real `claude` via `--resume` with full context preserved. Fully
  resolved, not merely mitigated.

## Checklist before undrafting

- [x] Manual in-IDE pass (backend-death scenario) — maintainer verified via
      `run-ide` (alpha build): on IDE quit, `dispose()` SIGTERMs the backend and
      `shutdownAll` group-kills the whole CLI tree (a 12-process tree incl. MCP
      grandchildren) within ~1s, zero orphans. (Tested on the `run-ide` sandbox
      rather than a pinned IC 2024.2 build.)
- [x] Repeat the primary repro scenarios from #186 on a **real** CLI at this
      branch tip — maintainer verified with a REAL `claude` across dev
      (SIGKILL→startup sweep; SIGTERM→immediate cleanup), `ccg stop` (tree kill),
      and IDE quit; plus the "prompt sent to a dead session's tab" re-test
      (resumes cleanly, see above). Zero orphans in every case.
- [x] Windows verification of the orphan-kill path — done in c439d00 (real-`claude`
      end-to-end + 6 win32 registry tests). Remaining: re-verify on Windows with the
      452848f `isValidSessionId` guard applied.


