### PR TITLE
fix: never pass the control-channel secret/token on argv

### DIFF
--- a/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
+++ b/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { JetBrainsBridge, parseProjectRoots } from '../jetbrains-bridge';
+import { JetBrainsBridge, parseProjectRoots, redactRpcLog } from '../jetbrains-bridge';
 import { MessageType } from '../../shared';
 import * as settings from '../../core/features/settings';
 
@@ -170,5 +170,44 @@ describe('JetBrainsBridge connect-time hostMode push', () => {
     const msg = sentMessage(ws);
     expect(msg?.method).toBe(MessageType.HOST_MODE_CHANGED);
     expect(msg?.params).toEqual({ hostMode: 'tool-window' });
+  });
+});
+
+describe('redactRpcLog', () => {
+  const req = (method: string, params: Record<string, unknown>) =>
+    ({ jsonrpc: '2.0' as const, id: 'rpc-7', method, params });
+
+  it('masks the pairing code carried in an OPEN_URL url', () => {
+    const url =
+      'http://localhost:33741/sessions/abc?workingDir=%2F%2Fwsl.localhost%2FUbuntu&pair=23C0UmxnhcediFn6MRYLr_a-I9kDBtxt';
+    const out = redactRpcLog(req('OPEN_URL', { url }));
+    expect(out).not.toContain('23C0UmxnhcediFn6MRYLr_a-I9kDBtxt');
+    expect(out).toContain('pair=<redacted>');
+  });
+
+  it('masks a pairing code that is the first query param', () => {
+    const out = redactRpcLog(req('OPEN_URL', { url: 'https://x.trycloudflare.com/?pair=SECRET123' }));
+    expect(out).not.toContain('SECRET123');
+    expect(out).toContain('pair=<redacted>');
+  });
+
+  it('defensively masks a token query param too', () => {
+    const out = redactRpcLog(req('OPEN_URL', { url: 'http://h/p?token=deadbeefcafe' }));
+    expect(out).not.toContain('deadbeefcafe');
+    expect(out).toContain('token=<redacted>');
+  });
+
+  it('preserves non-secret fields (method, id, workingDir)', () => {
+    const out = redactRpcLog(
+      req('OPEN_URL', { url: 'http://localhost:33741/s?workingDir=%2Fhome%2Fu&pair=abc' }),
+    );
+    expect(out).toContain('"method":"OPEN_URL"');
+    expect(out).toContain('"id":"rpc-7"');
+    expect(out).toContain('workingDir=%2Fhome%2Fu');
+  });
+
+  it('leaves a request without secrets structurally intact', () => {
+    const r = req('GET_IDE_ROOT', { workingDir: '//wsl.localhost/Ubuntu/home/yhk/proj' });
+    expect(redactRpcLog(r)).toBe(JSON.stringify(r));
   });
 });

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -167,7 +167,7 @@ export class JetBrainsBridge implements Bridge {
         params,
       };
 
-      console.error('[node-backend]', `[DEBUG:bridge.request] sending: ${JSON.stringify(request)}`);
+      console.error('[node-backend]', `[DEBUG:bridge.request] sending: ${redactRpcLog(request)}`);
       client.send(JSON.stringify(request) + '\n');
     });
   }
@@ -287,4 +287,18 @@ export function parseProjectRoots(params: Record<string, unknown> | undefined): 
   const roots = params?.['roots'];
   if (!Array.isArray(roots)) return [];
   return roots.filter((r): r is string => typeof r === 'string' && r.length > 0);
