### PR TITLE
feat: backend lifecycle PoC — keep-alive gate, ppid watchdog, /internal/status, status-bar widget

### DIFF
--- a/backend/src/core/__tests__/cli-registry.test.ts
+++ b/backend/src/core/__tests__/cli-registry.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+// The registry lives under homedir()/.claude-code-gui — point homedir at a scratch
+// dir so tests never touch the real user registry.
+let fakeHome: string;
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>();
+  return { ...actual, homedir: () => fakeHome };
+});
+
+import {
+  registerCliProcess,
+  unregisterCliProcess,
+  findLiveCliForSession,
+  killRegisteredCli,
+  sweepOrphanCliProcesses,
+  type CliRegistryEntry,
+} from '../cli-registry';
+
+// Real-process tests (like kill-tree.integration.test.ts): identity checks shell
+// out to `ps` and kills are real group signals — mocks cannot prove either.
+const isPosix = process.platform !== 'win32';
+
+const registryDir = () => join(fakeHome, '.claude-code-gui', 'cli-registry');
+const entryPath = (pid: number) => join(registryDir(), `${pid}.json`);
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('condition not met within timeout');
+}
+
+/** A dead-but-real pid: spawn `true` and wait for it to exit. */
+function deadPid(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('true');
+    proc.on('error', reject);
+    proc.on('exit', () => resolve(proc.pid as number));
+  });
+}
+
+/**
+ * Spawn a CLI stand-in whose argv carries [marker] (the `sh -c` $0 slot), the
+ * way the real chat spawn carries `--session-id <id>` — that argv marker is what
+ * the registry's identity check reads back via `ps`. The script must be a
+ * multi-command one: for a single command `sh -c` exec-optimizes itself away and
+ * the marker-bearing shell argv disappears from `ps`.
+ */
+function spawnMarked(marker: string, script = 'sleep 30; true'): ChildProcess {
+  return spawn('sh', ['-c', script, marker], { detached: true, stdio: 'ignore' });
+}
+
+function tamperOwner(pid: number, owner: { pid: number; argv1: string }): void {
+  const entry = JSON.parse(readFileSync(entryPath(pid), 'utf8')) as CliRegistryEntry;
+  entry.owner = owner;
+  writeFileSync(entryPath(pid), JSON.stringify(entry));
+}
+
+describe.skipIf(!isPosix)('cli-registry (POSIX, real processes)', () => {
+  const spawned: ChildProcess[] = [];
+
+  beforeEach(() => {
+    fakeHome = mkdtempSync(join(process.env.TMPDIR ?? '/tmp', 'cli-registry-test-'));
+  });
+
+  afterEach(() => {
+    for (const proc of spawned) {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, 'SIGKILL');
+        } catch {
+          // Not a leader or already gone
+        }
+      }
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+    spawned.length = 0;
+    rmSync(fakeHome, { recursive: true, force: true });
+  });
+
+  it('register writes an entry file, unregister removes it', () => {
+    const proc = spawnMarked('sess-lifecycle');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-lifecycle', '/tmp/proj');
+
+    expect(existsSync(entryPath(proc.pid as number))).toBe(true);
+    const entry = JSON.parse(readFileSync(entryPath(proc.pid as number), 'utf8')) as CliRegistryEntry;
+    expect(entry.sessionId).toBe('sess-lifecycle');
+    expect(entry.owner.pid).toBe(process.pid);
+
+    unregisterCliProcess(proc.pid);
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('finds a live orphan (dead owner) for its session', async () => {
+    const proc = spawnMarked('sess-orphan');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-orphan', '/tmp/proj');
+    tamperOwner(proc.pid as number, { pid: await deadPid(), argv1: 'node' });
+
+    const conflict = findLiveCliForSession('sess-orphan');
+    expect(conflict?.entry.pid).toBe(proc.pid);
+    expect(conflict?.ownerAlive).toBe(false);
+  });
+
+  it('reports ownerAlive for an entry owned by a live process', () => {
+    const proc = spawnMarked('sess-owned');
+    spawned.push(proc);
+    const owner = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(owner);
+    registerCliProcess(proc, 'sess-owned', '/tmp/proj');
+    tamperOwner(proc.pid as number, { pid: owner.pid as number, argv1: '/usr/bin/sleep' });
+
+    const conflict = findLiveCliForSession('sess-owned');
+    expect(conflict?.ownerAlive).toBe(true);
+  });
+
+  it('treats a pid whose argv lost the sessionId as dead (pid reuse) and GCs the entry', () => {
+    // The live process argv carries a DIFFERENT marker than the registered session.
+    const proc = spawnMarked('some-other-marker');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-reused', '/tmp/proj');
+
+    expect(findLiveCliForSession('sess-reused')).toBeNull();
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('killRegisteredCli escalates to SIGKILL when SIGTERM is ignored', async () => {
+    const proc = spawnMarked('sess-stubborn', 'trap "" TERM; sleep 30 & wait');
+    spawned.push(proc);
+    registerCliProcess(proc, 'sess-stubborn', '/tmp/proj');
+    const entry = JSON.parse(readFileSync(entryPath(proc.pid as number), 'utf8')) as CliRegistryEntry;
+
+    await killRegisteredCli(entry, 500);
+
+    await waitUntil(() => !pidAlive(proc.pid as number));
+    expect(existsSync(entryPath(proc.pid as number))).toBe(false);
+  });
+
+  it('sweep kills orphans, skips live-owner entries, and GCs dead ones', async () => {
+    const orphan = spawnMarked('sess-sweep-orphan');
+    spawned.push(orphan);
+    registerCliProcess(orphan, 'sess-sweep-orphan', '/tmp/proj');
+    tamperOwner(orphan.pid as number, { pid: await deadPid(), argv1: 'node' });
+
+    const owned = spawnMarked('sess-sweep-owned');
+    spawned.push(owned);
+    const owner = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(owner);
+    registerCliProcess(owned, 'sess-sweep-owned', '/tmp/proj');
+    tamperOwner(owned.pid as number, { pid: owner.pid as number, argv1: '/usr/bin/sleep' });
+
+    const gone = spawnMarked('sess-sweep-dead');
+    registerCliProcess(gone, 'sess-sweep-dead', '/tmp/proj');
+    process.kill(-(gone.pid as number), 'SIGKILL');
+    await waitUntil(() => !pidAlive(gone.pid as number));
+
+    const result = await sweepOrphanCliProcesses();
+
+    expect(result).toEqual({ killed: 1, skipped: 1 });
+    await waitUntil(() => !pidAlive(orphan.pid as number));
+    expect(pidAlive(owned.pid as number)).toBe(true);
+    expect(existsSync(entryPath(orphan.pid as number))).toBe(false);
+    expect(existsSync(entryPath(gone.pid as number))).toBe(false);
+    expect(existsSync(entryPath(owned.pid as number))).toBe(true);
+  });
+});

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { Claude } from '../claude';
+import { ConnectionManager } from '../../ws/connection-manager';
+
+// Real-process integration tests reproducing the orphaned-CLI bug.
+// claude.test.ts mocks child_process entirely; the process-group kill semantics
+// verified here are exactly what mocks cannot prove. POSIX-only: the win32 branch
+// shells out to taskkill, which needs Windows (untested locally).
+
+const isPosix = process.platform !== 'win32';
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (cond()) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error('condition not met within timeout');
+}
+
+/** First stdout line of [proc] — the fixtures echo their grandchild PID there. */
+function firstStdoutLine(proc: ChildProcess): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let buf = '';
+    proc.stdout?.on('data', (data: Buffer) => {
+      buf += data.toString();
+      const nl = buf.indexOf('\n');
+      if (nl >= 0) resolve(buf.slice(0, nl).trim());
+    });
+    proc.on('error', reject);
+    proc.on('exit', () => reject(new Error(`exited before printing a line: "${buf}"`)));
+  });
+}
+
+/**
+ * Spawn a fixture shaped like the chat CLI spawn (claude-process.ts): detached ⇒
+ * own process group, with a background grandchild whose PID it echoes — the
+ * stand-in for subagent shells / background tasks under a real CLI.
+ */
+function spawnDetachedTree(shellScript = 'sleep 30 & echo $!; wait'): ChildProcess {
+  return spawn('sh', ['-c', shellScript], {
+    detached: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+}
+
+describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
+  const spawned: ChildProcess[] = [];
+  afterEach(() => {
+    for (const proc of spawned) {
+      if (proc.pid) {
+        try {
+          process.kill(-proc.pid, 'SIGKILL');
+        } catch {
+          // Not a group leader or already gone
+        }
+      }
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+    spawned.length = 0;
+  });
+
+  it('kills the whole tree of a detached child — grandchild included', async () => {
+    const proc = spawnDetachedTree();
+    spawned.push(proc);
+    const grandchildPid = parseInt(await firstStdoutLine(proc), 10);
+    expect(Number.isFinite(grandchildPid)).toBe(true);
+    expect(pidAlive(grandchildPid)).toBe(true);
+
+    Claude.killTree(proc);
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    await waitUntil(() => !pidAlive(grandchildPid));
+  });
+
+  it('falls back to a plain signal for a non-detached (non-leader) child', async () => {
+    const proc = spawn('sleep', ['30'], { stdio: 'ignore' });
+    spawned.push(proc);
+
+    Claude.killTree(proc);
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    expect(proc.signalCode).toBe('SIGTERM');
+  });
+});
+
+describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
+  it('kill-sweeps every registered session tree', async () => {
+    const connections = new ConnectionManager();
+    const procs = [
+      spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+      spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      }),
+    ];
+    try {
+      const grandchildren = await Promise.all(
+        procs.map(async (proc) => parseInt(await firstStdoutLine(proc), 10)),
+      );
+      connections.getOrCreateSession('session-a');
+      connections.setProcess('session-a', procs[0]);
+      connections.getOrCreateSession('session-b');
+      connections.setProcess('session-b', procs[1]);
+
+      connections.shutdownAll();
+
+      await waitUntil(() => procs.every((p) => p.exitCode !== null || p.signalCode !== null));
+      await waitUntil(() => grandchildren.every((pid) => !pidAlive(pid)));
+    } finally {
+      for (const proc of procs) {
+        if (proc.pid) {
+          try {
+            process.kill(-proc.pid, 'SIGKILL');
+          } catch {
+            // Already gone
+          }
+        }
+      }
+    }
+  });
+});

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -3,7 +3,7 @@ import { spawn, type ChildProcess } from 'child_process';
 import { Claude } from '../claude';
 import { ConnectionManager } from '../../ws/connection-manager';
 
-// Real-process integration tests reproducing the orphaned-CLI bug.
+// Real-process integration tests for the orphaned-CLI hard-binding.
 // claude.test.ts mocks child_process entirely; the process-group kill semantics
 // verified here are exactly what mocks cannot prove. POSIX-only: the win32 branch
 // shells out to taskkill, which needs Windows (untested locally).
@@ -111,8 +111,8 @@ describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
   });
 });
 
-describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
-  it('kill-sweeps every registered session tree', async () => {
+describe.skipIf(!isPosix)('ConnectionManager.killAllSessionProcesses', () => {
+  it('kill-sweeps every registered session tree and reports the count', async () => {
     const connections = new ConnectionManager();
     const procs = [
       spawn('sh', ['-c', 'sleep 30 & echo $!; wait'], {
@@ -133,8 +133,9 @@ describe.skipIf(!isPosix)('ConnectionManager.shutdownAll', () => {
       connections.getOrCreateSession('session-b');
       connections.setProcess('session-b', procs[1]);
 
-      connections.shutdownAll();
+      const killed = connections.killAllSessionProcesses('SIGKILL');
 
+      expect(killed).toBe(2);
       await waitUntil(() => procs.every((p) => p.exitCode !== null || p.signalCode !== null));
       await waitUntil(() => grandchildren.every((pid) => !pidAlive(pid)));
     } finally {

--- a/backend/src/core/__tests__/kill-tree.integration.test.ts
+++ b/backend/src/core/__tests__/kill-tree.integration.test.ts
@@ -87,6 +87,19 @@ describe.skipIf(!isPosix)('Claude.killTree (POSIX, real processes)', () => {
     await waitUntil(() => !pidAlive(grandchildPid));
   });
 
+  it('supports SIGKILL (the exit-sweep signal) through the same path', async () => {
+    // The fixture shell ignores SIGTERM to prove the sweep's SIGKILL is what lands.
+    const proc = spawnDetachedTree('trap "" TERM; sleep 30 & echo $!; wait');
+    spawned.push(proc);
+    const grandchildPid = parseInt(await firstStdoutLine(proc), 10);
+    expect(pidAlive(grandchildPid)).toBe(true);
+
+    Claude.killTree(proc, 'SIGKILL');
+
+    await waitUntil(() => proc.exitCode !== null || proc.signalCode !== null);
+    await waitUntil(() => !pidAlive(grandchildPid));
+  });
+
   it('falls back to a plain signal for a non-detached (non-leader) child', async () => {
     const proc = spawn('sleep', ['30'], { stdio: 'ignore' });
     spawned.push(proc);

--- a/backend/src/core/__tests__/parent-watchdog.test.ts
+++ b/backend/src/core/__tests__/parent-watchdog.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { isParentDead, startParentWatchdog, type ParentWatchdogDeps } from '../parent-watchdog';
+
+function errnoError(code: string): NodeJS.ErrnoException {
+  const err = new Error(code) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+describe('isParentDead', () => {
+  it('reports alive while ppid is unchanged and the probe succeeds', () => {
+    expect(isParentDead(100, { getPpid: () => 100, probe: () => undefined })).toBe(false);
+  });
+
+  it('reports dead when the ppid changed (POSIX reparent to init/subreaper)', () => {
+    expect(isParentDead(100, { getPpid: () => 1, probe: () => undefined })).toBe(true);
+  });
+
+  it('reports dead when the probe throws ESRCH (win32 frozen ppid)', () => {
+    const probe = vi.fn(() => {
+      throw errnoError('ESRCH');
+    });
+    expect(isParentDead(100, { getPpid: () => 100, probe })).toBe(true);
+  });
+
+  it('reports alive when the probe throws EPERM (process exists, not signalable)', () => {
+    const probe = vi.fn(() => {
+      throw errnoError('EPERM');
+    });
+    expect(isParentDead(100, { getPpid: () => 100, probe })).toBe(false);
+  });
+});
+
+describe('startParentWatchdog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function deps(overrides: Partial<ParentWatchdogDeps>): ParentWatchdogDeps {
+    return {
+      getPpid: () => 100,
+      probe: () => undefined,
+      intervalMs: 10_000,
+      ...overrides,
+    };
+  }
+
+  it('does not fire while the parent lives', () => {
+    const onDeath = vi.fn();
+    startParentWatchdog(onDeath, deps({}));
+    vi.advanceTimersByTime(60_000);
+    expect(onDeath).not.toHaveBeenCalled();
+  });
+
+  it('fires once when the ppid changes, then disarms', () => {
+    const onDeath = vi.fn();
+    let ppid = 100;
+    startParentWatchdog(onDeath, deps({ getPpid: () => ppid }));
+
+    vi.advanceTimersByTime(10_000);
+    expect(onDeath).not.toHaveBeenCalled();
+
+    ppid = 1; // parent died, reparented
+    vi.advanceTimersByTime(10_000);
+    expect(onDeath).toHaveBeenCalledTimes(1);
+
+    // Disarmed: no further firings even though the parent stays dead.
+    vi.advanceTimersByTime(60_000);
+    expect(onDeath).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires when the probe starts throwing ESRCH with an unchanged ppid', () => {
+    const onDeath = vi.fn();
+    let parentGone = false;
+    startParentWatchdog(
+      onDeath,
+      deps({
+        probe: () => {
+          if (parentGone) throw errnoError('ESRCH');
+        },
+      }),
+    );
+
+    vi.advanceTimersByTime(10_000);
+    expect(onDeath).not.toHaveBeenCalled();
+
+    parentGone = true;
+    vi.advanceTimersByTime(10_000);
+    expect(onDeath).toHaveBeenCalledTimes(1);
+  });
+
+  it('never fires after stop()', () => {
+    const onDeath = vi.fn();
+    let ppid = 100;
+    const stop = startParentWatchdog(onDeath, deps({ getPpid: () => ppid }));
+
+    stop();
+    ppid = 1;
+    vi.advanceTimersByTime(60_000);
+    expect(onDeath).not.toHaveBeenCalled();
+  });
+
+  it('captures the initial ppid at arm time, not at poll time', () => {
+    const onDeath = vi.fn();
+    // ppid already 1 when armed (e.g. spawned by a short-lived wrapper):
+    // stable value = alive from the watchdog's point of view.
+    startParentWatchdog(onDeath, deps({ getPpid: () => 1 }));
+    vi.advanceTimersByTime(30_000);
+    expect(onDeath).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -419,6 +419,9 @@ export function sendMessageToProcess(
     : stdinMessage.trimEnd();
   console.error('[node-backend]', `Sending to stdin: ${logPreview}`);
   session.process.stdin.write(stdinMessage);
+  // Turn in flight — cleared on the CLI `result` event (turn end) or on
+  // STREAM_END (process death safety net inside broadcastToSession).
+  connections.setStreaming(sessionId, true);
   return true;
 }
 
@@ -562,6 +565,8 @@ function handleStreamEvent(
   // 백엔드 고유 사이드이펙트 (WebView 전달과 무관한 서버 내부 로직)
   if (eventType === 'result') {
     sessionsWithResult.add(targetSessionId);
+    // Turn ended (success, error and interrupt alike emit a result event).
+    connections.setStreaming(targetSessionId, false);
     connections.broadcastToAll(MessageType.SESSIONS_UPDATED, {
       action: 'upsert',
       session: {

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -170,6 +170,13 @@ export async function ensureClaudeProcess(
   const proc = await Claude.spawnAuthed(args, workingDir, {
     cwd: workingDir,
     stdio: ['pipe', 'pipe', 'pipe'],
+    // POSIX: detach the CLI into its own process group so every kill path can take
+    // down the WHOLE tree at once (Claude.killTree signals -pid: the CLI plus its
+    // subagent shells and background tasks). Trade-off: a detached CLI no longer
+    // shares the terminal's process group, so it stops receiving the terminal's
+    // SIGHUP alongside the backend — server.ts compensates with its own SIGHUP
+    // handler (graceful shutdownAll). Keep those two in sync.
+    detached: process.platform !== 'win32',
     env: {
       TERM: 'dumb',
       CI: 'true',

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -6,6 +6,7 @@ import { EditedFileTracker } from './features/editedFileTracker';
 import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
 import { reportBackendError } from './features/telemetry';
+import { findLiveCliForSession, killRegisteredCli, registerCliProcess, unregisterCliProcess } from './cli-registry';
 import { MessageType } from '../shared';
 
 // Tracks files Claude edits so the IDE can be told to reload them once the
@@ -149,6 +150,37 @@ export async function ensureClaudeProcess(
     return;
   }
 
+  // Liveness guard before spawning: a live, identity-checked CLI may
+  // already be writing this session's JSONL — an orphan left by a hard-killed
+  // backend, or a session legitimately open under another live backend. Spawning
+  // a second CLI would mean two writers on one JSONL (branched history,
+  // false task verdicts, interleaved GUI) — so kill the orphan / refuse the takeover.
+  const conflict = findLiveCliForSession(targetSessionId);
+  if (conflict) {
+    if (conflict.ownerAlive) {
+      const reason =
+        `Session ${targetSessionId} is already active under another backend ` +
+        `(CLI PID ${conflict.entry.pid}, backend PID ${conflict.entry.owner.pid}). ` +
+        'Refusing to start a second writer on the same session.';
+      console.error('[node-backend]', reason);
+      connections.broadcastToSession(targetSessionId, MessageType.SERVICE_ERROR, {
+        type: MessageType.SPAWN_ERROR,
+        reason,
+        error: reason,
+      });
+      connections.broadcastToSession(targetSessionId, MessageType.STREAM_END);
+      return;
+    }
+    console.error(
+      '[node-backend]',
+      `Killing orphaned CLI ${conflict.entry.pid} before respawning session ${targetSessionId}`,
+    );
+    await killRegisteredCli(conflict.entry);
+    // The orphan proves this session already ran — resume it instead of passing
+    // --session-id, which would fail with "already in use".
+    spawnedSessions.add(targetSessionId);
+  }
+
   const useResume = spawnedSessions.has(targetSessionId);
   const sessionFlag = useResume ? '--resume' : '--session-id';
 
@@ -219,6 +251,11 @@ export async function ensureClaudeProcess(
   // SessionRecord에 프로세스 저장
   connections.setProcess(targetSessionId, proc);
   connections.setBuffer(targetSessionId, '');
+
+  // Record the live CLI in the on-disk registry: lets a FUTURE backend detect this
+  // process as an orphan (startup sweep) or as a conflicting writer (resume guard)
+  // if we die hard before the 'close' handler unregisters it.
+  registerCliProcess(proc, targetSessionId, workingDir);
 
   // 모든 구독자에게 스트림 시작 알림
   connections.broadcastToSession(targetSessionId, MessageType.STREAM_START);
@@ -308,6 +345,9 @@ export async function ensureClaudeProcess(
 
       // 프로세스 참조만 해제 (세션 레코드는 유지 — 구독자가 아직 있을 수 있음)
       connections.setProcess(targetSessionId, null);
+      // Clean CLI exit — drop its registry entry (hard backend deaths skip this;
+      // that is exactly what the startup orphan sweep is for).
+      unregisterCliProcess(proc.pid);
     } catch (err) {
       reportBackendError(err instanceof Error ? err : new Error(String(err)), {
         layer: 'claude_stream',

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -154,10 +154,14 @@ export class Claude {
    * Terminate a process spawned via {@link spawn} AND its children. On win32
    * spawn() runs through a shell, so the real `claude` is a grandchild of
    * cmd.exe — a plain SIGTERM to `proc` leaves it orphaned. `taskkill /T` tears
-   * down the whole tree; macOS/Linux run the launcher directly, so SIGTERM
-   * suffices there. Used by every place that time-limits a spawned CLI child.
+   * down the whole tree. On macOS/Linux, chat CLIs are spawned detached (see
+   * claude-process.ts) so they lead their own process group and signalling
+   * `-pid` reaches the CLI plus every descendant (subagent shells, background
+   * tasks); for non-detached children the group signal fails with ESRCH and we
+   * fall back to a plain signal, which is the pre-existing behavior. Used by
+   * every kill path for a spawned CLI child.
    */
-  static killTree(proc: ChildProcess): void {
+  static killTree(proc: ChildProcess, signal: NodeJS.Signals = 'SIGTERM'): void {
     if (!proc.pid) return;
     if (process.platform === 'win32') {
       try {
@@ -166,7 +170,12 @@ export class Claude {
         proc.kill();
       }
     } else {
-      proc.kill('SIGTERM');
+      try {
+        process.kill(-proc.pid, signal);
+      } catch {
+        // Not a process-group leader (or already gone) — plain signal as before.
+        proc.kill(signal);
+      }
     }
   }
 

--- a/backend/src/core/cli-registry.ts
+++ b/backend/src/core/cli-registry.ts
@@ -1,0 +1,234 @@
+import { execFileSync, type ChildProcess } from 'child_process';
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { homedir } from 'os';
+import { basename, join } from 'path';
+
+/**
+ * On-disk registry of live chat CLI processes.
+ *
+ * The process-group hard-binding covers every backend death that still runs
+ * JS, but a hard SIGKILL of the backend bypasses all of it — the CLI survives as
+ * an orphan, invisible to any later backend. This registry closes that loop: every chat CLI spawn writes a small
+ * entry file, every clean CLI exit removes it, and a fresh backend can then
+ * (a) sweep orphans at startup and (b) refuse/kill a conflicting live writer
+ * before `--resume` (two CLIs appending to one session JSONL branch its history
+ * and emit false task verdicts).
+ *
+ * Layout: one JSON file per CLI pid under ~/.claude-code-gui/cli-registry/.
+ * Per-entry files avoid read-modify-write races between concurrently running
+ * backends (JetBrains mode legitimately runs one backend per project).
+ *
+ * PID reuse safety: a pid alone is not an identity. Before acting on an entry we
+ * re-read the live process argv (`ps -o args=`) and require it to still contain
+ * the entry's sessionId (the chat spawn always passes `--session-id <id>` or
+ * `--resume <id>`). win32 has no `ps`; identity is unknown there, so detection is
+ * log-only and nothing is auto-killed (an honest, documented gap).
+ */
+
+export interface CliRegistryEntry {
+  pid: number;
+  sessionId: string;
+  workingDir: string;
+  startedAt: string;
+  /** The backend that spawned the CLI; argv1 lets liveness checks survive pid reuse. */
+  owner: { pid: number; argv1: string };
+}
+
+function registryDir(): string {
+  return join(homedir(), '.claude-code-gui', 'cli-registry');
+}
+
+/** Live argv of [pid] as one string, or null when unknown (dead pid / win32). */
+function processArgs(pid: number): string | null {
+  if (process.platform === 'win32') return null;
+  try {
+    return execFileSync('ps', ['-o', 'args=', '-p', String(pid)], { encoding: 'utf8' }).trim();
+  } catch {
+    return null; // ps exits non-zero for a dead pid
+  }
+}
+
+function pidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Group signal with plain-signal fallback — pid-based twin of Claude.killTree. */
+function killPidTree(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(-pid, signal);
+  } catch {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // Already gone
+    }
+  }
+}
+
+const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export function registerCliProcess(proc: ChildProcess, sessionId: string, workingDir: string): void {
+  if (!proc.pid) return;
+  const entry: CliRegistryEntry = {
+    pid: proc.pid,
+    sessionId,
+    workingDir,
+    startedAt: new Date().toISOString(),
+    owner: { pid: process.pid, argv1: process.argv[1] ?? '' },
+  };
+  try {
+    mkdirSync(registryDir(), { recursive: true });
+    writeFileSync(join(registryDir(), `${proc.pid}.json`), JSON.stringify(entry, null, 2) + '\n');
+  } catch (err) {
+    // Best-effort: a failed registry write must never block the chat itself.
+    console.error('[node-backend]', 'CLI registry write failed:', err);
+  }
+}
+
+export function unregisterCliProcess(pid: number | undefined): void {
+  if (!pid) return;
+  try {
+    rmSync(join(registryDir(), `${pid}.json`), { force: true });
+  } catch (err) {
+    console.error('[node-backend]', 'CLI registry remove failed:', err);
+  }
+}
+
+function readEntries(): CliRegistryEntry[] {
+  let files: string[];
+  try {
+    files = readdirSync(registryDir()).filter((f) => f.endsWith('.json'));
+  } catch {
+    return []; // No registry dir yet — clean world
+  }
+  const entries: CliRegistryEntry[] = [];
+  for (const file of files) {
+    try {
+      const parsed = JSON.parse(readFileSync(join(registryDir(), file), 'utf8')) as CliRegistryEntry;
+      if (typeof parsed.pid === 'number' && typeof parsed.sessionId === 'string' && parsed.owner) {
+        entries.push(parsed);
+      } else {
+        rmSync(join(registryDir(), file), { force: true });
+      }
+    } catch {
+      rmSync(join(registryDir(), file), { force: true }); // Corrupt entry — drop it
+    }
+  }
+  return entries;
+}
+
+/**
+ * Identity-checked liveness of an entry's CLI:
+ * 'live' — pid alive and argv still carries the sessionId;
+ * 'dead' — pid gone, or pid reused by an unrelated process (argv mismatch);
+ * 'unknown' — pid alive but argv unreadable (win32) — do NOT auto-kill.
+ */
+function cliState(entry: CliRegistryEntry): 'live' | 'dead' | 'unknown' {
+  if (!pidAlive(entry.pid)) return 'dead';
+  const args = processArgs(entry.pid);
+  if (args === null) return process.platform === 'win32' ? 'unknown' : 'dead';
+  return args.includes(entry.sessionId) ? 'live' : 'dead';
+}
+
+/**
+ * Is the backend that spawned this CLI still alive (and not us)? Conservative on
+ * ambiguity: when the owner pid is alive but its argv is unreadable, assume alive
+ * — never kill a CLI that might belong to a living backend.
+ */
+function ownerAlive(entry: CliRegistryEntry): boolean {
+  if (entry.owner.pid === process.pid) return false; // our own stale record
+  if (!pidAlive(entry.owner.pid)) return false;
+  const args = processArgs(entry.owner.pid);
+  if (args === null) return true;
+  const hint = basename(entry.owner.argv1 || '');
+  return hint === '' || args.includes(hint);
+}
+
+export interface CliConflict {
+  entry: CliRegistryEntry;
+  ownerAlive: boolean;
+}
+
+/**
+ * A live, identity-checked CLI already attached to [sessionId], if any.
+ * Cleans up dead entries it encounters along the way.
+ */
+export function findLiveCliForSession(sessionId: string): CliConflict | null {
+  for (const entry of readEntries()) {
+    if (entry.sessionId !== sessionId) continue;
+    const state = cliState(entry);
+    if (state === 'dead') {
+      unregisterCliProcess(entry.pid);
+      continue;
+    }
+    if (state === 'unknown') {
+      // win32: cannot verify identity — report nothing rather than risk acting
+      // on a reused pid.
+      console.error(
+        '[node-backend]',
+        `CLI registry: pid ${entry.pid} for session ${sessionId} is alive but unverifiable on this platform — ignoring`,
+      );
+      continue;
+    }
+    return { entry, ownerAlive: ownerAlive(entry) };
+  }
+  return null;
+}
+
+/** SIGTERM the entry's process group, escalate to SIGKILL after [graceMs]. */
+export async function killRegisteredCli(entry: CliRegistryEntry, graceMs = 3_000): Promise<void> {
+  killPidTree(entry.pid, 'SIGTERM');
+  const deadline = Date.now() + graceMs;
+  while (Date.now() < deadline && cliState(entry) === 'live') {
+    await delay(100);
+  }
+  if (cliState(entry) === 'live') {
+    console.error('[node-backend]', `Orphaned CLI ${entry.pid} ignored SIGTERM — escalating to SIGKILL`);
+    killPidTree(entry.pid, 'SIGKILL');
+  }
+  unregisterCliProcess(entry.pid);
+}
+
+/**
+ * Startup orphan sweep: kill every registered CLI whose owning backend is gone.
+ * Entries owned by other LIVE backends are left alone (multi-backend setups are
+ * legitimate); dead/reused entries are garbage-collected.
+ */
+export async function sweepOrphanCliProcesses(): Promise<{ killed: number; skipped: number }> {
+  let killed = 0;
+  let skipped = 0;
+  for (const entry of readEntries()) {
+    const state = cliState(entry);
+    if (state === 'dead') {
+      unregisterCliProcess(entry.pid);
+      continue;
+    }
+    if (state === 'unknown') {
+      console.error(
+        '[node-backend]',
+        `Orphan sweep: pid ${entry.pid} (session ${entry.sessionId}) alive but unverifiable on this platform — left running`,
+      );
+      skipped++;
+      continue;
+    }
+    if (ownerAlive(entry)) {
+      skipped++;
+      continue;
+    }
+    console.error(
+      '[node-backend]',
+      `Orphan sweep: killing orphaned CLI ${entry.pid} (session ${entry.sessionId}, dead owner ${entry.owner.pid})`,
+    );
+    await killRegisteredCli(entry);
+    killed++;
+  }
+  if (killed > 0 || skipped > 0) {
+    console.error('[node-backend]', `Orphan sweep done: killed ${killed}, skipped ${skipped}`);
+  }
+  return { killed, skipped };
+}

--- a/backend/src/core/handlers/reclaimSession.ts
+++ b/backend/src/core/handlers/reclaimSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { markSessionAsSpawned } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 import { loadAndSendSession } from './loadAndSendSession';
 
@@ -34,7 +35,7 @@ export async function reclaimSessionHandler(
   const session = connections.getSession(sessionId);
   if (session?.process) {
     console.error('[node-backend]', `Killing internal process for session ${sessionId}`);
-    session.process.kill('SIGTERM');
+    Claude.killTree(session.process);
     connections.setProcess(sessionId, null);
     await new Promise(resolve => setTimeout(resolve, 500));
   }

--- a/backend/src/core/handlers/stopGeneration.ts
+++ b/backend/src/core/handlers/stopGeneration.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 export function stopGenerationHandler(
@@ -19,7 +20,7 @@ export function stopGenerationHandler(
       const sent = sendInterruptToProcess(connections, sessionId);
       if (!sent) {
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
-        session.process.kill('SIGTERM');
+        Claude.killTree(session.process);
       }
       // Settle any background workflows the interrupt just cancelled so the panel
       // doesn't leave them hanging on "running".

--- a/backend/src/core/handlers/stopSession.ts
+++ b/backend/src/core/handlers/stopSession.ts
@@ -2,6 +2,7 @@ import type { ConnectionManager } from '../../ws/connection-manager';
 import type { Bridge } from '../../bridge/bridge-interface';
 import type { IPCMessage } from '../types';
 import { sendInterruptToProcess, stopWorkflowsForSession } from '../claude-process';
+import { Claude } from '../claude';
 import { MessageType } from '../../shared';
 
 export function stopSessionHandler(
@@ -22,7 +23,7 @@ export function stopSessionHandler(
       if (!sent) {
         // stdin이 이미 닫혀있으면 fallback으로 SIGTERM
         console.error('[node-backend]', `Interrupt failed, falling back to SIGTERM for ${sessionId}`);
-        session.process.kill('SIGTERM');
+        Claude.killTree(session.process);
       }
       // Settle any background workflows the stop just cancelled so the panel
       // doesn't leave them hanging on "running".

--- a/backend/src/core/parent-watchdog.ts
+++ b/backend/src/core/parent-watchdog.ts
@@ -1,0 +1,73 @@
+/**
+ * Parent-process watchdog (keep-alive clamp on parent death).
+ *
+ * While the IDE lives, the keep-alive gate may hold the backend up forever.
+ * When the parent dies — clean close and crash alike — the backend must NOT
+ * exit (a browser/tunnel client may still be working); it only restores the
+ * idle-shutdown regime: live /ws clients keep it
+ * alive, and with none it exits after the usual grace.
+ *
+ * Detection is polling-based, no Kotlin cooperation needed:
+ *  - POSIX: on parent death the process is reparented, so `process.ppid`
+ *    changes (init/subreaper).
+ *  - win32: the ppid is frozen at spawn time and never changes, so we
+ *    additionally probe the original parent with `kill(ppid, 0)` — ESRCH
+ *    means it is gone. (Residual pid-reuse false negative accepted for MVP.)
+ */
+
+const PARENT_POLL_INTERVAL_MS = 10_000;
+
+export interface ParentWatchdogDeps {
+  /** Current parent pid — `() => process.ppid` in production. */
+  getPpid: () => number;
+  /** Signal-0 liveness probe — `(pid) => process.kill(pid, 0)` in production. */
+  probe: (pid: number) => void;
+  intervalMs: number;
+}
+
+const defaultDeps: ParentWatchdogDeps = {
+  getPpid: () => process.ppid,
+  probe: (pid) => process.kill(pid, 0),
+  intervalMs: PARENT_POLL_INTERVAL_MS,
+};
+
+/**
+ * Decide whether the parent captured as `initialPpid` is dead, given the
+ * current ppid and a signal-0 probe. Exported for unit tests.
+ */
+export function isParentDead(initialPpid: number, deps: Pick<ParentWatchdogDeps, 'getPpid' | 'probe'>): boolean {
+  if (deps.getPpid() !== initialPpid) return true;
+  try {
+    deps.probe(initialPpid);
+    return false;
+  } catch (err) {
+    // ESRCH = no such process. EPERM means it exists but we may not signal
+    // it — still alive, so only ESRCH counts as death.
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+}
+
+/**
+ * Arm the watchdog. Fires `onParentDeath` at most once, then disarms itself.
+ * Returns a stop function. The interval is unref'd so it never blocks a
+ * natural process exit.
+ */
+export function startParentWatchdog(
+  onParentDeath: () => void,
+  deps: ParentWatchdogDeps = defaultDeps,
+): () => void {
+  const initialPpid = deps.getPpid();
+
+  const timer = setInterval(() => {
+    if (!isParentDead(initialPpid, deps)) return;
+    clearInterval(timer);
+    console.error(
+      '[node-backend]',
+      `Parent process ${initialPpid} died — restoring the idle-shutdown regime (keep-alive clamp)`,
+    );
+    onParentDeath();
+  }, deps.intervalMs);
+  timer.unref();
+
+  return () => clearInterval(timer);
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -174,6 +174,21 @@ async function main() {
   // 3. 서버 시작 (logWs 전달)
   const { port, close, connections } = await startServerWithRetry(bridges, logWs);
 
+  // Last-resort orphan guard: tie CLI lifetime to backend lifetime. Every soft
+  // cleanup path (grace timers, shutdownAll) needs a LIVE backend; this hook
+  // covers every death that still runs 'exit' hooks (process.exit, fatal
+  // main().catch, handled signals). uncaughtException/unhandledRejection above
+  // deliberately do NOT exit (survival style), so they reach this hook only if
+  // the process really dies. A hard SIGKILL bypasses JS entirely — that residual
+  // gap is narrowed by the graceful port reclaim (startServerWithRetry) and,
+  // later, orphan detection at startup.
+  process.on('exit', () => {
+    const killed = connections.killAllSessionProcesses('SIGKILL');
+    if (killed > 0) {
+      console.error('[node-backend]', `Exit sweep: SIGKILLed ${killed} CLI process tree(s)`);
+    }
+  });
+
   // Stash native drop paths on drag-enter; the webview will flush them on its drop event.
   // The page's HTML5 `dataTransfer` doesn't expose absolute paths (browser security), so
   // Kotlin sends the paths it received from CefDragHandler over /rpc, and we hold them

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -13,6 +13,7 @@ import { isJetBrainsMode, serverPort, serverHost, webviewDir } from './config/en
 import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
 import { Claude } from './core/claude';
+import { sweepOrphanCliProcesses } from './core/cli-registry';
 import { ClientEnv } from './shared';
 import type { NativeDropEntry } from './core/types';
 
@@ -235,6 +236,12 @@ async function main() {
 
   // Load CLI path from settings before any handler can spawn claude
   await Claude.refresh();
+
+  // Orphan sweep: a backend that died hard (SIGKILL bypasses every
+  // JS-level guard from the process-group hard-binding) leaves its CLI children running
+  // headless. The registry written at spawn time lets this fresh backend find
+  // and kill them before it starts serving.
+  await sweepOrphanCliProcesses();
 
   const bridges: BridgeMap = {
     [ClientEnv.BROWSER]: new BrowserBridge(),

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -36,10 +36,16 @@ import type { NativeDropEntry } from './core/types';
  * 5. Kotlin이 http://localhost:{port} 로 JCEF 로드 → /ws WebSocket 연결
  */
 
-function killProcessOnPort(port: number): void {
+const GRACEFUL_RECLAIM_MS = 2_500;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function listeningPidsOnPort(port: number): number[] {
   // CRITICAL: only ever target processes *LISTENING* on the port. A plain
   // `lsof -ti :PORT` also returns processes merely connected to it — including the
-  // IDE JVM's RPC WebSocket — and SIGKILLing those kills the entire IDE (exit 137).
+  // IDE JVM's RPC WebSocket — and killing those kills the entire IDE (exit 137).
   // Restricting to LISTEN sockets + filtering our own PID (selectKillablePids)
   // ensures we only reclaim the port from a stale backend, never the IDE.
   if (process.platform === 'win32') {
@@ -47,38 +53,54 @@ function killProcessOnPort(port: number): void {
       const output = execSync(`netstat -ano | findstr :${port} | findstr LISTENING`, {
         encoding: 'utf8',
       }).trim();
-      if (!output) return;
+      if (!output) return [];
       // Last column of each netstat row is the PID.
       const rawPids = output
         .split('\n')
         .map((line) => line.trim().split(/\s+/).pop() ?? '')
         .join('\n');
-      selectKillablePids(rawPids, process.pid).forEach((pid) => {
-        try {
-          execFileSync('taskkill', ['/F', '/PID', String(pid)]);
-          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
-        } catch {
-          // Process may have already exited — ignore
-        }
-      });
+      return selectKillablePids(rawPids, process.pid);
     } catch {
       // netstat/findstr returns non-zero when no match — ignore
+      return [];
     }
-  } else {
-    try {
-      // -sTCP:LISTEN restricts the query to listening sockets only.
-      const raw = execFileSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' });
-      selectKillablePids(raw, process.pid).forEach((pid) => {
-        try {
-          process.kill(pid, 'SIGKILL');
-          console.error('[node-backend]', `Killed listening process ${pid} on port ${port}`);
-        } catch {
-          // Process may have already exited — ignore
-        }
-      });
-    } catch {
-      // lsof returns non-zero when no process found — ignore
+  }
+  try {
+    // -sTCP:LISTEN restricts the query to listening sockets only.
+    const raw = execFileSync('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { encoding: 'utf8' });
+    return selectKillablePids(raw, process.pid);
+  } catch {
+    // lsof returns non-zero when no process found — ignore
+    return [];
+  }
+}
+
+/**
+ * Direct children of a stale backend, captured BEFORE it is killed. If the
+ * graceful phase fails and we SIGKILL the backend, it can no longer clean its
+ * CLI children up itself — we sweep the survivors from here instead. POSIX only
+ * (win32 uses taskkill /T, which tears the whole tree down by itself).
+ */
+function childPidsOf(pid: number): number[] {
+  try {
+    const raw = execFileSync('pgrep', ['-P', String(pid)], { encoding: 'utf8' });
+    return selectKillablePids(raw, process.pid);
+  } catch {
+    // pgrep returns non-zero when there are no children — ignore
+    return [];
+  }
+}
+
+function sigkillPid(pid: number): void {
+  try {
+    if (process.platform === 'win32') {
+      execFileSync('taskkill', ['/F', '/T', '/PID', String(pid)]);
+    } else {
+      process.kill(pid, 'SIGKILL');
     }
+    console.error('[node-backend]', `SIGKILLed stale process ${pid}`);
+  } catch {
+    // Process may have already exited — ignore
   }
 }
 
@@ -86,18 +108,71 @@ async function startServerWithRetry(
   bridges: BridgeMap,
   logWs?: LogWebSocketServer,
 ): Promise<Awaited<ReturnType<typeof startWebSocketServer>>> {
+  const start = () =>
+    startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
   try {
-    return await startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
+    return await start();
   } catch (err: unknown) {
-    const nodeErr = err as NodeJS.ErrnoException;
-    if (nodeErr.code !== 'EADDRINUSE') throw err;
+    if ((err as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw err;
 
-    console.error('[node-backend]', `Port ${serverPort} already in use. Killing existing process and retrying...`);
-    killProcessOnPort(serverPort);
+    const stalePids = listeningPidsOnPort(serverPort);
+    console.error(
+      '[node-backend]',
+      `Port ${serverPort} already in use by PID(s) ${stalePids.join(', ') || '?'}. Reclaiming...`,
+    );
 
-    await new Promise((resolve) => setTimeout(resolve, 200));
+    if (process.platform === 'win32') {
+      // Node emulates SIGTERM with TerminateProcess on Windows, so there is no
+      // graceful phase to offer — go straight to the tree kill (taskkill /T takes
+      // the stale backend's CLI children down with it).
+      stalePids.forEach(sigkillPid);
+      await delay(200);
+      return await start();
+    }
 
-    return await startWebSocketServer(serverPort, serverHost, bridges, handleMessage, webviewDir, logWs);
+    // Ask the stale backend to shut down FIRST: its SIGTERM handler runs
+    // shutdownAll(), which kills its CLI children. The previous straight-SIGKILL
+    // behavior orphaned them (measured with a real orphan: it kept making API
+    // calls for ~5 more minutes). Children are captured up front so that if we
+    // do have to escalate, we can sweep the CLI trees the SIGKILL leaves behind.
+    const staleChildren = stalePids.flatMap(childPidsOf);
+    stalePids.forEach((pid) => {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {
+        // Process may have already exited — ignore
+      }
+    });
+
+    // The dying backend frees the port at close() almost immediately; it may then
+    // linger flushing logs, which is fine — we only need the LISTEN socket.
+    const deadline = Date.now() + GRACEFUL_RECLAIM_MS;
+    while (Date.now() < deadline) {
+      await delay(250);
+      try {
+        return await start();
+      } catch (retryErr: unknown) {
+        if ((retryErr as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw retryErr;
+      }
+    }
+
+    console.error('[node-backend]', 'Graceful port reclaim timed out — escalating to SIGKILL');
+    stalePids.forEach(sigkillPid);
+    for (const child of staleChildren) {
+      // Group signal first: post-fix backends spawn chat CLIs as process-group
+      // leaders, so -pid takes the whole CLI tree; plain kill covers pre-fix ones.
+      try {
+        process.kill(-child, 'SIGKILL');
+      } catch {
+        try {
+          process.kill(child, 'SIGKILL');
+        } catch {
+          // Already gone — ignore
+        }
+      }
+    }
+    await delay(200);
+    return await start();
   }
 }
 

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,7 +14,7 @@ import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
 import { Claude } from './core/claude';
 import { sweepOrphanCliProcesses } from './core/cli-registry';
-import { ClientEnv } from './shared';
+import { ClientEnv, MessageType } from './shared';
 import type { NativeDropEntry } from './core/types';
 
 /**
@@ -305,6 +305,15 @@ async function main() {
     if (!stashed) {
       console.error('[node-backend]', `[NATIVE_DROP] stash failed — no connection for panelId=${panelId}`);
     }
+  });
+
+  // Idle-shutdown gate ("keep backend running"). Kotlin pushes the
+  // desired state on every /rpc (re)connect and on user toggle; a `false` push
+  // with zero /ws connections arms the idle timer immediately (see
+  // ConnectionManager.setKeepAlive), which also closes the pre-existing
+  // prewarm leak where a backend that never received a /ws client lived forever.
+  (bridges[ClientEnv.JETBRAINS] as JetBrainsBridge).onNotification(MessageType.SET_KEEP_ALIVE, (_method, params) => {
+    connections.setKeepAlive(params.enabled === true);
   });
 
   // 4. Logger에 LogWS 참조 설정

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -251,6 +251,11 @@ async function main() {
 
   process.on('SIGTERM', () => shutdown('SIGTERM'));
   process.on('SIGINT', () => shutdown('SIGINT'));
+  // SIGHUP (terminal window closed): MANDATORY now that chat CLIs run in their own
+  // process groups — they no longer receive the terminal's SIGHUP alongside the
+  // backend (pre-fix they died with us for free). Without
+  // this handler the process-group isolation itself would mint a new orphan class.
+  process.on('SIGHUP', () => shutdown('SIGHUP'));
 }
 
 main().catch((err) => {

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -14,6 +14,7 @@ import { initLogger, getLogger } from './logging';
 import { LogWebSocketServer } from './logging/log-ws';
 import { Claude } from './core/claude';
 import { sweepOrphanCliProcesses } from './core/cli-registry';
+import { startParentWatchdog } from './core/parent-watchdog';
 import { ClientEnv, MessageType } from './shared';
 import type { NativeDropEntry } from './core/types';
 
@@ -306,6 +307,21 @@ async function main() {
       console.error('[node-backend]', `[NATIVE_DROP] stash failed — no connection for panelId=${panelId}`);
     }
   });
+
+  // Keep-alive clamp: when the IDE (our parent) dies — clean close and
+  // crash alike — the backend does NOT exit; it only flips the keep-alive gate
+  // off, restoring the idle-shutdown regime. A live browser/tunnel client then
+  // keeps it alive; with zero /ws connections setKeepAlive(false) arms the
+  // idle timer immediately, so a truly orphaned client-less backend exits
+  // ~60s after IDE death (including the prewarm-leak case).
+  if (isJetBrainsMode) {
+    startParentWatchdog(() => connections.setKeepAlive(false));
+  } else {
+    // Standalone: the keep-alive gate boots up (see ws-server.ts), so
+    // the idle self-shutdown never arms — the operator owns the backend
+    // lifetime (Ctrl+C → graceful shutdown). SESSION_CLEANUP stays active.
+    console.error('[node-backend]', 'Standalone mode: idle self-shutdown disabled (operator owns the backend lifetime)');
+  }
 
   // Idle-shutdown gate ("keep backend running"). Kotlin pushes the
   // desired state on every /rpc (re)connect and on user toggle; a `false` push

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -334,6 +334,13 @@ export enum MessageType {
    * routing. params: { hostMode: string }.
    */
   HOST_MODE_CHANGED = 'HOST_MODE_CHANGED',
+  /**
+   * Kotlin → Node notification toggling the idle-shutdown gate ("keep backend
+   * running"). Kotlin pushes the desired state on every RPC (re)connect
+   * and on user toggle; the backend's parent watchdog flips the gate back off
+   * when the IDE process dies. params: { enabled: boolean }.
+   */
+  SET_KEEP_ALIVE = 'SET_KEEP_ALIVE',
 
   // ───────────────────────────────────────────────────────────────────────
   // Logging channel (webview LogForwarder → backend log-ws)

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -184,6 +184,74 @@ describe('ConnectionManager', () => {
     });
   });
 
+  describe('getConnectionStats', () => {
+    it('classifies panelId connections as panels regardless of origin', () => {
+      cm.addConnection(createMockWs(), ClientEnv.JETBRAINS, 'panel-1', 'http://localhost:63412');
+      expect(cm.getConnectionStats()).toEqual({ total: 1, panels: 1, tunnels: 0, browsers: 0 });
+    });
+
+    it('classifies *.trycloudflare.com origins without panelId as tunnels', () => {
+      cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'https://demo-tunnel.trycloudflare.com');
+      expect(cm.getConnectionStats()).toEqual({ total: 1, panels: 0, tunnels: 1, browsers: 0 });
+    });
+
+    it('classifies everything else as browsers (incl. missing origin)', () => {
+      cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'http://127.0.0.1:63412');
+      cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, null);
+      expect(cm.getConnectionStats()).toEqual({ total: 2, panels: 0, tunnels: 0, browsers: 2 });
+    });
+
+    it('counts a mixed set and tracks removals', () => {
+      const panel = cm.addConnection(createMockWs(), ClientEnv.JETBRAINS, 'panel-1', null);
+      cm.addConnection(createMockWs(), ClientEnv.JETBRAINS, 'panel-2', null);
+      cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'https://x.trycloudflare.com');
+      cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'http://localhost:63412');
+      expect(cm.getConnectionStats()).toEqual({ total: 4, panels: 2, tunnels: 1, browsers: 1 });
+
+      cm.removeConnection(panel);
+      expect(cm.getConnectionStats()).toEqual({ total: 3, panels: 1, tunnels: 1, browsers: 1 });
+    });
+  });
+
+  describe('streaming flag / session counters', () => {
+    it('counts sessions and streaming sessions', () => {
+      cm.getOrCreateSession('sess-1');
+      cm.getOrCreateSession('sess-2');
+      expect(cm.getSessionCount()).toBe(2);
+      expect(cm.getStreamingSessionCount()).toBe(0);
+
+      cm.setStreaming('sess-1', true);
+      expect(cm.getStreamingSessionCount()).toBe(1);
+
+      cm.setStreaming('sess-1', false);
+      expect(cm.getStreamingSessionCount()).toBe(0);
+    });
+
+    it('ignores setStreaming for an unknown session', () => {
+      cm.setStreaming('nonexistent', true);
+      expect(cm.getStreamingSessionCount()).toBe(0);
+    });
+
+    it('clears the flag on STREAM_END broadcast (process death safety net)', () => {
+      const connId = cm.addConnection(createMockWs());
+      cm.subscribe(connId, 'sess-1');
+      cm.setStreaming('sess-1', true);
+      expect(cm.getStreamingSessionCount()).toBe(1);
+
+      cm.broadcastToSession('sess-1', MessageType.STREAM_END);
+      expect(cm.getStreamingSessionCount()).toBe(0);
+    });
+
+    it('does not clear the flag on other broadcasts', () => {
+      const connId = cm.addConnection(createMockWs());
+      cm.subscribe(connId, 'sess-1');
+      cm.setStreaming('sess-1', true);
+
+      cm.broadcastToSession('sess-1', MessageType.CLI_EVENT, { type: 'assistant' });
+      expect(cm.getStreamingSessionCount()).toBe(1);
+    });
+  });
+
   describe('keep-alive gate (idle shutdown)', () => {
     const IDLE_GRACE = 60_000;
     let exitSpy: ReturnType<typeof vi.spyOn>;

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -256,6 +256,28 @@ describe('ConnectionManager', () => {
       cm.setKeepAlive(false);
       expect(cm.isKeepAlive()).toBe(false);
     });
+
+    it('should boot with the gate up when constructed for standalone mode', () => {
+      // ws-server passes !isJetBrainsMode: a standalone backend never arms the
+      // idle timer — the operator owns its lifetime (Ctrl+C graceful shutdown).
+      const standalone = new ConnectionManager(true);
+      expect(standalone.isKeepAlive()).toBe(true);
+
+      const connId = standalone.addConnection(createMockWs());
+      standalone.removeConnection(connId);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should keep the JetBrains boot default (gate down) with the no-arg constructor', () => {
+      const jetbrains = new ConnectionManager();
+      expect(jetbrains.isKeepAlive()).toBe(false);
+
+      const connId = jetbrains.addConnection(createMockWs());
+      jetbrains.removeConnection(connId);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
   });
 
   describe('pending editor context buffer', () => {

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ConnectionManager } from '../connection-manager';
 import { ClientEnv } from '../../shared';
 import { MessageType } from '../../shared';
@@ -181,6 +181,80 @@ describe('ConnectionManager', () => {
       cm.addConnection(createMockWs());
       cm.removeConnection(connId);
       expect(cm.getConnectionCount()).toBe(1);
+    });
+  });
+
+  describe('keep-alive gate (idle shutdown)', () => {
+    const IDLE_GRACE = 60_000;
+    let exitSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+      exitSpy.mockClear();
+    });
+
+    afterEach(() => {
+      exitSpy.mockRestore();
+    });
+
+    it('should idle-shutdown 60s after the last connection leaves (baseline)', () => {
+      const connId = cm.addConnection(createMockWs());
+      cm.removeConnection(connId);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('should not schedule idle shutdown while keep-alive is enabled', () => {
+      cm.setKeepAlive(true);
+      const connId = cm.addConnection(createMockWs());
+      cm.removeConnection(connId);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should cancel an already-armed timer when keep-alive is enabled', () => {
+      const connId = cm.addConnection(createMockWs());
+      cm.removeConnection(connId); // arms the timer
+      cm.setKeepAlive(true);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should arm the timer on a false push with zero connections (prewarm-leak fix)', () => {
+      // Fresh manager, no /ws connection was ever added: removeConnection never
+      // fires, so without this push the backend would linger forever.
+      cm.setKeepAlive(false);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('should arm the timer when keep-alive is disabled at zero connections (keep-alive clamp)', () => {
+      cm.setKeepAlive(true);
+      cm.setKeepAlive(false);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).toHaveBeenCalledWith(0);
+    });
+
+    it('should not arm the timer when keep-alive is disabled with live connections', () => {
+      cm.addConnection(createMockWs());
+      cm.setKeepAlive(false);
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should cancel the setKeepAlive(false)-armed timer when a connection arrives', () => {
+      cm.setKeepAlive(false); // arms (zero connections)
+      cm.addConnection(createMockWs());
+      vi.advanceTimersByTime(IDLE_GRACE + 1);
+      expect(exitSpy).not.toHaveBeenCalled();
+    });
+
+    it('should report the gate state via isKeepAlive', () => {
+      expect(cm.isKeepAlive()).toBe(false);
+      cm.setKeepAlive(true);
+      expect(cm.isKeepAlive()).toBe(true);
+      cm.setKeepAlive(false);
+      expect(cm.isKeepAlive()).toBe(false);
     });
   });
 

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -2,6 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { ConnectionManager } from '../connection-manager';
 import { ClientEnv } from '../../shared';
 import { MessageType } from '../../shared';
+import { Claude } from '../../core/claude';
+
+// connection-manager delegates process kills to Claude.killTree (process-group
+// kill). Mock it here: unit tests use fake PIDs, and a real group
+// signal aimed at a fake PID could hit an unrelated live process group on the
+// test machine. Real-process coverage lives in kill-tree.integration.test.ts.
+vi.mock('../../core/claude', () => ({
+  Claude: { killTree: vi.fn() },
+}));
 
 function createMockWs(readyState = 1) {
   return {
@@ -121,12 +130,12 @@ describe('ConnectionManager', () => {
     it('should kill all session processes and close all connections', () => {
       const ws = createMockWs();
       cm.addConnection(ws);
-      const mockProcess = { kill: vi.fn() } as unknown as import('child_process').ChildProcess;
+      const mockProcess = { pid: 4242, kill: vi.fn() } as unknown as import('child_process').ChildProcess;
       cm.setProcess('sess-1', mockProcess);
 
       cm.shutdownAll();
 
-      expect(mockProcess.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(Claude.killTree).toHaveBeenCalledWith(mockProcess, 'SIGTERM');
       expect(ws.close).toHaveBeenCalled();
     });
   });

--- a/backend/src/ws/__tests__/status-route.test.ts
+++ b/backend/src/ws/__tests__/status-route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ConnectionManager } from '../connection-manager';
+import { handleStatusRequest } from '../status-route';
+import { ClientEnv } from '../../shared';
+
+vi.mock('../../core/claude', () => ({
+  Claude: { killTree: vi.fn() },
+}));
+
+function createMockWs(readyState = 1) {
+  return {
+    readyState,
+    send: vi.fn(),
+    close: vi.fn(),
+  } as unknown as import('ws').WebSocket;
+}
+
+describe('handleStatusRequest', () => {
+  let cm: ConnectionManager;
+
+  beforeEach(() => {
+    cm = new ConnectionManager();
+  });
+
+  it('returns 200 with the empty-backend snapshot', () => {
+    const result = handleStatusRequest(cm);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({
+      keepAlive: false,
+      connections: { total: 0, panels: 0, tunnels: 0, browsers: 0 },
+      sessions: { total: 0, streaming: 0 },
+    });
+  });
+
+  it('reflects gate state, connection breakdown and session counters', () => {
+    cm.setKeepAlive(true);
+    cm.addConnection(createMockWs(), ClientEnv.JETBRAINS, 'panel-1', null);
+    const browserConn = cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'http://localhost:63412');
+    cm.addConnection(createMockWs(), ClientEnv.BROWSER, null, 'https://x.trycloudflare.com');
+
+    cm.subscribe(browserConn, 'sess-1');
+    cm.getOrCreateSession('sess-2');
+    cm.setStreaming('sess-1', true);
+
+    expect(handleStatusRequest(cm).body).toEqual({
+      keepAlive: true,
+      connections: { total: 3, panels: 1, tunnels: 1, browsers: 1 },
+      sessions: { total: 2, streaming: 1 },
+    });
+  });
+});

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -57,6 +57,14 @@ export class ConnectionManager {
   private sessionRegistry = new Map<string, SessionRecord>();
   private cleanupTimers = new Map<string, NodeJS.Timeout>();
   private idleShutdownTimer: NodeJS.Timeout | null = null;
+  /**
+   * Idle-shutdown gate ("keep backend running"). While true the backend never
+   * schedules its zero-connection self-shutdown. Driven exclusively over the
+   * /rpc channel (SET_KEEP_ALIVE): Kotlin pushes the desired state on every
+   * RPC (re)connect and on user toggle; the parent watchdog flips it back to
+   * false when the IDE dies (keep-alive clamp).
+   */
+  private keepAlive = false;
   // Secondary index for O(1) panelId → connectionId resolution. Panel ↔ connection
   // is 1:1 (one JCEF browser per IDE panel, one /ws socket per browser), so this
   // map is always in sync with the panelId stored on each ClientRecord.
@@ -395,7 +403,35 @@ export class ConnectionManager {
     );
   }
 
+  /**
+   * Toggle the idle-shutdown gate. Enabling cancels any armed timer. Disabling
+   * restores the normal regime — and, when there are no /ws connections at that
+   * moment, arms the timer immediately: removeConnection() only fires on a
+   * connection that existed, so a backend that never received one (eager start,
+   * prewarm) would otherwise linger forever.
+   */
+  setKeepAlive(enabled: boolean): void {
+    // No early return on an unchanged value: the initial state is false, yet the
+    // very first SET_KEEP_ALIVE(false) push must still arm the timer below when
+    // the backend has no /ws connections (the eager-start/prewarm case).
+    if (this.keepAlive !== enabled) {
+      console.error('[node-backend]', `Keep-alive ${enabled ? 'enabled' : 'disabled'}`);
+    }
+    this.keepAlive = enabled;
+
+    if (enabled) {
+      this.cancelIdleShutdown();
+    } else if (this.connectionMap.size === 0) {
+      this.scheduleIdleShutdown();
+    }
+  }
+
+  isKeepAlive(): boolean {
+    return this.keepAlive;
+  }
+
   private scheduleIdleShutdown(): void {
+    if (this.keepAlive) return;
     if (this.idleShutdownTimer !== null) return;
 
     console.error(

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -2,6 +2,7 @@ import type { WebSocket } from 'ws';
 import type { ChildProcess } from 'child_process';
 import type { IPCMessage, NativeDropEntry } from '../core/types';
 import { ClientEnv, MessageType } from '../shared';
+import { Claude } from '../core/claude';
 
 const SESSION_CLEANUP_GRACE_MS = 30_000;
 const IDLE_SHUTDOWN_GRACE_MS = 60_000;
@@ -349,6 +350,23 @@ export class ConnectionManager {
 
   // ─── Internal ───────────────────────────────────────────────────────────────
 
+  /**
+   * Kill-sweep over every live session CLI tree. shutdownAll uses it with
+   * SIGTERM (graceful path); the process 'exit' hook in server.ts uses it with
+   * SIGKILL as the last-resort orphan guard, so it must stay synchronous —
+   * 'exit' handlers cannot await.
+   */
+  killAllSessionProcesses(signal: NodeJS.Signals): number {
+    let killed = 0;
+    for (const session of this.sessionRegistry.values()) {
+      if (session.process) {
+        Claude.killTree(session.process, signal);
+        killed++;
+      }
+    }
+    return killed;
+  }
+
   shutdownAll(): void {
     // Clear all pending cleanup timers
     for (const timer of this.cleanupTimers.values()) {
@@ -358,15 +376,8 @@ export class ConnectionManager {
 
     this.cancelIdleShutdown();
 
-    let killedSessions = 0;
+    const killedSessions = this.killAllSessionProcesses('SIGTERM');
     let closedConnections = 0;
-
-    for (const session of this.sessionRegistry.values()) {
-      if (session.process) {
-        session.process.kill('SIGTERM');
-        killedSessions++;
-      }
-    }
 
     for (const ws of this.connectionMap.values()) {
       ws.close();
@@ -415,7 +426,7 @@ export class ConnectionManager {
         '[node-backend]',
         `Killing process for session ${sessionId} (PID: ${session.process.pid})`,
       );
-      session.process.kill('SIGTERM');
+      Claude.killTree(session.process);
       session.process = null;
     }
 

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -29,6 +29,15 @@ interface SessionRecord {
   subscribers: Set<string>;
   buffer: string;
   workingDir: string;
+  /**
+   * True while a turn is in flight: set when a prompt is written to the CLI
+   * stdin, cleared on the CLI `result` event (turn end) and on STREAM_END
+   * (process death safety net). NOT the STREAM_START..STREAM_END window —
+   * the CLI process is long-lived across turns, so that window only means
+   * "process alive". Feeds the streaming-sessions counter (status endpoint,
+   * future IDE exit-confirm modal).
+   */
+  streaming: boolean;
 }
 
 interface ClientRecord {
@@ -49,6 +58,24 @@ interface ClientRecord {
    * own `drop` handler). Cleared on flush and on disconnect.
    */
   nativeDropStash: NativeDropEntry[] | null;
+  /**
+   * `Origin` header of the WebSocket upgrade request, when present. Used only
+   * to classify the connection type for status reporting: Remote Tunnel
+   * clients arrive with a *.trycloudflare.com origin (already allowlisted by
+   * ws-server's validateOrigin), local browsers with a localhost one.
+   */
+  origin: string | null;
+}
+
+/** Connection-count breakdown for the status endpoint / status-bar card. */
+export interface ConnectionStats {
+  total: number;
+  /** JCEF IDE panels — connections carrying a `panelId` query param. */
+  panels: number;
+  /** Remote Tunnel clients — recognized by their *.trycloudflare.com origin. */
+  tunnels: number;
+  /** Everything else: plain (local) browsers. */
+  browsers: number;
 }
 
 export class ConnectionManager {
@@ -86,12 +113,17 @@ export class ConnectionManager {
 
   // ─── Connection lifecycle ───────────────────────────────────────────────────
 
-  addConnection(ws: WebSocket, env: ClientEnv = ClientEnv.BROWSER, panelId: string | null = null): string {
+  addConnection(
+    ws: WebSocket,
+    env: ClientEnv = ClientEnv.BROWSER,
+    panelId: string | null = null,
+    origin: string | null = null,
+  ): string {
     const connectionId = `conn-${++this.nextId}-${Date.now()}`;
     this.connectionMap.set(connectionId, ws);
-    this.clientMap.set(connectionId, { subscribedSessionId: null, env, panelId, nativeDropStash: null });
+    this.clientMap.set(connectionId, { subscribedSessionId: null, env, panelId, nativeDropStash: null, origin });
     if (panelId) this.panelIdIndex.set(panelId, connectionId);
-    this.cancelIdleShutdown();
+    this.cancelIdleShutdown('new connection received');
     console.error(
       '[node-backend]',
       `Connection added: ${connectionId} (env: ${env}, panelId: ${panelId ?? 'none'})`,
@@ -200,6 +232,13 @@ export class ConnectionManager {
   ): void {
     const session = this.sessionRegistry.get(sessionId);
     if (!session) return;
+
+    // Safety net for the turn-in-flight flag: STREAM_END fires on every CLI
+    // process death path (close, spawn error, WSL mismatch), where no `result`
+    // event will ever arrive to clear the flag.
+    if (type === MessageType.STREAM_END) {
+      session.streaming = false;
+    }
 
     const message: IPCMessage = {
       type,
@@ -317,6 +356,45 @@ export class ConnectionManager {
     return this.connectionMap.size;
   }
 
+  /** Connection-count breakdown by client type (status endpoint / status-bar card). */
+  getConnectionStats(): ConnectionStats {
+    const stats: ConnectionStats = { total: 0, panels: 0, tunnels: 0, browsers: 0 };
+    for (const record of this.clientMap.values()) {
+      stats.total++;
+      if (record.panelId !== null) {
+        stats.panels++;
+      } else if (record.origin?.endsWith('.trycloudflare.com')) {
+        stats.tunnels++;
+      } else {
+        stats.browsers++;
+      }
+    }
+    return stats;
+  }
+
+  getSessionCount(): number {
+    return this.sessionRegistry.size;
+  }
+
+  /** Number of sessions with a turn in flight (see SessionRecord.streaming). */
+  getStreamingSessionCount(): number {
+    let count = 0;
+    for (const session of this.sessionRegistry.values()) {
+      if (session.streaming) count++;
+    }
+    return count;
+  }
+
+  /**
+   * Flip the per-session turn-in-flight flag. claude-process sets it true
+   * after writing a prompt to the CLI stdin and false on the `result` event;
+   * broadcastToSession clears it on STREAM_END as the process-death safety net.
+   */
+  setStreaming(sessionId: string, streaming: boolean): void {
+    const session = this.sessionRegistry.get(sessionId);
+    if (session) session.streaming = streaming;
+  }
+
   getClient(connectionId: string): ClientRecord | undefined {
     return this.clientMap.get(connectionId);
   }
@@ -338,6 +416,7 @@ export class ConnectionManager {
         subscribers: new Set(),
         buffer: '',
         workingDir: workingDir ?? '',
+        streaming: false,
       };
       this.sessionRegistry.set(sessionId, session);
     }
@@ -392,7 +471,7 @@ export class ConnectionManager {
     }
     this.cleanupTimers.clear();
 
-    this.cancelIdleShutdown();
+    this.cancelIdleShutdown('shutting down');
 
     const killedSessions = this.killAllSessionProcesses('SIGTERM');
     let closedConnections = 0;
@@ -430,7 +509,7 @@ export class ConnectionManager {
     this.keepAlive = enabled;
 
     if (enabled) {
-      this.cancelIdleShutdown();
+      this.cancelIdleShutdown('keep-alive enabled');
     } else if (this.connectionMap.size === 0) {
       this.scheduleIdleShutdown();
     }
@@ -450,17 +529,20 @@ export class ConnectionManager {
     );
     this.idleShutdownTimer = setTimeout(() => {
       console.error('[node-backend]', 'Idle shutdown grace period elapsed. Shutting down.');
+      // The timer has fired — null it out so shutdownAll()'s cancelIdleShutdown()
+      // no-ops instead of logging a misleading "timer cancelled" line.
+      this.idleShutdownTimer = null;
       this.shutdownAll();
       process.exit(0);
     }, IDLE_SHUTDOWN_GRACE_MS);
   }
 
-  private cancelIdleShutdown(): void {
+  private cancelIdleShutdown(reason: string): void {
     if (this.idleShutdownTimer === null) return;
 
     clearTimeout(this.idleShutdownTimer);
     this.idleShutdownTimer = null;
-    console.error('[node-backend]', 'Idle shutdown timer cancelled (new connection received)');
+    console.error('[node-backend]', `Idle shutdown timer cancelled (${reason})`);
   }
 
   private cleanupSession(sessionId: string): void {

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -59,12 +59,18 @@ export class ConnectionManager {
   private idleShutdownTimer: NodeJS.Timeout | null = null;
   /**
    * Idle-shutdown gate ("keep backend running"). While true the backend never
-   * schedules its zero-connection self-shutdown. Driven exclusively over the
-   * /rpc channel (SET_KEEP_ALIVE): Kotlin pushes the desired state on every
-   * RPC (re)connect and on user toggle; the parent watchdog flips it back to
-   * false when the IDE dies (keep-alive clamp).
+   * schedules its zero-connection self-shutdown.
+   *
+   * The boot value comes from the constructor: a standalone backend
+   * boots with the gate up and nothing ever lowers it — the operator owns the
+   * process lifetime (visible terminal, Ctrl+C → graceful shutdown), so the
+   * idle timer is never armed at all. In JetBrains mode the gate boots down
+   * and is driven exclusively over the /rpc channel (SET_KEEP_ALIVE): Kotlin
+   * pushes the desired state on every RPC (re)connect and on user toggle; the
+   * parent watchdog flips it back to false when the IDE dies (keep-alive
+   * clamp).
    */
-  private keepAlive = false;
+  private keepAlive: boolean;
   // Secondary index for O(1) panelId → connectionId resolution. Panel ↔ connection
   // is 1:1 (one JCEF browser per IDE panel, one /ws socket per browser), so this
   // map is always in sync with the panelId stored on each ClientRecord.
@@ -73,6 +79,10 @@ export class ConnectionManager {
   // connection that arrives within PENDING_EDITOR_CONTEXT_TTL_MS, then cleared.
   private pendingEditorContext: PendingEditorContext | null = null;
   private nextId = 0;
+
+  constructor(initialKeepAlive = false) {
+    this.keepAlive = initialKeepAlive;
+  }
 
   // ─── Connection lifecycle ───────────────────────────────────────────────────
 

--- a/backend/src/ws/status-route.ts
+++ b/backend/src/ws/status-route.ts
@@ -1,0 +1,32 @@
+import { ConnectionManager } from './connection-manager';
+
+/**
+ * Result of handling a GET /internal/status request. The caller writes
+ * `status` and JSON-serialized `body` back to the HTTP response.
+ */
+export interface StatusRouteResult {
+  status: number;
+  body: Record<string, unknown>;
+}
+
+/**
+ * Runtime status snapshot for IDE-side consumers (the status-bar card in the
+ * Kotlin plugin; the future IDE exit-confirm modal reuses the same counters).
+ * Follows the plugin-queries-the-backend-over-HTTP precedent set by /version.
+ *
+ * Extracted from the HTTP layer so the payload shape is unit-testable without
+ * spinning up a server.
+ */
+export function handleStatusRequest(connections: ConnectionManager): StatusRouteResult {
+  return {
+    status: 200,
+    body: {
+      keepAlive: connections.isKeepAlive(),
+      connections: connections.getConnectionStats(),
+      sessions: {
+        total: connections.getSessionCount(),
+        streaming: connections.getStreamingSessionCount(),
+      },
+    },
+  };
+}

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -8,6 +8,7 @@ import { handleIdeSelectionRequest } from './ide-selection-route';
 import type { Bridge } from '../bridge/bridge-interface';
 import type { IPCMessage } from '../core/types';
 import { ClientEnv, MessageType } from '../shared';
+import { isJetBrainsMode } from '../config/environment';
 import { getPluginVersion } from '../core/handlers/getVersion';
 import { cancelLogin } from '../core/handlers/login';
 import { reportBackendError, trackActivity } from '../core/features/telemetry';
@@ -195,7 +196,12 @@ export function startWebSocketServer(
   logWs?: LogWebSocketServer,
 ): Promise<WebSocketServerHandle> {
   return new Promise<WebSocketServerHandle>((resolve, reject) => {
-    const connections = new ConnectionManager();
+    // Standalone backends boot with the keep-alive gate up, so the
+    // idle-shutdown timer is never armed: the operator owns the process
+    // lifetime (visible terminal, Ctrl+C → graceful shutdown). Nothing lowers
+    // the gate in that mode — SET_KEEP_ALIVE only ever arrives from Kotlin,
+    // and the parent watchdog is JetBrains-only. SESSION_CLEANUP is untouched.
+    const connections = new ConnectionManager(!isJetBrainsMode);
     // Only relax Origin validation to strict same-origin when the operator
     // explicitly bound to a non-loopback address. Default loopback bind keeps
     // the historical allowlist-only behavior (DNS-rebinding stays closed).

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -5,6 +5,7 @@ import { WebSocketServer, type WebSocket } from 'ws';
 import { ConnectionManager } from './connection-manager';
 import { handleEditorContextRequest } from './editor-context-route';
 import { handleIdeSelectionRequest } from './ide-selection-route';
+import { handleStatusRequest } from './status-route';
 import type { Bridge } from '../bridge/bridge-interface';
 import type { IPCMessage } from '../core/types';
 import { ClientEnv, MessageType } from '../shared';
@@ -219,7 +220,15 @@ export function startWebSocketServer(
       const clientEnv = envParam === ClientEnv.JETBRAINS ? ClientEnv.JETBRAINS : ClientEnv.BROWSER;
       const panelId = params.get('panelId');
 
-      const connectionId = connections.addConnection(ws, clientEnv, panelId);
+      // Origin was already validated during the upgrade; keep it on the record
+      // so connection types (panel / tunnel / browser) can be told apart in
+      // status reporting.
+      const connectionId = connections.addConnection(
+        ws,
+        clientEnv,
+        panelId,
+        request.headers.origin ?? null,
+      );
       console.error('[node-backend]', `Client connected: ${connectionId}`);
 
       // 연결 준비 신호 전송
@@ -267,6 +276,16 @@ export function startWebSocketServer(
         if (urlPath === '/version') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ version: getPluginVersion() }));
+          return;
+        }
+
+        // Runtime status snapshot for the IDE status-bar card (and the future
+        // exit-confirm modal): keep-alive gate, connection counts by type,
+        // session/streaming counts. Read-only, no secrets.
+        if (req.method === 'GET' && urlPath === '/internal/status') {
+          const result = handleStatusRequest(connections);
+          res.writeHead(result.status, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify(result.body));
           return;
         }
 

--- a/backend/test-harness/backend-lifecycle.verify.mjs
+++ b/backend/test-harness/backend-lifecycle.verify.mjs
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+/**
+ * Backend keep-alive lifecycle verification: the gate (SET_KEEP_ALIVE over /rpc),
+ * ppid watchdog (keep-alive clamp), prewarm-leak fix and the
+ * GET /internal/status counters. Scripted, NO token burn — same fake-CLI
+ * approach as the cli-*.verify.mjs harnesses, isolated $HOME per scenario, scratch ports
+ * 19840+ (never the real 19836).
+ *
+ * The backend is spawned through a FAKE PARENT process (stand-in for the IDE
+ * JVM) so scenarios can kill the parent and watch the watchdog react. All
+ * scenarios run CONCURRENTLY — each one sits through the hardcoded 60 s idle
+ * grace (plus the 10 s watchdog poll), so a sequential run would take ~7 min.
+ *
+ * Scenarios:
+ *   S1 baseline — keep-alive OFF: /ws connect + disconnect → backend exits
+ *      after the ~60 s idle grace (unchanged behavior).
+ *   S2 gate — SET_KEEP_ALIVE(true) over /rpc, then /ws connect + disconnect →
+ *      backend is still alive well past the grace.
+ *   S3 clamp with client — keep-alive ON, SIGKILL the parent while a /ws
+ *      client is attached → watchdog fires, backend stays up; after
+ *      the client disconnects it exits within the grace.
+ *   S4 clamp without clients — keep-alive ON, SIGKILL the parent with zero
+ *      /ws clients → backend exits within watchdog poll + grace.
+ *   S5 prewarm-leak fix — backend that never receives any /ws client, /rpc
+ *      pushes SET_KEEP_ALIVE(false) (what Kotlin does on every connect) →
+ *      backend exits after the grace instead of lingering forever.
+ *   S6 status endpoint — GET /internal/status reflects the gate, the
+ *      panel/browser connection breakdown and the streaming-session count.
+ *
+ * Usage: node backend/test-harness/backend-lifecycle.verify.mjs
+ * Artifacts land in $TMPDIR/backend-lifecycle-verify/.
+ */
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(new URL('../package.json', import.meta.url));
+const WebSocket = require('ws');
+
+const BASE_PORT = Number(process.env.LIFECYCLE_PORT ?? 19840);
+const ROOT = join(process.env.TMPDIR || os.tmpdir(), 'backend-lifecycle-verify');
+const BACKEND = fileURLToPath(new URL('../dist/backend.mjs', import.meta.url));
+
+const IDLE_GRACE_MS = 60_000;
+const WATCHDOG_POLL_MS = 10_000;
+// "Exits after the grace" allowance: grace + watchdog poll + scheduling slack.
+const EXIT_ALLOWANCE_MS = IDLE_GRACE_MS + WATCHDOG_POLL_MS + 15_000;
+// "Still alive past the grace" probe point.
+const SURVIVE_PROBE_MS = IDLE_GRACE_MS + 15_000;
+
+const results = [];
+let failed = false;
+
+function report(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) failed = true;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return true;
+    await delay(200);
+  }
+  throw new Error(`timeout waiting for: ${what}`);
+}
+
+// ── Per-scenario context ─────────────────────────────────────────────────────
+
+const contexts = [];
+
+/**
+ * Isolated home + fake CLI + backend spawned under a killable fake parent
+ * (the IDE JVM stand-in). Backend stdio is inherited from the parent, so its
+ * PORT line and logs arrive on the parent's pipes and stay readable after the
+ * parent dies (the backend keeps the fd open).
+ */
+async function startContext(name, port) {
+  const root = join(ROOT, name);
+  const home = join(root, 'home');
+  rmSync(root, { recursive: true, force: true });
+  mkdirSync(join(home, '.claude-code-gui'), { recursive: true });
+  mkdirSync(join(root, 'bin'), { recursive: true });
+  mkdirSync(join(root, 'proj'), { recursive: true });
+
+  const fakeCli = join(root, 'bin', 'claude');
+  writeFileSync(fakeCli, `#!/bin/bash
+log="\${FAKE_CLI_LOG:?}"
+echo "started pid=$$ args=$*" >> "$log"
+trap 'echo "SIGTERM pid=$$" >> "$log"; exit 0' TERM
+while true; do sleep 1; done
+`);
+  chmodSync(fakeCli, 0o755);
+  writeFileSync(
+    join(home, '.claude-code-gui', 'settings.js'),
+    `export default {\n  cliPath: ${JSON.stringify(fakeCli)},\n};\n`,
+  );
+
+  const fakeParent = join(root, 'fake-parent.cjs');
+  writeFileSync(fakeParent, `
+const { spawn } = require('child_process');
+const child = spawn(process.execPath, [process.argv[2]], { stdio: ['ignore', 'inherit', 'inherit'] });
+console.log('BACKEND_PID:' + child.pid);
+setInterval(() => {}, 1000); // stay alive until killed
+`);
+
+  const parent = spawn(process.execPath, [fakeParent, BACKEND], {
+    env: {
+      ...process.env,
+      HOME: home,
+      PORT: String(port),
+      JETBRAINS_MODE: 'true',
+      FAKE_CLI_LOG: join(root, 'fake-cli.log'),
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  const ctx = { name, port, root, parent, out: '', err: '', backendPid: null };
+  parent.stdout.on('data', (d) => (ctx.out += d.toString()));
+  parent.stderr.on('data', (d) => (ctx.err += d.toString()));
+  contexts.push(ctx);
+
+  await waitUntil(() => /BACKEND_PID:(\d+)/.test(ctx.out), 10_000, `${name} backend pid`);
+  ctx.backendPid = Number(/BACKEND_PID:(\d+)/.exec(ctx.out)[1]);
+  await waitUntil(() => ctx.out.includes(`PORT:${port}`), 15_000, `${name} PORT line`);
+  return ctx;
+}
+
+function openWs(port, query = '') {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws${query}`);
+    ws.on('open', () => resolve(ws));
+    ws.on('error', reject);
+  });
+}
+
+/** Send a Kotlin-style SET_KEEP_ALIVE JSON-RPC notification over /rpc. */
+function pushKeepAlive(port, enabled) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/rpc`);
+    ws.on('open', () => {
+      ws.send(JSON.stringify({ jsonrpc: '2.0', method: 'SET_KEEP_ALIVE', params: { enabled } }));
+      // Give the frame a beat to flush, then drop the socket — the gate is
+      // backend state, not connection state.
+      setTimeout(() => {
+        ws.close();
+        resolve();
+      }, 300);
+    });
+    ws.on('error', reject);
+  });
+}
+
+/** Connect /ws, SEND_MESSAGE for a fake-CLI session, resolve on ACK. */
+function drive(port, sessionId, workingDir) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const timer = setTimeout(() => reject(new Error(`ws drive timeout (${sessionId})`)), 15_000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'SEND_MESSAGE',
+          requestId: `harness-${sessionId}`,
+          timestamp: Date.now(),
+          payload: {
+            content: 'lifecycle probe',
+            workingDir,
+            sessionId,
+            isNewSession: true,
+            inputMode: 'text',
+          },
+        }),
+      );
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'ACK') {
+        clearTimeout(timer);
+        resolve(ws);
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+async function fetchStatus(port) {
+  const res = await fetch(`http://127.0.0.1:${port}/internal/status`);
+  return { httpStatus: res.status, body: await res.json() };
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function s1_baseline(port) {
+  const ctx = await startContext('s1', port);
+  const ws = await openWs(port);
+  await delay(500);
+  ws.close();
+  const start = Date.now();
+  await waitUntil(() => !pidAlive(ctx.backendPid), EXIT_ALLOWANCE_MS, 'S1 idle exit');
+  const elapsed = Date.now() - start;
+  report('S1 keep-alive OFF: backend exits after the idle grace', true, `${Math.round(elapsed / 1000)}s`);
+  report('S1 exit not premature (>= grace)', elapsed >= IDLE_GRACE_MS - 2_000, `${Math.round(elapsed / 1000)}s`);
+}
+
+async function s2_gate(port) {
+  const ctx = await startContext('s2', port);
+  await pushKeepAlive(port, true);
+  const ws = await openWs(port);
+  await delay(500);
+  ws.close();
+  await delay(SURVIVE_PROBE_MS);
+  report('S2 keep-alive ON: backend survives past the idle grace', pidAlive(ctx.backendPid));
+  report('S2 gate log present', ctx.err.includes('Keep-alive enabled'));
+}
+
+async function s3_clampWithClient(port) {
+  const ctx = await startContext('s3', port);
+  await pushKeepAlive(port, true);
+  const ws = await openWs(port);
+  await delay(500);
+
+  process.kill(ctx.parent.pid, 'SIGKILL');
+  await waitUntil(
+    () => ctx.err.includes('Parent process') && ctx.err.includes('died'),
+    WATCHDOG_POLL_MS + 10_000,
+    'S3 watchdog log',
+  );
+  report('S3 watchdog detected parent death', true);
+  await delay(SURVIVE_PROBE_MS);
+  report('S3 backend survives parent death while a /ws client is attached', pidAlive(ctx.backendPid));
+
+  ws.close();
+  await waitUntil(() => !pidAlive(ctx.backendPid), EXIT_ALLOWANCE_MS, 'S3 exit after client left');
+  report('S3 backend exits after the last client leaves', true);
+}
+
+async function s4_clampWithoutClients(port) {
+  const ctx = await startContext('s4', port);
+  await pushKeepAlive(port, true);
+  await delay(500);
+
+  process.kill(ctx.parent.pid, 'SIGKILL');
+  const start = Date.now();
+  await waitUntil(() => !pidAlive(ctx.backendPid), EXIT_ALLOWANCE_MS, 'S4 orphan backend exit');
+  const elapsed = Date.now() - start;
+  report('S4 client-less backend exits after parent death (watchdog + grace)', true, `${Math.round(elapsed / 1000)}s`);
+  report('S4 watchdog log present', ctx.err.includes('keep-alive clamp') || ctx.err.includes('died'));
+}
+
+async function s5_prewarmLeakFix(port) {
+  const ctx = await startContext('s5', port);
+  // What Kotlin does on every /rpc connect, keep-alive toggle OFF: push false.
+  // No /ws client EVER connects — before the fix this backend lived forever.
+  await pushKeepAlive(port, false);
+  const start = Date.now();
+  await waitUntil(() => !pidAlive(ctx.backendPid), EXIT_ALLOWANCE_MS, 'S5 prewarm backend exit');
+  const elapsed = Date.now() - start;
+  report('S5 never-connected backend exits after SET_KEEP_ALIVE(false) push', true, `${Math.round(elapsed / 1000)}s`);
+  report('S5 exit not premature (>= grace)', elapsed >= IDLE_GRACE_MS - 2_000, `${Math.round(elapsed / 1000)}s`);
+}
+
+async function s6_statusEndpoint(port) {
+  const ctx = await startContext('s6', port);
+  const empty = await fetchStatus(port);
+  report(
+    'S6 empty snapshot',
+    empty.httpStatus === 200 &&
+      empty.body.keepAlive === false &&
+      empty.body.connections.total === 0 &&
+      empty.body.sessions.total === 0,
+    JSON.stringify(empty.body),
+  );
+
+  await pushKeepAlive(port, true);
+  const panelWs = await openWs(port, '?env=jetbrains&panelId=harness-panel');
+  const driveWs = await drive(port, 'harness-status-session', join(ctx.root, 'proj'));
+  await delay(1_000);
+
+  const busy = await fetchStatus(port);
+  const c = busy.body.connections;
+  const s = busy.body.sessions;
+  report('S6 keepAlive reflected', busy.body.keepAlive === true);
+  report(
+    'S6 connection breakdown (1 panel + 1 browser)',
+    c.total === 2 && c.panels === 1 && c.browsers === 1 && c.tunnels === 0,
+    JSON.stringify(c),
+  );
+  report(
+    'S6 session counters (1 session, 1 streaming — fake CLI never sends result)',
+    s.total === 1 && s.streaming === 1,
+    JSON.stringify(s),
+  );
+
+  panelWs.close();
+  driveWs.close();
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main() {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(ROOT, { recursive: true });
+
+  const scenarios = [s1_baseline, s2_gate, s3_clampWithClient, s4_clampWithoutClients, s5_prewarmLeakFix, s6_statusEndpoint];
+  const outcomes = await Promise.allSettled(scenarios.map((fn, i) => fn(BASE_PORT + i)));
+  for (const [i, outcome] of outcomes.entries()) {
+    if (outcome.status === 'rejected') {
+      report(`S${i + 1} scenario error`, false, String(outcome.reason));
+    }
+  }
+
+  console.log('\nArtifacts in', ROOT);
+  console.log(failed ? 'RESULT: FAIL' : 'RESULT: ALL PASS');
+  process.exitCode = failed ? 1 : 0;
+}
+
+main()
+  .catch((err) => {
+    console.error('VERIFY ERROR:', err);
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    for (const ctx of contexts) {
+      for (const pid of [ctx.backendPid, ctx.parent?.pid]) {
+        if (pid && pidAlive(pid)) {
+          try {
+            process.kill(pid, 'SIGKILL');
+          } catch {
+            // Already gone
+          }
+        }
+      }
+    }
+  });

--- a/backend/test-harness/cli-pid-registry.verify.mjs
+++ b/backend/test-harness/cli-pid-registry.verify.mjs
@@ -1,0 +1,302 @@
+#!/usr/bin/env node
+/**
+ * Pid-registry verification: startup orphan sweep and the
+ * pre-`--resume` liveness guard. Scripted, NO token burn — same fake-CLI
+ * approach as cli-process-tree.verify.mjs (worst-case CLI ignoring stdin EOF), isolated
+ * $HOME, scratch ports 19838/19839 (never the real 19836).
+ *
+ * Scenarios:
+ *   S1 startup sweep — SIGKILL a backend with a live CLI (the SIGKILL residual
+ *      gap), start a fresh backend on the same port: its startup sweep must
+ *      find the orphan via the registry and kill the whole tree.
+ *   S2 resume guard (orphan) — plant a live orphan registered for a session,
+ *      then send a prompt for that session: the backend must kill the orphan
+ *      BEFORE spawning its own CLI (no dual writer on one JSONL).
+ *   S3 resume guard (live owner) — the same session driven through a SECOND
+ *      backend on another port must be REFUSED (SERVICE_ERROR), and the first
+ *      backend's CLI must stay untouched.
+ *
+ * Usage: node backend/test-harness/cli-pid-registry.verify.mjs
+ * Artifacts land in $TMPDIR/cli-pid-registry-verify/.
+ */
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, readdirSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(new URL('../package.json', import.meta.url));
+const WebSocket = require('ws');
+
+const PORT_A = Number(process.env.PID_REGISTRY_PORT ?? 19838);
+const PORT_B = PORT_A + 1;
+const ROOT = join(process.env.TMPDIR || os.tmpdir(), 'cli-pid-registry-verify');
+const HOME = join(ROOT, 'home');
+const PROJ = join(ROOT, 'proj');
+const CLI_LOG = join(ROOT, 'fake-cli.log');
+const REGISTRY = join(HOME, '.claude-code-gui', 'cli-registry');
+const BACKEND = fileURLToPath(new URL('../dist/backend.mjs', import.meta.url));
+
+const results = [];
+let failed = false;
+
+function report(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) failed = true;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return true;
+    await delay(100);
+  }
+  throw new Error(`timeout waiting for: ${what}`);
+}
+
+// ── Fixtures (same fake CLI as cli-process-tree.verify) ──────────────────────────────────
+
+function setupFixtures() {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(join(HOME, '.claude-code-gui'), { recursive: true });
+  mkdirSync(join(ROOT, 'bin'), { recursive: true });
+  mkdirSync(PROJ, { recursive: true });
+
+  const fakeCli = join(ROOT, 'bin', 'claude');
+  writeFileSync(fakeCli, `#!/bin/bash
+log="\${FAKE_CLI_LOG:?}"
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+echo "started pid=$$ pgid=$pgid args=$*" >> "$log"
+sleep 600 &
+child=$!
+echo "child pid=$$ childpid=$child" >> "$log"
+trap 'echo "SIGTERM pid=$$" >> "$log"; kill $child 2>/dev/null; exit 0' TERM
+trap 'echo "SIGHUP pid=$$" >> "$log"' HUP
+while true; do sleep 1; done
+`);
+  chmodSync(fakeCli, 0o755);
+
+  writeFileSync(
+    join(HOME, '.claude-code-gui', 'settings.js'),
+    `export default {\n  cliPath: ${JSON.stringify(fakeCli)},\n};\n`,
+  );
+}
+
+// ── Backend + ws driving ─────────────────────────────────────────────────────
+
+const backends = [];
+
+function startBackend(label, port) {
+  const proc = spawn(process.execPath, [BACKEND], {
+    env: { ...process.env, HOME, PORT: String(port), FAKE_CLI_LOG: CLI_LOG, JETBRAINS_MODE: '' },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const record = { label, port, proc, stdout: '', stderr: '', exited: false };
+  proc.stdout.on('data', (d) => (record.stdout += d.toString()));
+  proc.stderr.on('data', (d) => (record.stderr += d.toString()));
+  proc.on('exit', () => (record.exited = true));
+  backends.push(record);
+  return record;
+}
+
+async function waitForPortLine(backend) {
+  await waitUntil(
+    () => backend.stdout.includes(`PORT:${backend.port}`),
+    15_000,
+    `${backend.label} PORT line`,
+  );
+}
+
+/** Connect, SEND_MESSAGE, collect pushed messages; resolve on ACK. */
+function drive(port, sessionId) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+    const messages = [];
+    const timer = setTimeout(() => reject(new Error(`ws drive timeout (session ${sessionId})`)), 15_000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'SEND_MESSAGE',
+          requestId: `harness-${sessionId}`,
+          timestamp: Date.now(),
+          payload: {
+            content: 'lifecycle probe',
+            workingDir: PROJ,
+            sessionId,
+            isNewSession: true,
+            inputMode: 'text',
+          },
+        }),
+      );
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      messages.push(msg);
+      if (msg.type === 'ACK') {
+        clearTimeout(timer);
+        resolve({ ws, messages });
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** n-th (0-based) fake-CLI instance recorded in the log. */
+function cliFromLog(index) {
+  let content;
+  try {
+    content = readFileSync(CLI_LOG, 'utf8');
+  } catch {
+    return null;
+  }
+  const lines = content.trim().split('\n');
+  const started = lines.filter((l) => l.startsWith('started'))[index];
+  if (!started) return null;
+  const pid = Number(/pid=(\d+)/.exec(started)[1]);
+  const childLine = lines.filter((l) => l.startsWith(`child pid=${pid}`)).pop();
+  if (!childLine) return null;
+  return { pid, child: Number(/childpid=(\d+)/.exec(childLine)[1]) };
+}
+
+async function waitForCli(index, what) {
+  await waitUntil(() => cliFromLog(index) !== null, 10_000, what);
+  return cliFromLog(index);
+}
+
+/** A dead-but-real pid for crafting orphan entries. */
+function deadPid() {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('true');
+    proc.on('error', reject);
+    proc.on('exit', () => resolve(proc.pid));
+  });
+}
+
+/**
+ * Plant a fake orphan: a live marked process + a registry entry with a dead
+ * owner, exactly what a hard-killed backend leaves behind. The marker script is
+ * multi-command so `sh -c` does not exec-optimize the marker out of its argv.
+ */
+async function plantOrphan(sessionId) {
+  const proc = spawn('sh', ['-c', 'sleep 600; true', sessionId], {
+    detached: true,
+    stdio: 'ignore',
+  });
+  await waitUntil(() => proc.pid !== undefined, 5_000, 'orphan spawn');
+  mkdirSync(REGISTRY, { recursive: true });
+  writeFileSync(
+    join(REGISTRY, `${proc.pid}.json`),
+    JSON.stringify({
+      pid: proc.pid,
+      sessionId,
+      workingDir: PROJ,
+      startedAt: new Date().toISOString(),
+      owner: { pid: await deadPid(), argv1: 'backend.mjs' },
+    }),
+  );
+  return proc;
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function main() {
+  setupFixtures();
+
+  // S1: startup orphan sweep after a SIGKILLed backend (the SIGKILL residual gap).
+  const a = startBackend('backend-A', PORT_A);
+  await waitForPortLine(a);
+  const driveA = await drive(PORT_A, 'harness-session-1');
+  const cliA = await waitForCli(0, 'fake CLI under backend-A');
+  process.kill(a.proc.pid, 'SIGKILL');
+  await waitUntil(() => a.exited, 5_000, 'backend-A SIGKILLed');
+  await delay(500);
+  report('S1 orphan exists after backend SIGKILL', pidAlive(cliA.pid) && pidAlive(cliA.child));
+  report('S1 registry entry survived the hard death',
+    readdirSync(REGISTRY).includes(`${cliA.pid}.json`));
+
+  const b = startBackend('backend-B', PORT_A);
+  await waitForPortLine(b);
+  await waitUntil(() => !pidAlive(cliA.pid) && !pidAlive(cliA.child), 10_000, 'S1 orphan killed by sweep');
+  report('S1 startup sweep killed the orphan tree',
+    !pidAlive(cliA.pid) && !pidAlive(cliA.child));
+  report('S1 sweep logged its kill', b.stderr.includes('Orphan sweep: killing orphaned CLI'));
+  try {
+    driveA.ws.terminate();
+  } catch {
+    // Died with backend-A
+  }
+
+  // S2: resume guard — planted live orphan for the session must die BEFORE spawn.
+  const orphan = await plantOrphan('harness-session-2');
+  const driveB = await drive(PORT_A, 'harness-session-2');
+  await waitUntil(() => !pidAlive(orphan.pid), 10_000, 'S2 orphan killed by resume guard');
+  const cliB = await waitForCli(1, 'fake CLI spawned after the guard');
+  report('S2 resume guard killed the live orphan first', !pidAlive(orphan.pid));
+  report('S2 guard logged the kill', b.stderr.includes('Killing orphaned CLI'));
+  report('S2 fresh CLI runs for the session afterwards', pidAlive(cliB.pid));
+  report('S2 respawn switched to --resume (session already ran)',
+    b.stderr.includes('--resume') && b.stderr.includes('harness-session-2'));
+
+  // S3: resume guard — same session via a SECOND backend must be refused.
+  const c = startBackend('backend-C', PORT_B);
+  await waitForPortLine(c);
+  const driveC = await drive(PORT_B, 'harness-session-2');
+  const refusal = driveC.messages.find(
+    (m) => m.type === 'SERVICE_ERROR' && String(m.payload?.reason ?? '').includes('already active under another backend'),
+  );
+  report('S3 second backend refused the takeover (SERVICE_ERROR)', Boolean(refusal));
+  report('S3 first backend CLI untouched', pidAlive(cliB.pid) && pidAlive(cliB.child));
+  report('S3 no second fake CLI was spawned', cliFromLog(2) === null);
+  try {
+    driveB.ws.terminate();
+    driveC.ws.terminate();
+  } catch {
+    // Already closed
+  }
+
+  console.log('\nArtifacts in', ROOT);
+  console.log(failed ? 'RESULT: FAIL' : 'RESULT: ALL PASS');
+  process.exitCode = failed ? 1 : 0;
+}
+
+main()
+  .catch((err) => {
+    console.error('VERIFY ERROR:', err);
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    for (const backend of backends) {
+      if (!backend.exited) {
+        try {
+          backend.proc.kill('SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    }
+    for (let i = 0; ; i++) {
+      const cli = cliFromLog(i);
+      if (!cli) break;
+      try {
+        process.kill(-cli.pid, 'SIGKILL');
+      } catch {
+        // Already gone
+      }
+    }
+  });

--- a/backend/test-harness/cli-process-tree.verify.mjs
+++ b/backend/test-harness/cli-process-tree.verify.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Orphaned-CLI hard-binding verification: scripted, NO token burn.
+ *
+ * Drives the BUILT backend (backend/dist/backend.mjs) with a fake `claude` binary
+ * (bash fixture that never exits on stdin EOF — the worst-case mid-turn CLI) under
+ * an isolated $HOME, on a scratch port (19837, NOT the real 19836), and asserts:
+ *
+ *   1. spawn shape: the chat CLI runs detached — pgid == pid (own process group);
+ *   2. double-start: a second backend reclaims the port with
+ *      SIGTERM first → the stale backend's shutdownAll() kills the whole CLI
+ *      tree (fake CLI + its background child) — NO orphan;
+ *   3. SIGHUP: terminal-close signal on the backend still takes
+ *      the CLI tree down, now via the explicit SIGHUP handler (mandatory since
+ *      process-group isolation detached the CLI from the terminal's group);
+ *   4. residual gap (documented, not fixed here): SIGKILL of the backend
+ *      still orphans the CLI — recorded honestly for the issue write-up.
+ *
+ * Usage: node backend/test-harness/cli-process-tree.verify.mjs
+ * Artifacts (backend logs, fake-CLI log) land in $TMPDIR/cli-process-tree-verify/.
+ */
+import { spawn } from 'child_process';
+import { mkdirSync, writeFileSync, readFileSync, chmodSync, rmSync } from 'fs';
+import { join } from 'path';
+import os from 'os';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(new URL('../package.json', import.meta.url));
+const WebSocket = require('ws');
+
+const PORT = Number(process.env.CLI_TREE_PORT ?? 19837);
+const ROOT = join(process.env.TMPDIR || os.tmpdir(), 'cli-process-tree-verify');
+const HOME = join(ROOT, 'home');
+const PROJ = join(ROOT, 'proj');
+const CLI_LOG = join(ROOT, 'fake-cli.log');
+const BACKEND = fileURLToPath(new URL('../dist/backend.mjs', import.meta.url));
+
+const results = [];
+let failed = false;
+
+function report(name, ok, detail = '') {
+  results.push({ name, ok, detail });
+  if (!ok) failed = true;
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function pidAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitUntil(cond, timeoutMs, what) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await cond()) return true;
+    await delay(100);
+  }
+  throw new Error(`timeout waiting for: ${what}`);
+}
+
+// ── Fixture setup ────────────────────────────────────────────────────────────
+
+function setupFixtures() {
+  rmSync(ROOT, { recursive: true, force: true });
+  mkdirSync(join(HOME, '.claude-code-gui'), { recursive: true });
+  mkdirSync(join(ROOT, 'bin'), { recursive: true });
+  mkdirSync(PROJ, { recursive: true });
+
+  const fakeCli = join(ROOT, 'bin', 'claude');
+  // Worst-case CLI: ignores stdin EOF entirely, keeps a background child (the
+  // stand-in for subagent shells / background tasks), exits cleanly on SIGTERM.
+  writeFileSync(fakeCli, `#!/bin/bash
+log="\${FAKE_CLI_LOG:?}"
+pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+echo "started pid=$$ pgid=$pgid ppid=$PPID" >> "$log"
+sleep 600 &
+child=$!
+echo "child pid=$$ childpid=$child" >> "$log"
+trap 'echo "SIGTERM pid=$$" >> "$log"; kill $child 2>/dev/null; exit 0' TERM
+trap 'echo "SIGHUP pid=$$" >> "$log"' HUP
+while true; do sleep 1; done
+`);
+  chmodSync(fakeCli, 0o755);
+
+  writeFileSync(
+    join(HOME, '.claude-code-gui', 'settings.js'),
+    `export default {\n  cliPath: ${JSON.stringify(fakeCli)},\n};\n`,
+  );
+}
+
+// ── Backend + ws driving ─────────────────────────────────────────────────────
+
+const backends = [];
+
+function startBackend(label) {
+  const proc = spawn(process.execPath, [BACKEND], {
+    env: {
+      ...process.env,
+      HOME,
+      PORT: String(PORT),
+      FAKE_CLI_LOG: CLI_LOG,
+      JETBRAINS_MODE: '',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const record = { label, proc, stdout: '', stderr: '', exited: false };
+  proc.stdout.on('data', (d) => (record.stdout += d.toString()));
+  proc.stderr.on('data', (d) => (record.stderr += d.toString()));
+  proc.on('exit', () => (record.exited = true));
+  backends.push(record);
+  return record;
+}
+
+async function waitForPortLine(backend) {
+  await waitUntil(() => backend.stdout.includes(`PORT:${PORT}`), 15_000, `${backend.label} PORT line`);
+}
+
+/** Connect to /ws and SEND_MESSAGE; resolves with the open socket after ACK. */
+function driveSession(sessionId) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${PORT}/ws`);
+    const timer = setTimeout(() => reject(new Error('ws drive timeout')), 10_000);
+    ws.on('open', () => {
+      ws.send(
+        JSON.stringify({
+          type: 'SEND_MESSAGE',
+          requestId: `harness-${sessionId}`,
+          timestamp: Date.now(),
+          payload: {
+            content: 'lifecycle probe',
+            workingDir: PROJ,
+            sessionId,
+            isNewSession: true,
+            inputMode: 'text',
+          },
+        }),
+      );
+    });
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'ACK' || msg.type === 'STREAM_START') {
+        clearTimeout(timer);
+        resolve(ws);
+      }
+    });
+    ws.on('error', (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+  });
+}
+
+/** n-th (0-based) fake-CLI instance recorded in the log: { pid, pgid, child }. */
+function cliFromLog(index) {
+  const lines = readFileSync(CLI_LOG, 'utf8').trim().split('\n');
+  const started = lines.filter((l) => l.startsWith('started'))[index];
+  if (!started) return null;
+  const pid = Number(/pid=(\d+)/.exec(started)[1]);
+  const pgid = Number(/pgid=(\d+)/.exec(started)[1]);
+  const childLine = lines.filter((l) => l.startsWith(`child pid=${pid}`)).pop();
+  if (!childLine) return null; // start recorded, child not yet — treat as incomplete
+  return { pid, pgid, child: Number(/childpid=(\d+)/.exec(childLine)[1]) };
+}
+
+/** Wait until the n-th fake CLI has fully registered (started + child lines). */
+async function waitForCli(index, what) {
+  await waitUntil(() => {
+    try {
+      return cliFromLog(index) !== null;
+    } catch {
+      return false;
+    }
+  }, 10_000, what);
+  return cliFromLog(index);
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────────────
+
+async function main() {
+  setupFixtures();
+
+  // Scenario 1: spawn shape — detached chat CLI leads its own process group.
+  const a = startBackend('backend-A');
+  await waitForPortLine(a);
+  const wsA = await driveSession('harness-session-1');
+  const cliA = await waitForCli(0, 'fake CLI started under backend-A');
+  report('S1 fake CLI spawned', pidAlive(cliA.pid) && pidAlive(cliA.child));
+  report('S1 CLI is a process-group leader (pgid == pid)', cliA.pgid === cliA.pid,
+    `pid=${cliA.pid} pgid=${cliA.pgid}`);
+
+  // Scenario 2: double-start on the same port.
+  const b = startBackend('backend-B');
+  await waitForPortLine(b);
+  await waitUntil(() => a.exited, 10_000, 'backend-A exit after SIGTERM reclaim');
+  await waitUntil(() => !pidAlive(cliA.pid) && !pidAlive(cliA.child), 10_000, 'CLI tree of A dead');
+  report('S2 second backend reclaimed the port gracefully',
+    b.stderr.includes('already in use') && a.stderr.includes('SIGTERM received'));
+  report('S2 stale backend CLI tree died with it (no orphan)',
+    !pidAlive(cliA.pid) && !pidAlive(cliA.child));
+  report('S2 fake CLI observed SIGTERM (graceful, not SIGKILL)',
+    readFileSync(CLI_LOG, 'utf8').includes(`SIGTERM pid=${cliA.pid}`));
+  try {
+    wsA.terminate();
+  } catch {
+    // Socket already died with backend-A
+  }
+
+  // Scenario 3: SIGHUP on the backend (terminal close analog).
+  const wsB = await driveSession('harness-session-2');
+  const cliB = await waitForCli(1, 'fake CLI started under backend-B');
+  report('S3 fake CLI spawned under backend-B', pidAlive(cliB.pid) && pidAlive(cliB.child));
+  process.kill(b.proc.pid, 'SIGHUP');
+  await waitUntil(() => b.exited, 10_000, 'backend-B exit on SIGHUP');
+  await waitUntil(() => !pidAlive(cliB.pid) && !pidAlive(cliB.child), 10_000, 'CLI tree of B dead');
+  report('S3 SIGHUP handler shut the backend down', b.stderr.includes('SIGHUP received'));
+  report('S3 CLI tree died on SIGHUP (no orphan)', !pidAlive(cliB.pid) && !pidAlive(cliB.child));
+  try {
+    wsB.terminate();
+  } catch {
+    // Socket already died with backend-B
+  }
+
+  // Scenario 4: residual gap — SIGKILL of the backend still orphans the CLI.
+  const c = startBackend('backend-C');
+  await waitForPortLine(c);
+  const wsC = await driveSession('harness-session-3');
+  const cliC = await waitForCli(2, 'fake CLI started under backend-C');
+  report('S4 fake CLI spawned under backend-C', pidAlive(cliC.pid) && pidAlive(cliC.child));
+  process.kill(c.proc.pid, 'SIGKILL');
+  await waitUntil(() => c.exited, 5_000, 'backend-C SIGKILLed');
+  await delay(1_500);
+  report('S4 residual gap confirmed: SIGKILL of backend orphans the CLI (pid-registry territory)',
+    pidAlive(cliC.pid) && pidAlive(cliC.child));
+  try {
+    wsC.terminate();
+  } catch {
+    // Socket died with backend-C
+  }
+  // Manual cleanup of the intentional orphan.
+  try {
+    process.kill(-cliC.pid, 'SIGKILL');
+  } catch {
+    // Already gone
+  }
+
+  console.log('\nArtifacts in', ROOT);
+  console.log(failed ? 'RESULT: FAIL' : 'RESULT: ALL PASS');
+  process.exitCode = failed ? 1 : 0;
+}
+
+main()
+  .catch((err) => {
+    console.error('VERIFY ERROR:', err);
+    process.exitCode = 2;
+  })
+  .finally(() => {
+    for (const backend of backends) {
+      if (!backend.exited) {
+        try {
+          backend.proc.kill('SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    }
+    try {
+      for (let i = 0; ; i++) {
+        const cli = cliFromLog(i);
+        if (!cli) break;
+        try {
+          process.kill(-cli.pid, 'SIGKILL');
+        } catch {
+          // Already gone
+        }
+      }
+    } catch {
+      // No CLI ever started
+    }
+  });

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -196,6 +196,10 @@ class NodeProcessManager(
      * Start the Node.js backend process.
      */
     fun start() {
+        // The field is born STARTING, but a field initializer fires no listener —
+        // without this the status-bar dot never sees the STARTING phase (it keeps
+        // the last painted color, e.g. RED after a crash, until RUNNING/DEAD).
+        setLifecycle(Lifecycle.STARTING)
         // Everything here — node discovery, shell PATH capture, backend extraction —
         // can block for seconds (the `$SHELL -lic` capture is bounded only by a 10s
         // timeout). It must NOT run on the caller's thread (EDT): start() is reached
@@ -315,7 +319,11 @@ class NodeProcessManager(
 
                 val proc = pb.start()
                 process = proc
-                setLifecycle(Lifecycle.RUNNING)
+                // NOT RUNNING yet: the OS process exists but the server is still
+                // booting until it reports its PORT line (readStdout flips the
+                // lifecycle there). Flipping here made the STARTING (yellow) phase
+                // of the status-bar dot last mere milliseconds — the dot went
+                // straight to green while the backend was not even listening.
                 onProgress?.invoke(LoadingPhase.WAITING_FOR_PORT)
 
                 // Read stdout: first line is PORT, rest are logged
@@ -407,6 +415,10 @@ class NodeProcessManager(
                     val portNum = portStr.toIntOrNull()
                     if (portNum != null) {
                         logger.info("Node.js backend listening on port $portNum")
+                        // RUNNING means "listening on a known port". Set it BEFORE
+                        // completing the deferred: waiters resumed by complete() may
+                        // immediately read the lifecycle (portOf gates on RUNNING).
+                        setLifecycle(Lifecycle.RUNNING)
                         _portDeferred.complete(portNum)
                         portRead = true
                     } else {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -64,6 +64,26 @@ class NodeProcessManager(
      */
     private val onRestartRequested: (() -> Unit)? = null,
     /**
+     * Invoked when the backend Node process exits **cleanly on its own decision**
+     * (exit code 0 and NOT caused by [dispose]) — in practice the idle
+     * self-shutdown. The managing side must stand its reconnect/restart watchdog
+     * down (dispose the RPC client) instead of treating the silence as a crash:
+     * otherwise the RPC reconnect loop respawns the backend ~15 s after every
+     * idle shutdown, forever (the mode-D manual pass caught exactly that loop —
+     * and before the D2 idle-gate fix the respawned backend never armed its idle
+     * timer, so the same trigger used to leak one silent eternal backend
+     * instead). Crash exits (non-zero) keep the restart recovery; exit code 75
+     * keeps [onRestartRequested]. Called off the EDT inside the start() coroutine.
+     */
+    private val onIntentionalExit: (() -> Unit)? = null,
+    /**
+     * Invoked on every [Lifecycle] transition (STARTING → RUNNING → DEAD), so the
+     * status-bar widget can reflect backend liveness without polling. Called from
+     * whichever thread performs the transition (start() coroutine or dispose());
+     * the listener is responsible for marshalling to the UI thread.
+     */
+    private val onLifecycleChanged: ((Lifecycle) -> Unit)? = null,
+    /**
      * The shared, application-scoped extraction gate. The plugin's webview/backend
      * resources are extracted once per (IDE product, plugin version) by
      * [com.github.yhk1038.claudecodegui.services.NodeBackendService]; every backend
@@ -117,6 +137,20 @@ class NodeProcessManager(
 
     @Volatile
     private var lifecycle = Lifecycle.STARTING
+
+    /** Current [Lifecycle] — read by the status-bar widget alongside [onLifecycleChanged]. */
+    val currentLifecycle: Lifecycle
+        get() = lifecycle
+
+    private fun setLifecycle(value: Lifecycle) {
+        lifecycle = value
+        try {
+            onLifecycleChanged?.invoke(value)
+        } catch (e: Exception) {
+            // A UI listener failure must never break process management.
+            logger.warn("onLifecycleChanged listener threw", e)
+        }
+    }
 
     // True once dispose() has run. dispose() destroys the process (typically SIGTERM →
     // exit 143), and also sets lifecycle = DEAD up front — so the natural exit observed
@@ -182,7 +216,7 @@ class NodeProcessManager(
                         "  3. Or set the NODE_PATH_OVERRIDE environment variable to your node binary " +
                         "(e.g. ~/.nvm/versions/node/v24.16.0/bin/node)."
                 )
-                lifecycle = Lifecycle.DEAD
+                setLifecycle(Lifecycle.DEAD)
                 _portDeferred.completeExceptionally(
                     IllegalStateException("Node.js executable not found")
                 )
@@ -204,7 +238,7 @@ class NodeProcessManager(
                 }
             if (resources == null) {
                 logger.error("Plugin resources not ready (extraction gate absent or timed out).")
-                lifecycle = Lifecycle.DEAD
+                setLifecycle(Lifecycle.DEAD)
                 _portDeferred.completeExceptionally(
                     IllegalStateException("Plugin resources not ready")
                 )
@@ -281,7 +315,7 @@ class NodeProcessManager(
 
                 val proc = pb.start()
                 process = proc
-                lifecycle = Lifecycle.RUNNING
+                setLifecycle(Lifecycle.RUNNING)
                 onProgress?.invoke(LoadingPhase.WAITING_FOR_PORT)
 
                 // Read stdout: first line is PORT, rest are logged
@@ -313,7 +347,7 @@ class NodeProcessManager(
 
                 // Wait for process to exit and log the result
                 val exitCode = proc.waitFor()
-                lifecycle = Lifecycle.DEAD
+                setLifecycle(Lifecycle.DEAD)
                 logger.info("Node.js backend exited with code $exitCode")
 
                 if (!_portDeferred.isCompleted) {
@@ -333,11 +367,20 @@ class NodeProcessManager(
                         // A restart callback failure must not escape the start() coroutine.
                         logger.warn("onRestartRequested callback threw", e)
                     }
+                } else if (isIntentionalExit(exitCode, disposed)) {
+                    // Clean self-exit (idle shutdown): the managing side stands its
+                    // RPC reconnect/restart watchdog down instead of respawning.
+                    logger.info("Node.js backend exited intentionally (code 0) — not a crash")
+                    try {
+                        onIntentionalExit?.invoke()
+                    } catch (e: Exception) {
+                        logger.warn("onIntentionalExit callback threw", e)
+                    }
                 }
             } catch (e: CancellationException) {
                 // Normal shutdown
             } catch (e: Exception) {
-                lifecycle = Lifecycle.DEAD
+                setLifecycle(Lifecycle.DEAD)
                 logger.error("Failed to start Node.js backend", e)
                 if (!_portDeferred.isCompleted) {
                     _portDeferred.completeExceptionally(e)
@@ -555,7 +598,7 @@ class NodeProcessManager(
         // in start() must see this flag set, so it suppresses the restart callback for this
         // intentional shutdown rather than respawning a backend we're trying to kill.
         disposed = true
-        lifecycle = Lifecycle.DEAD
+        setLifecycle(Lifecycle.DEAD)
 
         stdoutJob?.cancel()
         stderrJob?.cancel()
@@ -613,5 +656,14 @@ class NodeProcessManager(
          */
         fun shouldRequestRestart(exitCode: Int, disposed: Boolean): Boolean =
             exitCode == RESTART_EXIT_CODE && !disposed
+
+        /**
+         * A clean exit the backend chose for itself (idle self-shutdown = exit 0),
+         * as opposed to a [dispose]-driven kill (SIGTERM → 143, `disposed` set) or
+         * a crash (any other non-zero code). Only this case stands the RPC
+         * reconnect/restart watchdog down — crash recovery stays untouched.
+         */
+        fun isIntentionalExit(exitCode: Int, disposed: Boolean): Boolean =
+            exitCode == 0 && !disposed
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -7,11 +7,13 @@ import com.github.yhk1038.claudecodegui.bridge.RpcWebSocketClient
 import com.github.yhk1038.claudecodegui.bridge.WslPathResolver
 import com.github.yhk1038.claudecodegui.bridge.parseHostModeParam
 import com.github.yhk1038.claudecodegui.hosting.HostModeCache
+import com.github.yhk1038.claudecodegui.settings.KeepAliveSetting
 import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.ProjectManager
 import kotlinx.coroutines.*
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.add
@@ -19,6 +21,7 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CopyOnWriteArrayList
 
 /**
  * Application-level service that manages **one Node.js backend per IDE project
@@ -49,6 +52,31 @@ class NodeBackendService : Disposable {
 
     // key = IDE 프로젝트 루트 (project.basePath)
     private val backends = ConcurrentHashMap<String, BackendInstance>()
+
+    /**
+     * Listeners notified (with the affected project root) whenever a backend's
+     * lifecycle changes or the keep-alive toggle flips — the status-bar widget's
+     * update signal. Called from arbitrary threads; listeners marshal to the EDT.
+     */
+    private val stateListeners = CopyOnWriteArrayList<(String) -> Unit>()
+
+    fun addBackendStateListener(listener: (String) -> Unit) {
+        stateListeners.add(listener)
+    }
+
+    fun removeBackendStateListener(listener: (String) -> Unit) {
+        stateListeners.remove(listener)
+    }
+
+    private fun fireBackendStateChanged(basePath: String) {
+        for (listener in stateListeners) {
+            try {
+                listener(basePath)
+            } catch (e: Exception) {
+                logger.warn("Backend state listener threw", e)
+            }
+        }
+    }
 
     /**
      * Application-scoped resource-extraction gate (issue #149). The plugin's webview
@@ -218,6 +246,14 @@ class NodeBackendService : Disposable {
                 // @Synchronized and runs stop()+start(), so it can't re-enter the start()
                 // that is still in progress, and lastPort is reused for a seamless reconnect.
                 onRestartRequested = { restart() },
+                // Clean self-exit (idle shutdown): stand the RPC reconnect/restart
+                // watchdog down — otherwise it treats the silence as a crash and
+                // respawns the backend ~15 s after EVERY idle shutdown, forever.
+                // The next panel open / eager start respawns on demand as usual.
+                onIntentionalExit = { releaseRpcClientAfterIntentionalExit() },
+                // Status-bar widget signal: every lifecycle transition of this root's
+                // backend re-renders the widgets watching this root.
+                onLifecycleChanged = { fireBackendStateChanged(basePath) },
                 // Shared extraction gate: the manager awaits this instead of extracting its
                 // own temp dir, so all backend generations share one live dir (#149).
                 resourcesReady = resourcesReady,
@@ -250,7 +286,11 @@ class NodeBackendService : Disposable {
                 scope,
                 Router(),
                 onPersistentFailure = { restart() },
-                onConnected = { registerRoot() },
+                // Re-assert the desired keep-alive state on EVERY (re)connect — this
+                // covers fresh spawns, exit-75 respawns and RPC reconnects, and a
+                // `false` push arms the backend's idle timer when it has no /ws
+                // clients yet (closing the pre-existing prewarm leak).
+                onConnected = { registerRoot(); pushKeepAlive() },
                 // Route RPC-handling failures to the single Kotlin reporting point. This
                 // backend is connected (the error came over its socket), so prefer it.
                 onError = { throwable, where -> reportError(throwable, where, basePath) },
@@ -291,10 +331,59 @@ class NodeBackendService : Disposable {
             rpcClient?.sendNotification("REGISTER_PROJECT_ROOTS", params)
         }
 
+        /**
+         * Push the EFFECTIVE keep-alive state to this backend's idle-shutdown gate:
+         * the global toggle holds the gate up only while this backend's project is
+         * open in the IDE. Closing the project window re-pushes (via
+         * [BackendProjectCloseListener]) and the recomputed `false` restores the
+         * idle regime — the same keep-alive clamp the ppid watchdog applies on IDE death,
+         * just per project. Without this, every closed project window would leave
+         * an immortal backend behind (one per project opened during the session).
+         * A live browser session still keeps the backend alive (open /ws clients
+         * block the idle timer); only a client-less backend retires after 60 s.
+         *
+         * Always sent, `false` included — idempotent on the backend side, and the
+         * `false` push is what arms the idle timer on a backend that never received
+         * a /ws client (the prewarm-leak fix). The method literal mirrors the shared
+         * MessageType enum on the TS side (SET_KEEP_ALIVE).
+         */
+        fun pushKeepAlive() {
+            val projectOpen = ProjectManager.getInstance().openProjects.any { it.basePath == basePath }
+            val params = buildJsonObject { put("enabled", KeepAliveSetting.get() && projectOpen) }
+            rpcClient?.sendNotification("SET_KEEP_ALIVE", params)
+        }
+
+        /** Current process lifecycle, or null when no manager exists (never started). */
+        fun lifecycleOrNull(): NodeProcessManager.Lifecycle? = nodeProcessManager?.currentLifecycle
+
+        /** The bound port, or null while not RUNNING / not yet known. */
+        fun portOrNull(): Int? {
+            if (nodeProcessManager?.currentLifecycle != NodeProcessManager.Lifecycle.RUNNING) return null
+            // lastPort is written the moment the PORT line arrives; 0 = not yet known.
+            return lastPort.takeIf { it != 0 }
+        }
+
         @Synchronized
         fun restart() {
             stop()
             start()
+        }
+
+        /**
+         * The backend exited cleanly by its own decision (idle self-shutdown, exit 0).
+         * Dispose the RPC client so its reconnect loop cannot escalate into a full
+         * backend restart — that loop is crash RECOVERY, and this exit is not a crash.
+         * Guard: skip when a newer backend generation is already alive (a racing
+         * restart owns the current rpcClient; its connect() manages it).
+         */
+        @Synchronized
+        fun releaseRpcClientAfterIntentionalExit() {
+            if (nodeProcessManager?.isAlive == true) return
+            rpcClient?.dispose(); rpcClient = null
+            logger.info(
+                "Backend for '$basePath' retired (idle shutdown) — RPC watchdog stood down; " +
+                    "the next panel open / eager start respawns it",
+            )
         }
 
         fun sendNotification(method: String, params: JsonObject) {
@@ -336,6 +425,57 @@ class NodeBackendService : Disposable {
     }
 
     /**
+     * Start the backend for [projectBasePath] WITHOUT registering any panel handler
+     * (eager start — keep-alive ON, project opened, no JCEF yet). No-op when
+     * the backend is already running.
+     *
+     * Deliberately not the `ensureStarted(…, NoopRpcHandler)` prewarm pattern: that
+     * registers a permanent handler, and Router.any() picks an arbitrary one — a
+     * lingering no-op handler could shadow a real panel's handler and silently
+     * swallow openFile/applyDiff.
+     */
+    @Synchronized
+    fun startEager(projectBasePath: String) {
+        if (projectBasePath.isBlank()) return
+        val inst = backends.getOrPut(projectBasePath) { BackendInstance(projectBasePath) }
+        inst.start()
+        // Reopen path: when the backend survived a project close (live browser
+        // clients) and its RPC socket never dropped, onConnected won't fire again —
+        // re-push so the gate reflects "project open" once more. No-op before the
+        // RPC connect (the fresh-spawn case is covered by onConnected).
+        inst.pushKeepAlive()
+    }
+
+    /**
+     * Current backend lifecycle for [projectBasePath]; null = no backend was ever
+     * started for that root (the widget renders this as "stopped").
+     */
+    fun lifecycleOf(projectBasePath: String): NodeProcessManager.Lifecycle? =
+        backends[projectBasePath]?.lifecycleOrNull()
+
+    /** Bound port for [projectBasePath]'s backend, or null while not running. */
+    fun portOf(projectBasePath: String): Int? = backends[projectBasePath]?.portOrNull()
+
+    /**
+     * The single entry point for flipping the "Keep backend running" toggle (both
+     * the Settings page and the status-bar card call this): persists the value,
+     * eagerly starts a backend for every open project when turning ON, pushes the
+     * new gate state to every RPC-connected backend, and refreshes the widgets.
+     * Turning OFF restores the idle-shutdown regime backend-side (the push arms
+     * the timer on client-less backends).
+     */
+    fun applyKeepAlive(enabled: Boolean) {
+        KeepAliveSetting.set(enabled)
+        val openRoots = ProjectManager.getInstance().openProjects.mapNotNull { it.basePath }
+        if (enabled) {
+            openRoots.forEach { startEager(it) }
+        }
+        backends.values.forEach { it.pushKeepAlive() }
+        (openRoots + backends.keys).distinct().forEach { fireBackendStateChanged(it) }
+        logger.info("Keep-alive toggle applied: $enabled (open roots: ${openRoots.size}, backends: ${backends.size})")
+    }
+
+    /**
      * Register a loading-progress [listener] for [panelId] so the panel can mirror the
      * backend's start sub-phases in its placeholder. Register BEFORE [ensureStarted] so
      * the first phase emitted by start() is not missed. See issue #97.
@@ -357,6 +497,20 @@ class NodeBackendService : Disposable {
      */
     fun recentBackendDiagnostics(projectBasePath: String): String? =
         backends[projectBasePath]?.recentDiagnostics()
+
+    /**
+     * Per-project keep-alive clamp, invoked by [BackendProjectCloseListener] after a
+     * project window closes. Re-pushes the effective keep-alive state — which
+     * [BackendInstance.pushKeepAlive] now computes as `false` (project no longer
+     * open) — so a client-less backend retires after the usual 60 s instead of
+     * outliving its window until IDE exit. A backend with live browser clients
+     * keeps running until they disconnect (keep-alive promise kept).
+     */
+    fun clampAfterProjectClose(projectBasePath: String) {
+        val inst = backends[projectBasePath]?.takeIf { it.isRpcReady() } ?: return
+        inst.pushKeepAlive()
+        logger.info("Project '$projectBasePath' closed — keep-alive gate released (idle regime restored)")
+    }
 
     /** Restart the backend for [projectBasePath] (retry path). */
     @Synchronized

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/ClaudeCodeSettingsConfigurable.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/ClaudeCodeSettingsConfigurable.kt
@@ -1,5 +1,6 @@
 package com.github.yhk1038.claudecodegui.settings
 
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
 import com.intellij.openapi.options.Configurable
 import com.intellij.openapi.ui.DialogPanel
 import com.intellij.ui.dsl.builder.*
@@ -17,6 +18,7 @@ class ClaudeCodeSettingsConfigurable : Configurable {
     // UI 바인딩용 임시 변수
     private var cliPath: String = ""
     private var nodePath: String = ""
+    private var keepBackendRunning: Boolean = false
 
     override fun getDisplayName(): String = "Claude Code"
 
@@ -24,6 +26,7 @@ class ClaudeCodeSettingsConfigurable : Configurable {
         // 현재 설정값 로드
         cliPath = settings.get("cliPath")?.jsonPrimitive?.contentOrNull ?: ""
         nodePath = settings.get("nodePath")?.jsonPrimitive?.contentOrNull ?: ""
+        keepBackendRunning = KeepAliveSetting.get()
 
         panel = panel {
             group("CLI Configuration") {
@@ -40,6 +43,18 @@ class ClaudeCodeSettingsConfigurable : Configurable {
                         .comment("Path to the Node.js executable that runs the backend. Leave empty for auto-detection. Restart required after change.")
                 }
             }
+            group("Backend") {
+                row {
+                    checkBox("Keep backend running")
+                        .bindSelected(::keepBackendRunning)
+                        .comment(
+                            "Starts the backend when a project opens and keeps it running for " +
+                                "browser access (the URL is shown in the status-bar widget), until " +
+                                "the IDE exits. Off: the backend starts on demand and shuts down " +
+                                "when idle."
+                        )
+                }
+            }
         }
         return panel!!
     }
@@ -52,11 +67,18 @@ class ClaudeCodeSettingsConfigurable : Configurable {
             "cliPath" to if (cliPath.isBlank()) JsonNull else JsonPrimitive(cliPath),
             "nodePath" to if (nodePath.isBlank()) JsonNull else JsonPrimitive(nodePath)
         ))
+        // Route through the single toggle entry point (eager start + RPC pushes +
+        // widget refresh) — but only on a real change, so unrelated settings edits
+        // don't re-fire eager starts.
+        if (keepBackendRunning != KeepAliveSetting.get()) {
+            NodeBackendService.getInstance().applyKeepAlive(keepBackendRunning)
+        }
     }
 
     override fun reset() {
         cliPath = settings.get("cliPath")?.jsonPrimitive?.contentOrNull ?: ""
         nodePath = settings.get("nodePath")?.jsonPrimitive?.contentOrNull ?: ""
+        keepBackendRunning = KeepAliveSetting.get()
         panel?.reset()
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/KeepAliveSetting.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/KeepAliveSetting.kt
@@ -1,0 +1,53 @@
+package com.github.yhk1038.claudecodegui.settings
+
+import com.intellij.ide.util.PropertiesComponent
+
+/**
+ * Global "Keep backend running" toggle.
+ *
+ * ON: every project's backend starts eagerly with the project (no JCEF needed)
+ * and its idle shutdown is gated off while the IDE lives — the backend stays
+ * reachable for plain-browser clients. OFF: today's lazy-start behaviour with
+ * the idle shutdown active.
+ *
+ * Stored in the application-level [PropertiesComponent] (the [com.github.yhk1038.claudecodegui.hosting.HostModeCache]
+ * pattern), NOT in `settings.js`: the value is consumed synchronously by Kotlin
+ * before any backend exists (the project-open eager-start decision), and on
+ * WSL2 the settings file lives under the Linux home the JVM cannot reliably
+ * read. The backend never reads this from disk — Kotlin pushes the state over
+ * RPC (SET_KEEP_ALIVE) on every connect and on every toggle.
+ *
+ * The logic talks to a [Store] abstraction so it is unit-testable with an
+ * in-memory fake.
+ */
+object KeepAliveSetting {
+
+    /** The PropertiesComponent key the toggle is persisted under. */
+    private const val KEY = "com.github.yhk1038.claudecodegui.keepBackendRunning"
+
+    /** Minimal persistence backend, so the logic can be tested without the IDE. */
+    interface Store {
+        fun read(): Boolean
+        fun write(value: Boolean)
+    }
+
+    /** Production [Store] backed by the application-level [PropertiesComponent]. */
+    private object PropertiesComponentStore : Store {
+        override fun read(): Boolean = PropertiesComponent.getInstance().getBoolean(KEY, false)
+        override fun write(value: Boolean) = PropertiesComponent.getInstance().setValue(KEY, value, false)
+    }
+
+    fun get(store: Store): Boolean = store.read()
+
+    fun set(store: Store, value: Boolean) = store.write(value)
+
+    /** Read the toggle from the production PropertiesComponent store. */
+    fun get(): Boolean = get(PropertiesComponentStore)
+
+    /**
+     * Persist the toggle. Pure storage — side effects (eager start, RPC pushes,
+     * widget refresh) live in [com.github.yhk1038.claudecodegui.services.NodeBackendService.applyKeepAlive],
+     * the single toggle entry point.
+     */
+    fun set(value: Boolean) = set(PropertiesComponentStore, value)
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/BackendKeepAliveActivity.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/BackendKeepAliveActivity.kt
@@ -1,0 +1,27 @@
+package com.github.yhk1038.claudecodegui.startup
+
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.github.yhk1038.claudecodegui.settings.KeepAliveSetting
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.startup.ProjectActivity
+
+/**
+ * Keep-alive eager start: when the global "Keep backend running" toggle is ON, the
+ * project's backend spawns together with the project — no JCEF panel needed —
+ * so browser clients can reach it right away (the URL is surfaced in the
+ * status-bar card).
+ *
+ * The close counterpart is [BackendProjectCloseListener]: closing the project
+ * window releases the keep-alive gate for that backend (per-project keep-alive
+ * clamp) — a browser user with a live session keeps it alive, a client-less
+ * backend retires after 60 s. IDE death is additionally covered backend-side
+ * by the ppid watchdog.
+ */
+class BackendKeepAliveActivity : ProjectActivity {
+
+    override suspend fun execute(project: Project) {
+        if (!KeepAliveSetting.get()) return
+        val basePath = project.basePath ?: return
+        NodeBackendService.getInstance().startEager(basePath)
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/BackendProjectCloseListener.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/startup/BackendProjectCloseListener.kt
@@ -1,0 +1,24 @@
+package com.github.yhk1038.claudecodegui.startup
+
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.ProjectCloseListener
+
+/**
+ * Per-project keep-alive clamp (the close counterpart of
+ * [BackendKeepAliveActivity]). Without it, every project window closed with
+ * "Keep backend running" ON would leave an immortal backend behind until IDE
+ * exit — a real workday over dozens of projects piles up dozens of orphan
+ * Node processes (found in manual testing).
+ *
+ * The clamp only re-pushes the keep-alive gate — it never kills the process —
+ * so a browser session that is still using the backend keeps it alive; a
+ * client-less backend retires after the normal 60 s idle grace.
+ */
+class BackendProjectCloseListener : ProjectCloseListener {
+
+    override fun projectClosed(project: Project) {
+        val basePath = project.basePath ?: return
+        NodeBackendService.getInstance().clampAfterProjectClose(basePath)
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendDotState.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendDotState.kt
@@ -1,0 +1,55 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager.Lifecycle
+
+/**
+ * Pure presentation logic for the backend status-bar widget dot. The dot encodes ONLY the runtime state — the mode/toggle is
+ * carried by the tooltip and the card, never by the color:
+ *
+ *  - GREEN  — backend process running,
+ *  - YELLOW — starting/restarting,
+ *  - GRAY   — not running and that is normal (keep-alive off: starts on
+ *             demand, stops when idle; also: never started yet),
+ *  - RED    — error ONLY: keep-alive is ON yet the backend process died
+ *             (crash/crash-loop). Never shown in the on-demand regime.
+ *
+ * Free of any IDE API so it is unit-testable (see BackendDotStateTest).
+ */
+object BackendDotState {
+
+    enum class DotState { GREEN, YELLOW, GRAY, RED }
+
+    /**
+     * @param lifecycle current process lifecycle, or null when no backend was
+     *   ever started for the project root.
+     * @param keepAlive the global "Keep backend running" toggle.
+     */
+    fun compute(lifecycle: Lifecycle?, keepAlive: Boolean): DotState = when (lifecycle) {
+        Lifecycle.RUNNING -> DotState.GREEN
+        Lifecycle.STARTING -> DotState.YELLOW
+        Lifecycle.DEAD -> if (keepAlive) DotState.RED else DotState.GRAY
+        // Never started: normal before the first panel (keep-alive off) and a
+        // momentary state before the eager-start activity runs (keep-alive on) —
+        // not an error either way.
+        null -> DotState.GRAY
+    }
+
+    /** Widget tooltip: state + mode, e.g. `CCG Backend (Running, keep-alive)`. */
+    fun tooltip(lifecycle: Lifecycle?, keepAlive: Boolean): String {
+        val state = when (compute(lifecycle, keepAlive)) {
+            DotState.GREEN -> if (keepAlive) "Running, keep-alive" else "Running"
+            DotState.YELLOW -> "Starting…"
+            DotState.GRAY -> if (keepAlive) "Not running — keep-alive on" else "Stopped — starts on demand"
+            DotState.RED -> "Dead — keep-alive on, backend exited"
+        }
+        return "CCG Backend ($state)"
+    }
+
+    /** The card's "Backend:" line, e.g. `running (port 63412)`. */
+    fun cardStateLine(lifecycle: Lifecycle?, keepAlive: Boolean, port: Int?): String = when (lifecycle) {
+        Lifecycle.RUNNING -> if (port != null) "running (port $port)" else "running"
+        Lifecycle.STARTING -> "starting…"
+        Lifecycle.DEAD, null ->
+            if (keepAlive) "not running (keep-alive on)" else "stopped (starts on demand)"
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusBarWidget.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusBarWidget.kt
@@ -1,0 +1,76 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.github.yhk1038.claudecodegui.settings.KeepAliveSetting
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBar
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.ui.JBColor
+import com.intellij.util.Consumer
+import com.intellij.util.ui.ColorIcon
+import java.awt.event.MouseEvent
+import javax.swing.Icon
+
+/**
+ * Status-bar dot for the project root's backend.
+ * Useful in EVERY mode, not only D: it is a window into backend liveness
+ * without opening the sidebar. The dot encodes pure runtime state
+ * ([BackendDotState]); clicking opens the [BackendStatusPopup] card.
+ *
+ * Each project window's widget tracks its own root's backend (one backend per
+ * `project.basePath`); updates arrive over [NodeBackendService]'s state
+ * listeners — no polling.
+ */
+class BackendStatusBarWidget(private val project: Project) : StatusBarWidget, StatusBarWidget.IconPresentation {
+
+    private val service = NodeBackendService.getInstance()
+    private var statusBar: StatusBar? = null
+
+    private val stateListener: (String) -> Unit = { changedBasePath ->
+        if (changedBasePath == project.basePath) {
+            ApplicationManager.getApplication().invokeLater {
+                statusBar?.updateWidget(ID())
+            }
+        }
+    }
+
+    override fun ID(): String = WIDGET_ID
+
+    override fun getPresentation(): StatusBarWidget.WidgetPresentation = this
+
+    override fun install(statusBar: StatusBar) {
+        this.statusBar = statusBar
+        service.addBackendStateListener(stateListener)
+    }
+
+    override fun dispose() {
+        service.removeBackendStateListener(stateListener)
+        statusBar = null
+    }
+
+    override fun getIcon(): Icon {
+        val dot = BackendDotState.compute(lifecycle(), KeepAliveSetting.get())
+        val color = when (dot) {
+            BackendDotState.DotState.GREEN -> JBColor(0x59A869, 0x499C54)
+            BackendDotState.DotState.YELLOW -> JBColor(0xEDA200, 0xF0A732)
+            BackendDotState.DotState.GRAY -> JBColor(0x9AA7B0, 0x6E6E6E)
+            BackendDotState.DotState.RED -> JBColor(0xDB5860, 0xC75450)
+        }
+        return ColorIcon(ICON_SIZE, color)
+    }
+
+    override fun getTooltipText(): String =
+        BackendDotState.tooltip(lifecycle(), KeepAliveSetting.get())
+
+    override fun getClickConsumer(): Consumer<MouseEvent> = Consumer { event ->
+        BackendStatusPopup(project).showAbove(event.component)
+    }
+
+    private fun lifecycle() = project.basePath?.let { service.lifecycleOf(it) }
+
+    companion object {
+        const val WIDGET_ID = "ClaudeCodeGui.BackendStatus"
+        private const val ICON_SIZE = 10
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusBarWidgetFactory.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusBarWidgetFactory.kt
@@ -1,0 +1,20 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.wm.StatusBarWidget
+import com.intellij.openapi.wm.StatusBarWidgetFactory
+
+/**
+ * Registers the backend status dot in every project window's status bar.
+ * Public platform API only.
+ */
+class BackendStatusBarWidgetFactory : StatusBarWidgetFactory {
+
+    override fun getId(): String = BackendStatusBarWidget.WIDGET_ID
+
+    override fun getDisplayName(): String = "Claude Code GUI Backend"
+
+    override fun isAvailable(project: Project): Boolean = true
+
+    override fun createWidget(project: Project): StatusBarWidget = BackendStatusBarWidget(project)
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusClient.kt
@@ -1,0 +1,71 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.intellij.openapi.diagnostic.Logger
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+/**
+ * Blocking client for the backend's `GET /internal/status` endpoint (loopback
+ * only). Called off the EDT by the status-bar card's refresh alarm; every
+ * failure maps to null so a dying backend degrades to "no counters" instead of
+ * an error. The payload mirrors backend/src/ws/status-route.ts.
+ */
+object BackendStatusClient {
+
+    private val logger = Logger.getInstance(BackendStatusClient::class.java)
+
+    @Serializable
+    data class ConnectionStats(
+        val total: Int,
+        val panels: Int,
+        val tunnels: Int,
+        val browsers: Int,
+    )
+
+    @Serializable
+    data class SessionStats(
+        val total: Int,
+        val streaming: Int,
+    )
+
+    @Serializable
+    data class BackendStatus(
+        val keepAlive: Boolean,
+        val connections: ConnectionStats,
+        val sessions: SessionStats,
+    )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // HTTP/1.1 is mandatory: the default (HTTP_2) sends an h2c upgrade request
+    // (`Connection: Upgrade, HTTP2-Settings`), and the backend's HTTP server has a
+    // WebSocket 'upgrade' handler that destroys the socket of every non-WebSocket
+    // upgrade — the fetch then dies with "EOF reached while reading" before any
+    // response arrives (curl works because it never attempts the upgrade).
+    private val httpClient: HttpClient = HttpClient.newBuilder()
+        .version(HttpClient.Version.HTTP_1_1)
+        .connectTimeout(Duration.ofMillis(1_000))
+        .build()
+
+    /** Fetch the status snapshot from the backend on [port], or null on any failure. */
+    fun fetch(port: Int): BackendStatus? {
+        return try {
+            val request = HttpRequest.newBuilder()
+                .uri(URI.create("http://127.0.0.1:$port/internal/status"))
+                .timeout(Duration.ofMillis(1_500))
+                .GET()
+                .build()
+            val response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+            if (response.statusCode() != 200) return null
+            json.decodeFromString<BackendStatus>(response.body())
+        } catch (e: Exception) {
+            logger.debug("GET /internal/status failed on port $port", e)
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusPopup.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendStatusPopup.kt
@@ -1,0 +1,238 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.github.yhk1038.claudecodegui.services.NodeBackendService
+import com.github.yhk1038.claudecodegui.settings.ClaudeCodeSettingsConfigurable
+import com.github.yhk1038.claudecodegui.settings.KeepAliveSetting
+import com.intellij.icons.AllIcons
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.ide.CopyPasteManager
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.popup.JBPopup
+import com.intellij.openapi.ui.popup.JBPopupFactory
+import com.intellij.ui.components.ActionLink
+import com.intellij.ui.components.JBCheckBox
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.awt.RelativePoint
+import com.intellij.ui.components.panels.VerticalLayout
+import com.intellij.util.Alarm
+import com.intellij.util.ui.JBUI
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.Point
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import javax.swing.Timer
+
+/**
+ * The status-bar widget's popup card:
+ *
+ * ```
+ * Claude Code GUI Backend                      ⚙
+ * [x] Keep backend running
+ * Backend: running (port 63412)
+ * 3 connections: 2 × IDE panel, 1 × browser
+ * 2 sessions, 1 actively streaming
+ * http://127.0.0.1:63412 ↗                [copy]
+ * ```
+ *
+ * Kotlin-side state (lifecycle, port, toggle) renders immediately; the counter
+ * lines come from `GET /internal/status`, fetched on open and refreshed every
+ * [REFRESH_INTERVAL_MS] while the popup is visible (pooled thread, EDT update).
+ * All UI text is English only.
+ */
+class BackendStatusPopup(private val project: Project) {
+
+    private val service = NodeBackendService.getInstance()
+    private val basePath: String? = project.basePath
+
+    private val keepAliveBox = JBCheckBox("Keep backend running")
+    private val stateLabel = JBLabel()
+    private val connectionsLabel = JBLabel()
+    private val sessionsLabel = JBLabel()
+    private val urlLink = ActionLink("") { BrowserUtil.browse(currentUrl ?: return@ActionLink) }
+    private val copyLink: ActionLink = ActionLink("Copy") {
+        currentUrl?.let {
+            CopyPasteManager.copyTextToClipboard(it)
+            showCopyFeedback()
+        }
+    }.apply {
+        // Reserve the width of the wider "Copied!" feedback text up front: the
+        // card is only re-laid-out by the periodic pack(), so a text that grows
+        // the link mid-flash would render clipped (looking like the label just
+        // vanished) until the next 2 s tick resized the whole card around it.
+        text = "Copied!"
+        preferredSize = preferredSize
+        text = "Copy"
+    }
+
+    @Volatile
+    private var currentUrl: String? = null
+
+    private var popup: JBPopup? = null
+    private var anchor: Component? = null
+
+    /** Create the popup and show it just above [component] (the status-bar dot). */
+    fun showAbove(component: Component) {
+        anchor = component
+        val popup = createPopup()
+        popup.show(anchorPoint(component, popup.content.preferredSize))
+    }
+
+    /**
+     * Popup top-left corner for a given card [size]: bottom edge just above the
+     * anchor, RIGHT edge aligned with the anchor's right edge. The status bar sits
+     * at the window's bottom-right, so the card must grow leftwards into the IDE —
+     * left-edge alignment made it overflow the IDE window onto the desktop
+     * (the platform's own status-bar cards, e.g. MCP Server, open the same way).
+     */
+    private fun anchorPoint(a: Component, size: Dimension): RelativePoint =
+        RelativePoint(a, Point(a.width - size.width, -size.height))
+
+    /** The clipboard write has no visible effect of its own — flash the link text. */
+    private fun showCopyFeedback() {
+        copyLink.text = "Copied!"
+        Timer(COPY_FEEDBACK_MS) { copyLink.text = "Copy" }.apply {
+            isRepeats = false
+            start()
+        }
+    }
+
+    private fun createPopup(): JBPopup {
+        // First render from Kotlin-side state BEFORE the popup is built: the popup
+        // is sized from the content's preferred size at creation, so empty labels
+        // would produce a clipped card (the counter lines then grow it via pack()).
+        val initialLifecycle = basePath?.let { service.lifecycleOf(it) }
+        val initialPort = basePath?.let { service.portOf(it) }
+        currentUrl = initialPort?.let { "http://127.0.0.1:$it" }
+        stateLabel.text = "Backend: " + BackendDotState.cardStateLine(initialLifecycle, KeepAliveSetting.get(), initialPort)
+        connectionsLabel.isVisible = false
+        sessionsLabel.isVisible = false
+        urlLink.text = currentUrl ?: ""
+
+        keepAliveBox.isSelected = KeepAliveSetting.get()
+        keepAliveBox.addActionListener {
+            val enabled = keepAliveBox.isSelected
+            // applyKeepAlive spawns backends / touches sockets — keep it off the EDT.
+            ApplicationManager.getApplication().executeOnPooledThread {
+                service.applyKeepAlive(enabled)
+                refresh()
+            }
+        }
+
+        val gear = ActionLink("") {
+            ShowSettingsUtil.getInstance()
+                .showSettingsDialog(project, ClaudeCodeSettingsConfigurable::class.java)
+        }
+        gear.icon = AllIcons.General.Settings
+        gear.toolTipText = "Open Claude Code settings"
+
+        val titleRow = JPanel(BorderLayout()).apply {
+            isOpaque = false
+            add(JBLabel("Claude Code GUI Backend").apply { font = JBUI.Fonts.label().asBold() }, BorderLayout.WEST)
+            add(gear, BorderLayout.EAST)
+        }
+
+        val urlRow = JPanel(FlowLayout(FlowLayout.LEFT, JBUI.scale(8), 0)).apply {
+            isOpaque = false
+            add(urlLink)
+            add(copyLink)
+        }
+
+        val content = JPanel(VerticalLayout(JBUI.scale(6))).apply {
+            border = JBUI.Borders.empty(10, 12)
+            add(titleRow)
+            add(keepAliveBox)
+            add(stateLabel)
+            add(connectionsLabel)
+            add(sessionsLabel)
+            add(urlRow)
+        }
+
+        val popup = JBPopupFactory.getInstance()
+            .createComponentPopupBuilder(content, keepAliveBox)
+            .setRequestFocus(true)
+            .setCancelOnClickOutside(true)
+            .createPopup()
+        this.popup = popup
+
+        // Periodic counter refresh while the popup is visible; the popup is the
+        // parent disposable, so closing it cancels the alarm.
+        val alarm = Alarm(Alarm.ThreadToUse.POOLED_THREAD, popup)
+        lateinit var tick: () -> Unit
+        tick = {
+            refresh()
+            if (!alarm.isDisposed) alarm.addRequest(tick, REFRESH_INTERVAL_MS)
+        }
+        alarm.addRequest(tick, 0)
+
+        return popup
+    }
+
+    /**
+     * Recompute every card line. Runs on a pooled thread (may block on the HTTP
+     * fetch); label mutations are marshalled to the EDT.
+     */
+    private fun refresh() {
+        val lifecycle = basePath?.let { service.lifecycleOf(it) }
+        val keepAlive = KeepAliveSetting.get()
+        val port = basePath?.let { service.portOf(it) }
+        val status = port?.let { BackendStatusClient.fetch(it) }
+
+        val stateText = "Backend: " + BackendDotState.cardStateLine(lifecycle, keepAlive, port)
+        val connectionsText = status?.let { formatConnections(it.connections) } ?: ""
+        val sessionsText = status?.let { formatSessions(it.sessions) } ?: ""
+        val url = port?.let { "http://127.0.0.1:$it" }
+
+        SwingUtilities.invokeLater {
+            currentUrl = url
+            keepAliveBox.isSelected = keepAlive
+            stateLabel.text = stateText
+            connectionsLabel.text = connectionsText
+            connectionsLabel.isVisible = connectionsText.isNotEmpty()
+            sessionsLabel.text = sessionsText
+            sessionsLabel.isVisible = sessionsText.isNotEmpty()
+            urlLink.text = url ?: ""
+            urlLink.parent?.isVisible = url != null
+            // Counter lines appear asynchronously and can be wider than the initial
+            // content — grow the popup to fit instead of clipping the text. pack()
+            // keeps the top-left corner, so a height change would detach the card
+            // from the status-bar dot below it — re-anchor the bottom edge after.
+            // The anchor math MUST use preferredSize, not content.height: the window
+            // resize requested by pack() lands asynchronously, so content.height is
+            // still the pre-pack value here — anchoring on it left the grown card
+            // covering the status bar until the next 2 s tick (D2 manual pass 3).
+            popup?.takeIf { it.isVisible }?.let { p ->
+                p.pack(true, true)
+                anchor?.takeIf { it.isShowing }?.let { a ->
+                    p.setLocation(anchorPoint(a, p.content.preferredSize).screenPoint)
+                }
+            }
+        }
+    }
+
+    private fun formatConnections(stats: BackendStatusClient.ConnectionStats): String {
+        if (stats.total == 0) return "No connections"
+        val parts = buildList {
+            if (stats.panels > 0) add("${stats.panels} × IDE panel")
+            if (stats.browsers > 0) add("${stats.browsers} × browser")
+            if (stats.tunnels > 0) add("${stats.tunnels} × tunnel")
+        }
+        val noun = if (stats.total == 1) "connection" else "connections"
+        return "${stats.total} $noun: ${parts.joinToString(", ")}"
+    }
+
+    private fun formatSessions(stats: BackendStatusClient.SessionStats): String {
+        if (stats.total == 0) return "No sessions"
+        val noun = if (stats.total == 1) "session" else "sessions"
+        return "${stats.total} $noun, ${stats.streaming} actively streaming"
+    }
+
+    companion object {
+        private const val REFRESH_INTERVAL_MS = 2_000
+        private const val COPY_FEEDBACK_MS = 1_500
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -93,6 +93,11 @@
         <!-- Tab icon badge for unread streaming completions -->
         <fileIconPatcher
             implementation="com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileIconPatcher"/>
+
+        <!-- Backend liveness dot + status card in the status bar -->
+        <statusBarWidgetFactory
+            id="ClaudeCodeGui.BackendStatus"
+            implementation="com.github.yhk1038.claudecodegui.statusbar.BackendStatusBarWidgetFactory"/>
     </extensions>
 
     <!-- Prewarm version-scoped resource extraction at app frame creation (issue #149) -->

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -75,6 +75,11 @@
         <postStartupActivity
             implementation="com.github.yhk1038.claudecodegui.startup.IdeSelectionActivity"/>
 
+        <!-- Keep-alive eager start: spawn the project's backend on project open (no JCEF)
+             when the global "Keep backend running" toggle is ON -->
+        <postStartupActivity
+            implementation="com.github.yhk1038.claudecodegui.startup.BackendKeepAliveActivity"/>
+
         <!-- WebView resource server -->
         <httpRequestHandler
             implementation="com.github.yhk1038.claudecodegui.toolwindow.WebViewRequestHandler"/>
@@ -95,6 +100,11 @@
         <listener
             class="com.github.yhk1038.claudecodegui.startup.ResourceExtractionPrewarmActivity"
             topic="com.intellij.ide.AppLifecycleListener"/>
+        <!-- Per-project keep-alive clamp: release the keep-alive gate when a project
+             window closes so its backend cannot outlive the window forever -->
+        <listener
+            class="com.github.yhk1038.claudecodegui.startup.BackendProjectCloseListener"
+            topic="com.intellij.openapi.project.ProjectCloseListener"/>
     </applicationListeners>
 
     <!-- Clean up session state only on real tab close (not on tab move/split) -->

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManagerLifecycleTest.kt
@@ -99,4 +99,28 @@ class NodeProcessManagerLifecycleTest {
         assertFalse(NodeProcessManager.shouldRequestRestart(143, disposed = false))
         assertFalse(NodeProcessManager.shouldRequestRestart(1, disposed = false))
     }
+
+    @Test
+    fun `isIntentionalExit is true only for a clean self-exit`() {
+        // Exit 0 with no dispose = the backend retired on its own (idle shutdown).
+        // Only this case stands the RPC reconnect/restart watchdog down — treating
+        // it as a crash respawned the backend ~15 s after every idle shutdown,
+        // forever (the D2 manual-pass restart loop).
+        assertTrue(
+            NodeProcessManager.isIntentionalExit(0, disposed = false),
+            "a clean self-exit must stand the RPC watchdog down",
+        )
+    }
+
+    @Test
+    fun `isIntentionalExit is false for dispose-driven and crash exits`() {
+        // dispose() kills on purpose (and typically yields 143, but even a 0 with the
+        // flag set is ours); any non-zero code is a crash and must keep the
+        // reconnect→restart recovery path intact.
+        assertFalse(NodeProcessManager.isIntentionalExit(0, disposed = true))
+        assertFalse(NodeProcessManager.isIntentionalExit(143, disposed = false))
+        assertFalse(NodeProcessManager.isIntentionalExit(137, disposed = false))
+        assertFalse(NodeProcessManager.isIntentionalExit(75, disposed = false))
+        assertFalse(NodeProcessManager.isIntentionalExit(1, disposed = false))
+    }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/KeepAliveSettingTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/KeepAliveSettingTest.kt
@@ -1,0 +1,39 @@
+package com.github.yhk1038.claudecodegui.settings
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure-logic tests for [KeepAliveSetting], the global "Keep backend running"
+ * toggle. The logic talks to a [KeepAliveSetting.Store] abstraction
+ * (the HostModeCache pattern), so it runs as a plain unit test with an
+ * in-memory fake store.
+ */
+class KeepAliveSettingTest {
+
+    /** In-memory [KeepAliveSetting.Store] standing in for the PropertiesComponent. */
+    private class FakeStore(var value: Boolean = false) : KeepAliveSetting.Store {
+        override fun read(): Boolean = value
+        override fun write(value: Boolean) { this.value = value }
+    }
+
+    @Test
+    fun `defaults to false (today's lazy-start behaviour)`() {
+        assertFalse(KeepAliveSetting.get(FakeStore()))
+    }
+
+    @Test
+    fun `set true is read back as true`() {
+        val store = FakeStore()
+        KeepAliveSetting.set(store, true)
+        assertTrue(KeepAliveSetting.get(store))
+    }
+
+    @Test
+    fun `set false after true restores the default regime`() {
+        val store = FakeStore(value = true)
+        KeepAliveSetting.set(store, false)
+        assertFalse(KeepAliveSetting.get(store))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendDotStateTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/statusbar/BackendDotStateTest.kt
@@ -1,0 +1,49 @@
+package com.github.yhk1038.claudecodegui.statusbar
+
+import com.github.yhk1038.claudecodegui.bridge.NodeProcessManager.Lifecycle
+import com.github.yhk1038.claudecodegui.statusbar.BackendDotState.DotState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * The dot encodes pure runtime state; the mode/toggle never changes the color
+ * except for the single error case (keep-alive ON + process dead). RED must
+ * never appear in the on-demand regime — a stopped backend is normal there.
+ */
+class BackendDotStateTest {
+
+    @Test
+    fun `full state matrix`() {
+        // lifecycle, keepAlive -> expected dot
+        assertEquals(DotState.GREEN, BackendDotState.compute(Lifecycle.RUNNING, false))
+        assertEquals(DotState.GREEN, BackendDotState.compute(Lifecycle.RUNNING, true))
+        assertEquals(DotState.YELLOW, BackendDotState.compute(Lifecycle.STARTING, false))
+        assertEquals(DotState.YELLOW, BackendDotState.compute(Lifecycle.STARTING, true))
+        assertEquals(DotState.GRAY, BackendDotState.compute(Lifecycle.DEAD, false))
+        assertEquals(DotState.RED, BackendDotState.compute(Lifecycle.DEAD, true))
+        assertEquals(DotState.GRAY, BackendDotState.compute(null, false))
+        // Never-started with keep-alive ON is a momentary pre-eager-start state,
+        // not an error — the dot stays calm.
+        assertEquals(DotState.GRAY, BackendDotState.compute(null, true))
+    }
+
+    @Test
+    fun `tooltip carries state and mode`() {
+        assertEquals("CCG Backend (Running, keep-alive)", BackendDotState.tooltip(Lifecycle.RUNNING, true))
+        assertEquals("CCG Backend (Running)", BackendDotState.tooltip(Lifecycle.RUNNING, false))
+        assertEquals("CCG Backend (Starting…)", BackendDotState.tooltip(Lifecycle.STARTING, false))
+        assertEquals("CCG Backend (Stopped — starts on demand)", BackendDotState.tooltip(Lifecycle.DEAD, false))
+        assertEquals("CCG Backend (Stopped — starts on demand)", BackendDotState.tooltip(null, false))
+        assertEquals("CCG Backend (Not running — keep-alive on)", BackendDotState.tooltip(null, true))
+        assertEquals("CCG Backend (Dead — keep-alive on, backend exited)", BackendDotState.tooltip(Lifecycle.DEAD, true))
+    }
+
+    @Test
+    fun `card state line`() {
+        assertEquals("running (port 63412)", BackendDotState.cardStateLine(Lifecycle.RUNNING, false, 63412))
+        assertEquals("running", BackendDotState.cardStateLine(Lifecycle.RUNNING, false, null))
+        assertEquals("starting…", BackendDotState.cardStateLine(Lifecycle.STARTING, true, null))
+        assertEquals("stopped (starts on demand)", BackendDotState.cardStateLine(Lifecycle.DEAD, false, null))
+        assertEquals("not running (keep-alive on)", BackendDotState.cardStateLine(null, true, null))
+    }
+}

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -334,6 +334,13 @@ export enum MessageType {
    * routing. params: { hostMode: string }.
    */
   HOST_MODE_CHANGED = 'HOST_MODE_CHANGED',
+  /**
+   * Kotlin → Node notification toggling the idle-shutdown gate ("keep backend
+   * running"). Kotlin pushes the desired state on every RPC (re)connect
+   * and on user toggle; the backend's parent watchdog flips the gate back off
+   * when the IDE process dies. params: { enabled: boolean }.
+   */
+  SET_KEEP_ALIVE = 'SET_KEEP_ALIVE',
 
   // ───────────────────────────────────────────────────────────────────────
   // Logging channel (webview LogForwarder → backend log-ws)


### PR DESCRIPTION
PoC for #188. **Stacked on #187** — see the stacking note
below.

This also fixes #190

## What this is (and is not)

This is a **working proof of concept** of the core of #188: an
explicit backend lifecycle policy instead of the hardcoded 60 s idle self-shutdown.
It is submitted as a draft to give the proposal something concrete to poke at — I
expect the design discussion to happen on the issue, and I'd rather rework this
branch on my side than have it patched in place (hence "allow edits" is off).
It intentionally does NOT touch `SESSION_CLEANUP_GRACE_MS` (the 30 s
no-subscriber safety net — see proposal point 3 in the issue) and does not add any
`settings.js` keys (proposal-only there).

## Stacking note

This branch is built on top of #187 (disabling the idle shutdown is only
safe once CLI lifetime is hard-bound to backend lifetime). Until that PR merges,
this PR's diff shows its 6 commits too — **review from
[`31ee66b`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/31ee66b18b6575526503b2176a1eb3d779a361b6)
(the keep-alive gate) onward**, 7 commits total.

## The 7 commits

1. [`31ee66b`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/31ee66b18b6575526503b2176a1eb3d779a361b6)
   **keep-alive gate** — new `MessageType.SET_KEEP_ALIVE` (Node↔Kotlin RPC): while
   the gate is up, the backend never schedules the zero-connection idle
   self-shutdown. Pushed by the IDE on every RPC (re)connect and on user toggle.
2. [`b89032a`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/b89032adca494bfad49a2496ab76fb5ae595451c)
   **standalone default** — a backend started without `JETBRAINS_MODE` boots with
   the gate up: the idle shutdown is never armed in standalone; the operator owns
   the lifetime (Ctrl+C → the existing graceful shutdown). Also collapses the old
   asymmetry (never-connected lives forever vs disconnected dies after 60 s) into
   one rule.
3. [`b9f6159`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/b9f6159e5894b827b6cfb50442092fb8130c33a5)
   **ppid watchdog** — in JetBrains mode a 10 s ppid poll detects the parent IDE's
   death (reparenting to init/subreaper, or ESRCH on the probe; fires at most once,
   then disarms) and flips the gate back down: a kept-alive backend must not
   outlive the IDE unattended. This is also the fix for the never-connected-backend leak
   (#190).
4. [`5a0542a`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/5a0542a05ee33612bbc050edbbe8c73c8dfd163e)
   **`GET /internal/status`** — introspection endpoint (loopback-bound under the
   default host; note that an active Remote Tunnel proxies it like every
   `/internal/*` route — read-only counters, no secrets): gate state, connection
   breakdown (IDE panels / browsers / tunnel clients), session + turn-based
   streaming counters. Consumed by the widget card; reusable by the exit-dialog
   extension.
5. [`fb5c66e`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/fb5c66eaed765cba0cd67ae35197dff20541dc12)
   **real-process harness** — `node backend/test-harness/backend-lifecycle.verify.mjs`:
   the built backend spawned under a killable fake parent (standing in for the IDE
   JVM) with a fake `claude` binary; scenarios sit through the real 60 s grace and
   kill the parent to watch the watchdog react. Zero token burn.
6. [`28e9ee7`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/28e9ee7230d3c1b2a8ff630b4ac2770281cc947e)
   **Kotlin toggle + eager start** — application-level "Keep backend running"
   setting; eager backend spawn at project startup; the keep-alive push on every
   RPC (re)connect; a per-project clamp on window close (the pushed gate value is
   `toggle && project still open`); the RPC watchdog stands down on an intentional
   backend self-exit (an idle shutdown is not a crash — prevents an endless
   respawn loop that would fight the gate).
7. [`9138991`](https://github.com/lukaszszczesniak/claude-code-gui-jetbrains/commit/9138991e412b36569e153d1d7da508827ecfcc25)
   **status-bar widget + card** — public platform API only
   (`StatusBarWidgetFactory`); dot = pure runtime state (red ONLY for keep-alive ON
   + process dead), mode in the tooltip; the card shows the counters from
   `/internal/status` (2 s poll only while the popup is open), clickable URL + copy
   button.

## User-visible behavior (summary)

- The status-bar dot shows **pure runtime state**: green = running, yellow =
  starting, gray = stopped (normal under auto-shutdown — not an error), red
  **only** for keep-alive ON + backend dead. Mode details live in the tooltip,
  not the color.
- The card: keep-alive checkbox (same setting as in Settings), backend state +
  port, connection breakdown (IDE panels / browsers / Remote Tunnel clients),
  session + actively-streaming counters, clickable URL with a copy button, and a
  settings shortcut — so the IDE-spawned backend is usable from a plain browser
  without fishing the port out of logs.
- **Toggle OFF (default): today's behavior, untouched** — lazy start with the
  first panel, 60 s idle stop. Toggle ON: eager start per project window and no
  idle stop while that project stays open; closing the window releases that
  project's keep-alive (live browser clients still keep the backend alive);
  IDE death — crash included — restores the auto-shutdown regime via the
  watchdog.
- Keep-alive warms the **backend process** only: the 30 s per-session cleanup
  after the last subscriber disconnects is untouched, so sessions never run
  unattended in the background.

## Verification

- Unit suites: backend vitest + webview lint (mirrored `shared/message-type.ts`) +
  Kotlin gradle — green at every commit.
- The scripted harness (commit 5): gate semantics, watchdog clamp with/without live
  `/ws` clients (parent SIGKILLed), never-connected-leak fix, status counters —
  all green at the tip, with scenarios sitting through the real 60 s grace.
- Manual in-IDE passes went through several rounds during development; the fixes
  they surfaced are folded into the relevant commits (widget timing, per-project
  clamp, watchdog stand-down, HTTP/1.1 for the JVM-side status client — see
  #191).

## API note

`ProjectCloseListener` (used by the per-project clamp) is marked
`@ApiStatus.Experimental` in 2024.2-era SDKs — the Plugin Verifier reports it as a
**warning, not an error** — and is no longer experimental in 2026.2, so it is
already de facto stabilized upstream. Happy to swap the mechanism if you prefer a
different hook.

## Checklist before undrafting

- [ ] Manual in-IDE pass (toggle / widget / clamp scenarios) on 2024.2 and
      IntelliJ IDEA Community
- [ ] Design feedback on #188 folded in
