### PR TITLE
feat: authenticate the WebSocket control channel (token + device pairing)

### DIFF
--- a/backend/esbuild.mjs
+++ b/backend/esbuild.mjs
@@ -34,6 +34,14 @@ const common = {
   external: [],
   define: {
     '__PLUGIN_VERSION__': JSON.stringify(pkg.version),
+    // The esbuild bundle (backend.mjs) is by definition the shipped, production
+    // artifact — dev runs `src/server.ts` through tsx (`pnpm dev`) and never the
+    // bundle. Bake NODE_ENV=production so isDev()/isProd() are reliable at
+    // runtime even though the launchers (Kotlin spawn, ccg foreground.sh) clear
+    // or omit NODE_ENV. This is what lets the per-launch auth token default to a
+    // RANDOM secret in production (never the shared dev token) when
+    // CCG_AUTH_TOKEN is somehow unset — see backend/src/config/environment.ts.
+    'process.env.NODE_ENV': JSON.stringify('production'),
     // Keys defined in the root .env, injected at build time — never committed
     // as source constants.
     ...injectedDefine,

--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -1,4 +1,5 @@
 import { existsSync } from 'fs';
+import { randomBytes } from 'crypto';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -35,6 +36,32 @@ export const serverPort = parseInt(process.env.PORT ?? String(DEFAULT_PORT), 10)
 // ws-server가 strict same-origin 완화를 함께 켠다(ws-server.ts::startWebSocketServer).
 const DEFAULT_HOST = '127.0.0.1';
 export const serverHost = process.env.CCG_BIND?.trim() || DEFAULT_HOST;
+
+// ── 제어 채널 인증 토큰 ───────────────────────────────────
+// /ws · /rpc · /logs 제어 채널과 /internal/* 푸시를 인증하는 인증 토큰.
+// 인증이 없으면 포트에 닿는 임의 클라이언트가 bypass 권한으로 Claude 세션을
+// 시작할 수 있어 RCE가 된다(제보 배경).
+//
+// 소유권(중요): 이제 토큰은 **런처(Kotlin 플러그인 / ccg CLI)가 소유하는 STABLE
+// per-machine 토큰**이다. 런처가 디스크에 영속화한 비밀(→ HMAC 파생)로 안정적인
+// 토큰을 만들어 CCG_AUTH_TOKEN env로 백엔드에 주입한다. 백엔드는 그 값을 그대로
+// 소비할 뿐, 비밀을 디스크에서 읽거나 생성하지 않는다(디스크-비밀 로직은 런처의 몫).
+// 프로덕션(JetBrains/ccg)에서는 런처가 항상 CCG_AUTH_TOKEN을 주입하므로 아래
+// randomBytes 분기는 어떤 부트스트랩도 토큰을 주지 못했을 때의 안전 폴백일 뿐이다.
+// serverHost와 동일하게 모듈 로드 시 1회 평가되는 상수라 프로세스 수명 내내 같은
+// 값이 쓰인다. 주의: 이 값은 절대 로그로 출력하지 않는다.
+//
+// dev 편의(footgun 없이): 로컬 Vite 개발에서는 부트스트랩(Kotlin/foreground.sh)이
+// 없어 CCG_AUTH_TOKEN이 주입되지 않는다. 이때 dev에 한해 고정 dev 토큰을 기본값으로
+// 써서 webview(import.meta.env.VITE_CCG_DEV_TOKEN 미설정 시 동일 상수)와 짝이 맞게
+// 한다. 이 고정값은 의도적으로 안전하지 않은 개발 전용 값이며, 프로덕션(dev 신호 없음)
+// 에서는 절대 쓰이지 않고 랜덤 토큰으로 폴백한다. dev 신호는 isDev()(NODE_ENV)로 판정
+// 하며, 배포 번들(backend.mjs)은 esbuild가 NODE_ENV='production'을 박제하므로
+// 프로덕션에서 isDev()는 확실히 false다(backend/esbuild.mjs 참조). webview 연결 빌더가
+// 이 토큰을 Sec-WebSocket-Protocol 헤더(`['ccg-auth', token]`)로 부착한다.
+const DEV_INSECURE_AUTH_TOKEN = 'ccg-dev-insecure-token';
+export const authToken = process.env.CCG_AUTH_TOKEN?.trim()
+  || (isDev() ? DEV_INSECURE_AUTH_TOKEN : randomBytes(32).toString('hex'));
 
 // ── 재기동 신호 ─────────────────────────────────────────
 // "플러그인 재기동"의 통일 신호. 프론트엔드 실행환경(브라우저 환경/JetBrains)이나

--- a/backend/src/core/features/__tests__/tunnel-pairing.test.ts
+++ b/backend/src/core/features/__tests__/tunnel-pairing.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import {
+  TunnelPairingStore,
+  buildPairingUrl,
+  PAIRING_CODE_TTL_MS,
+  PAIRING_MAX_ATTEMPTS,
+  PAIRING_LOCKOUT_MS,
+  INITIAL_PAIR_CODE_TTL_MS,
+} from '../tunnel-pairing';
+
+// Unit tests for the short-lived one-time pairing store that backs the
+// Remote-Control tunnel (WhatsApp-Web "link a device" model). A fake clock is
+// injected so TTL / lockout behavior is deterministic and does not depend on
+// real wall-clock time.
+
+const TOKEN = 'the-real-per-launch-token';
+
+function makeStore(startNow = 1_000_000) {
+  let now = startNow;
+  const store = new TunnelPairingStore({
+    token: TOKEN,
+    now: () => now,
+  });
+  return {
+    store,
+    advance: (ms: number) => {
+      now += ms;
+    },
+    setNow: (v: number) => {
+      now = v;
+    },
+  };
+}
+
+describe('TunnelPairingStore.issueCode', () => {
+  it('generates a high-entropy URL-safe code', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    // base64url alphabet only, and long enough to resist brute force.
+    expect(code).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(code.length).toBeGreaterThanOrEqual(22);
+  });
+
+  it('rotates the active code on re-issue (old code no longer redeems)', () => {
+    const { store } = makeStore();
+    const first = store.issueCode();
+    const second = store.issueCode();
+    expect(second).not.toBe(first);
+
+    // The old code is dead; only the freshly-issued one works.
+    expect(store.redeem(first)).toEqual({ ok: false, reason: 'invalid' });
+    expect(store.redeem(second)).toEqual({ ok: true, token: TOKEN });
+  });
+});
+
+describe('TunnelPairingStore.redeem — happy path + single use', () => {
+  it('returns the token for the active, unexpired code', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    expect(store.redeem(code)).toEqual({ ok: true, token: TOKEN });
+  });
+
+  it('consumes the code so a second redeem of the same code fails', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    expect(store.redeem(code).ok).toBe(true);
+    // Single-use: immediately invalidated after a successful exchange.
+    expect(store.redeem(code)).toEqual({ ok: false, reason: 'invalid' });
+  });
+});
+
+describe('TunnelPairingStore.redeem — TTL expiry', () => {
+  it('rejects a code once its TTL has elapsed', () => {
+    const { store, advance } = makeStore();
+    const code = store.issueCode();
+    advance(PAIRING_CODE_TTL_MS + 1);
+    expect(store.redeem(code)).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('accepts a code right up to the edge of its TTL', () => {
+    const { store, advance } = makeStore();
+    const code = store.issueCode();
+    advance(PAIRING_CODE_TTL_MS - 1);
+    expect(store.redeem(code)).toEqual({ ok: true, token: TOKEN });
+  });
+});
+
+describe('TunnelPairingStore.redeem — wrong code', () => {
+  it('rejects a wrong code as invalid without consuming the real one', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    expect(store.redeem('not-the-code')).toEqual({ ok: false, reason: 'invalid' });
+    // The real code still works (wrong guesses must not consume it).
+    expect(store.redeem(code)).toEqual({ ok: true, token: TOKEN });
+  });
+
+  it('rejects when no code has ever been issued', () => {
+    const { store } = makeStore();
+    expect(store.redeem('anything')).toEqual({ ok: false, reason: 'invalid' });
+  });
+});
+
+describe('TunnelPairingStore.redeem — rate-limit / lockout', () => {
+  it('locks out after PAIRING_MAX_ATTEMPTS failed attempts', () => {
+    const { store } = makeStore();
+    store.issueCode();
+    for (let i = 0; i < PAIRING_MAX_ATTEMPTS - 1; i++) {
+      expect(store.redeem('wrong')).toEqual({ ok: false, reason: 'invalid' });
+    }
+    // The attempt that hits the threshold flips into lockout.
+    expect(store.redeem('wrong')).toEqual({ ok: false, reason: 'locked' });
+  });
+
+  it('rejects even the CORRECT code while locked (brute-force resistance)', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    for (let i = 0; i < PAIRING_MAX_ATTEMPTS; i++) store.redeem('wrong');
+    // Locked → the real code is refused too.
+    expect(store.redeem(code)).toEqual({ ok: false, reason: 'locked' });
+  });
+
+  it('lifts the lockout after the cooldown, and a fresh code works again', () => {
+    const { store, advance } = makeStore();
+    store.issueCode();
+    for (let i = 0; i < PAIRING_MAX_ATTEMPTS; i++) store.redeem('wrong');
+    expect(store.redeem('wrong')).toEqual({ ok: false, reason: 'locked' });
+
+    advance(PAIRING_LOCKOUT_MS + 1);
+    // Operator re-issues after the cooldown; the new code redeems cleanly.
+    const fresh = store.issueCode();
+    expect(store.redeem(fresh)).toEqual({ ok: true, token: TOKEN });
+  });
+
+  it('re-issuing clears the failed-attempt counter', () => {
+    const { store } = makeStore();
+    store.issueCode();
+    for (let i = 0; i < PAIRING_MAX_ATTEMPTS - 1; i++) store.redeem('wrong');
+    // Operator rotates the code before lockout — counter resets.
+    const fresh = store.issueCode();
+    // A single wrong guess must not immediately lock (counter was reset).
+    expect(store.redeem('wrong')).toEqual({ ok: false, reason: 'invalid' });
+    expect(store.redeem(fresh)).toEqual({ ok: true, token: TOKEN });
+  });
+});
+
+describe('TunnelPairingStore.seedCode — launcher-provided initial local code', () => {
+  it('redeems the seeded code for the token and consumes it (single-use)', () => {
+    const { store } = makeStore();
+    store.seedCode('launcher-initial-code');
+    expect(store.redeem('launcher-initial-code')).toEqual({ ok: true, token: TOKEN });
+    // Single-use: a second redeem of the same seeded code fails.
+    expect(store.redeem('launcher-initial-code')).toEqual({ ok: false, reason: 'invalid' });
+  });
+
+  it('rejects a wrong code without consuming the seeded one', () => {
+    const { store } = makeStore();
+    store.seedCode('launcher-initial-code');
+    expect(store.redeem('nope')).toEqual({ ok: false, reason: 'invalid' });
+    // The seeded code still works (wrong guesses must not consume it).
+    expect(store.redeem('launcher-initial-code')).toEqual({ ok: true, token: TOKEN });
+  });
+
+  it('honors the default INITIAL_PAIR_CODE_TTL_MS via the injected clock', () => {
+    const { store, advance } = makeStore();
+    store.seedCode('launcher-initial-code');
+    // Just inside the generous local TTL → still valid.
+    advance(INITIAL_PAIR_CODE_TTL_MS - 1);
+    // Re-seed to reset the clock reference for the expiry-edge assertion below.
+    // (Redeeming here would consume it, so we assert validity indirectly via a
+    // fresh seed + full-TTL advance.)
+    expect(store.hasActiveCode()).toBe(true);
+
+    store.seedCode('second-initial-code');
+    advance(INITIAL_PAIR_CODE_TTL_MS + 1);
+    expect(store.redeem('second-initial-code')).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('accepts an explicit ttlMs override', () => {
+    const { store, advance } = makeStore();
+    store.seedCode('short-lived', 1_000);
+    advance(1_001);
+    expect(store.redeem('short-lived')).toEqual({ ok: false, reason: 'expired' });
+  });
+
+  it('clears any prior failed-attempt counter and lock (like issueCode)', () => {
+    const { store } = makeStore();
+    store.issueCode();
+    for (let i = 0; i < PAIRING_MAX_ATTEMPTS; i++) store.redeem('wrong'); // engage lockout
+    // Seeding a fresh code must clear the lock so the new code redeems cleanly.
+    store.seedCode('post-lock-code');
+    expect(store.redeem('post-lock-code')).toEqual({ ok: true, token: TOKEN });
+  });
+
+  it('INITIAL_PAIR_CODE_TTL_MS is more generous than the tunnel code TTL', () => {
+    // The seeded local code tolerates a slow first load; it stays single-use.
+    expect(INITIAL_PAIR_CODE_TTL_MS).toBeGreaterThan(PAIRING_CODE_TTL_MS);
+  });
+});
+
+describe('TunnelPairingStore.hasActiveCode', () => {
+  it('reflects issue → expiry → re-issue lifecycle', () => {
+    const { store, advance } = makeStore();
+    expect(store.hasActiveCode()).toBe(false);
+    store.issueCode();
+    expect(store.hasActiveCode()).toBe(true);
+    advance(PAIRING_CODE_TTL_MS + 1);
+    expect(store.hasActiveCode()).toBe(false);
+  });
+
+  it('is false right after a successful redeem (consumed)', () => {
+    const { store } = makeStore();
+    const code = store.issueCode();
+    store.redeem(code);
+    expect(store.hasActiveCode()).toBe(false);
+  });
+});
+
+describe('buildPairingUrl', () => {
+  it('appends ?pair=<code> to the tunnel base, tolerating a trailing slash', () => {
+    expect(buildPairingUrl('https://abc.trycloudflare.com', 'CODE123')).toBe(
+      'https://abc.trycloudflare.com/?pair=CODE123',
+    );
+    expect(buildPairingUrl('https://abc.trycloudflare.com/', 'CODE123')).toBe(
+      'https://abc.trycloudflare.com/?pair=CODE123',
+    );
+  });
+
+  it('URL-encodes the pairing code', () => {
+    // base64url never yields reserved chars, but encode defensively anyway.
+    const url = buildPairingUrl('https://abc.trycloudflare.com', 'a b+c');
+    expect(url).toBe('https://abc.trycloudflare.com/?pair=a%20b%2Bc');
+  });
+
+  it('never embeds the raw auth token', () => {
+    const url = buildPairingUrl('https://abc.trycloudflare.com', 'CODE');
+    expect(url).not.toContain('token');
+  });
+});

--- a/backend/src/core/features/tunnel-pairing.ts
+++ b/backend/src/core/features/tunnel-pairing.ts
@@ -1,0 +1,200 @@
+import { randomBytes, timingSafeEqual } from 'crypto';
+import { authToken } from '../../config/environment';
+
+// ── Remote-Control tunnel: short-lived one-time pairing ─────────────────────
+//
+// The Remote-Control feature publishes the backend to the public internet via a
+// cloudflared trycloudflare URL + QR. We must NOT bake the per-launch auth token
+// into that URL — a leaked URL would then equal full compromise. Instead the
+// QR/URL carries only a short-lived, single-use, high-entropy PAIRING CODE
+// (WhatsApp-Web "link a device" model). The remote device exchanges the code
+// (over the HTTPS tunnel, POST /pair) for the real token exactly once, within a
+// short window. A later URL leak is useless: the code has expired or been
+// consumed.
+//
+// Security posture (the code — never URL secrecy — is the protection):
+//   - high entropy: PAIRING_CODE_BYTES bytes of crypto randomness (base64url),
+//   - short TTL: the code dies after PAIRING_CODE_TTL_MS,
+//   - single use: a successful redeem immediately invalidates the code,
+//   - rate-limit + lockout: PAIRING_MAX_ATTEMPTS wrong guesses lock further
+//     attempts (including the correct code) for PAIRING_LOCKOUT_MS.
+//
+// This module NEVER logs the pairing code or the token.
+
+/** How long an issued pairing code stays valid. Kept short but with enough
+ * headroom for a human to open the modal and scan the QR with a phone. */
+export const PAIRING_CODE_TTL_MS = 120_000; // 2 minutes
+
+/** TTL for the launcher-seeded INITIAL LOCAL pairing code (see seedCode). The
+ * local webview redeems this on first load to obtain the auth token, so it needs
+ * enough headroom for a slow cold start. A longer TTL is acceptable here because
+ * the code is still strictly single-use — one successful redeem consumes it. */
+export const INITIAL_PAIR_CODE_TTL_MS = 600_000; // 10 minutes
+
+/** Failed redeem attempts (within the active window) before we lock out. */
+export const PAIRING_MAX_ATTEMPTS = 5;
+
+/** Cooldown after a lockout before redeems are accepted again. During the
+ * lockout even the correct code is refused. The operator can re-issue a fresh
+ * code (which also clears the lock) once they are back in control. */
+export const PAIRING_LOCKOUT_MS = 60_000; // 1 minute
+
+/** Entropy of each pairing code. 24 bytes = 192 bits, ~32 base64url chars —
+ * infeasible to brute force within the TTL even without the lockout. */
+export const PAIRING_CODE_BYTES = 24;
+
+export type RedeemFailureReason = 'invalid' | 'expired' | 'locked';
+
+export type RedeemResult =
+  | { ok: true; token: string }
+  | { ok: false; reason: RedeemFailureReason };
+
+interface PairingOptions {
+  /** Injectable clock (ms epoch). Defaults to Date.now — overridden in tests. */
+  now?: () => number;
+  /** The token handed out on a successful redeem. Defaults to the per-launch authToken. */
+  token?: string;
+  ttlMs?: number;
+  maxAttempts?: number;
+  lockoutMs?: number;
+}
+
+/**
+ * In-memory manager holding at most one active pairing code per launch.
+ * Re-issuing rotates the code and resets the failure counter/lock.
+ */
+export class TunnelPairingStore {
+  private readonly now: () => number;
+  private readonly token: string;
+  private readonly ttlMs: number;
+  private readonly maxAttempts: number;
+  private readonly lockoutMs: number;
+
+  private activeCode: string | null = null;
+  private codeExpiresAt = 0;
+  private failedAttempts = 0;
+  private lockedUntil = 0;
+
+  constructor(opts: PairingOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.token = opts.token ?? authToken;
+    this.ttlMs = opts.ttlMs ?? PAIRING_CODE_TTL_MS;
+    this.maxAttempts = opts.maxAttempts ?? PAIRING_MAX_ATTEMPTS;
+    this.lockoutMs = opts.lockoutMs ?? PAIRING_LOCKOUT_MS;
+  }
+
+  /**
+   * Generate and store a fresh single-use code, replacing any previous one.
+   * Re-issuing clears the failed-attempt counter and any active lock: the
+   * operator is present and deliberately rotating, so the new code must not be
+   * punished for the old code's failed guesses.
+   */
+  issueCode(): string {
+    const code = randomBytes(PAIRING_CODE_BYTES).toString('base64url');
+    this.activeCode = code;
+    this.codeExpiresAt = this.now() + this.ttlMs;
+    this.failedAttempts = 0;
+    this.lockedUntil = 0;
+    return code;
+  }
+
+  /**
+   * Seed a pre-generated single-use code as the active code, replacing any
+   * previous one. Unlike issueCode() (which mints fresh randomness for the
+   * tunnel QR), the code here is generated OUT-OF-BAND by the launcher (Kotlin
+   * plugin / ccg CLI) and injected via env at startup: the launcher embeds the
+   * same code as `?pair=` in the LOCAL webview URL so the local webview can
+   * redeem it for the auth token on first load. Pairing is thus used for LOCAL
+   * too, not just the tunnel.
+   *
+   * Integrates identically to issueCode(): it resets the failed-attempt counter
+   * and clears any active lock, and the code remains strictly single-use —
+   * redeem() consumes it on the first successful exchange. Defaults to a
+   * generous local TTL (INITIAL_PAIR_CODE_TTL_MS) for a slow first load.
+   *
+   * The caller MUST NOT log the code value.
+   */
+  seedCode(code: string, ttlMs: number = INITIAL_PAIR_CODE_TTL_MS): void {
+    this.activeCode = code;
+    this.codeExpiresAt = this.now() + ttlMs;
+    this.failedAttempts = 0;
+    this.lockedUntil = 0;
+  }
+
+  /**
+   * Exchange a code for the token. Constant-time compares against the active,
+   * non-expired code. On success the code is CONSUMED (single-use). On failure
+   * the attempt is counted toward the lockout threshold.
+   */
+  redeem(code: string): RedeemResult {
+    const now = this.now();
+
+    // Locked out — refuse everything (including the correct code) until cooldown.
+    if (now < this.lockedUntil) {
+      return { ok: false, reason: 'locked' };
+    }
+
+    // No live code (never issued, already consumed, or expired).
+    if (this.activeCode === null || now >= this.codeExpiresAt) {
+      const expired = this.activeCode !== null; // had a code, but it aged out
+      const locked = this.registerFailure(now);
+      return { ok: false, reason: locked ? 'locked' : expired ? 'expired' : 'invalid' };
+    }
+
+    // Constant-time comparison against the live code.
+    if (!safeEqual(code, this.activeCode)) {
+      const locked = this.registerFailure(now);
+      return { ok: false, reason: locked ? 'locked' : 'invalid' };
+    }
+
+    // Success → single-use consumption + reset counters.
+    this.activeCode = null;
+    this.codeExpiresAt = 0;
+    this.failedAttempts = 0;
+    this.lockedUntil = 0;
+    return { ok: true, token: this.token };
+  }
+
+  /** True when a live (issued, unexpired, unconsumed) code exists right now. */
+  hasActiveCode(now = this.now()): boolean {
+    return this.activeCode !== null && now < this.codeExpiresAt;
+  }
+
+  /** Record a failed attempt; returns true when this attempt engaged the lockout. */
+  private registerFailure(now: number): boolean {
+    this.failedAttempts += 1;
+    if (this.failedAttempts >= this.maxAttempts) {
+      // Threshold reached → engage the lockout and burn any active code so a
+      // near-guessed code can't be used the instant the counter would reset.
+      this.lockedUntil = now + this.lockoutMs;
+      this.failedAttempts = 0;
+      this.activeCode = null;
+      this.codeExpiresAt = 0;
+      return true;
+    }
+    return false;
+  }
+}
+
+/**
+ * Constant-time string compare that never throws on length mismatch. The early
+ * length check is not itself constant-time, but the code length is not secret.
+ */
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Build the URL encoded into the tunnel QR: the tunnel base + `?pair=<code>`.
+ * Deliberately carries ONLY the pairing code — never the auth token.
+ */
+export function buildPairingUrl(baseUrl: string, code: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, '');
+  return `${trimmed}/?pair=${encodeURIComponent(code)}`;
+}
+
+/** Process-wide singleton bound to the real per-launch token + wall clock. */
+export const tunnelPairing = new TunnelPairingStore();

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -68,6 +68,7 @@ import { tunnelStartHandler } from './tunnelStart';
 import { tunnelStopHandler } from './tunnelStop';
 import { getTunnelStatusHandler } from './getTunnelStatus';
 import { getTunnelPrereqsHandler } from './getTunnelPrereqs';
+import { issueTunnelPairingHandler } from './issueTunnelPairing';
 import { installCloudflaredHandler } from './installCloudflared';
 import { sleepGuardEnableHandler } from './sleepGuardEnable';
 import { sleepGuardDisableHandler } from './sleepGuardDisable';
@@ -304,6 +305,9 @@ export async function handleMessage(
       break;
     case MessageType.GET_TUNNEL_PREREQS:
       await getTunnelPrereqsHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.ISSUE_TUNNEL_PAIRING:
+      await issueTunnelPairingHandler(connectionId, message, connections, bridge);
       break;
     case MessageType.INSTALL_CLOUDFLARED:
       await installCloudflaredHandler(connectionId, message, connections, bridge);

--- a/backend/src/core/handlers/issueTunnelPairing.ts
+++ b/backend/src/core/handlers/issueTunnelPairing.ts
@@ -1,0 +1,45 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { getTunnelStatus, validateTunnelStatus } from '../features/tunnel-manager';
+import { tunnelPairing, buildPairingUrl } from '../features/tunnel-pairing';
+import { MessageType } from '../../shared';
+
+/**
+ * Issue a fresh single-use pairing code for the running Remote-Control tunnel
+ * and return the QR pairing URL (`<tunnel>/?pair=<code>`). The URL carries only
+ * the short-lived code — never the auth token. Called by the tunnel modal each
+ * time it needs a live QR (open, or after the previous code expired).
+ *
+ * The requesting webview is the LOCAL, already-authenticated operator, so
+ * handing it the code is safe; the code is what the remote device then redeems
+ * over the tunnel via POST /pair.
+ */
+export async function issueTunnelPairingHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  // Correct any stale restored-tunnel state before reading the URL.
+  validateTunnelStatus();
+  const status = getTunnelStatus();
+
+  if (!status.enabled || !status.url) {
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'error',
+      error: 'Tunnel is not running',
+    });
+    return;
+  }
+
+  const code = tunnelPairing.issueCode();
+  const pairUrl = buildPairingUrl(status.url, code);
+  // Never log the code or the URL (the URL embeds the code).
+  connections.sendTo(connectionId, MessageType.ACK, {
+    requestId: message.requestId,
+    status: 'ok',
+    pairUrl,
+  });
+}

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import { initSettingsWatcher, stopSettingsWatcher } from './core/features/settin
 import { ensureProfile } from './core/features/profile';
 import { trackEvent, reportBackendError } from './core/features/telemetry';
 import { restoreTunnelState } from './core/features/tunnel-manager';
