### PR TITLE
fix: make backend + webview test suites hermetic (#192, #193)

### DIFF
--- a/backend/src/core/features/telemetry.test.ts
+++ b/backend/src/core/features/telemetry.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { MessageType } from '../../shared';
 
+// config/environment를 hoisted mock으로 대체하고, telemetry가 읽는 API 키만 holder로
+// 주입한다. process.env(_CCG_RYBBIT_API_KEY) 전역 stub을 쓰지 않는 이유: process.env는
+// 워커 프로세스 전역이라 다른 테스트 파일과 공유되고, vitest 병렬 실행 시 이 파일이 읽기
+// 직전에 원복/오염될 수 있다 → RYBBIT_API_KEY 빈 값 → send() 조기 return → flush 후
+// fetch 0회로 산발 실패(#192). holder는 파일-로컬이라 그 전역 경합에서 완전히 벗어난다.
+// (profile은 파일마다 값이 다르므로 loadTelemetry 내 doMock으로 계속 주입한다 — hoisted
+// vi.mock과 비-hoisted vi.doMock을 분리해야 서로 간섭하지 않는다.)
+const envHolder = vi.hoisted(() => ({ apiKey: '' }));
+vi.mock('../../config/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../config/environment')>();
+  return {
+    ...actual,
+    get CCG_RYBBIT_API_KEY() {
+      return envHolder.apiKey;
+    },
+  };
+});
+
 // 동의 상태별 전송 게이팅 검증. profile/settings/version을 주입한 뒤 telemetry 모듈을
 // 동적 import하여(모듈 로드 시 API key를 const로 고정하므로) fetch 호출 여부를 본다.
 // trackEvent/trackError는 fire-and-forget(void)이라 flushTelemetry()로 결정적으로 기다린다.
