### PR TITLE
fix(webview): dark-mode scrollbars render light on Windows/Linux (#200)

### DIFF
--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -83,6 +83,13 @@
    Semantic Color Tokens — Light (default :root)
    ============================================ */
 :root {
+  /* Tell the UA to paint its built-in widgets (scrollbars, form controls,
+     spellcheck underlines) with the light palette. Without this the browser
+     defaults to light regardless of our tokens — harmless on macOS overlay
+     scrollbars, but on Windows/Linux Chromium & JCEF the classic scrollbar is
+     always drawn, so it renders light-on-dark in dark mode (issue #200). */
+  color-scheme: light;
+
   /* Surface
      Solid tokens carry an `-rgb` channel source (space-separated R G B) so
      Tailwind utilities can apply `/NN` opacity modifiers. The legacy hex name
@@ -219,6 +226,11 @@
    Semantic Color Tokens — Dark
    ============================================ */
 .dark {
+  /* Dark counterpart of the :root declaration — makes the UA render scrollbars
+     and other built-in widgets with the dark palette, fixing the light
+     scrollbar seen on Windows/Linux Chromium & JCEF in dark mode (issue #200). */
+  color-scheme: dark;
+
   --surface-base-rgb:    26 26 26;
   --surface-base:        rgb(var(--surface-base-rgb));
   --surface-raised-rgb:  30 30 33;


### PR DESCRIPTION
## Summary

In dark mode the scrollbars were painted with the **light** palette, clashing with the dark UI. Reported in #200 (screenshots show a light scrollbar on both the document and the composer input on Windows/Chromium).

## Root cause

`webview/src/index.css` never declared `color-scheme`. Without it, the browser renders its built-in widgets (scrollbars, form controls) using the light scheme regardless of our design tokens.

- **macOS** uses overlay scrollbars, so this was invisible during development.
- **Windows / Linux Chromium & JCEF** always draw a classic scrollbar, so it showed up as light-on-dark.

## Fix

Declare `color-scheme` alongside the existing token blocks:

- `:root { color-scheme: light; }`
- `.dark { color-scheme: dark; }`

`.dark` lives on `<html>`, so the document scrollbar and **every nested scroller (the composer included)** inherit the correct palette. This is the standard, root-cause fix — no `::-webkit-scrollbar` overrides or scrollbar-width changes — and it covers macOS, Windows, Linux, JCEF and Firefox at once.

## Note

`color-scheme: dark` also aligns the default colors of native form controls in dark mode. The webview's inputs are almost all custom components, so the impact is negligible (and where it applies, it looks more natural in dark mode).

## Verification

- `wv-lint` (type check) passes
- `wv-build` succeeds; built bundle contains both `color-scheme:dark` and `color-scheme:light`
- macOS cannot reproduce the Windows classic scrollbar locally, so the color change was not screenshot-verified; `color-scheme` is standardized CSS with deterministic behavior.

Fixes #200