+import { tunnelPairing } from './core/features/tunnel-pairing';
 import { restoreSleepGuardState } from './core/features/sleep-guard';
 import { isJetBrainsMode, serverPort, serverHost, webviewDir } from './config/environment';
 import { initLogger, getLogger } from './logging';
@@ -224,6 +225,18 @@ async function main() {
     `(mode: ${isJetBrainsMode ? 'JetBrains' : 'browser'})`,
     webviewDir ? `(webviewDir: ${webviewDir})` : '',
   );
+
+  // Seed the launcher-provided INITIAL LOCAL pairing code. The launcher (Kotlin
+  // plugin / ccg CLI) owns the stable auth token and, on each launch, mints a
+  // single-use pairing code that it (a) passes here via CCG_INITIAL_PAIR_CODE and
+  // (b) embeds as `?pair=` in the local webview URL. Seeding it lets the local
+  // webview redeem it at /pair for the token on first load — the token is thus
+  // NEVER placed in any URL. Guarded on presence; the code value is NEVER logged.
+  const initialPairCode = process.env.CCG_INITIAL_PAIR_CODE?.trim();
+  if (initialPairCode) {
+    tunnelPairing.seedCode(initialPairCode);
+    console.error('[node-backend]', 'Seeded initial local pairing code');
+  }
 
   // Restore tunnel/sleep state from previous session
   restoreTunnelState();

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -209,6 +209,13 @@ export enum MessageType {
   GET_TUNNEL_PREREQS = 'GET_TUNNEL_PREREQS',
   /** Install the cloudflared binary. */
   INSTALL_CLOUDFLARED = 'INSTALL_CLOUDFLARED',
+  /**
+   * inbound webview→backend. Issue a fresh single-use, short-lived pairing code
+   * for the running tunnel and return the QR pairing URL
+   * (`https://<sub>.trycloudflare.com/?pair=<code>`). Carries only the code —
+   * never the auth token. Re-callable to rotate an expired code.
+   */
+  ISSUE_TUNNEL_PAIRING = 'ISSUE_TUNNEL_PAIRING',
 
   // -- Sleep guard (keep-awake) --
   /** Enable the system sleep guard. */

--- a/backend/src/ws/__tests__/ws-server-auth.test.ts
+++ b/backend/src/ws/__tests__/ws-server-auth.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { WebSocket } from 'ws';
+import { startWebSocketServer, AUTH_SUBPROTOCOL } from '../ws-server';
+import { LogWebSocketServer } from '../../logging/log-ws';
+import { authToken } from '../../config/environment';
+import { ClientEnv } from '../../shared';
+import { tunnelPairing, PAIRING_MAX_ATTEMPTS } from '../../core/features/tunnel-pairing';
+import type { Bridge } from '../../bridge/bridge-interface';
+
+// End-to-end auth tests: boot a REAL server on an ephemeral port and drive it
+// with real WebSocket / HTTP clients. The token is carried in the standard
+// Sec-WebSocket-Protocol header (`new WebSocket(url, ['ccg-auth', token])`) for
+// WS, and in the `x-ccg-token` header for /internal/* HTTP POSTs. Origin is
+// always set to an allowed value so these tests isolate the TOKEN gate from the
+// (unchanged) Origin gate.
+
+const ALLOWED_ORIGIN = 'http://localhost';
+const WRONG_TOKEN = `${authToken}-nope`; // guaranteed different value
+
+function createMockBridge(withRpc: boolean): Bridge {
+  const base: Record<string, unknown> = {
+    openFile: vi.fn(),
+    openDiff: vi.fn(),
+    applyDiff: vi.fn().mockResolvedValue({ applied: false }),
+    rejectDiff: vi.fn(),
+    refreshFiles: vi.fn(),
+    createSession: vi.fn(),
+    openNewTab: vi.fn(),
+    openSettings: vi.fn(),
+    openTerminal: vi.fn(),
+    openUrl: vi.fn(),
+    pickFiles: vi.fn().mockResolvedValue({ paths: [] }),
+    updatePlugin: vi.fn(),
+    requiresRestart: vi.fn().mockResolvedValue(false),
+  };
+  if (withRpc) base.addRpcClient = vi.fn();
+  return base as unknown as Bridge;
+}
+
+type ConnectResult =
+  | { ok: true; protocol: string }
+  | { ok: false; status?: number };
+
+/** Attempt a WebSocket upgrade and resolve with acceptance / rejection status. */
+function tryWsConnect(
+  port: number,
+  path: string,
+  protocols?: string[],
+): Promise<ConnectResult> {
+  return new Promise<ConnectResult>((resolve) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}${path}`, protocols, {
+      origin: ALLOWED_ORIGIN,
+    });
+    ws.on('open', () => {
+      const protocol = ws.protocol;
+      ws.close();
+      resolve({ ok: true, protocol });
+    });
+    ws.on('unexpected-response', (_req, res) => {
+      resolve({ ok: false, status: res.statusCode });
+      ws.terminate();
+    });
+    ws.on('error', () => {
+      resolve({ ok: false });
+    });
+  });
+}
+
+describe('ws-server auth (Sec-WebSocket-Protocol token)', () => {
+  let port: number;
+  let close: () => void;
+
+  beforeAll(async () => {
+    const bridges = {
+      [ClientEnv.BROWSER]: createMockBridge(false),
+      [ClientEnv.JETBRAINS]: createMockBridge(true),
+    };
+    const logWs = new LogWebSocketServer(() => {});
+    const handle = await startWebSocketServer(
+      0,
+      '127.0.0.1',
+      bridges,
+      async () => {},
+      undefined,
+      logWs,
+    );
+    port = handle.port;
+    close = handle.close;
+  });
+
+  afterAll(() => {
+    close?.();
+  });
+
+  describe.each(['/ws', '/rpc', '/logs'])('control channel %s', (path) => {
+    it('rejects when the token is missing (origin allowed)', async () => {
+      const result = await tryWsConnect(port, path, [AUTH_SUBPROTOCOL]);
+      expect(result.ok).toBe(false);
+      if (!result.ok && result.status !== undefined) {
+        expect(result.status).toBe(401);
+      }
+    });
+
+    it('rejects when the token is wrong (origin allowed)', async () => {
+      const result = await tryWsConnect(port, path, [AUTH_SUBPROTOCOL, WRONG_TOKEN]);
+      expect(result.ok).toBe(false);
+      if (!result.ok && result.status !== undefined) {
+        expect(result.status).toBe(401);
+      }
+    });
+
+    it('accepts with the correct token and negotiates ccg-auth (never the token)', async () => {
+      const result = await tryWsConnect(port, path, [AUTH_SUBPROTOCOL, authToken]);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.protocol).toBe(AUTH_SUBPROTOCOL);
+        expect(result.protocol).not.toBe(authToken);
+      }
+    });
+  });
+
+  describe('/internal/editor-context HTTP POST', () => {
+    const body = JSON.stringify({ absolutePath: '/a/b.ts', relativePath: 'b.ts' });
+
+    it('rejects with 401 when the x-ccg-token header is missing', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/internal/editor-context`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('rejects with 401 when the token is wrong', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/internal/editor-context`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ccg-token': WRONG_TOKEN },
+        body,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('processes the request with the correct token', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/internal/editor-context`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ccg-token': authToken },
+        body,
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('/internal/ide-selection HTTP POST', () => {
+    const body = JSON.stringify({ absolutePath: '/a/b.ts', relativePath: 'b.ts' });
+
+    it('rejects with 401 when the token is missing', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/internal/ide-selection`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('processes the request with the correct token', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/internal/ide-selection`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-ccg-token': authToken },
+        body,
+      });
+      expect(res.status).toBe(200);
+    });
+  });
+
+  describe('/version health check', () => {
+    it('is reachable WITHOUT a token (port-readiness probe)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/version`);
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { version: unknown };
+      expect(json).toHaveProperty('version');
+    });
+  });
+
+  // POST /pair — the short-lived one-time pairing exchange. Reachable WITHOUT
+  // the auth token (the remote device has no token yet; the code is its
+  // credential). Gated entirely on the pairing store. Each test issues a fresh
+  // code first so the shared module singleton is in a known state.
+  describe('/pair pairing exchange (no auth token required)', () => {
+    it('returns the token for a valid, freshly-issued code (via JSON body)', async () => {
+      const code = tunnelPairing.issueCode();
+      const res = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { token: unknown };
+      expect(json.token).toBe(authToken);
+    });
+
+    it('accepts the code via the x-ccg-pair-code header', async () => {
+      const code = tunnelPairing.issueCode();
+      const res = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'x-ccg-pair-code': code },
+      });
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as { token: unknown };
+      expect(json.token).toBe(authToken);
+    });
+
+    it('consumes the code — a second redeem of the same code is 401', async () => {
+      const code = tunnelPairing.issueCode();
+      const first = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      expect(first.status).toBe(200);
+      const second = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      expect(second.status).toBe(401);
+    });
+
+    it('rejects a wrong code with 401', async () => {
+      tunnelPairing.issueCode();
+      const res = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: 'definitely-not-the-code' }),
+      });
+      expect(res.status).toBe(401);
+    });
+
+    it('locks out with 429 after too many wrong attempts', async () => {
+      tunnelPairing.issueCode();
+      let lastStatus = 0;
+      for (let i = 0; i < PAIRING_MAX_ATTEMPTS; i++) {
+        const res = await fetch(`http://127.0.0.1:${port}/pair`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ code: 'wrong' }),
+        });
+        lastStatus = res.status;
+      }
+      expect(lastStatus).toBe(429);
+      // Re-issue clears the lock so later tests are unaffected.
+      tunnelPairing.issueCode();
+    });
+
+    it('never reflects the token in the pairing URL contract (token only in body)', async () => {
+      const code = tunnelPairing.issueCode();
+      const res = await fetch(`http://127.0.0.1:${port}/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      // The token is delivered ONLY in the JSON response body of the exchange,
+      // never encoded into any URL. The code carried in was not the token.
+      expect(code).not.toBe(authToken);
+      expect(res.status).toBe(200);
+    });
+  });
+});

--- a/backend/src/ws/__tests__/ws-server-security.test.ts
+++ b/backend/src/ws/__tests__/ws-server-security.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { validateOrigin, isNonLoopbackBind } from '../ws-server';
+import {
+  validateOrigin,
+  isNonLoopbackBind,
+  extractAuthToken,
+  validateAuthToken,
+  AUTH_SUBPROTOCOL,
+} from '../ws-server';
 
 // These tests exercise the REAL exported validateOrigin (not a replica), so the
 // security contract can never silently drift from the source implementation.
@@ -82,6 +88,60 @@ describe('ws-server security', () => {
 
     it('should keep allowing loopback origins', () => {
       expect(validateOrigin('http://localhost:19836', '192.168.0.5:19836', true)).toBe(true);
+    });
+  });
+
+  describe('extractAuthToken() — Sec-WebSocket-Protocol parsing', () => {
+    it('returns undefined for a missing header', () => {
+      expect(extractAuthToken(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for an empty header', () => {
+      expect(extractAuthToken('')).toBeUndefined();
+    });
+
+    it('extracts the token paired with the ccg-auth marker (with space)', () => {
+      expect(extractAuthToken(`${AUTH_SUBPROTOCOL}, my-secret-token`)).toBe('my-secret-token');
+    });
+
+    it('extracts the token paired with the ccg-auth marker (no space)', () => {
+      expect(extractAuthToken(`${AUTH_SUBPROTOCOL},my-secret-token`)).toBe('my-secret-token');
+    });
+
+    it('returns undefined when only the marker is present (no token)', () => {
+      expect(extractAuthToken(AUTH_SUBPROTOCOL)).toBeUndefined();
+    });
+
+    it('returns undefined when the marker is absent (bare token, no marker)', () => {
+      expect(extractAuthToken('my-secret-token')).toBeUndefined();
+    });
+  });
+
+  describe('validateAuthToken() — timing-safe comparison', () => {
+    const expected = 'a'.repeat(64);
+
+    it('accepts the correct token behind the marker', () => {
+      expect(validateAuthToken(`${AUTH_SUBPROTOCOL}, ${expected}`, expected)).toBe(true);
+    });
+
+    it('rejects a wrong token of equal length', () => {
+      expect(validateAuthToken(`${AUTH_SUBPROTOCOL}, ${'b'.repeat(64)}`, expected)).toBe(false);
+    });
+
+    it('rejects a token of different length without throwing', () => {
+      expect(validateAuthToken(`${AUTH_SUBPROTOCOL}, short`, expected)).toBe(false);
+    });
+
+    it('rejects a missing token (marker only)', () => {
+      expect(validateAuthToken(AUTH_SUBPROTOCOL, expected)).toBe(false);
+    });
+
+    it('rejects a missing header', () => {
+      expect(validateAuthToken(undefined, expected)).toBe(false);
+    });
+
+    it('rejects when the marker is absent', () => {
+      expect(validateAuthToken(expected, expected)).toBe(false);
     });
   });
 

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -1,7 +1,9 @@
 import { createServer, type Server, type IncomingMessage, type ServerResponse } from 'http';
 import { readFile } from 'fs/promises';
 import { join, extname, resolve, sep } from 'path';
+import { timingSafeEqual } from 'crypto';
 import { WebSocketServer, type WebSocket } from 'ws';
+import { authToken } from '../config/environment';
 import { ConnectionManager } from './connection-manager';
 import { handleEditorContextRequest } from './editor-context-route';
 import { handleIdeSelectionRequest } from './ide-selection-route';
@@ -11,6 +13,7 @@ import { ClientEnv, MessageType } from '../shared';
 import { getPluginVersion } from '../core/handlers/getVersion';
 import { cancelLogin } from '../core/handlers/login';
 import { reportBackendError, trackActivity } from '../core/features/telemetry';
+import { tunnelPairing } from '../core/features/tunnel-pairing';
 import { LogWebSocketServer } from '../logging/log-ws';
 
 const ALLOWED_WS_ORIGINS = new Set([
@@ -70,6 +73,80 @@ export function validateOrigin(
   } catch {
     return false;
   }
+}
+
+// ── 제어 채널 토큰 인증 ─────────────────────────────────────
+// RFC 6455 WebSocket에는 내장 인증이 없다. 브라우저 WebSocket이 handshake에 붙일
+// 수 있는 유일한 헤더인 Sec-WebSocket-Protocol(서브프로토콜)에 토큰을 실어 보낸다.
+// 클라이언트는 `new WebSocket(url, ['ccg-auth', token])`로 접속하므로 헤더는
+// `ccg-auth, <token>` 형태의 콤마 구분 목록이 된다. 쿼리스트링(`?token=`)은
+// 로그·히스토리·Referer로 유출될 수 있어 채택하지 않는다(표준 하드닝).
+export const AUTH_SUBPROTOCOL = 'ccg-auth';
+
+// /internal/* HTTP POST 푸시(에디터 컨텍스트/셀렉션)는 loopback 전용이나 방어심화로
+// 동일 토큰을 요구한다. 커스텀 헤더를 쓴다 — Claude 자체 인증(Authorization)과
+// 혼동을 피하고, 프록시가 Authorization을 건드릴 여지를 없애기 위해서다.
+//
+// IMPORTANT: this header carries the AUTH/bearer token (the per-launch auth
+// token), NOT a CSRF token. It is a secret credential that authenticates the
+// caller — treat it as such (never log it, compare it constant-time). Do not
+// mistake it for a CSRF/double-submit cookie token or handle it more loosely.
+export const HTTP_AUTH_HEADER = 'x-ccg-token';
+
+// POST /pair 의 페어링 코드 전달 헤더(대안: JSON 바디 { code }). 원격 기기는 아직
+// 토큰이 없으므로(닭-달걀) 이 엔드포인트는 토큰 없이 접근 가능하며, 페어링 코드
+// 자체가 자격증명이다. 헤더 이름은 node가 소문자로 정규화한다.
+export const PAIR_CODE_HEADER = 'x-ccg-pair-code';
+
+/** Constant-time token compare that never throws on length mismatch. */
+function timingSafeTokenEqual(provided: string | undefined, expected: string): boolean {
+  if (!provided) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  // timingSafeEqual throws on differing lengths — guard first. The early length
+  // check is not itself constant-time, but token length is not secret.
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * Extract the auth token from a Sec-WebSocket-Protocol header value.
+ *
+ * The header is a comma-separated list; a valid request pairs the `ccg-auth`
+ * marker with the secret token, e.g. `"ccg-auth, <token>"`. Returns the token
+ * paired with the marker, or undefined when the marker or token is absent.
+ */
+export function extractAuthToken(protocolHeader: string | undefined): string | undefined {
+  if (!protocolHeader) return undefined;
+  const parts = protocolHeader
+    .split(',')
+    .map((p) => p.trim())
+    .filter(Boolean);
+  if (!parts.includes(AUTH_SUBPROTOCOL)) return undefined;
+  const token = parts.find((p) => p !== AUTH_SUBPROTOCOL);
+  return token || undefined;
+}
+
+/**
+ * Validate the token carried in a Sec-WebSocket-Protocol header against the
+ * expected per-launch token, using a constant-time comparison.
+ */
+export function validateAuthToken(
+  protocolHeader: string | undefined,
+  expected: string,
+): boolean {
+  return timingSafeTokenEqual(extractAuthToken(protocolHeader), expected);
+}
+
+/**
+ * handleProtocols for the ws WebSocketServers: always negotiate back the
+ * `ccg-auth` marker (never the secret token), so the browser's
+ * WebSocket.protocol resolves cleanly and the token is never reflected in the
+ * handshake response. The token itself was already validated in the upgrade
+ * handler before handleUpgrade runs.
+ */
+export function selectAuthSubprotocol(protocols: Set<string>): string | false {
+  return protocols.has(AUTH_SUBPROTOCOL) ? AUTH_SUBPROTOCOL : false;
 }
 
 export type BridgeMap = Record<ClientEnv, Bridge>;
@@ -201,9 +278,11 @@ export function startWebSocketServer(
     // the historical allowlist-only behavior (DNS-rebinding stays closed).
     const allowSameOrigin = isNonLoopbackBind(host);
 
-    // wss와 connections는 한 번만 생성
-    const wss = new WebSocketServer({ noServer: true });
-    const rpcWss = new WebSocketServer({ noServer: true });
+    // wss와 connections는 한 번만 생성. handleProtocols는 협상되는 서브프로토콜을
+    // 항상 `ccg-auth` 마커로 고정한다 — 클라이언트가 순서를 바꿔 보내더라도 비밀
+    // 토큰이 handshake 응답에 반영되지 않도록 방어한다.
+    const wss = new WebSocketServer({ noServer: true, handleProtocols: selectAuthSubprotocol });
+    const rpcWss = new WebSocketServer({ noServer: true, handleProtocols: selectAuthSubprotocol });
 
     // WebSocket 연결 핸들러 — 한 번만 등록
     wss.on('connection', (ws: WebSocket, request: IncomingMessage) => {
@@ -258,10 +337,74 @@ export function startWebSocketServer(
       async (req: IncomingMessage, res: ServerResponse) => {
         const urlPath = (req.url ?? '/').split('?')[0];
 
+        // /version is a harmless read used as a port-readiness/health probe by the
+        // bootstrap (Kotlin/foreground.sh) BEFORE any token is available. Leave it
+        // UNAUTHENTICATED so readiness probes keep working; it exposes no secrets
+        // and mutates nothing.
         if (urlPath === '/version') {
           res.writeHead(200, { 'Content-Type': 'application/json' });
           res.end(JSON.stringify({ version: getPluginVersion() }));
           return;
+        }
+
+        // POST /pair — short-lived one-time pairing exchange for the Remote-Control
+        // tunnel. The remote device has NO auth token yet; the single-use pairing
+        // code (delivered out-of-band via the QR the operator shows) IS its
+        // credential, so this endpoint is intentionally reachable WITHOUT the auth
+        // token. A valid, unexpired, unconsumed code → 200 { token }; invalid or
+        // expired → 401; rate-limited/locked → 429.
+        //
+        // Design choice (documented): returning the token to anyone holding a live
+        // code IS the intended handshake. The protection is the code's 192-bit
+        // entropy + short TTL + single-use + lockout, NOT URL/endpoint secrecy.
+        // The route is always-on and gated purely on "is there a live issued
+        // code": with no code issued (tunnel off) every attempt fails as 'invalid'.
+        // The code and token are never logged.
+        if (req.method === 'POST' && urlPath === '/pair') {
+          const headerCode = req.headers[PAIR_CODE_HEADER];
+          let code = Array.isArray(headerCode) ? headerCode[0] : headerCode;
+          if (!code) {
+            try {
+              const rawBody = await readRequestBody(req);
+              if (rawBody) {
+                const parsed = JSON.parse(rawBody) as { code?: unknown };
+                if (typeof parsed.code === 'string') code = parsed.code;
+              }
+            } catch {
+              // Missing/invalid body → treated as an invalid code below.
+            }
+          }
+          const result = tunnelPairing.redeem(code ?? '');
+          if (result.ok) {
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ token: result.token }));
+          } else if (result.reason === 'locked') {
+            console.error('[node-backend]', 'Pairing attempt rejected: rate-limited (locked)');
+            res.writeHead(429, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Too many attempts' }));
+          } else {
+            console.error('[node-backend]', `Pairing attempt rejected: ${result.reason}`);
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Invalid or expired pairing code' }));
+          }
+          return;
+        }
+
+        // /internal/* are loopback-only IDE→backend mutation pushes. Defense-in-depth:
+        // require the per-launch token via the `x-ccg-token` HTTP header (Bearer-style
+        // custom header — chosen over Authorization to avoid clashing with Claude's own
+        // auth and proxy rewrites). Missing/invalid → 401. Static file serving and
+        // /version stay unauthenticated (webview bootstrap must load before it has a token).
+        // TODO(phase 2): Kotlin's editor-context / ide-selection POSTs must send this header.
+        if (urlPath.startsWith('/internal/')) {
+          const httpToken = req.headers[HTTP_AUTH_HEADER];
+          const provided = Array.isArray(httpToken) ? httpToken[0] : httpToken;
+          if (!timingSafeTokenEqual(provided, authToken)) {
+            console.error('[node-backend]', `Rejected ${req.method} ${urlPath}: missing or invalid auth token`);
+            res.writeHead(401, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Unauthorized' }));
+            return;
+          }
         }
 
         // IDE → backend editor selection push. Kotlin POSTs the active editor
@@ -314,11 +457,25 @@ export function startWebSocketServer(
     httpServer.on('upgrade', (request, socket, head) => {
       const url = request.url;
 
-      // Origin 검증 — /ws, /logs 공통
+      // Origin 검증 — /ws, /rpc, /logs 공통. Origin은 인증이 아니라 CSWSH 방어
+      // 하드닝 레이어로 그대로 유지한다(약화 금지). 실제 인증은 아래 토큰이 담당.
       const origin = request.headers.origin;
       if (!validateOrigin(origin, request.headers.host, allowSameOrigin)) {
         console.error('[node-backend]', `WebSocket connection rejected: disallowed origin "${origin}"`);
         socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
+      // 토큰 검증 — /ws, /rpc, /logs 공통. Sec-WebSocket-Protocol 헤더에서
+      // `ccg-auth` 마커와 짝지어진 토큰을 constant-time 비교한다. 누락/불일치는
+      // 401로 소켓 종료. 토큰 값은 절대 로그로 남기지 않는다(성공/실패만).
+      // TODO(phase 2): webview 연결 빌더가 `new WebSocket(url, ['ccg-auth', token])`로
+      //   이 토큰을 부착해야 정상 UX가 복구된다. CLI/Kotlin은 토큰을 env로 전파.
+      const protocolHeader = request.headers['sec-websocket-protocol'];
+      if (!validateAuthToken(protocolHeader, authToken)) {
+        console.error('[node-backend]', 'WebSocket connection rejected: missing or invalid auth token');
+        socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
         socket.destroy();
         return;
       }

--- a/cli/commands/run/index.sh
+++ b/cli/commands/run/index.sh
@@ -64,11 +64,16 @@ cmd_run() {
       ;;
     already_latest)
       printf '%s\n' "$(t running_already "$current_ver")"
+      # Backend already running: open the plain URL (no pairing code). Its initial
+      # pairing code was already consumed/expired by the first load, and sending a
+      # stale code would just fail its single-use redeem (and count toward lockout).
+      # The webview reuses the auth token it persisted for this origin on first pair.
       _open_browser "$(_webview_url "$(pwd)")"
       return 0
       ;;
     use_existing)
       printf '%s\n' "$(t running_already "$current_ver")" >&2
+      # Backend already running: open the plain URL (see already_latest above).
       _open_browser "$(_webview_url "$(pwd)")"
       return 0
       ;;
@@ -86,6 +91,8 @@ cmd_run() {
           ;;
         *)
           printf '%s\n' "$(t update_declined "$current_ver")"
+          # Kept the running backend: open the plain URL (no pairing code — the
+          # webview reuses the token it persisted for this origin on first pair).
           _open_browser "$(_webview_url "$(pwd)")"
           ;;
       esac

--- a/cli/lib/browser.sh
+++ b/cli/lib/browser.sh
@@ -2,9 +2,11 @@
 # browser.sh — build the WebView URL and open it in the user's browser.
 #
 # Public API:
-#   _urlencode <string>   → percent-encoded string (pure bash)
-#   _webview_url <cwd>    → http://localhost:<CCG_PORT>/?workingDir=<encoded cwd>
-#   _open_browser <url>   → open the URL via open/xdg-open/start
+#   _urlencode <string>         → percent-encoded string (pure bash)
+#   _webview_url <cwd> [pair]   → http://localhost:<CCG_PORT>/?workingDir=<cwd>[&pair=<code>]
+#   _open_browser <url>         → open the URL via open/xdg-open/start
+#   _ccg_auth_token             → stable token derived from the persisted secret (HMAC)
+#   _ccg_new_pair_code          → fresh single-use pairing code (URL-safe base64)
 
 # Percent-encode a string for use in URL query parameters.
 # Pure bash (no python/perl), handles spaces, Korean, &, =, etc.
@@ -24,9 +26,115 @@ _urlencode() {
 
 # Build the WebView URL for a given working directory. Port comes from CCG_PORT
 # (default 19836) so `ccg run -p <n>` opens the browser on the chosen port.
+#
+# The optional second arg is a single-use PAIRING CODE. When non-empty it is
+# appended as `&pair=<code>` so the webview can read it once at startup and redeem
+# it (POST /pair) for the auth token — the token itself is NEVER placed in a URL.
+# The webview then attaches the redeemed token as the `ccg-auth` subprotocol on
+# its /ws, /rpc, /logs connections.
 _webview_url() {
   local cwd=$1
-  printf 'http://localhost:%s/?workingDir=%s' "${CCG_PORT:-19836}" "$(_urlencode "$cwd")"
+  local pair=${2:-}
+  local url
+  url=$(printf 'http://localhost:%s/?workingDir=%s' "${CCG_PORT:-19836}" "$(_urlencode "$cwd")")
+  if [[ -n "$pair" ]]; then
+    url="${url}&pair=$(_urlencode "$pair")"
+  fi
+  printf '%s' "$url"
+}
+
+# ── Control-channel auth: STABLE token via a persisted secret ────────────────
+# The Node backend requires an auth token on every /ws, /rpc, /logs upgrade (and
+# the /internal routes). The LAUNCHER owns this token and it must be STABLE across
+# separate `ccg run` invocations, so the backend can restart (frequent) without
+# stranding a webview. We persist a random SECRET (0600) and DERIVE the token as
+# HMAC-SHA256(secret, "ccg-auth") — the token itself never touches disk. The
+# secret is stored as lowercase hex so it is shell-safe and byte-for-byte
+# compatible with the JetBrains plugin's derivation (same ~/.claude-code-gui path
+# when XDG_CONFIG_HOME is unset).
+
+# Config dir holding the secret. XDG-aware, defaulting to ~/.claude-code-gui to
+# mirror the JetBrains plugin. Portable across macOS/Linux/WSL.
+_ccg_config_dir() {
+  printf '%s' "${XDG_CONFIG_HOME:-$HOME/.claude-code-gui}"
+}
+
+# Path to the persisted secret file (0600).
+_ccg_auth_secret_file() {
+  printf '%s/auth-secret' "$(_ccg_config_dir)"
+}
+
+# Generate a random 64-char hex secret. Prefer openssl; fall back to node's crypto
+# (node is required to run the backend anyway), then to /dev/urandom via od. All
+# three are available across macOS/Linux/WSL, so no bashism/GNU-ism is assumed.
+_ccg_generate_secret_hex() {
+  if command -v openssl >/dev/null 2>&1; then
+    openssl rand -hex 32
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'process.stdout.write(require("crypto").randomBytes(32).toString("hex"))'
+  else
+    od -An -tx1 -N32 /dev/urandom | tr -d ' \n'
+  fi
+}
+
+# Read the persisted secret, or create it (0600) on first use, and print it.
+# Stable across launches. Trims surrounding whitespace/newlines on read so a file
+# written by either launcher round-trips cleanly.
+_ccg_read_or_create_secret() {
+  local file secret dir
+  file=$(_ccg_auth_secret_file)
+  if [[ -f "$file" ]]; then
+    secret=$(tr -d ' \t\r\n' < "$file" 2>/dev/null || printf '')
+    if [[ -n "$secret" ]]; then
+      printf '%s' "$secret"
+      return 0
+    fi
+  fi
+  secret=$(_ccg_generate_secret_hex)
+  dir=$(_ccg_config_dir)
+  mkdir -p "$dir" 2>/dev/null || true
+  # Restrict to the owner (0600). The umask change is confined to the subshell so
+  # it never leaks into the caller's file-creation mask.
+  ( umask 077; printf '%s' "$secret" > "$file" ) 2>/dev/null || true
+  chmod 600 "$file" 2>/dev/null || true
+  printf '%s' "$secret"
+}
+
+# Derive the stable auth token: HMAC-SHA256(secret, "ccg-auth") as lowercase hex.
+# Prefer openssl (portable output parsed to the trailing hex field); fall back to
+# node's crypto. The secret is passed to node via env (never as an argv token).
+_ccg_derive_token() {
+  local secret=$1
+  if command -v openssl >/dev/null 2>&1; then
+    printf '%s' 'ccg-auth' | openssl dgst -sha256 -hmac "$secret" 2>/dev/null | awk '{print $NF}'
+  elif command -v node >/dev/null 2>&1; then
+    CCG_HMAC_SECRET="$secret" node -e 'process.stdout.write(require("crypto").createHmac("sha256", process.env.CCG_HMAC_SECRET).update("ccg-auth").digest("hex"))'
+  else
+    printf ''
+  fi
+}
+
+# Print the STABLE control-channel auth token for this user. Idempotent across
+# launches (derived from the persisted secret), so a later `ccg run` that finds
+# the backend already running derives the same token the backend was spawned with.
+_ccg_auth_token() {
+  local secret
+  secret=$(_ccg_read_or_create_secret)
+  _ccg_derive_token "$secret"
+}
+
+# Generate a FRESH single-use pairing code (URL-safe base64, ~32 chars from 24
+# random bytes). One per launch: seeded into node via CCG_INITIAL_PAIR_CODE and
+# embedded as `?pair=` in the browser URL so the webview redeems it for the token.
+_ccg_new_pair_code() {
+  if command -v openssl >/dev/null 2>&1; then
+    # base64 → URL-safe (+/→-_), strip padding.
+    openssl rand -base64 24 | tr '+/' '-_' | tr -d '='
+  elif command -v node >/dev/null 2>&1; then
+    node -e 'process.stdout.write(require("crypto").randomBytes(24).toString("base64url"))'
+  else
+    od -An -tx1 -N24 /dev/urandom | tr -d ' \n'
+  fi
 }
 
 # Open a URL in the platform browser, best-effort (never fails the caller).

--- a/cli/lib/spawn/foreground.sh
+++ b/cli/lib/spawn/foreground.sh
@@ -10,20 +10,30 @@ readonly _CCG_RESTART_EXIT_CODE=75
 # Minimum seconds between successive restarts (crash-loop guard).
 readonly _CCG_RESTART_MIN_INTERVAL=2
 
-# _spawn_one_iteration <cache_dir> <first_run> [bind]
+# _spawn_one_iteration <cache_dir> <first_run> <bind> <auth_token> <pair_code>
 #   Spawns node backend.mjs once. Blocks until node exits.
 #   Outputs log lines (including PORT:n handshake) to stdout.
 #   Browser is opened only when first_run=1.
 #   <bind> (default loopback) is passed to node as CCG_BIND (bind address).
+#   <auth_token> is the STABLE control-channel token: exported to node as
+#     CCG_AUTH_TOKEN. Derived from the persisted secret, so it is identical across
+#     respawns AND across separate `ccg run` invocations. NEVER placed in a URL.
+#   <pair_code> is the fresh single-use pairing code: exported to node as
+#     CCG_INITIAL_PAIR_CODE (the backend seeds its pairing store with it) and
+#     appended to the browser URL as ?pair=<code>. The webview redeems it once for
+#     the token. Reused across respawns within one launch (the already-open webview
+#     already holds the token and reconnects with it).
 #   Returns node's exit code.
 _spawn_one_iteration() {
   local cache_dir=$1
   local first_run=$2
   local bind=${3:-127.0.0.1}
+  local auth_token=${4:-}
+  local pair_code=${5:-}
   local backend="$cache_dir/backend.mjs"
   local webview="$cache_dir/webview"
   local cwd_url
-  cwd_url=$(_webview_url "$(pwd)")
+  cwd_url=$(_webview_url "$(pwd)" "$pair_code")
 
   # Unique fifo path. Pre-clean any stale leftover with the same name.
   local fifo
@@ -34,7 +44,11 @@ _spawn_one_iteration() {
   # Start node directly (no wrapping subshell) so $! is node's actual PID.
   # </dev/null detaches stdin: the backend cannot swallow Ctrl+C as 0x03.
   # PORT/CCG_BIND select the backend's listen port/host (default 19836/loopback).
-  PORT="${CCG_PORT:-19836}" CCG_BIND="$bind" WEBVIEW_DIR="$webview" node "$backend" </dev/null >"$fifo" 2>&1 &
+  # CCG_AUTH_TOKEN is the stable control-channel token the backend requires on
+  # /ws, /rpc, /logs and the /internal routes (backend authToken picks it up).
+  # CCG_INITIAL_PAIR_CODE seeds the backend's pairing store so the webview can
+  # redeem the `?pair=` code for the token on first load.
+  PORT="${CCG_PORT:-19836}" CCG_BIND="$bind" CCG_AUTH_TOKEN="$auth_token" CCG_INITIAL_PAIR_CODE="$pair_code" WEBVIEW_DIR="$webview" node "$backend" </dev/null >"$fifo" 2>&1 &
   local pid=$!
 
   # Background reader: forward log lines, detect PORT:n, print URL + open browser.
@@ -89,12 +103,21 @@ _spawn_backend_and_open_browser() {
   local first_run=1
   local last_start rc
 
+  # STABLE auth token derived from the persisted secret — identical across respawns
+  # AND across separate `ccg run` invocations. Plus a FRESH single-use pairing code
+  # for THIS launch, reused across respawns (exit 75): the already-open webview has
+  # already redeemed it for the token and reconnects with the token, so the seeded
+  # code only matters for the initial first_run browser load.
+  local auth_token pair_code
+  auth_token=$(_ccg_auth_token)
+  pair_code=$(_ccg_new_pair_code)
+
   while true; do
     last_start=$(date +%s)
     rc=0
 
     # Capture exit code without triggering set -e on nonzero returns.
-    _spawn_one_iteration "$cache_dir" "$first_run" "$bind" || rc=$?
+    _spawn_one_iteration "$cache_dir" "$first_run" "$bind" "$auth_token" "$pair_code" || rc=$?
 
     if [[ "$rc" -ne "$_CCG_RESTART_EXIT_CODE" ]]; then
       # Normal exit or unrelated error — propagate the exit code.

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/actions/SendSelectionToClaudeAction.kt
@@ -174,7 +174,8 @@ class SendSelectionToClaudeAction : AnAction() {
         CoroutineScope(Dispatchers.IO).launch {
             try {
                 val port = backend.awaitPort(backendKey)
-                postJson(port, "/internal/editor-context", payload)
+                // /internal routes require the stable token (Phase 1 defense-in-depth).
+                postJson(port, "/internal/editor-context", payload, backend.authToken(backendKey))
             } catch (ex: Exception) {
                 logger.warn("Failed to send editor context to backend", ex)
             } finally {
@@ -199,7 +200,7 @@ class SendSelectionToClaudeAction : AnAction() {
         }
     }
 
-    private fun postJson(port: Int, path: String, payload: JsonObject) {
+    private fun postJson(port: Int, path: String, payload: JsonObject, authToken: String?) {
         val url = URI("http://127.0.0.1:$port$path").toURL()
         val conn = url.openConnection() as HttpURLConnection
         try {
@@ -208,6 +209,9 @@ class SendSelectionToClaudeAction : AnAction() {
             conn.requestMethod = "POST"
             conn.doOutput = true
             conn.setRequestProperty("Content-Type", "application/json")
+            // Stable control-channel token in the custom header the backend requires
+            // on the /internal routes (mirrors backend HTTP_AUTH_HEADER). Never logged.
+            if (!authToken.isNullOrEmpty()) conn.setRequestProperty("x-ccg-token", authToken)
             conn.outputStream.use { it.write(payload.toString().toByteArray(Charsets.UTF_8)) }
             // Fire-and-forget: read the response code only to flush the request.
             val code = conn.responseCode

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -73,6 +73,31 @@ class NodeProcessManager(
      * Null only in unit tests that never reach the extraction step.
      */
     private val resourcesReady: Deferred<ExtractedResources>? = null,
+    /**
+     * Stable control-channel auth token. Injected into the backend process as the
+     * `CCG_AUTH_TOKEN` env var so the backend's [authToken] picks it up and requires
+     * it on every /ws, /rpc, /logs upgrade and /internal POST routes. The SAME token
+     * is used by this backend's [RpcWebSocketClient] (/rpc subprotocol) and the
+     * IDE→backend /internal POSTs, so a single value gates the whole control channel.
+     * The token is NEVER placed in a URL — the JCEF webview obtains it by redeeming
+     * the single-use `?pair=` code (see [initialPairCode]). Derived from a persisted
+     * per-user secret by [com.github.yhk1038.claudecodegui.services.NodeBackendService],
+     * so it is STABLE across restarts (an already-loaded webview reconnects with the
+     * same value even after a backend respawn). NEVER logged. Empty only in unit
+     * tests that don't reach a real spawn.
+     */
+    private val authToken: String = "",
+    /**
+     * Fresh single-use INITIAL pairing code for this spawn. Injected into the backend
+     * process as the `CCG_INITIAL_PAIR_CODE` env var so the backend seeds its pairing
+     * store with it at startup; the JCEF webview then redeems it once (POST /pair) for
+     * [authToken]. This keeps the auth token out of every URL — the URL carries only
+     * `?pair=<code>`. Regenerated per spawn by the owning
+     * [com.github.yhk1038.claudecodegui.services.NodeBackendService] BackendInstance.
+     * NEVER logged (redacted from the WSL command log below). Empty only in unit tests
+     * that don't reach a real spawn.
+     */
+    private val initialPairCode: String = "",
 ) : Disposable {
 
     private val logger = Logger.getInstance(NodeProcessManager::class.java)
@@ -235,6 +260,14 @@ class NodeProcessManager(
                         put("JETBRAINS_MODE", "true")
                         put("CCG_CLIENT_INFO", clientInfo)
                         put("PORT", requestedPort.toString())
+                        // Stable control-channel auth token (see [authToken]). Required
+                        // by the backend on /ws, /rpc, /logs, /internal routes. Redacted from
+                        // the command log below.
+                        if (authToken.isNotEmpty()) put("CCG_AUTH_TOKEN", authToken)
+                        // Fresh single-use initial pairing code (see [initialPairCode]). The
+                        // backend seeds its pairing store with it; the webview redeems it via
+                        // `?pair=`. Redacted from the command log below.
+                        if (initialPairCode.isNotEmpty()) put("CCG_INITIAL_PAIR_CODE", initialPairCode)
                         webviewDir?.let { wv ->
                             WslPathResolver.toWslPath(wv.absolutePath)?.let { put("WEBVIEW_DIR", it) }
                         }
@@ -243,7 +276,20 @@ class NodeProcessManager(
                         // are pruned at extraction time by PluginResourceExtractor (#149).
                     }
                     val cmd = WslPathResolver.buildWslNodeCommand(wslDistro, wslCwd, wslEnv, linuxBackend)
-                    logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${cmd.joinToString(" ")}")
+                    // The WSL command embeds env as `export K=V`, so the token and pairing
+                    // code would appear in the joined command — redact both before logging
+                    // (never log the token or the pairing code).
+                    val redactedCmd = cmd.map { part ->
+                        var redacted = part
+                        if (authToken.isNotEmpty() && redacted.contains("CCG_AUTH_TOKEN=")) {
+                            redacted = redacted.replace(authToken, "<redacted>")
+                        }
+                        if (initialPairCode.isNotEmpty() && redacted.contains("CCG_INITIAL_PAIR_CODE=")) {
+                            redacted = redacted.replace(initialPairCode, "<redacted>")
+                        }
+                        redacted
+                    }
+                    logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${redactedCmd.joinToString(" ")}")
                     pb = ProcessBuilder(cmd).redirectErrorStream(false)
                 } else {
                     val env = buildMap {
@@ -270,6 +316,14 @@ class NodeProcessManager(
                         // and reports the real port via its PORT:{n} stdout line. Lets one
                         // backend per IDE project root coexist without a fixed-port clash (#57).
                         put("PORT", requestedPort.toString())
+                        // Stable control-channel auth token (see [authToken]). The backend
+                        // requires it on /ws, /rpc, /logs and the /internal routes. Set via the
+                        // env map (never logged — the native branch does not log the env).
+                        if (authToken.isNotEmpty()) put("CCG_AUTH_TOKEN", authToken)
+                        // Fresh single-use initial pairing code (see [initialPairCode]). The
+                        // backend seeds its pairing store with it so the webview can redeem it
+                        // (via `?pair=`) for the token. Set via the env map (never logged).
+                        if (initialPairCode.isNotEmpty()) put("CCG_INITIAL_PAIR_CODE", initialPairCode)
                         // PROJECT_DIR removed — workingDir is passed via WebSocket message
                     }
                     pb = ProcessBuilder(nodePath!!, backendFile.absolutePath)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/RpcWebSocketClient.kt
@@ -11,6 +11,13 @@ import java.util.concurrent.CompletionStage
 import java.util.concurrent.CompletableFuture
 
 /**
+ * The Sec-WebSocket-Protocol marker paired with the per-launch auth token on the
+ * control channel. Mirrors the backend's AUTH_SUBPROTOCOL (ws-server.ts) and the
+ * webview's AUTH_SUBPROTOCOL (webview authToken.ts) — one wire value everywhere.
+ */
+internal const val AUTH_SUBPROTOCOL = "ccg-auth"
+
+/**
  * WebSocket client that connects to the Node.js backend's /rpc endpoint.
  * Receives JSON-RPC requests from the backend and dispatches them to
  * the provided RpcHandler (which routes to the correct project's panel).
@@ -38,6 +45,14 @@ class RpcWebSocketClient(
      * so the dispatch stays unit-testable and the client has no upward dependency.
      */
     private val onNotification: ((String, JsonObject) -> Unit)? = null,
+    /**
+     * Stable control-channel auth token. The backend requires it on the /rpc upgrade
+     * (Phase 1), carried in the Sec-WebSocket-Protocol header alongside the `ccg-auth`
+     * marker — the same value the node process was spawned with (CCG_AUTH_TOKEN) and
+     * the value the JCEF webview obtains by redeeming its pairing code. NEVER logged.
+     * Empty only in unit tests that don't open a real socket.
+     */
+    private val authToken: String = "",
 ) : Disposable {
 
     private val logger = Logger.getInstance(RpcWebSocketClient::class.java)
@@ -89,7 +104,16 @@ class RpcWebSocketClient(
 
         logger.info("Connecting to RPC WebSocket: $uri")
 
-        client.newWebSocketBuilder()
+        // Carry the per-launch auth token as the `ccg-auth` subprotocol so the
+        // backend's upgrade handler accepts the /rpc control channel. The header
+        // becomes `Sec-WebSocket-Protocol: ccg-auth, <token>`; the backend echoes
+        // back only the `ccg-auth` marker. When the token is empty (tests) we skip
+        // the subprotocol entirely.
+        val builder = client.newWebSocketBuilder()
+        if (authToken.isNotEmpty()) {
+            builder.subprotocols(AUTH_SUBPROTOCOL, authToken)
+        }
+        builder
             .buildAsync(uri, RpcWebSocketListener(port))
             .thenAccept { ws ->
                 webSocket = ws

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/IdeSelectionDispatcher.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/IdeSelectionDispatcher.kt
@@ -244,7 +244,8 @@ object IdeSelectionDispatcher {
         ioScope.launch {
             try {
                 val port = backend.awaitPort(backendKey)
-                postIdeSelection(port, payload.toString())
+                // /internal routes require the stable token (Phase 1 defense-in-depth).
+                postIdeSelection(port, payload.toString(), backend.authToken(backendKey))
             } catch (ex: Exception) {
                 logger.debug("ide-selection dispatch failed (no backend yet or error): ${ex.message}")
             }
@@ -256,8 +257,11 @@ object IdeSelectionDispatcher {
      *
      * Runs on [ioScope] (never the EDT). Short timeouts are intentional — this is
      * a passive channel and must not block the IDE if the backend is slow.
+     *
+     * [authToken] is the backend's stable control-channel token; sent in the
+     * `x-ccg-token` header the backend requires on the /internal routes (never logged).
      */
-    private fun postIdeSelection(port: Int, jsonBody: String) {
+    private fun postIdeSelection(port: Int, jsonBody: String, authToken: String?) {
         val url = URI("http://127.0.0.1:$port/internal/ide-selection").toURL()
         val conn = url.openConnection() as HttpURLConnection
         try {
@@ -266,6 +270,9 @@ object IdeSelectionDispatcher {
             conn.requestMethod = "POST"
             conn.doOutput = true
             conn.setRequestProperty("Content-Type", "application/json")
+            // Custom header (mirrors backend HTTP_AUTH_HEADER) — chosen over
+            // Authorization to avoid clashing with Claude's own auth / proxy rewrites.
+            if (!authToken.isNullOrEmpty()) conn.setRequestProperty("x-ccg-token", authToken)
             conn.outputStream.use { it.write(jsonBody.toByteArray(Charsets.UTF_8)) }
             val code = conn.responseCode
             logger.debug("POST /internal/ide-selection returned HTTP $code")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -86,6 +86,29 @@ class NodeBackendService : Disposable {
         private var nodeProcessManager: NodeProcessManager? = null
         private var rpcClient: RpcWebSocketClient? = null
 
+        /**
+         * Stable control-channel auth token for THIS root's backend. Derived from a
+         * persisted per-user secret (see [stableAuthToken]), so it is the SAME value on
+         * every launch and every respawn — the backend restarts frequently, and an
+         * already-loaded webview (which redeemed the token once via a pairing code) must
+         * still authenticate against the respawned backend without re-pairing. The
+         * launcher OWNS this token: it is handed to the node spawn (CCG_AUTH_TOKEN env),
+         * this backend's [RpcWebSocketClient] (`ccg-auth` /rpc subprotocol), and the
+         * IDE to backend /internal POSTs. It is NEVER placed in any URL and NEVER logged.
+         */
+        val authToken: String = stableAuthToken
+
+        /**
+         * Fresh single-use INITIAL pairing code for THIS root's backend, regenerated on
+         * every spawn ([start]). Injected into the node process (CCG_INITIAL_PAIR_CODE)
+         * so the backend seeds its pairing store with it, and embedded as `?pair=` in the
+         * JCEF load URL so the webview redeems it once (POST /pair) for [authToken]. This
+         * keeps the auth token out of every URL. NEVER logged.
+         */
+        @Volatile
+        var initialPairCode: String = ""
+            private set
+
         @Volatile
         var portDeferred = CompletableDeferred<Int>()
             private set
@@ -205,6 +228,11 @@ class NodeBackendService : Disposable {
             // A WSL project root (UNC basePath) runs its backend inside the distro so
             // node/claude execute as Linux natives (issue #57); a native root runs locally.
             val wsl = WslPathResolver.parseUncPath(basePath)
+            // Fresh single-use pairing code for this (re)spawn. Seeded into the node
+            // process (CCG_INITIAL_PAIR_CODE) and embedded as `?pair=` in the JCEF URL,
+            // so the webview redeems it for the stable token instead of the token ever
+            // appearing in a URL. Regenerated per spawn; the value is never logged.
+            initialPairCode = generateInitialPairCode()
             val manager = NodeProcessManager(
                 scope,
                 // Reuse the last bound port on respawn (0 only on first start) so a WebView
@@ -221,6 +249,12 @@ class NodeBackendService : Disposable {
                 // Shared extraction gate: the manager awaits this instead of extracting its
                 // own temp dir, so all backend generations share one live dir (#149).
                 resourcesReady = resourcesReady,
+                // Stable control-channel token — injected into the node process as
+                // CCG_AUTH_TOKEN so it requires the token on every /ws, /rpc, /logs upgrade.
+                authToken = authToken,
+                // Fresh single-use pairing code — injected as CCG_INITIAL_PAIR_CODE so the
+                // backend seeds its pairing store; the webview redeems it via `?pair=`.
+                initialPairCode = initialPairCode,
             )
             nodeProcessManager = manager
             manager.start()
@@ -260,6 +294,9 @@ class NodeBackendService : Disposable {
                 // for synchronous host routing (issue #7). The method literal mirrors the
                 // shared MessageType enum on the TS side.
                 onNotification = ::handleRpcNotification,
+                // Same per-launch token the node process was spawned with — attached as
+                // the `ccg-auth` subprotocol so the /rpc upgrade passes Phase 1 auth.
+                authToken = authToken,
             )
             rpcClient = client
             client.connect(port)
@@ -352,6 +389,25 @@ class NodeBackendService : Disposable {
             ?: error("No backend registered for project root: $projectBasePath")).awaitPort()
 
     /**
+     * The stable control-channel auth token of the backend serving [projectBasePath],
+     * or null when no backend is registered for that root. Used by this backend's
+     * [RpcWebSocketClient] (`ccg-auth` /rpc subprotocol) and the IDE to backend
+     * /internal POSTs (`x-ccg-token` header) so they authenticate against the same
+     * token the backend was spawned with. It is NEVER placed in a URL — the webview
+     * obtains it by redeeming [initialPairCode]. Never logged by callers.
+     */
+    fun authToken(projectBasePath: String): String? = backends[projectBasePath]?.authToken
+
+    /**
+     * The fresh single-use initial pairing code of the backend serving
+     * [projectBasePath], or null when no backend is registered for that root. The JCEF
+     * load URL embeds this as `?pair=`; the webview redeems it once at POST /pair for
+     * the stable auth token, keeping the token out of every URL. Regenerated on each
+     * spawn. Never logged by callers.
+     */
+    fun initialPairCode(projectBasePath: String): String? = backends[projectBasePath]?.initialPairCode
+
+    /**
      * Most recent backend stderr for [projectBasePath], or null when none. Used to
      * attach a concrete cause to a start failure/timeout error panel. See issue #97.
      */
@@ -428,7 +484,113 @@ class NodeBackendService : Disposable {
     }
 
     companion object {
+        private val companionLogger = Logger.getInstance(NodeBackendService::class.java)
+
         fun getInstance(): NodeBackendService =
             ApplicationManager.getApplication().getService(NodeBackendService::class.java)
+
+        /**
+         * Stable control-channel auth token for this user: `HMAC-SHA256(secret,
+         * "ccg-auth")` as 64 lowercase hex chars, where `secret` is a persisted random
+         * value (see [loadOrCreateAuthSecret]). Because the secret survives on disk, the
+         * derived token is the SAME on every launch and every backend respawn — which is
+         * exactly what lets an already-loaded webview reconnect to a restarted backend
+         * without re-pairing. The launcher owns this token and injects it into the node
+         * process via CCG_AUTH_TOKEN. Computed once per process (lazy). NEVER logged.
+         */
+        val stableAuthToken: String by lazy { deriveAuthToken(loadOrCreateAuthSecret()) }
+
+        /**
+         * On-disk location of the per-user auth secret. Mirrors the plugin config dir
+         * (SettingsManager persists `~/.claude-code-gui/settings.js`), so we keep the
+         * secret alongside it at `~/.claude-code-gui/auth-secret`. The TOKEN itself is
+         * derived from this secret and never written to disk.
+         */
+        private fun authSecretPath(): java.nio.file.Path =
+            java.nio.file.Path.of(System.getProperty("user.home"), ".claude-code-gui", "auth-secret")
+
+        /**
+         * Read the persisted secret, or create it (0600) on first use. Stored as a
+         * lowercase-hex string so it is shell-safe and byte-for-byte interoperable with
+         * the ccg CLI's openssl-based HMAC (both HMAC over the hex string). Returns the
+         * secret's UTF-8 bytes. Any I/O failure falls back to a fresh in-memory secret
+         * for this process (a per-process token, rather than crashing). NEVER logged.
+         */
+        private fun loadOrCreateAuthSecret(): ByteArray {
+            val path = authSecretPath()
+            try {
+                if (java.nio.file.Files.exists(path)) {
+                    val existing = java.nio.file.Files.readAllBytes(path)
+                        .toString(Charsets.UTF_8).trim()
+                    if (existing.isNotEmpty()) return existing.toByteArray(Charsets.UTF_8)
+                }
+            } catch (e: Exception) {
+                companionLogger.warn("Could not read auth secret; regenerating")
+            }
+            val raw = ByteArray(32)
+            java.security.SecureRandom().nextBytes(raw)
+            val hex = raw.joinToString("") { "%02x".format(it) }
+            try {
+                java.nio.file.Files.createDirectories(path.parent)
+                java.nio.file.Files.write(path, hex.toByteArray(Charsets.UTF_8))
+                restrictToOwner(path)
+            } catch (e: Exception) {
+                companionLogger.warn("Could not persist auth secret; using an in-memory secret this session")
+            }
+            return hex.toByteArray(Charsets.UTF_8)
+        }
+
+        /**
+         * Best-effort 0600 on the secret file. Uses POSIX permissions where supported;
+         * on Windows / non-POSIX filesystems POSIX perms are unavailable, so fall back to
+         * the owner-only File flags and never fail. Public JDK APIs only (Plugin Verifier
+         * stays clean).
+         */
+        private fun restrictToOwner(path: java.nio.file.Path) {
+            try {
+                java.nio.file.Files.setPosixFilePermissions(
+                    path,
+                    java.nio.file.attribute.PosixFilePermissions.fromString("rw-------"),
+                )
+                return
+            } catch (_: UnsupportedOperationException) {
+                // Non-POSIX filesystem (e.g. Windows) — fall through to the File API.
+            } catch (_: Exception) {
+                return
+            }
+            try {
+                val f = path.toFile()
+                f.setReadable(false, false); f.setReadable(true, true)
+                f.setWritable(false, false); f.setWritable(true, true)
+            } catch (_: Exception) {
+                // best-effort only
+            }
+        }
+
+        /**
+         * Derive the stable token: `HMAC-SHA256(secret, "ccg-auth")` as 64 lowercase hex
+         * chars. Uses only public JDK crypto (javax.crypto.Mac "HmacSHA256") — no
+         * Internal/impl platform API, so the marketplace Plugin Verifier stays clean.
+         */
+        private fun deriveAuthToken(secret: ByteArray): String {
+            val mac = javax.crypto.Mac.getInstance("HmacSHA256")
+            mac.init(javax.crypto.spec.SecretKeySpec(secret, "HmacSHA256"))
+            val out = mac.doFinal("ccg-auth".toByteArray(Charsets.UTF_8))
+            return out.joinToString("") { "%02x".format(it) }
+        }
+
+        /**
+         * Generate a fresh single-use INITIAL pairing code: 24 cryptographically secure
+         * random bytes (192 bits) rendered as URL-safe base64 without padding (~32
+         * chars). Matches the backend's pairing-code entropy/shape. The launcher seeds
+         * this into the node process (CCG_INITIAL_PAIR_CODE) AND embeds it as `?pair=` in
+         * the webview URL; the webview redeems it once for the stable token, so the token
+         * never appears in a URL. Public JDK APIs only (SecureRandom, Base64). NEVER logged.
+         */
+        private fun generateInitialPairCode(): String {
+            val bytes = ByteArray(24)
+            java.security.SecureRandom().nextBytes(bytes)
+            return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+        }
     }
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -1035,9 +1035,17 @@ class ClaudeCodePanel(
             workingDir = project.basePath,
             panelId = panelId,
             isBright = com.intellij.ui.JBColor.isBright(),
+            // Deliver the single-use pairing code to the webview out-of-band via the load
+            // URL. The webview reads it once, strips it from the address bar, and redeems
+            // it at POST /pair for the stable auth token (which it then attaches as the
+            // `ccg-auth` subprotocol) — the token itself is NEVER placed in the URL.
+            // NEVER logged — buildWebViewUrl is not passed to any logger below.
+            pairCode = backendService.initialPairCode(project.basePath ?: ""),
         )
-        System.err.println("[ClaudeCodePanel] Loading URL: $url")
-        logger.info("Loading WebView from Node.js backend: $url")
+        // Redact the pairing code (and any token) from any log — they are secrets.
+        val loggedUrl = redactUrlSecrets(url)
+        System.err.println("[ClaudeCodePanel] Loading URL: $loggedUrl")
+        logger.info("Loading WebView from Node.js backend: $loggedUrl")
 
         javax.swing.SwingUtilities.invokeLater {
             val b = browser!!
@@ -1479,6 +1487,12 @@ class ClaudeCodePanel(
  *   - `theme`      — `light` | `dark`, derived from the IDE LAF ([isBright]).
  *                    Consumed by the FOUC guard in webview/index.html to paint
  *                    the right surface color before CSS/React load.
+ *   - `pair`       — single-use initial pairing code (omitted when null/blank).
+ *                    Out-of-band delivery of the code the webview redeems once (POST
+ *                    /pair) for the auth token, which it then attaches to its ws
+ *                    connections as the `ccg-auth` subprotocol. The auth token itself
+ *                    is NEVER placed in a URL. MUST still be redacted (see
+ *                    [redactUrlSecrets]) before the URL is ever logged.
  */
 internal fun buildWebViewUrl(
     port: Int,
@@ -1486,15 +1500,28 @@ internal fun buildWebViewUrl(
     workingDir: String?,
     panelId: String,
     isBright: Boolean,
+    pairCode: String? = null,
 ): String {
     val workingDirParam = workingDir?.let {
         "workingDir=${java.net.URLEncoder.encode(it, "UTF-8")}"
     }
     val panelParam = "panelId=${java.net.URLEncoder.encode(panelId, "UTF-8")}"
     val themeParam = "theme=${if (isBright) "light" else "dark"}"
-    val query = listOfNotNull(workingDirParam, panelParam, themeParam).joinToString("&")
+    val pairParam = pairCode?.takeIf { it.isNotBlank() }?.let {
+        "pair=${java.net.URLEncoder.encode(it, "UTF-8")}"
+    }
+    val query = listOfNotNull(workingDirParam, panelParam, themeParam, pairParam).joinToString("&")
     return "http://localhost:$port$pathSegment?$query"
 }
+
+/**
+ * Replace the value of a `token=` or `pair=` query param with `<redacted>` so a
+ * WebView URL can be logged without leaking the auth token or the single-use pairing
+ * code. Matches `?token=`/`&token=` and `?pair=`/`&pair=` up to the next `&` (or end
+ * of string). Pure string transform, unit-testable.
+ */
+internal fun redactUrlSecrets(url: String): String =
+    url.replace(Regex("([?&](?:token|pair)=)[^&]*"), "$1<redacted>")
 
 internal fun resolveFileUriPath(raw: String): String? {
     return runCatching {

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/BuildWebViewUrlTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/BuildWebViewUrlTest.kt
@@ -114,4 +114,112 @@ class BuildWebViewUrlTest {
             assertTrue(url.startsWith("http://localhost:9/sessions/abc?"), "got: $url")
         }
     }
+
+    @Nested
+    inner class PairParam {
+        @Test
+        fun `omits pair param when pairCode is null`() {
+            val url = buildWebViewUrl(
+                port = 1,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = true,
+                pairCode = null,
+            )
+            assertFalse(url.contains("pair="), "got: $url")
+        }
+
+        @Test
+        fun `omits pair param when pairCode is blank`() {
+            val url = buildWebViewUrl(
+                port = 1,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = true,
+                pairCode = "  ",
+            )
+            assertFalse(url.contains("pair="), "got: $url")
+        }
+
+        @Test
+        fun `never emits a token param even when a pair code is present`() {
+            val url = buildWebViewUrl(
+                port = 9,
+                pathSegment = "/sessions/new",
+                workingDir = "/tmp",
+                panelId = "p1",
+                isBright = false,
+                pairCode = "abc123",
+            )
+            assertFalse(url.contains("token="), "the auth token must never appear in the URL: $url")
+        }
+
+        @Test
+        fun `appends pair as the last param after theme`() {
+            val url = buildWebViewUrl(
+                port = 9,
+                pathSegment = "/sessions/new",
+                workingDir = "/tmp",
+                panelId = "p1",
+                isBright = false,
+                pairCode = "abc123",
+            )
+            assertEquals(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark&pair=abc123",
+                url,
+            )
+        }
+
+        @Test
+        fun `url-encodes the pair code`() {
+            val url = buildWebViewUrl(
+                port = 9,
+                pathSegment = "/sessions/new",
+                workingDir = null,
+                panelId = "p1",
+                isBright = false,
+                pairCode = "a+b/c=",
+            )
+            assertTrue(url.contains("pair=a%2Bb%2Fc%3D"), "got: $url")
+        }
+    }
+
+    @Nested
+    inner class RedactUrlSecrets {
+        @Test
+        fun `redacts pair value when present`() {
+            val redacted = redactUrlSecrets(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark&pair=deadbeef",
+            )
+            assertEquals(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark&pair=<redacted>",
+                redacted,
+            )
+        }
+
+        @Test
+        fun `redacts token value when present`() {
+            val redacted = redactUrlSecrets(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark&token=deadbeef",
+            )
+            assertEquals(
+                "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark&token=<redacted>",
+                redacted,
+            )
+        }
+
+        @Test
+        fun `redacts pair when it is the first query param`() {
+            val redacted = redactUrlSecrets("http://localhost:9/?pair=secret&foo=bar")
+            assertEquals("http://localhost:9/?pair=<redacted>&foo=bar", redacted)
+        }
+
+        @Test
+        fun `leaves urls without a secret untouched`() {
+            val url = "http://localhost:9/sessions/new?workingDir=%2Ftmp&panelId=p1&theme=dark"
+            assertEquals(url, redactUrlSecrets(url))
+        }
+    }
 }

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -5,6 +5,9 @@ import { AppProviders } from './contexts';
 import { I18nLocaleSync } from './i18n/I18nLocaleSync';
 import { ChatPage, SettingsPage, SettingsOverlay, SwitchAccountPage, ProjectSelectorPage, SessionPanelPage } from './pages';
 import { AccountUsageModal } from './components/AccountUsageModal';
+import { ForbiddenNotice } from './components/ForbiddenNotice';
+import { isRemoteBlocked } from './api/bridge/authToken';
+import { usePairingStatus } from './hooks/usePairingStatus';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { OPEN_ACCOUNT_USAGE_EVENT } from './commandPalette/sections/model/AccountUsageItem';
@@ -49,6 +52,10 @@ function AppContent() {
       {isAccountUsageOpen && (
         <AccountUsageModal onClose={() => setIsAccountUsageOpen(false)} />
       )}
+
+      {/* Remote-device pairing failure (expired/locked/unreachable ?pair= code):
+          shows "rescan the QR" instead of a silent 401 reconnect loop. Renders
+          nothing in normal local use. */}
       <Toaster
         position="top-center"
         containerStyle={{ top: 40 }}
@@ -74,6 +81,20 @@ function AppContent() {
 }
 
 function App() {
+  // Access is blocked when EITHER the device is an unpaired remote (a tunnel URL
+  // with no `?pair=` code) OR a pairing attempt did not succeed for any reason
+  // (expired / wrong / rate-limited / unreachable). usePairingStatus makes this
+  // reactive so a pairing that fails after mount flips us to the block. A LOCAL
+  // transient disconnect is NEVER blocked (isRemoteBlocked stays false).
+  const { state: pairingState } = usePairingStatus();
+  const blocked = isRemoteBlocked() || pairingState === 'failed';
+
+  // Render ONLY the hard "403" block on an EMPTY template — do NOT mount the app
+  // providers, router, or chat UI (nothing to connect, nothing leaking behind).
+  if (blocked) {
+    return <ForbiddenNotice />;
+  }
+
   return (
     <ErrorBoundary>
       <AppProviders>

--- a/webview/src/api/bridge/WebSocketConnector.ts
+++ b/webview/src/api/bridge/WebSocketConnector.ts
@@ -2,6 +2,14 @@
 
 import type { Connector, RawMessageHandler, ConnectionChangeHandler } from './Connector';
 import { detectRuntime } from '../../config/environment';
+import {
+  authSubprotocols,
+  ensureAuthTokenReady,
+  hasPairCode,
+  getPairingStatus,
+  persistValidatedToken,
+  isRemoteBlocked,
+} from './authToken';
 import { MessageType } from '@/shared';
 
 export class WebSocketConnector implements Connector {
@@ -33,6 +41,51 @@ export class WebSocketConnector implements Connector {
     if (this.isConnecting || this.disposed) return;
     this.isConnecting = true;
 
+    // Token acquisition may be ASYNC on the pairing path: a `?pair=` code (the
+    // sole production delivery, for both local and remote clients) must be
+    // exchanged for the real token at POST /pair before we can open the control
+    // channel. Await it so no socket is ever opened token-less. When a validated
+    // token is already cached (sessionStorage) or in dev, this resolves
+    // synchronously-fast.
+    ensureAuthTokenReady()
+      .then((token) => {
+        if (this.disposed) {
+          this.isConnecting = false;
+          return;
+        }
+        // Remote pairing failed (code expired/locked/unreachable): don't open a
+        // doomed socket and don't spin a silent 401 reconnect loop — the UI
+        // surfaces a "rescan the QR" state driven by the pairing status.
+        if (!token && hasPairCode() && getPairingStatus().state === 'failed') {
+          this.isConnecting = false;
+          onFirstError?.(new Error('Remote pairing failed'));
+          onFirstError = undefined;
+          onFirstConnect = undefined;
+          return;
+        }
+        // Unpaired remote device (tunnel URL, no ?pair= code, no stored token):
+        // definitively forbidden. Don't hammer /ws with 401s — the ForbiddenNotice
+        // shows a hard "403" block instead.
+        if (!token && isRemoteBlocked()) {
+          this.isConnecting = false;
+          onFirstError?.(new Error('Forbidden: unpaired remote device'));
+          onFirstError = undefined;
+          onFirstConnect = undefined;
+          return;
+        }
+        this.openSocket(onFirstConnect, onFirstError);
+      })
+      .catch(() => {
+        // ensureAuthTokenReady never rejects, but guard defensively.
+        this.isConnecting = false;
+        this.scheduleReconnect();
+      });
+  }
+
+  private openSocket(
+    onFirstConnect?: (value: void) => void,
+    onFirstError?: (reason: Error) => void
+  ): void {
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const env = detectRuntime();
     // panelId (Kotlin IDE panel UUID) is embedded in the page URL by ClaudeCodePanel.
@@ -43,13 +96,20 @@ export class WebSocketConnector implements Connector {
     const wsUrl = `${protocol}//${window.location.host}/ws?env=${env}${panelParam}`;
     console.log('[WebSocketConnector] Connecting to:', wsUrl);
 
-    const ws = new WebSocket(wsUrl);
+    // Carry the per-launch auth token as the `ccg-auth` subprotocol so the
+    // backend's upgrade handler accepts the control channel (Phase 1 requires it).
+    const ws = new WebSocket(wsUrl, authSubprotocols());
     this.ws = ws;
 
     ws.onopen = () => {
       console.log('[WebSocketConnector] Connected');
       this.isConnecting = false;
       this.connected = true;
+      // The handshake passed the backend's token gate, so this token is valid —
+      // persist it (validate-then-store) so a page reload reconnects without
+      // re-redeeming a pairing code (the ?pair= code is single-use / already
+      // consumed). A wrong token never reaches here.
+      persistValidatedToken();
       this.notifyConnectionChange(true);
       // 텔레메트리 client 식별용으로 브라우저 UA를 백엔드에 알린다(standalone 모드 의미).
       // JetBrains 모드는 CCG_CLIENT_INFO env가 우선하므로 무해하다.
@@ -87,12 +147,7 @@ export class WebSocketConnector implements Connector {
       this.notifyConnectionChange(false);
 
       // 자동 재연결 (disposed 되지 않은 경우만)
-      if (!this.disposed) {
-        this.reconnectTimeout = setTimeout(() => {
-          console.log('[WebSocketConnector] Attempting to reconnect...');
-          this.connectInternal();
-        }, 2000);
-      }
+      this.scheduleReconnect();
     };
 
     ws.onerror = (error) => {
@@ -104,6 +159,27 @@ export class WebSocketConnector implements Connector {
         onFirstConnect = undefined;
       }
     };
+  }
+
+  /**
+   * Schedule a delayed reconnect unless disposed or the remote pairing failed
+   * unrecoverably (an expired/locked code can only be fixed by rescanning the
+   * QR, i.e. a fresh page load — retrying token-less would just 401-loop).
+   */
+  private scheduleReconnect(): void {
+    if (this.disposed) return;
+    if (hasPairCode() && getPairingStatus().state === 'failed') {
+      console.log('[WebSocketConnector] Remote pairing failed — not reconnecting; rescan the QR.');
+      return;
+    }
+    if (isRemoteBlocked()) {
+      console.log('[WebSocketConnector] Unpaired remote device — not reconnecting (403).');
+      return;
+    }
+    this.reconnectTimeout = setTimeout(() => {
+      console.log('[WebSocketConnector] Attempting to reconnect...');
+      this.connectInternal();
+    }, 2000);
   }
 
   disconnect(): void {

--- a/webview/src/api/bridge/__tests__/authToken.test.ts
+++ b/webview/src/api/bridge/__tests__/authToken.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  AUTH_SUBPROTOCOL,
+  authSubprotocols,
+  getAuthToken,
+  initAuthToken,
+  ensureAuthTokenReady,
+  hasPairCode,
+  getPairingStatus,
+  persistValidatedToken,
+  isLoopbackHostname,
+  isRemoteBlocked,
+  _resetAuthTokenCache,
+} from '../authToken';
+
+// The dev-only shared default mirrored from backend DEV_INSECURE_AUTH_TOKEN.
+const DEV_INSECURE_AUTH_TOKEN = 'ccg-dev-insecure-token';
+
+function setUrl(url: string): void {
+  window.history.replaceState({}, '', url);
+}
+
+describe('authToken', () => {
+  beforeEach(() => {
+    _resetAuthTokenCache();
+    setUrl('/');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    _resetAuthTokenCache();
+    setUrl('/');
+  });
+
+  it('attaches the resolved token as the ["ccg-auth", token] subprotocol array', () => {
+    window.sessionStorage.setItem('ccg-auth-token', 'secret123');
+    expect(authSubprotocols()).toEqual([AUTH_SUBPROTOCOL, 'secret123']);
+    expect(AUTH_SUBPROTOCOL).toBe('ccg-auth');
+  });
+
+  it('caches the token so it is only resolved once', () => {
+    window.sessionStorage.setItem('ccg-auth-token', 'first');
+    expect(getAuthToken()).toBe('first');
+    // Even if storage changes later, the cached value is reused.
+    window.sessionStorage.setItem('ccg-auth-token', 'second');
+    expect(getAuthToken()).toBe('first');
+  });
+
+  // ── The `?token=` URL param is gone: the token is NEVER carried in a URL.
+  //    Every client now redeems a single-use `?pair=` code at POST /pair. A
+  //    stray `?token=` must be IGNORED entirely (not read, not stored). ────────
+  it('IGNORES a ?token= URL param (the token is never carried in a URL)', () => {
+    vi.stubEnv('DEV', false);
+    _resetAuthTokenCache();
+    setUrl('/?token=ignored');
+    // Production build, no sessionStorage token: the param is not read.
+    expect(getAuthToken()).toBe('');
+    expect(authSubprotocols()).toEqual([AUTH_SUBPROTOCOL]);
+    // Nothing was persisted from the URL either.
+    expect(window.sessionStorage.getItem('ccg-auth-token')).toBeNull();
+  });
+
+  describe('dev fallback (import.meta.env.DEV)', () => {
+    it('falls back to the shared dev default when no stored token and no env', () => {
+      // Vitest runs with import.meta.env.DEV = true by default.
+      expect(import.meta.env.DEV).toBe(true);
+      expect(getAuthToken()).toBe(DEV_INSECURE_AUTH_TOKEN);
+    });
+
+    it('prefers VITE_CCG_DEV_TOKEN over the shared default in dev', () => {
+      vi.stubEnv('VITE_CCG_DEV_TOKEN', 'my-dev-token');
+      _resetAuthTokenCache();
+      expect(getAuthToken()).toBe('my-dev-token');
+    });
+
+    it('returns empty (no insecure default) in a production build with no stored token', () => {
+      vi.stubEnv('DEV', false);
+      _resetAuthTokenCache();
+      expect(getAuthToken()).toBe('');
+      expect(authSubprotocols()).toEqual([AUTH_SUBPROTOCOL]);
+    });
+
+    // The dev fallback is gated on a LOOPBACK host so it is NEVER handed out over
+    // a tunnel (a dev server exposed via cloudflared would otherwise let anyone
+    // with the URL connect with a well-known token = public RCE). The loopback
+    // predicate is pure and tested directly here.
+    it('treats localhost / 127.0.0.1 / ::1 as loopback (dev fallback allowed)', () => {
+      expect(isLoopbackHostname('localhost')).toBe(true);
+      expect(isLoopbackHostname('127.0.0.1')).toBe(true);
+      expect(isLoopbackHostname('::1')).toBe(true);
+      expect(isLoopbackHostname('[::1]')).toBe(true);
+    });
+
+    it('treats a tunnel / LAN host as non-loopback (no dev fallback over remote)', () => {
+      expect(isLoopbackHostname('x.trycloudflare.com')).toBe(false);
+      expect(isLoopbackHostname('192.168.0.10')).toBe(false);
+      expect(isLoopbackHostname('example.com')).toBe(false);
+      expect(isLoopbackHostname('')).toBe(false);
+    });
+
+    it('isRemoteBlocked is false on a loopback host (local is never hard-blocked)', () => {
+      // jsdom serves from localhost → loopback → a local client with no token is a
+      // transient outage, never "forbidden". The remote branch is covered by the
+      // isLoopbackHostname tests above + the isRemoteBlocked composition.
+      vi.stubEnv('DEV', false);
+      _resetAuthTokenCache();
+      setUrl('/'); // no ?pair=
+      expect(isRemoteBlocked()).toBe(false);
+    });
+  });
+
+  // ── Reload persistence (validate-then-store): the `?pair=` code is single-use
+  //    and stripped from the URL, so a full page reload must recover a VALIDATED
+  //    token from sessionStorage or the legit user is locked out (backend 401)
+  //    in production. Only a token that actually connected is stored, so a wrong
+  //    token never sticks and poisons the tab into an endless 401 loop. ────────
+  describe('reload persistence (sessionStorage, validate-then-store)', () => {
+    it('does NOT persist a resolved token until a connection succeeds', () => {
+      // In dev getAuthToken resolves the dev token, but nothing is stored until
+      // persistValidatedToken() is called on a successful WS open.
+      expect(getAuthToken()).toBe(DEV_INSECURE_AUTH_TOKEN);
+      expect(window.sessionStorage.getItem('ccg-auth-token')).toBeNull();
+    });
+
+    it('persistValidatedToken() stores the resolved token (called on WS open)', () => {
+      expect(getAuthToken()).toBe(DEV_INSECURE_AUTH_TOKEN);
+      persistValidatedToken();
+      expect(window.sessionStorage.getItem('ccg-auth-token')).toBe(DEV_INSECURE_AUTH_TOKEN);
+    });
+
+    it('recovers a validated token from sessionStorage after a reload (prod, no dev fallback)', () => {
+      // State right after a reload: production build (no dev fallback), the
+      // single-use pairing code already consumed, but a previously-validated
+      // token survived in sessionStorage.
+      vi.stubEnv('DEV', false);
+      window.sessionStorage.setItem('ccg-auth-token', 'survived');
+      setUrl('/panel');
+      expect(getAuthToken()).toBe('survived');
+    });
+
+    it('a validated sessionStorage token takes precedence over the dev fallback', () => {
+      // sessionStorage is precedence (1); the dev fallback is (2).
+      window.sessionStorage.setItem('ccg-auth-token', 'stored');
+      expect(getAuthToken()).toBe('stored');
+    });
+  });
+
+  // ── Remote-Control tunnel pairing (?pair=<code> → POST /pair → token). This is
+  //    now the SOLE production delivery for BOTH local and remote clients. ──────
+  describe('remote pairing (?pair=)', () => {
+    function mockFetchOnce(impl: () => Promise<Response> | Response): ReturnType<typeof vi.fn> {
+      const fn = vi.fn(impl);
+      vi.stubGlobal('fetch', fn);
+      return fn;
+    }
+
+    function jsonResponse(status: number, body: unknown): Response {
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+      } as unknown as Response;
+    }
+
+    beforeEach(() => {
+      // Pairing only matters in a production build (dev has a sync token).
+      vi.stubEnv('DEV', false);
+      _resetAuthTokenCache();
+    });
+
+    it('detects a ?pair= code and strips it from the URL', () => {
+      setUrl('/?pair=abc123&keep=1');
+      initAuthToken();
+      expect(hasPairCode()).toBe(true);
+      expect(window.location.search).toBe('?keep=1');
+    });
+
+    it('exchanges the pair code at POST /pair and caches the returned token', async () => {
+      setUrl('/?pair=paircode');
+      const fetchFn = mockFetchOnce(() => jsonResponse(200, { token: 'paired-token' }));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('paired-token');
+
+      // The exchange hit /pair with the code in the JSON body.
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchFn.mock.calls[0];
+      expect(url).toBe('/pair');
+      expect(JSON.parse((init as RequestInit).body as string)).toEqual({ code: 'paircode' });
+
+      // Subsequent connections reuse the paired token.
+      expect(getAuthToken()).toBe('paired-token');
+      expect(authSubprotocols()).toEqual([AUTH_SUBPROTOCOL, 'paired-token']);
+      expect(getPairingStatus().state).toBe('paired');
+    });
+
+    it('redeems the pair code on a fresh local first-load (empty sessionStorage)', async () => {
+      // The launcher embeds `?pair=<code>` for the LOCAL webview too. With an
+      // empty sessionStorage and a production build, ensureAuthTokenReady must
+      // redeem the code and return the token (no ?token= shortcut exists).
+      expect(window.sessionStorage.getItem('ccg-auth-token')).toBeNull();
+      setUrl('/?pair=local-first-load');
+      const fetchFn = mockFetchOnce(() => jsonResponse(200, { token: 'local-token' }));
+
+      // Synchronous resolution is empty — the token only arrives via /pair.
+      expect(getAuthToken()).toBe('');
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('local-token');
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(getAuthToken()).toBe('local-token');
+    });
+
+    it('only POSTs once even across repeated ensureAuthTokenReady calls', async () => {
+      setUrl('/?pair=paircode');
+      const fetchFn = mockFetchOnce(() => jsonResponse(200, { token: 'paired-token' }));
+
+      const [a, b] = await Promise.all([ensureAuthTokenReady(), ensureAuthTokenReady()]);
+      expect(a).toBe('paired-token');
+      expect(b).toBe('paired-token');
+      await ensureAuthTokenReady();
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces a "failed/expired" state on 401 and returns no token', async () => {
+      setUrl('/?pair=stale');
+      mockFetchOnce(() => jsonResponse(401, { error: 'Invalid or expired pairing code' }));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('');
+      expect(getPairingStatus()).toEqual({ state: 'failed', reason: 'expired' });
+    });
+
+    it('surfaces a "failed/locked" state on 429', async () => {
+      setUrl('/?pair=stale');
+      mockFetchOnce(() => jsonResponse(429, { error: 'Too many attempts' }));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('');
+      expect(getPairingStatus()).toEqual({ state: 'failed', reason: 'locked' });
+    });
+
+    it('surfaces a "failed/network" state when the request throws', async () => {
+      setUrl('/?pair=stale');
+      mockFetchOnce(() => Promise.reject(new Error('offline')));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('');
+      expect(getPairingStatus()).toEqual({ state: 'failed', reason: 'network' });
+    });
+
+    it('a validated sessionStorage token wins over any ?pair= (no pairing round-trip)', async () => {
+      window.sessionStorage.setItem('ccg-auth-token', 'stored-token');
+      setUrl('/?pair=ignored');
+      const fetchFn = mockFetchOnce(() => jsonResponse(200, { token: 'should-not-be-used' }));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('stored-token');
+      expect(fetchFn).not.toHaveBeenCalled();
+    });
+
+    it('a stray ?token= does NOT short-circuit pairing (it is ignored)', async () => {
+      // Both params present: `?token=` is ignored, `?pair=` still redeems.
+      setUrl('/?token=ignored&pair=realcode');
+      const fetchFn = mockFetchOnce(() => jsonResponse(200, { token: 'paired-token' }));
+
+      const token = await ensureAuthTokenReady();
+      expect(token).toBe('paired-token');
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      const [, init] = fetchFn.mock.calls[0];
+      expect(JSON.parse((init as RequestInit).body as string)).toEqual({ code: 'realcode' });
+    });
+  });
+});

--- a/webview/src/api/bridge/authToken.ts
+++ b/webview/src/api/bridge/authToken.ts
@@ -1,0 +1,346 @@
+// webview/src/api/bridge/authToken.ts
+//
+// Central acquisition of the per-launch control-channel auth token.
+//
+// The Node backend requires this token on every /ws, /rpc, /logs upgrade,
+// carried in the Sec-WebSocket-Protocol header as `['ccg-auth', <token>]`
+// (RFC 6455 — the only header a browser WebSocket can attach at handshake).
+// This module is the SINGLE place the webview resolves that token, so every
+// backend connection attaches the same value.
+//
+// The token is NEVER placed in a URL. EVERY browser client — the local webview
+// AND a remote phone — obtains the token by redeeming a single-use PAIRING CODE
+// at POST /pair. The trusted bootstrap embeds an initial pairing code as
+// `?pair=<code>` in the page URL (the JetBrains JCEF load URL / the ccg
+// standalone browser URL for local, the QR a remote device scans for remote).
+// `?pair=` is therefore the SOLE production delivery path for the token; the
+// legacy `?token=` URL param is gone (URLs leak via logs/history/Referer).
+//
+// Resolution priority (see design doc ignore/plans/control-channel-auth.md):
+//   1. sessionStorage (per-tab) — a token that ACTUALLY authenticated is stored
+//      here (persistValidatedToken, called on WebSocket `open`) so a full page
+//      RELOAD survives. The `?pair=` code is single-use and stripped from the
+//      URL, so a reload would otherwise lose the in-memory token (and cannot
+//      re-redeem the consumed code), locking the legitimate user out (backend
+//      401) in production, where there is no dev fallback. We store only AFTER a
+//      successful connect (validate-then-store) so a wrong/stale token never
+//      sticks and poisons the tab into an endless 401 reconnect loop.
+//      sessionStorage is per-tab and cleared on tab close (unlike localStorage).
+//      An attacker never had a valid token to store here, so this does not weaken
+//      the gate.
+//   2. Dev fallback (Vite dev only, import.meta.env.DEV): the VITE_CCG_DEV_TOKEN
+//      env, else a hard-coded shared DEV-ONLY default that matches the backend's
+//      DEV_INSECURE_AUTH_TOKEN so `bb`/`ww` work with zero manual env.
+//   3. Otherwise '' synchronously — the production path. The `?pair=<code>`
+//      exchange in ensureAuthTokenReady() then redeems the pairing code at POST
+//      /pair and, on success, caches the returned token in-memory. Token
+//      acquisition is ASYNC here — callers MUST `await ensureAuthTokenReady()`
+//      before opening a WebSocket. If no code and no token, the backend rejects
+//      the connection (401), the correct secure-by-default outcome.
+//
+// The token is NEVER read from localStorage and NEVER injected into statically
+// served HTML — an attacker reaching the port could otherwise GET / and read it.
+
+/**
+ * The subprotocol marker paired with the token. Mirrors the backend's
+ * AUTH_SUBPROTOCOL in backend/src/ws/ws-server.ts.
+ */
+export const AUTH_SUBPROTOCOL = 'ccg-auth';
+
+/**
+ * Dev-only, INSECURE-by-design shared default. Mirrors the backend's
+ * DEV_INSECURE_AUTH_TOKEN (backend/src/config/environment.ts). Applies ONLY in
+ * Vite dev (import.meta.env.DEV) so local backend+webview dev servers pair up
+ * without any manual env. Never used in a production build.
+ */
+const DEV_INSECURE_AUTH_TOKEN = 'ccg-dev-insecure-token';
+
+// sessionStorage key under which the validated token is persisted so a page
+// reload survives after the single-use `?pair=` code has been stripped/consumed.
+const SESSION_TOKEN_KEY = 'ccg-auth-token';
+
+// In-memory module singleton. Resolved once, then reused for every connection.
+let cachedToken: string | null = null;
+
+/** Read the persisted token from sessionStorage, tolerating storage being unavailable. */
+function readStoredToken(): string | null {
+  try {
+    return window.sessionStorage.getItem(SESSION_TOKEN_KEY) || null;
+  } catch {
+    return null;
+  }
+}
+
+/** Persist the token to sessionStorage so a reload survives. Best-effort. */
+function storeToken(token: string): void {
+  if (!token) return;
+  try {
+    window.sessionStorage.setItem(SESSION_TOKEN_KEY, token);
+  } catch {
+    // sessionStorage can be unavailable (private mode, exotic embeddings); the
+    // in-memory cache still serves this page load, only reload-persistence is lost.
+  }
+}
+
+// ── Remote-Control tunnel pairing state ─────────────────────────────────────
+// The `?pair=` code captured from the URL (null when absent). A single-use
+// short-lived credential the remote device exchanges for the real token.
+let pairCode: string | null = null;
+// Memoized in-flight/settled redemption so reconnects never re-POST the code.
+let pairPromise: Promise<string> | null = null;
+
+/** Remote-device pairing lifecycle, surfaced to the UI so an expired/locked code
+ * shows a clear "rescan the QR" state instead of a silent 401 loop. */
+export type PairingState = 'idle' | 'pairing' | 'paired' | 'failed';
+/** Why pairing failed — drives the message shown to the remote user. */
+export type PairingFailureReason = 'expired' | 'locked' | 'network' | null;
+
+let pairingState: PairingState = 'idle';
+let pairingFailureReason: PairingFailureReason = null;
+const pairingListeners = new Set<() => void>();
+
+function setPairingState(state: PairingState, reason: PairingFailureReason = null): void {
+  pairingState = state;
+  pairingFailureReason = reason;
+  pairingListeners.forEach((cb) => {
+    try {
+      cb();
+    } catch {
+      // a listener throwing must not break pairing
+    }
+  });
+}
+
+/**
+ * Read a query param from the current page URL, and if present strip it from the
+ * visible URL (history.replaceState) while preserving every other query param,
+ * the path, and the hash. Returns the raw value, or null when absent.
+ */
+function readAndStripParam(name: string): string | null {
+  if (typeof window === 'undefined' || !window.location) return null;
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(name);
+  if (!value) return null;
+
+  params.delete(name);
+  const rest = params.toString();
+  const newUrl = window.location.pathname + (rest ? `?${rest}` : '') + window.location.hash;
+  try {
+    window.history.replaceState(window.history.state, '', newUrl);
+  } catch {
+    // replaceState can throw in exotic embeddings; keeping the value is what
+    // matters, the address-bar cleanup is best-effort.
+  }
+  return value;
+}
+
+/**
+ * True when [hostname] is a loopback host (localhost / 127.0.0.1 / ::1). Pure so
+ * it is directly unit-testable without mocking window.location. Used to gate the
+ * insecure dev fallback so it is NEVER applied over a tunnel or any remote host.
+ */
+export function isLoopbackHostname(hostname: string): boolean {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '::1' ||
+    hostname === '[::1]'
+  );
+}
+
+/** Whether the current page is served from a loopback host. */
+function isLoopbackHost(): boolean {
+  if (typeof window === 'undefined' || !window.location) return false;
+  return isLoopbackHostname(window.location.hostname);
+}
+
+function resolveToken(): string {
+  // 1. sessionStorage — a token that SUCCESSFULLY connected on a previous load of
+  //    THIS tab (persisted by persistValidatedToken on WS open). Lets a full page
+  //    reload reconnect without re-redeeming a pairing code (the `?pair=` code is
+  //    single-use and already consumed/stripped on the first load).
+  const fromSession = readStoredToken();
+  if (fromSession) return fromSession;
+
+  // 2. Dev fallback — Vite dev only, AND only when the page is served from a
+  //    LOOPBACK host. The shared insecure dev token must NEVER be used over a
+  //    tunnel: a dev server exposed via cloudflared (`*.trycloudflare.com`) would
+  //    otherwise let anyone with the URL connect with a well-known token = public
+  //    RCE. Over a remote host we fall through to the pairing path so even a dev
+  //    build must redeem a `?pair=` code — matching production behavior.
+  if (import.meta.env.DEV && isLoopbackHost()) {
+    const envToken = import.meta.env.VITE_CCG_DEV_TOKEN as string | undefined;
+    return envToken && envToken.length > 0 ? envToken : DEV_INSECURE_AUTH_TOKEN;
+  }
+
+  // 3. Production with no stored token: return empty synchronously. The `?pair=`
+  //    exchange in ensureAuthTokenReady() supplies the token (the launcher put a
+  //    pairing code in the URL); if none, the backend rejects the connection
+  //    (401) — the correct secure-by-default outcome. `?token=` is intentionally
+  //    NOT read — the token is never carried in a URL.
+  return '';
+}
+
+/**
+ * The per-launch auth token, resolved once and cached in-memory. Safe to call
+ * repeatedly; the URL is only read/stripped on the first call. Returns '' when
+ * no synchronous token is available (a `?pair=` exchange may still supply one —
+ * use ensureAuthTokenReady()).
+ */
+export function getAuthToken(): string {
+  if (cachedToken === null) {
+    cachedToken = resolveToken();
+  }
+  return cachedToken;
+}
+
+/**
+ * Capture the `?pair=` code from the URL (and strip it) if present. Idempotent.
+ */
+function capturePairCode(): void {
+  if (pairCode === null) {
+    pairCode = readAndStripParam('pair');
+  }
+}
+
+/**
+ * Redeem the captured pairing code at POST /pair, exchanging it for the real
+ * token. Memoized so concurrent connects / reconnects share one round-trip and
+ * a failed/consumed code is never re-POSTed. On success the token is cached so
+ * getAuthToken()/authSubprotocols() return it thereafter.
+ */
+function redeemPairCode(code: string): Promise<string> {
+  if (pairPromise) return pairPromise;
+  setPairingState('pairing');
+  pairPromise = (async () => {
+    try {
+      const res = await fetch('/pair', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code }),
+      });
+      if (!res.ok) {
+        // 429 → rate-limited/locked; anything else (401) → expired/invalid.
+        setPairingState('failed', res.status === 429 ? 'locked' : 'expired');
+        return '';
+      }
+      const data = (await res.json()) as { token?: unknown };
+      const token = typeof data.token === 'string' ? data.token : '';
+      if (!token) {
+        setPairingState('failed', 'expired');
+        return '';
+      }
+      cachedToken = token;
+      setPairingState('paired');
+      return token;
+    } catch {
+      setPairingState('failed', 'network');
+      return '';
+    }
+  })();
+  return pairPromise;
+}
+
+/**
+ * Resolve the auth token, performing the async `/pair` exchange when the token
+ * is only obtainable via a remote pairing code. Callers (the WebSocket
+ * connector) MUST await this before opening a connection so no socket is ever
+ * opened token-less. Returns '' when no token can be resolved.
+ */
+export async function ensureAuthTokenReady(): Promise<string> {
+  // A synchronously-known token (a validated sessionStorage token, or the dev
+  // fallback) always wins — no pairing round-trip needed.
+  const sync = getAuthToken();
+  if (sync) return sync;
+
+  // Otherwise attempt the remote pairing exchange if a code was captured.
+  capturePairCode();
+  if (pairCode) return redeemPairCode(pairCode);
+
+  // No token, no pairing code — leave it to the backend to reject (401).
+  return '';
+}
+
+/**
+ * True when access is DEFINITIVELY forbidden: the page is on a REMOTE host (a
+ * tunnel — not loopback) with no way to authenticate (no validated token and no
+ * `?pair=` code to redeem). This is an unpaired remote device and must be shown a
+ * hard "403 / pair required" block instead of a blank reconnect loop.
+ *
+ * Deliberately NARROW so a legitimate client is never bounced to a block screen:
+ * - a LOCAL (loopback) client with no token = a transient backend outage → keep
+ *   reconnecting, never forbidden;
+ * - a remote client WITH a `?pair=` code = pairing in flight (or, if it failed,
+ *   handled by the pairing-failed notice) → not "forbidden" here;
+ * - a remote client with a previously-validated token (sessionStorage) → connects.
+ */
+export function isRemoteBlocked(): boolean {
+  return !isLoopbackHost() && !getAuthToken() && !hasPairCode();
+}
+
+/**
+ * Explicitly resolve the token and capture (and strip) the `?pair=` code at app
+ * startup, before React Router or any other code can mutate the URL. The actual
+ * pairing round-trip happens lazily in ensureAuthTokenReady(). Idempotent.
+ */
+export function initAuthToken(): void {
+  getAuthToken();
+  capturePairCode();
+}
+
+/**
+ * Persist the currently-resolved token to sessionStorage. Call this ONLY after a
+ * connection has actually authenticated (WebSocket `open`), so a wrong/stale
+ * token is never stored — that would poison the tab into an endless 401 reconnect
+ * loop across reloads. A validated token, by contrast, must survive a reload so
+ * the legitimate user isn't locked out after refreshing (the URL was stripped).
+ */
+export function persistValidatedToken(): void {
+  if (cachedToken) storeToken(cachedToken);
+}
+
+/**
+ * The subprotocol array for a backend WebSocket. `['ccg-auth', <token>]` when a
+ * token is known, or just `['ccg-auth']` when it is not — an EMPTY subprotocol
+ * string is invalid and makes `new WebSocket()` throw, so the token element is
+ * omitted rather than passed as ''. The backend rejects a tokenless `ccg-auth`
+ * with 401 (never a crash). Connectors await ensureAuthTokenReady() first so a
+ * paired token is normally already in place.
+ */
+export function authSubprotocols(): string[] {
+  const token = getAuthToken();
+  return token ? [AUTH_SUBPROTOCOL, token] : [AUTH_SUBPROTOCOL];
+}
+
+/** True when a `?pair=` code was captured (this is a remote pairing session). */
+export function hasPairCode(): boolean {
+  capturePairCode();
+  return pairCode !== null;
+}
+
+/** Current remote-pairing lifecycle state + failure reason (for the UI). */
+export function getPairingStatus(): { state: PairingState; reason: PairingFailureReason } {
+  return { state: pairingState, reason: pairingFailureReason };
+}
+
+/** Subscribe to pairing-state changes. Returns an unsubscribe function. */
+export function subscribePairingStatus(cb: () => void): () => void {
+  pairingListeners.add(cb);
+  return () => {
+    pairingListeners.delete(cb);
+  };
+}
+
+/** @internal test-only: reset all cached state for isolation between cases. */
+export function _resetAuthTokenCache(): void {
+  cachedToken = null;
+  pairCode = null;
+  pairPromise = null;
+  pairingState = 'idle';
+  pairingFailureReason = null;
+  try {
+    window.sessionStorage.removeItem(SESSION_TOKEN_KEY);
+  } catch {
+    // ignore — storage may be unavailable in the test/host environment
+  }
+}