+}
+
+/**
+ * Serialize a JSON-RPC request for the debug log with bootstrap credentials
+ * masked. A single-use pairing code rides inside OPEN_URL's `params.url` as
+ * `?pair=<code>` — the credential the webview redeems for the stable control-channel
+ * token. Logging it verbatim would let anyone who can read the process logs
+ * (idea.log / stdout) redeem it first and hijack the token — the same class of
+ * secret leak that #208 closes for argv, via the log channel instead. Mirrors the
+ * Kotlin-side `pair=<redacted>` masking in ClaudeCodePanel's URL log. `token` is
+ * masked too as defense in depth.
+ */
+export function redactRpcLog(request: JsonRpcRequest): string {
+  return JSON.stringify(request).replace(/([?&](?:pair|token)=)[^"&\\]+/gi, '$1<redacted>');
 }

--- a/cli/lib/browser.sh
+++ b/cli/lib/browser.sh
@@ -101,13 +101,16 @@ _ccg_read_or_create_secret() {
 }
 
 # Derive the stable auth token: HMAC-SHA256(secret, "ccg-auth") as lowercase hex.
-# Prefer openssl (portable output parsed to the trailing hex field); fall back to
-# node's crypto. The secret is passed to node via env (never as an argv token).
+# The secret is passed to node ONLY via env (CCG_HMAC_SECRET), never as an argv
+# token: on a multi-user host, argv is world-readable via `ps` / /proc/<pid>/cmdline,
+# so `openssl dgst -hmac "$secret"` would leak the persistent master secret and let
+# another local user recompute the token — defeating the 0600 on the secret file.
+# `/proc/<pid>/environ` is owner-only, so env is safe. openssl has no argv-free way
+# to pass an HMAC key, so we do not use it here; node is always present because the
+# very next step spawns the backend with it.
 _ccg_derive_token() {
   local secret=$1
-  if command -v openssl >/dev/null 2>&1; then
-    printf '%s' 'ccg-auth' | openssl dgst -sha256 -hmac "$secret" 2>/dev/null | awk '{print $NF}'
-  elif command -v node >/dev/null 2>&1; then
+  if command -v node >/dev/null 2>&1; then
     CCG_HMAC_SECRET="$secret" node -e 'process.stdout.write(require("crypto").createHmac("sha256", process.env.CCG_HMAC_SECRET).update("ccg-auth").digest("hex"))'
   else
     printf ''

--- a/cli/test/browser.bats
+++ b/cli/test/browser.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# Tests for cli/lib/browser.sh — control-channel token derivation.
+#
+# Focus: the auth secret must reach the HMAC computation via ENV only, never on
+# argv. On a multi-user host, argv is world-readable (`ps` / /proc/<pid>/cmdline),
+# so passing the persistent master secret as a command-line argument (e.g.
+# `openssl dgst -hmac "$secret"`) would let another local user recompute the token
+# and drive /ws into a bypassPermissions session. Regression guard for the fix that
+# dropped the openssl argv path in favor of the env-based node path.
+
+load 'helpers/common'
+
+setup() {
+  isolate_env
+
+  # Capture the real node BEFORE installing the mock (isolate_env only prepends
+  # MOCK_BIN to PATH; node itself is not mocked yet, so this resolves the system node).
+  REAL_NODE="$(command -v node)"
+  export REAL_NODE
+
+  export ARGV_LOG="$BATS_TEST_TMPDIR/node-argv.log"
+  export ENV_LOG="$BATS_TEST_TMPDIR/node-env.log"
+  export OPENSSL_MARKER="$BATS_TEST_TMPDIR/openssl-called"
+
+  # Mock node: record its argv and the CCG_HMAC_SECRET env, then delegate to the
+  # real node so the derived token is a genuine HMAC.
+  cat > "$MOCK_BIN/node" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$ARGV_LOG"
+printf 'CCG_HMAC_SECRET=%s\n' "\${CCG_HMAC_SECRET:-<unset>}" >> "$ENV_LOG"
+exec "$REAL_NODE" "\$@"
+EOF
+  chmod +x "$MOCK_BIN/node"
+
+  # Mock openssl: if it is ever invoked, leave a marker (and a copy of its argv) so
+  # the test can prove the secret-leaking openssl path is not taken.
+  cat > "$MOCK_BIN/openssl" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$OPENSSL_MARKER"
+exit 0
+EOF
+  chmod +x "$MOCK_BIN/openssl"
+
+  # shellcheck source=../lib/browser.sh
+  source "$CLI_LIB/browser.sh"
+}
+
+@test "_ccg_derive_token passes the secret via env, never on argv" {
+  local secret="s3cr3t-master-key-abc123"
+  run _ccg_derive_token "$secret"
+  [ "$status" -eq 0 ]
+
+  # The secret must appear in the env log...
+  grep -q "CCG_HMAC_SECRET=$secret" "$ENV_LOG"
+  # ...but never anywhere on the argv.
+  ! grep -q "$secret" "$ARGV_LOG"
+}
+
+@test "_ccg_derive_token does not invoke openssl (avoids -hmac argv leak)" {
+  run _ccg_derive_token "another-secret"
+  [ "$status" -eq 0 ]
+  # openssl leaks the HMAC key on argv, so the fix must not call it here.
+  [ ! -f "$OPENSSL_MARKER" ]
+}
+
+@test "_ccg_derive_token emits a 64-char lowercase hex token" {
+  run _ccg_derive_token "some-secret"
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9a-f]{64}$ ]]
+}
+
+@test "_ccg_derive_token is deterministic for a given secret" {
+  run _ccg_derive_token "stable-secret"
+  local first="$output"
+  run _ccg_derive_token "stable-secret"
+  [ "$output" = "$first" ]
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -250,47 +250,59 @@ class NodeProcessManager(
                 if (wslDistro != null) {
                     // WSL project root: launch the backend inside the distro via wsl.exe.
                     // backend.mjs / webview were extracted to a Windows temp dir; WSL sees
-                    // them through /mnt/<drive>/... so convert the paths. Backend env is
-                    // passed inside the command (env K=V — see buildWslNodeCommand); the
-                    // process environment is left intact so wsl.exe resolves on the Windows
-                    // PATH. NOTE: not verifiable on our dev host — see issue #57 (S4b).
+                    // them through /mnt/<drive>/... so convert the paths.
+                    //
+                    // Env split by sensitivity:
+                    // - NON-secret values (mode, port, paths) go through buildWslNodeCommand
+                    //   as `export K=V` inside the `bash -lic` snippet.
+                    // - SECRETS (the auth token, the pairing code) must NOT be put on the
+                    //   argv: the whole `bash -lic "export … "` snippet is a wsl.exe argument,
+                    //   which any local user can read via `ps` / /proc/<pid>/cmdline and use to
+                    //   drive /ws into a bypassPermissions session. Hand them to WSL via WSLENV
+                    //   + the wsl.exe process environment instead — /proc/<pid>/environ is
+                    //   owner-only, so env is safe. wsl.exe injects WSLENV-listed vars into the
+                    //   Linux process, and `exec node` inherits them.
+                    // The rest of the process environment is left intact so wsl.exe resolves on
+                    // the Windows PATH. NOTE: not verifiable on our dev host — see issue #57 (S4b).
                     val linuxBackend = WslPathResolver.toWslPath(backendFile.absolutePath)
                         ?: backendFile.absolutePath
                     val wslEnv = buildMap {
                         put("JETBRAINS_MODE", "true")
                         put("CCG_CLIENT_INFO", clientInfo)
                         put("PORT", requestedPort.toString())
-                        // Stable control-channel auth token (see [authToken]). Required
-                        // by the backend on /ws, /rpc, /logs, /internal routes. Redacted from
-                        // the command log below.
-                        if (authToken.isNotEmpty()) put("CCG_AUTH_TOKEN", authToken)
-                        // Fresh single-use initial pairing code (see [initialPairCode]). The
-                        // backend seeds its pairing store with it; the webview redeems it via
-                        // `?pair=`. Redacted from the command log below.
-                        if (initialPairCode.isNotEmpty()) put("CCG_INITIAL_PAIR_CODE", initialPairCode)
                         webviewDir?.let { wv ->
                             WslPathResolver.toWslPath(wv.absolutePath)?.let { put("WEBVIEW_DIR", it) }
                         }
+                        // NOTE: CCG_AUTH_TOKEN / CCG_INITIAL_PAIR_CODE are intentionally NOT
+                        // here — they are secrets and are passed via WSLENV below, never on argv.
                         // No CLEANUP_TEMP_* env: resources are version-scoped and shared,
                         // extracted once and never deleted on exit. Stale other-version dirs
                         // are pruned at extraction time by PluginResourceExtractor (#149).
                     }
                     val cmd = WslPathResolver.buildWslNodeCommand(wslDistro, wslCwd, wslEnv, linuxBackend)
-                    // The WSL command embeds env as `export K=V`, so the token and pairing
-                    // code would appear in the joined command — redact both before logging
-                    // (never log the token or the pairing code).
-                    val redactedCmd = cmd.map { part ->
-                        var redacted = part
-                        if (authToken.isNotEmpty() && redacted.contains("CCG_AUTH_TOKEN=")) {
-                            redacted = redacted.replace(authToken, "<redacted>")
-                        }
-                        if (initialPairCode.isNotEmpty() && redacted.contains("CCG_INITIAL_PAIR_CODE=")) {
-                            redacted = redacted.replace(initialPairCode, "<redacted>")
-                        }
-                        redacted
-                    }
-                    logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${redactedCmd.joinToString(" ")}")
+                    // cmd no longer carries any secret (token/pairing code moved to WSLENV), so
+                    // it is safe to log verbatim.
+                    logger.info("Starting WSL backend (distro=$wslDistro, cwd=$wslCwd): ${cmd.joinToString(" ")}")
                     pb = ProcessBuilder(cmd).redirectErrorStream(false)
+                    // Pass secrets out-of-band: set them in the wsl.exe process environment and
+                    // list them in WSLENV so wsl.exe forwards them into the distro's process env
+                    // (never on the argv). `/u` = share Win→WSL only, no path translation.
+                    // Append to any pre-existing WSLENV rather than clobbering the user's.
+                    val passthrough = mutableListOf<String>()
+                    if (authToken.isNotEmpty()) {
+                        pb.environment()["CCG_AUTH_TOKEN"] = authToken
+                        passthrough += "CCG_AUTH_TOKEN/u"
+                    }
+                    if (initialPairCode.isNotEmpty()) {
+                        pb.environment()["CCG_INITIAL_PAIR_CODE"] = initialPairCode
+                        passthrough += "CCG_INITIAL_PAIR_CODE/u"
+                    }
+                    if (passthrough.isNotEmpty()) {
+                        val existingWslEnv = pb.environment()["WSLENV"]
+                        pb.environment()["WSLENV"] =
+                            if (existingWslEnv.isNullOrBlank()) passthrough.joinToString(":")
+                            else existingWslEnv + ":" + passthrough.joinToString(":")
+                    }
                 } else {
                     val env = buildMap {
                         putAll(EnvironmentUtil.getEnvironmentMap())

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/WslPathResolver.kt
@@ -120,8 +120,13 @@ object WslPathResolver {
      * - The leading `wsl.exe` is resolved on the Windows PATH (System32).
      * - Everything after `--` runs inside the distro, so `bash`/`node` are the distro's.
      * - [env] entries become `export K=V` inside the login shell, so they reach `node` as
-     *   process env vars (no WSLENV needed). `exec` replaces the bash process so signals
-     *   from the IDE reach `node` directly.
+     *   process env vars. `exec` replaces the bash process so signals from the IDE reach
+     *   `node` directly. SECURITY: put only NON-secret values in [env] — a `bash -lic
+     *   "export K=V …"` snippet is passed on the wsl.exe argv, which is world-readable via
+     *   `ps` / /proc/<pid>/cmdline on a multi-user host. Secrets (the auth token, the
+     *   pairing code) must instead be handed to WSL out-of-band via `WSLENV` + the wsl.exe
+     *   process environment, where /proc/<pid>/environ is owner-only. See the WSL branch of
+     *   NodeProcessManager.start().
      * - [scriptLinuxPath] must already be a WSL-visible path (use [toWslPath] on the
      *   Windows extraction path). [nodeExec] defaults to `node` (resolved on the distro's
      *   login + interactive shell PATH).


### PR DESCRIPTION
## Summary

Follow-up to the control-channel authentication work in #204. A reviewer (glow.io, coordinated private disclosure) pointed out that the auth **secret** and the derived **token** were still reachable by another local user on a **multi-user host**, because they were passed on a command line. `argv` is world-readable via `ps` / `/proc/<pid>/cmdline`, so this defeats the `0600` protecting the persisted secret file: another local user could read it, recompute the token, and drive `/ws` into a `bypassPermissions` session (code execution as the victim).

Single-user dev machines are unaffected (no other local user to read argv); the risk is on shared/multi-user hosts and multi-user WSL.

## Changes

**1. `cli/lib/browser.sh` — `_ccg_derive_token`**
- Removed the `openssl dgst -sha256 -hmac "$secret"` path, which placed the **persistent master secret** on argv.
- The secret now reaches the HMAC only via the env-based node path (`CCG_HMAC_SECRET`); `/proc/<pid>/environ` is owner-only, so env is safe. `node` is guaranteed present because the very next step spawns the backend with it.

**2. JetBrains WSL launch — `NodeProcessManager` / `WslPathResolver`**
- The auth token and initial pairing code were embedded as `export K=V` inside the `bash -lic "…"` snippet, i.e. on the `wsl.exe` argv.
- They are now handed to the distro **out-of-band via `WSLENV` + the `wsl.exe` process environment** (never on argv), appended to any pre-existing `WSLENV` rather than clobbering it. Non-secret env (mode, port, paths) still flows through the snippet as before.
- Since the command no longer carries any secret, the log-redaction shim was removed and the command is logged verbatim.

**3. Tests**
- Added `cli/test/browser.bats`: locks in that the secret is passed via env and **never** on argv, that `openssl` is not invoked here, and that the token is a deterministic 64-char lowercase hex.

## Verification

- ✅ `cli` bats suite — full pass (incl. 4 new `browser.bats` tests)
- ✅ backend `vitest` — 765 pass (control-channel auth unaffected: the backend consumes the final token from `CCG_AUTH_TOKEN` regardless of how it was transported)
- ✅ `gradle test` — BUILD SUCCESSFUL, `WslPathResolverTest` green, Kotlin compiles

## ⚠️ Needs a Windows + WSL smoke check

The `WSLENV` passthrough cannot be exercised on a non-Windows dev host (consistent with the existing "not verifiable on our dev host — #57" note). Please verify on a real Windows + WSL setup that the backend still authenticates and connects (i.e. the token/pairing code reach the Linux `node` process via env).