@@ -38,9 +56,9 @@ async function loadTelemetry(
   fetchImpl?: (input: string, init: { body: string }) => Promise<unknown>,
 ) {
   vi.resetModules();
-  // 빌드 박제 키는 `_` prefix(.env의 _CCG_RYBBIT_API_KEY). environment.ts가
-  // process.env._CCG_RYBBIT_API_KEY를 const로 평가하므로 import 전에 stub한다.
-  vi.stubEnv('_CCG_RYBBIT_API_KEY', apiKey);
+  // hoisted environment mock의 CCG_RYBBIT_API_KEY getter가 반환할 값을 이 파일에 주입한다
+  // (process.env 전역을 건드리지 않음 — 상단 mock 주석 참고).
+  envHolder.apiKey = apiKey;
   vi.doMock('./profile', () => ({
     readProfile: async () => profile,
     ConsentStatus: CONSENT_ENUM,
@@ -60,7 +78,6 @@ async function loadTelemetry(
 
 describe('telemetry consent gating', () => {
   afterEach(async () => {
-    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.doUnmock('./profile');
     vi.doUnmock('../handlers/getVersion');
@@ -140,7 +157,6 @@ describe('telemetry consent gating', () => {
 
 describe('trackActivity (활동 단일 진입점)', () => {
   afterEach(async () => {
-    vi.unstubAllEnvs();
     vi.unstubAllGlobals();
     vi.doUnmock('./profile');
     vi.doUnmock('../handlers/getVersion');

--- a/webview/src/__tests__/setup.ts
+++ b/webview/src/__tests__/setup.ts
@@ -1,2 +1,68 @@
 import 'reflect-metadata';
 import '@testing-library/jest-dom/vitest';
+
+// ---------------------------------------------------------------------------
+// Hermetic browser-env guarantees (issue #193)
+//
+// The webview suite runs under jsdom, but a couple of browser globals are not
+// dependable across the Node/jsdom versions contributors run on:
+//   - `localStorage`/`sessionStorage` can be `undefined` on some Node+jsdom
+//     combos. That surfaced directly as "Cannot read properties of undefined
+//     (reading 'setItem')" and indirectly as theme/dir tests failing — a
+//     swallowed seed write left components rendering on their defaults.
+//   - jsdom never implements `matchMedia`, so any code path that reaches it
+//     (e.g. SYSTEM theme resolution) throws unless a test stubs it first.
+//
+// We install deterministic implementations here so a red always means a real
+// regression, regardless of the host environment. Individual tests remain free
+// to re-define these (the descriptors are `configurable`/`writable`).
+// ---------------------------------------------------------------------------
+
+function createStorageMock(): Storage {
+  const store = new Map<string, string>();
+  return {
+    get length() {
+      return store.size;
+    },
+    clear() {
+      store.clear();
+    },
+    getItem(key: string): string | null {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    key(index: number): string | null {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    removeItem(key: string): void {
+      store.delete(key);
+    },
+    setItem(key: string, value: string): void {
+      store.set(String(key), String(value));
+    },
+  } as Storage;
+}
+
+function installStorage(name: 'localStorage' | 'sessionStorage'): void {
+  const mock = createStorageMock();
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value: mock });
+  if (typeof window !== 'undefined') {
+    Object.defineProperty(window, name, { configurable: true, writable: true, value: mock });
+  }
+}
+
+installStorage('localStorage');
+installStorage('sessionStorage');
+
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  const matchMediaStub = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }) as MediaQueryList;
+  Object.defineProperty(window, 'matchMedia', { configurable: true, writable: true, value: matchMediaStub });
+}

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Gmail/__tests__/formatGmailDate.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Gmail/__tests__/formatGmailDate.test.ts
@@ -4,6 +4,10 @@ import {formatGmailDate} from '../_shared/helpers';
 // Fixed reference point: 2026-06-24 10:00:00 local time
 const NOW = new Date('2026-06-24T10:00:00');
 
+// Pin the formatting locale so month/day rendering does not depend on the
+// host's system locale (issue #193 — Polish "gru"/"sty" broke /Dec|Jan/).
+const LOCALE = 'en-US';
+
 describe('formatGmailDate', () => {
     describe('fallback cases', () => {
         it('returns empty string when value is undefined', () => {
@@ -24,7 +28,7 @@ describe('formatGmailDate', () => {
         it('omits year, month, and day for a mail sent today', () => {
             // Same year, month, day as NOW (2026-06-24)
             const todayMail = '2026-06-24T01:01:00';
-            const result = formatGmailDate(todayMail, NOW);
+            const result = formatGmailDate(todayMail, NOW, LOCALE);
             // Should NOT contain year
             expect(result).not.toMatch(/2026/);
             // Should NOT contain month indicator (e.g. '6월' or 'Jun')
@@ -40,7 +44,7 @@ describe('formatGmailDate', () => {
         it('omits year and month for a mail sent this month', () => {
             // Same year+month (2026-06), different day (9)
             const thisMonthMail = '2026-06-09T01:01:00';
-            const result = formatGmailDate(thisMonthMail, NOW);
+            const result = formatGmailDate(thisMonthMail, NOW, LOCALE);
             // Should NOT contain year
             expect(result).not.toMatch(/2026/);
             // Should NOT contain month indicator
@@ -56,7 +60,7 @@ describe('formatGmailDate', () => {
         it('omits year but includes month for a mail sent this year in a different month', () => {
             // Same year (2026), different month (January)
             const thisYearMail = '2026-01-15T08:30:00';
-            const result = formatGmailDate(thisYearMail, NOW);
+            const result = formatGmailDate(thisYearMail, NOW, LOCALE);
             // Should NOT contain year
             expect(result).not.toMatch(/2026/);
             // Should contain month indicator (1월 or Jan)
@@ -71,7 +75,7 @@ describe('formatGmailDate', () => {
     describe('different year — shows full date including year', () => {
         it('includes year for a mail from a previous year', () => {
             const lastYearMail = '2025-12-25T09:00:00';
-            const result = formatGmailDate(lastYearMail, NOW);
+            const result = formatGmailDate(lastYearMail, NOW, LOCALE);
             // Should contain year
             expect(result).toMatch(/2025/);
             // Should contain month indicator
@@ -84,7 +88,7 @@ describe('formatGmailDate', () => {
 
         it('includes year for a mail from a future year', () => {
             const futureYearMail = '2027-03-10T14:00:00';
-            const result = formatGmailDate(futureYearMail, NOW);
+            const result = formatGmailDate(futureYearMail, NOW, LOCALE);
             expect(result).toMatch(/2027/);
         });
     });

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Gmail/_shared/helpers.ts
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Gmail/_shared/helpers.ts
@@ -25,8 +25,12 @@ export function safeParseJson<T>(text: string): T | undefined {
  *
  * Falls back to the original string when it is not a parseable date, so the
  * original Claude Code value is never lost. Never throws.
+ *
+ * `locale` defaults to `undefined`, i.e. the host locale — production keeps
+ * following the user's environment. Tests pass an explicit BCP-47 locale so
+ * their assertions do not depend on the machine's system locale (issue #193).
  */
-export function formatGmailDate(value?: string, now: Date = new Date()): string {
+export function formatGmailDate(value?: string, now: Date = new Date(), locale?: string): string {
     if (!value) return '';
     const date = new Date(value);
     if (Number.isNaN(date.getTime())) return value;
@@ -43,7 +47,7 @@ export function formatGmailDate(value?: string, now: Date = new Date()): string 
     if (!sameMonth) opts.month = 'short';
     if (!sameYear) opts.year = 'numeric';
 
-    return date.toLocaleString(undefined, opts);
+    return date.toLocaleString(locale, opts);
 }
 
 /**


### PR DESCRIPTION
## Summary

Two sibling issues — the default test suites were not a reliable regression signal — fixed as two independent commits.

### #193 — webview suite not hermetic across host locale / browser globals
`webview/src/__tests__/setup.ts` left the suite exposed to the host environment, so **33 tests failed on a non-English/Korean machine** (Polish locale). Three disjoint mechanisms:

- **Locale leak**: `formatGmailDate` used `toLocaleString(undefined, …)`; assertions like `/Dec|Jan/i` broke on Polish `gru`/`sty`. Added an optional `locale` param (production still follows the user's locale via `undefined`) and pinned `en-US` in the test.
- **`localStorage`/`sessionStorage` undefined** on some Node+jsdom combos — broke storage tests directly and theme/dir tests indirectly (a swallowed seed write left components on their defaults). Installed a deterministic in-memory `Storage` in the shared setup.
- **`matchMedia`** is never implemented by jsdom — added a default stub in setup.

Verified: full webview suite is **1356 passed / 0 failed under `LC_ALL=pl_PL.UTF-8`** (previously 33 failed / 1323 passed).

### #192 — telemetry.test.ts flakes under the parallel backend suite
The API-key gate was driven via `vi.stubEnv` on the shared `_CCG_RYBBIT_API_KEY`. `process.env` is a per-worker global, so under the full parallel suite a sibling file could revert/clobber it right as telemetry's dynamic import read it → `RYBBIT_API_KEY` became empty → `send()` returned early → "expected N calls, got 0 after flush", sporadically and on a different test each run.

Replaced the `process.env` stub with a **hoisted `vi.mock` of `config/environment`** whose `CCG_RYBBIT_API_KEY` getter returns a file-local holder value. The suite no longer touches `process.env` at all, so it cannot race a sibling file. Production code is unchanged.

Verified: solo 14/14; full backend suite 665/665 across repeated `--pool=threads` runs; passes even with a poisoned or empty `_CCG_RYBBIT_API_KEY` in the real `process.env`.

Closes #192
Closes #193