--- a/webview/src/api/logging/LogForwarder.ts
+++ b/webview/src/api/logging/LogForwarder.ts
@@ -1,4 +1,5 @@
 import { MessageType } from '@/shared';
+import { authSubprotocols, ensureAuthTokenReady, isRemoteBlocked } from '../bridge/authToken';
 
 enum LogLevel {
   LOG = 'log',
@@ -58,23 +59,39 @@ class LogForwarder {
   }
 
   private connect(): void {
+    // Never open a doomed/forbidden logs socket (unpaired remote device). Logging
+    // is best-effort — silently stay disconnected.
+    if (this.disposed || isRemoteBlocked()) return;
+
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${protocol}//${window.location.host}/logs`;
 
-    const ws = new WebSocket(wsUrl);
-    ws.onopen = () => {
-      this.ws = ws;
-      this.flush();
-    };
-    ws.onclose = () => {
-      this.ws = null;
-      if (!this.disposed) {
+    // The /logs control channel requires the same per-launch auth token, carried
+    // as the `ccg-auth` subprotocol. The token may only be available after the
+    // async pairing exchange, so resolve it first — and never construct a socket
+    // with an empty token ('' subprotocol is invalid and throws).
+    void ensureAuthTokenReady().then((token) => {
+      if (this.disposed || isRemoteBlocked()) return;
+      if (!token) {
+        // No token yet (pairing pending/failed) — retry later, best-effort.
         this.reconnectTimer = setTimeout(() => this.connect(), RECONNECT_DELAY_MS);
+        return;
       }
-    };
-    ws.onerror = () => {
-      // onclose가 자동으로 호출됨
-    };
+      const ws = new WebSocket(wsUrl, authSubprotocols());
+      ws.onopen = () => {
+        this.ws = ws;
+        this.flush();
+      };
+      ws.onclose = () => {
+        this.ws = null;
+        if (!this.disposed && !isRemoteBlocked()) {
+          this.reconnectTimer = setTimeout(() => this.connect(), RECONNECT_DELAY_MS);
+        }
+      };
+      ws.onerror = () => {
+        // onclose가 자동으로 호출됨
+      };
+    });
   }
 
   private interceptConsole(): void {

--- a/webview/src/components/ForbiddenNotice/index.tsx
+++ b/webview/src/components/ForbiddenNotice/index.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { NoSymbolIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from '@/i18n';
+
+/** Browser tab title while the hard block is shown. */
+const PAGE_TITLE = '403 Forbidden';
+
+/**
+ * Standalone, opaque, full-screen "403 · Forbidden" page. Rendered by <App/> on an
+ * EMPTY template (no providers / router / chat UI) whenever access is blocked —
+ * either an unpaired remote device (no `?pair=` code) OR a pairing attempt that
+ * did not succeed for ANY reason (expired, wrong, rate-limited, unreachable). All
+ * failure modes look identical: there is no partial access.
+ *
+ * Sets the page title to "403 Forbidden" and strips the sensitive session path
+ * from the address bar (history.replaceState → `/403`).
+ */
+export function ForbiddenNotice() {
+  const { t } = useTranslation('common');
+
+  useEffect(() => {
+    const prevTitle = document.title;
+    document.title = PAGE_TITLE;
+    try {
+      window.history.replaceState(window.history.state, '', '/403');
+    } catch {
+      // best-effort — the block screen is what matters
+    }
+    return () => {
+      document.title = prevTitle;
+    };
+  }, []);
+
+  return (
+    <div className="fixed inset-0 z-[100] flex flex-col items-center justify-center gap-4 p-6 bg-surface-base text-center">
+      <NoSymbolIcon className="w-12 h-12 text-state-error-fg" />
+      <h1 className="text-lg font-semibold text-text-primary">{t('forbidden.title')}</h1>
+      <p className="max-w-sm text-sm text-text-secondary">{t('forbidden.detail')}</p>
+    </div>
+  );
+}

--- a/webview/src/components/TunnelModal/index.tsx
+++ b/webview/src/components/TunnelModal/index.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState, useRef, useMemo } from 'react';
-import { XMarkIcon, ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import { useEffect, useState, useRef } from 'react';
+import { XMarkIcon, ClipboardDocumentIcon, ClipboardDocumentCheckIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { QRCodeSVG } from 'qrcode.react';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { Portal } from '@/components/Portal';
@@ -18,6 +18,9 @@ export function TunnelModal(props: Props) {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    pairUrl,
+    pairLoading,
+    issuePairing,
     cloudflaredAvailable,
     awaitingInstallConsent,
     installing,
@@ -36,15 +39,14 @@ export function TunnelModal(props: Props) {
   const [elapsedSec, setElapsedSec] = useState(0);
   const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  const fullTunnelUrl = useMemo(() => {
-    if (!tunnelUrl) return '';
-    const params = new URLSearchParams(window.location.search);
-    params.delete('env');
-    const search = params.toString() ? `?${params.toString()}` : '';
-    const pathname = window.location.pathname || '';
-    const hash = window.location.hash || '';
-    return `${tunnelUrl}${pathname}${search}${hash}`;
-  }, [tunnelUrl]);
+  // Once the tunnel is up, request a fresh single-use pairing code so the QR
+  // encodes `<tunnel>/?pair=<code>` (never the auth token). Re-issue happens via
+  // the regenerate button when the short-lived code expires.
+  useEffect(() => {
+    if (tunnelEnabled && tunnelUrl && !pairUrl && !pairLoading) {
+      issuePairing();
+    }
+  }, [tunnelEnabled, tunnelUrl, pairUrl, pairLoading, issuePairing]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -73,8 +75,8 @@ export function TunnelModal(props: Props) {
   }, [tunnelLoading, installing]);
 
   const handleCopy = () => {
-    if (!fullTunnelUrl) return;
-    navigator.clipboard.writeText(fullTunnelUrl).then(() => {
+    if (!pairUrl) return;
+    navigator.clipboard.writeText(pairUrl).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
@@ -142,11 +144,13 @@ export function TunnelModal(props: Props) {
             </div>
           )}
 
-          {/* URL + QR */}
-          {tunnelEnabled && fullTunnelUrl && (
+          {/* Pairing URL + QR — encodes a short-lived single-use pairing code
+              (?pair=), never the auth token. */}
+          {tunnelEnabled && pairUrl && (
             <div className="space-y-3">
+              <p className="text-xs text-text-tertiary">{t('tunnelModal.pairingHint')}</p>
               <div className="flex items-center gap-2">
-                <span className="font-mono text-[0.8461rem] text-text-secondary flex-1 truncate">{fullTunnelUrl}</span>
+                <span className="font-mono text-[0.8461rem] text-text-secondary flex-1 truncate">{pairUrl}</span>
                 <button onClick={handleCopy} className="flex-shrink-0">
                   {copied
                     ? <ClipboardDocumentCheckIcon className="w-3 h-3 text-state-success-fg" />
@@ -156,9 +160,17 @@ export function TunnelModal(props: Props) {
               </div>
               <div className="flex justify-start">
                 <div className="bg-white p-3 rounded-lg">
-                  <QRCodeSVG value={fullTunnelUrl} size={100} bgColor="#ffffff" fgColor="#000000" />
+                  <QRCodeSVG value={pairUrl} size={100} bgColor="#ffffff" fgColor="#000000" />
                 </div>
               </div>
+              <button
+                onClick={() => issuePairing()}
+                disabled={pairLoading}
+                className="flex items-center gap-1.5 text-xs text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-50"
+              >
+                <ArrowPathIcon className={`w-3 h-3 ${pairLoading ? 'animate-spin' : ''}`} />
+                <span>{t('tunnelModal.regeneratePairing')}</span>
+              </button>
             </div>
           )}
 

--- a/webview/src/hooks/__tests__/buildRemotePairUrl.test.ts
+++ b/webview/src/hooks/__tests__/buildRemotePairUrl.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { buildRemotePairUrl } from '../buildRemotePairUrl';
+
+const BACKEND = 'https://dial-ace-ctrl.trycloudflare.com/?pair=CODE123';
+
+describe('buildRemotePairUrl', () => {
+  it('carries the desktop session path + query onto the tunnel origin', () => {
+    const href = 'http://localhost:5175/sessions/abc?workingDir=%2Fprivate%2Ftmp';
+    expect(buildRemotePairUrl(BACKEND, href)).toBe(
+      'https://dial-ace-ctrl.trycloudflare.com/sessions/abc?workingDir=%2Fprivate%2Ftmp&pair=CODE123',
+    );
+  });
+
+  it('preserves the pairing code and drops any local auth token', () => {
+    const href = 'http://localhost:5175/sessions/x?token=SECRET&workingDir=%2Ftmp';
+    const out = buildRemotePairUrl(BACKEND, href);
+    expect(out).toContain('pair=CODE123');
+    expect(out).not.toContain('token');
+    expect(out).not.toContain('SECRET');
+    expect(out).toContain('/sessions/x');
+  });
+
+  it('does not duplicate pair when the local URL already had one', () => {
+    const href = 'http://localhost:5175/sessions/y?pair=OLD&foo=1';
+    const out = buildRemotePairUrl(BACKEND, href);
+    expect(out.match(/pair=/g)).toHaveLength(1);
+    expect(out).toContain('pair=CODE123');
+    expect(out).not.toContain('OLD');
+  });
+
+  it('works at the project-list root', () => {
+    expect(buildRemotePairUrl(BACKEND, 'http://localhost:5175/')).toBe(
+      'https://dial-ace-ctrl.trycloudflare.com/?pair=CODE123',
+    );
+  });
+
+  it('preserves the hash fragment', () => {
+    const href = 'http://localhost:5175/sessions/z#frag';
+    expect(buildRemotePairUrl(BACKEND, href)).toBe(
+      'https://dial-ace-ctrl.trycloudflare.com/sessions/z?pair=CODE123#frag',
+    );
+  });
+
+  it('falls back to the backend URL on malformed input', () => {
+    expect(buildRemotePairUrl('not a url', 'http://x/')).toBe('not a url');
+  });
+});

--- a/webview/src/hooks/buildRemotePairUrl.ts
+++ b/webview/src/hooks/buildRemotePairUrl.ts
@@ -1,0 +1,27 @@
+/**
+ * The backend issues a pairing URL of the form `<tunnelOrigin>/?pair=<code>` —
+ * root path only. Rebuild it onto the desktop's CURRENT location (path + query +
+ * hash) so a device scanning the QR lands on the SAME session the user is
+ * viewing, not the project-list root.
+ *
+ * The single-use pairing code is preserved; any `token`/`pair` already present in
+ * the local URL is dropped first — the per-launch auth token must NEVER travel in
+ * the QR (only the short-lived pairing code may). Session path/`workingDir` are
+ * not secrets, so carrying them does not weaken the pairing gate.
+ *
+ * Pure function (takes the current href explicitly) so it is trivially testable.
+ * Falls back to the backend URL unchanged if either input is not a valid URL.
+ */
+export function buildRemotePairUrl(backendPairUrl: string, currentHref: string): string {
+  try {
+    const fromBackend = new URL(backendPairUrl);
+    const code = fromBackend.searchParams.get('pair');
+    const local = new URL(currentHref);
+    local.searchParams.delete('token');
+    local.searchParams.delete('pair');
+    if (code) local.searchParams.set('pair', code);
+    return fromBackend.origin + local.pathname + local.search + local.hash;
+  } catch {
+    return backendPairUrl;
+  }
+}

--- a/webview/src/hooks/usePairingStatus.ts
+++ b/webview/src/hooks/usePairingStatus.ts
@@ -1,0 +1,33 @@
+import { useSyncExternalStore } from 'react';
+import {
+  getPairingStatus,
+  subscribePairingStatus,
+  type PairingState,
+  type PairingFailureReason,
+} from '@/api/bridge/authToken';
+
+export interface PairingStatus {
+  state: PairingState;
+  reason: PairingFailureReason;
+}
+
+// Cache the last snapshot so useSyncExternalStore gets a stable reference while
+// nothing changed (getPairingStatus() returns a fresh object each call).
+let lastSnapshot: PairingStatus = getPairingStatus();
+
+function getSnapshot(): PairingStatus {
+  const next = getPairingStatus();
+  if (next.state !== lastSnapshot.state || next.reason !== lastSnapshot.reason) {
+    lastSnapshot = next;
+  }
+  return lastSnapshot;
+}
+
+/**
+ * Subscribe to the Remote-Control pairing lifecycle (idle → pairing → paired |
+ * failed). Drives the "pairing expired — rescan the QR" notice on a remote
+ * device whose `?pair=` code could not be exchanged for a token.
+ */
+export function usePairingStatus(): PairingStatus {
+  return useSyncExternalStore(subscribePairingStatus, getSnapshot);
+}

--- a/webview/src/hooks/useTunnelStatus.ts
+++ b/webview/src/hooks/useTunnelStatus.ts
@@ -1,12 +1,24 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useBridge } from './useBridge';
 import type { TunnelErrorCode } from './tunnelError';
+import { buildRemotePairUrl } from './buildRemotePairUrl';
 import { MessageType } from '@/shared';
 
 interface TunnelStatus {
   tunnelEnabled: boolean;
   tunnelUrl: string | null;
   tunnelLoading: boolean;
+  /**
+   * The QR pairing URL for the running tunnel, or null until issued. Built as
+   * `<tunnel>/<current session path>?...&pair=<code>` so the scanning device opens
+   * the same session the user is viewing. Carries a short-lived single-use pairing
+   * code — NEVER the auth token. Rotated by issuePairing().
+   */
+  pairUrl: string | null;
+  /** True while a fresh pairing code is being issued. */
+  pairLoading: boolean;
+  /** Issue (or rotate) a fresh single-use pairing code and refresh pairUrl. */
+  issuePairing: () => Promise<void>;
   /** null until the prerequisite probe returns; false means cloudflared is missing. */
   cloudflaredAvailable: boolean | null;
   /** true when the user toggled on but cloudflared must be installed first. */
@@ -37,6 +49,29 @@ export function useTunnelStatus(): TunnelStatus {
   const [sleepLoading, setSleepLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [errorCode, setErrorCode] = useState<TunnelErrorCode | null>(null);
+  const [pairUrl, setPairUrl] = useState<string | null>(null);
+  const [pairLoading, setPairLoading] = useState(false);
+
+  // Issue (or rotate) a single-use pairing code and refresh the QR pairing URL.
+  // Only valid while the tunnel is running; errors are swallowed (the QR simply
+  // stays absent) so a transient failure never breaks the modal.
+  const issuePairing = useCallback(async () => {
+    setPairLoading(true);
+    try {
+      const res = await send(MessageType.ISSUE_TUNNEL_PAIRING, {});
+      const p = res.payload ?? res;
+      if (p.status === 'ok' && typeof p.pairUrl === 'string') {
+        // The backend returns `<tunnelOrigin>/?pair=<code>` (root path). Rebuild it
+        // onto the desktop's current session location so the scanning device opens
+        // the SAME session, not the project list. Token is never carried.
+        setPairUrl(buildRemotePairUrl(p.pairUrl, window.location.href));
+      }
+    } catch {
+      // leave pairUrl as-is; the modal shows a regenerate affordance
+    } finally {
+      setPairLoading(false);
+    }
+  }, [send]);
 
   // Start the tunnel unconditionally (caller has ensured cloudflared exists).
   const startTunnelNow = useCallback(async () => {
@@ -77,9 +112,12 @@ export function useTunnelStatus(): TunnelStatus {
   useEffect(() => {
     const unsubTunnel = subscribe(MessageType.TUNNEL_STATUS, (msg) => {
       const p = msg.payload as Record<string, unknown>;
-      setTunnelEnabled(p.enabled as boolean);
+      const enabled = p.enabled as boolean;
+      setTunnelEnabled(enabled);
       setTunnelUrl(p.url as string | null);
       setTunnelLoading(false);
+      // A stopped tunnel invalidates any pairing URL (the code is dead anyway).
+      if (!enabled) setPairUrl(null);
       if (p.error) {
         setError(p.error as string);
         setErrorCode((p.errorCode as TunnelErrorCode) ?? 'unknown');
@@ -165,6 +203,9 @@ export function useTunnelStatus(): TunnelStatus {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    pairUrl,
+    pairLoading,
+    issuePairing,
     cloudflaredAvailable,
     awaitingInstallConsent,
     installing,

--- a/webview/src/i18n/locales/en/common.json
+++ b/webview/src/i18n/locales/en/common.json
@@ -3,6 +3,16 @@
     "confirm": "Confirm",
     "cancel": "Cancel"
   },
+  "pairing": {
+    "title": "Pairing expired",
+    "expiredDetail": "This one-time link has expired or was already used. Rescan the QR code from the host to link this device again.",
+    "lockedDetail": "Too many attempts. Wait a moment, then rescan a fresh QR code from the host.",
+    "networkDetail": "Couldn’t reach the host to complete pairing. Check your connection, then rescan the QR code from the host."
+  },
+  "forbidden": {
+    "title": "403 · Forbidden",
+    "detail": "This device isn’t paired. Open the Remote Control panel on the host and scan its QR code to connect."
+  },
   "contextChip": {
     "removeContext": "Remove context"
   },
@@ -133,7 +143,9 @@
     "connecting": "Connecting…",
     "typicalTime": "Typically ~1 min (install: ~3 min)",
     "preventSleep": "Prevent Sleep",
-    "keepAwake": "Keep awake while tunnel is active"
+    "keepAwake": "Keep awake while tunnel is active",
+    "pairingHint": "Scan to link a device. The QR carries a one-time code that expires shortly — regenerate it if it stops working.",
+    "regeneratePairing": "Regenerate code"
   },
   "tunnelStatusNotice": {
     "tryAgain": "Try again",

--- a/webview/src/i18n/locales/en/settings.json
+++ b/webview/src/i18n/locales/en/settings.json
@@ -231,7 +231,9 @@
       },
       "installingProgress": "Installing cloudflared… ({{seconds}}s)",
       "establishingProgress": "Establishing tunnel connection… ({{seconds}}s)",
-      "estimatedTime": "This typically takes ~1 min (If installation is required, it takes about 3 mins.)"
+      "estimatedTime": "This typically takes ~1 min (If installation is required, it takes about 3 mins.)",
+      "pairingHint": "Scan to link a device. The QR carries a one-time code that expires shortly — regenerate it if it stops working.",
+      "regeneratePairing": "Regenerate code"
     },
     "sleepPrevention": {
       "title": "Sleep Prevention",

--- a/webview/src/main.tsx
+++ b/webview/src/main.tsx
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
 import './i18n/config'; // initialize i18next before the first render
+import { initAuthToken } from './api/bridge/authToken';
 import { initLogForwarder } from './api/logging';
 import { installGlobalErrorHooks } from './api/errorReporting';
 import { StrictMode } from 'react';
@@ -7,6 +8,12 @@ import { createRoot } from 'react-dom/client';
 import App from './App';
 import './index.css';
 import {isMobile} from "@/config/environment.ts";
+
+// Capture the per-launch pairing code from `?pair=` BEFORE anything opens a
+// backend WebSocket or React Router mutates the URL. Resolves any already-known
+// token and strips the pairing param from the address bar; the actual /pair
+// exchange happens lazily when the first WebSocket connects.
+initAuthToken();
 
 // 가능한 한 빨리 초기화하여 초기 로그도 캡처
 initLogForwarder();

--- a/webview/src/pages/SettingsPage/Tunnel/index.tsx
+++ b/webview/src/pages/SettingsPage/Tunnel/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
-import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import { ClipboardDocumentIcon, ClipboardDocumentCheckIcon, ArrowPathIcon } from '@heroicons/react/24/outline';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { TunnelStatusNotice } from '@/components/TunnelStatusNotice';
 import { SettingSection, SettingRow } from '../common';
@@ -13,6 +13,9 @@ export function TunnelSettings() {
     tunnelEnabled,
     tunnelUrl,
     tunnelLoading,
+    pairUrl,
+    pairLoading,
+    issuePairing,
     cloudflaredAvailable,
     awaitingInstallConsent,
     installing,
@@ -31,6 +34,14 @@ export function TunnelSettings() {
   const [elapsedSec, setElapsedSec] = useState(0);
   const elapsedRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Request a fresh single-use pairing code once the tunnel is up so the QR
+  // encodes `<tunnel>/?pair=<code>` (never the auth token).
+  useEffect(() => {
+    if (tunnelEnabled && tunnelUrl && !pairUrl && !pairLoading) {
+      issuePairing();
+    }
+  }, [tunnelEnabled, tunnelUrl, pairUrl, pairLoading, issuePairing]);
+
   useEffect(() => {
     if (tunnelLoading || installing) {
       setElapsedSec(0);
@@ -47,8 +58,8 @@ export function TunnelSettings() {
   }, [tunnelLoading, installing]);
 
   const handleCopy = () => {
-    if (!tunnelUrl) return;
-    navigator.clipboard.writeText(tunnelUrl).then(() => {
+    if (!pairUrl) return;
+    navigator.clipboard.writeText(pairUrl).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     });
@@ -99,10 +110,11 @@ export function TunnelSettings() {
           </div>
         )}
 
-        {tunnelEnabled && tunnelUrl && (
+        {tunnelEnabled && pairUrl && (
           <div className="py-4 border-b border-border-default">
+            <p className="text-xs text-text-tertiary mb-3">{t('tunnel.connection.pairingHint')}</p>
             <div className="flex items-center gap-2 mb-4">
-              <span className="font-mono text-[0.8461rem] text-text-secondary flex-1 truncate">{tunnelUrl}</span>
+              <span className="font-mono text-[0.8461rem] text-text-secondary flex-1 truncate">{pairUrl}</span>
               <button onClick={handleCopy} className="flex-shrink-0">
                 {copied
                   ? <ClipboardDocumentCheckIcon className="w-3 h-3 text-state-success-fg" />
@@ -112,9 +124,17 @@ export function TunnelSettings() {
             </div>
             <div className="flex justify-start">
               <div className="bg-white p-3 rounded-lg">
-                <QRCodeSVG value={tunnelUrl} size={100} bgColor="#ffffff" fgColor="#000000" />
+                <QRCodeSVG value={pairUrl} size={100} bgColor="#ffffff" fgColor="#000000" />
               </div>
             </div>
+            <button
+              onClick={() => issuePairing()}
+              disabled={pairLoading}
+              className="mt-3 flex items-center gap-1.5 text-xs text-text-tertiary hover:text-text-secondary transition-colors disabled:opacity-50"
+            >
+              <ArrowPathIcon className={`w-3 h-3 ${pairLoading ? 'animate-spin' : ''}`} />
+              <span>{t('tunnel.connection.regeneratePairing')}</span>
+            </button>
           </div>
         )}
       </SettingSection>

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -209,6 +209,13 @@ export enum MessageType {
   GET_TUNNEL_PREREQS = 'GET_TUNNEL_PREREQS',
   /** Install the cloudflared binary. */
   INSTALL_CLOUDFLARED = 'INSTALL_CLOUDFLARED',
+  /**
+   * inbound webview→backend. Issue a fresh single-use, short-lived pairing code
+   * for the running tunnel and return the QR pairing URL
+   * (`https://<sub>.trycloudflare.com/?pair=<code>`). Carries only the code —
+   * never the auth token. Re-callable to rotate an expired code.
+   */
+  ISSUE_TUNNEL_PAIRING = 'ISSUE_TUNNEL_PAIRING',
 
   // -- Sleep guard (keep-awake) --
   /** Enable the system sleep guard. */

--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -44,6 +44,16 @@ export default defineConfig(({ mode }) => {
         target: `ws://localhost:${backendPort}`,
         ws: true,
       },
+      // HTTP 엔드포인트도 백엔드로 프록시 — 없으면 vite가 404를 돌려준다.
+      // /pair: 페어링 코드↔토큰 교환(원격/터널 접속의 유일한 인증 경로). 이게
+      // 프록시되지 않으면 dev 터널에서 올바른 코드조차 404로 실패한다.
+      // /version: 백엔드 헬스/버전 조회.
+      '/pair': {
+        target: `http://localhost:${backendPort}`,
+      },
+      '/version': {
+        target: `http://localhost:${backendPort}`,
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

Adds authentication to the backend WebSocket control channel so that only the legitimate webview can drive it. The control channel previously relied on the `Origin` header alone; this PR introduces a real credential.

## What changed

- **Backend** — require a per-launch token on every `/ws`, `/rpc`, `/logs` upgrade (carried in the `Sec-WebSocket-Protocol: ccg-auth` header) and on the `/internal` push endpoints (`x-ccg-token` header). The `Origin` check is kept as CSWSH hardening only.
- **Single-use pairing delivery** — the token is never placed in a URL. Every browser client (the local webview and a remote tunnel device) redeems a short-lived, single-use, rate-limited pairing code at `POST /pair` to obtain the token. The launcher (Kotlin plugin / `ccg` CLI) owns the token, derives it from a persisted per-machine secret (HMAC) so it stays stable across the frequent backend restarts, and seeds an initial local pairing code (`?pair=`).
- **Webview** — a single `authToken` module; validate-then-store the token in `sessionStorage` so a reload reconnects; the dev fallback token is gated to loopback hosts (never used over a tunnel); a standalone **403 Forbidden** screen for unpaired remote devices.
- **Dev** — proxy `/pair` and `/version` in the vite dev server.

## Testing

- Backend: 744 tests pass, `be-build` clean.
- Webview: 1433 tests pass, `wv-lint` / `wv-build` clean.
- Kotlin: `./gradlew compileKotlin compileTestKotlin test` — BUILD SUCCESSFUL.
- Manual: verified pairing (local + tunnel), backend-restart reconnect, and the 403 block for unpaired remote devices.