### PR TITLE
Clickable jump-to-line file references in chat

### DIFF
--- a/webview/src/pages/ChatPage/StreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/StreamingMessage.tsx
@@ -4,37 +4,15 @@ import {math} from '../../utils/mathPlugin';
 import {isInsideCodeBlock, isMarkdownComplete} from '../../utils/markdownParser';
 import './streaming.css';
 import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/common";
+import {useWorkingDirOrNull} from '@/contexts/WorkingDirContext';
+import {MARKDOWN_COMPONENTS} from '@/pages/ChatPage/message-renderers/components/MarkdownFileLink';
+import {normalizeMarkdownLinkUrls} from '@/pages/ChatPage/message-renderers/utils/markdownFileLink';
 
 interface StreamingMessageProps {
     content: string;
     isStreaming: boolean;
     className?: string;
     message?: import('../../types').LoadedMessageDto;
-}
-
-/**
- * Normalize bare relative URLs in markdown links so rehype-harden doesn't block them.
- * e.g., [file.tsx](src/file.tsx) → [file.tsx](./src/file.tsx)
- */
-function normalizeRelativeUrls(markdown: string): string {
-    // Match markdown links: [text](url)
-    // But NOT image links: ![text](url)
-    return markdown.replace(
-        /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g,
-        (match, text, url) => {
-            // Skip if already has protocol, starts with /, ./, ../, or #
-            if (
-                /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url) || // has protocol
-                url.startsWith('/') ||
-                url.startsWith('./') ||
-                url.startsWith('../') ||
-                url.startsWith('#')
-            ) {
-                return match;
-            }
-            return `[${text}](./${url})`;
-        }
-    );
 }
 
 export const StreamingMessage: React.FC<StreamingMessageProps> = ({
@@ -44,6 +22,12 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
     message,
 }) => {
     const [shouldAnimate, setShouldAnimate] = useState(isStreaming);
+
+    // useWorkingDirOrNull (not useWorkingDir): StreamingMessage is broadly reused
+    // and rendered without a WorkingDirProvider in some places (and in tests),
+    // where useWorkingDir throws. Used to resolve relative link URLs to absolute
+    // project paths; absolute links work regardless.
+    const workingDirectory = useWorkingDirOrNull()?.workingDirectory ?? null;
 
     // Handle streaming animation
     useEffect(() => {
@@ -69,13 +53,14 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
                         parseIncompleteMarkdown={isStreaming}
                         isAnimating={isStreaming}
                         shikiTheme={['github-dark', 'github-light']}
+                        components={MARKDOWN_COMPONENTS}
                         controls={{
                             code: true,
                             table: true,
                         }}
                         plugins={{ math }}
                     >
-                        {normalizeRelativeUrls(content)}
+                        {normalizeMarkdownLinkUrls(content, workingDirectory)}
                     </Streamdown>
                 </div>
 

--- a/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
@@ -8,6 +8,9 @@ import {useChatStreamContext} from '../../contexts/ChatStreamContext';
 import {formatThinkingTokens} from '../../utils/formatThinkingTokens';
 import {useTranslation} from '@/i18n';
 import {useAnimatedThinkingTokens} from '../../hooks/useAnimatedThinkingTokens';
+import {useWorkingDirOrNull} from '@/contexts/WorkingDirContext';
+import {MARKDOWN_COMPONENTS} from '@/pages/ChatPage/message-renderers/components/MarkdownFileLink';
+import {normalizeMarkdownLinkUrls} from '@/pages/ChatPage/message-renderers/utils/markdownFileLink';
 
 interface ThinkingStreamingMessageProps {
     thinking: string;
@@ -18,31 +21,6 @@ interface ThinkingStreamingMessageProps {
     durationMillis?: number;
     className?: string;
     message?: import('../../types').LoadedMessageDto;
-}
-
-/**
- * Normalize bare relative URLs in markdown links so rehype-harden doesn't block them.
- * e.g., [file.tsx](src/file.tsx) → [file.tsx](./src/file.tsx)
- */
-function normalizeRelativeUrls(markdown: string): string {
-    // Match markdown links: [text](url)
-    // But NOT image links: ![text](url)
-    return markdown.replace(
-        /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g,
-        (match, text, url) => {
-            // Skip if already has protocol, starts with /, ./, ../, or #
-            if (
-                /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url) || // has protocol
-                url.startsWith('/') ||
-                url.startsWith('./') ||
-                url.startsWith('../') ||
-                url.startsWith('#')
-            ) {
-                return match;
-            }
-            return `[${text}](./${url})`;
-        }
-    );
 }
 
 export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> = ({
@@ -56,6 +34,9 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
     const { t } = useTranslation('chat');
     const [shouldAnimate, setShouldAnimate] = useState(isStreaming);
     const { isThinkingExpanded, toggleThinkingExpanded } = useChatStreamContext();
+    // Null-safe: reasoning blocks may render without a WorkingDirProvider. Used to
+    // resolve relative file-link URLs; absolute links work regardless.
+    const workingDirectory = useWorkingDirOrNull()?.workingDirectory ?? null;
 
     // The block is "still thinking" until its duration is stamped at content_block_stop.
     const isThinking = durationMillis === undefined && isStreaming;
@@ -105,13 +86,14 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
                             parseIncompleteMarkdown={isStreaming}
                             isAnimating={isStreaming}
                             shikiTheme={['github-dark', 'github-light']}
+                            components={MARKDOWN_COMPONENTS}
                             controls={{
                                 code: true,
                                 table: true,
                             }}
                             plugins={{ math }}
                         >
-                            {normalizeRelativeUrls(thinking)}
+                            {normalizeMarkdownLinkUrls(thinking, workingDirectory)}
                         </Streamdown>
                     </div>
                 </div>

--- a/webview/src/pages/ChatPage/__tests__/StreamingMessage.file-links.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/StreamingMessage.file-links.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { StreamingMessage } from '../StreamingMessage';
+
+const mockOpenFile = vi.fn((_path: string, _line?: number) => Promise.resolve());
+
+// Override only getAdapter().openFile; keep the rest of the module so ToolWrapper
+// and other consumers still work.
+vi.mock('@/adapters', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/adapters')>()),
+  getAdapter: () => ({ openFile: mockOpenFile }),
+}));
+
+// Provide a working directory so relative links resolve; keep the rest of the module.
+vi.mock('@/contexts/WorkingDirContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/contexts/WorkingDirContext')>()),
+  useWorkingDirOrNull: () => ({ workingDirectory: '/wd', setWorkingDirectory: () => {}, ideRoot: null }),
+}));
+
+describe('StreamingMessage — local file links open in the IDE', () => {
+  beforeEach(() => mockOpenFile.mockClear());
+
+  it('opens an absolute local link at its line', () => {
+    render(<StreamingMessage content="See [foo.ts:12](/abs/foo.ts#L12)." isStreaming={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'foo.ts:12' }));
+    expect(mockOpenFile).toHaveBeenCalledTimes(1);
+    expect(mockOpenFile).toHaveBeenCalledWith('/abs/foo.ts', 12);
+  });
+
+  it('resolves a relative link against the working directory', () => {
+    render(<StreamingMessage content="See [x](./src/foo.ts#L3)." isStreaming={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'x' }));
+    expect(mockOpenFile).toHaveBeenCalledWith('/wd/src/foo.ts', 3);
+  });
+
+  it('opens a link with no #L at the top (no line argument)', () => {
+    render(<StreamingMessage content="See [x](/abs/foo.ts)." isStreaming={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'x' }));
+    expect(mockOpenFile).toHaveBeenCalledWith('/abs/foo.ts', undefined);
+  });
+
+  it('opens a Windows drive-absolute link (survives sanitize/harden)', () => {
+    // The link must round-trip through rehype-sanitize (which would strip a bare
+    // `C:` scheme) — the preprocessor carries it as `/C:/…`.
+    const { container } = render(
+      <StreamingMessage content="See [foo.ts](C:/proj/foo.ts#L7)." isStreaming={false} />,
+    );
+    // Not blocked (no greyed-out placeholder), and clickable.
+    expect(container.textContent).not.toMatch(/\[blocked\]/i);
+    fireEvent.click(screen.getByRole('button', { name: 'foo.ts' }));
+    const [path, line] = mockOpenFile.mock.calls[0];
+    // harden may lowercase the drive letter; the filesystem is case-insensitive.
+    expect(path.toLowerCase()).toBe('c:/proj/foo.ts');
+    expect(line).toBe(7);
+  });
+
+  it('does not rewrite link URLs inside inline code', () => {
+    const { container } = render(
+      <StreamingMessage content={'Use `[a](./foo.ts)` here.'} isStreaming={false} />,
+    );
+    const code = container.querySelector('[data-streamdown="inline-code"]');
+    expect(code?.textContent).toBe('[a](./foo.ts)'); // verbatim, no /wd/ injected
+    expect(mockOpenFile).not.toHaveBeenCalled();
+  });
+
+  it('renders an in-page # anchor as a same-tab link', () => {
+    render(<StreamingMessage content="See [Sec](#section)." isStreaming={false} />);
+    const anchor = screen.getByRole('link', { name: 'Sec' });
+    expect(anchor.getAttribute('href')).toBe('#section');
+    expect(anchor.getAttribute('target')).toBeNull();
+  });
+
+  it('renders an external link as a normal web link and never calls openFile', () => {
+    render(<StreamingMessage content="See [site](https://example.com)." isStreaming={false} />);
+    const anchor = screen.getByRole('link', { name: 'site' }) as HTMLAnchorElement;
+    expect(anchor.getAttribute('href')).toMatch(/^https:\/\/example\.com/);
+    expect(anchor.getAttribute('target')).toBe('_blank');
+    fireEvent.click(anchor);
+    expect(mockOpenFile).not.toHaveBeenCalled();
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/components/MarkdownFileLink.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/MarkdownFileLink.tsx
@@ -1,0 +1,65 @@
+import React, { ReactNode } from 'react';
+import { getAdapter } from '@/adapters';
+import { useWorkingDirOrNull } from '@/contexts/WorkingDirContext';
+import { resolveMarkdownFileLink } from '../utils/markdownFileLink';
+
+// Streamdown's default link classes, re-applied because a custom component fully
+// replaces the default renderer (and its styling).
+const MARKDOWN_LINK_CLASS = 'wrap-anywhere font-medium text-primary underline';
+
+/**
+ * Assistant-markdown anchor renderer. A local file href (absolute or `./`/`../`,
+ * optional `#Lnn`) renders as a clickable reference that opens the file in the IDE
+ * at its line; anything else is a normal external link. Replaces Streamdown's
+ * default link, whose modal would `window.open` a root-relative local href against
+ * the webview origin (a dead localhost tab). `stopPropagation` keeps the click
+ * from also toggling a surrounding container, as `MessagePathChip` / `PathRow` do.
+ */
+export const MarkdownFileLink: React.FC<{ href?: string; children?: ReactNode }> = ({ href, children }) => {
+  const workingDirectory = useWorkingDirOrNull()?.workingDirectory ?? null;
+  const link = href ? resolveMarkdownFileLink(href, workingDirectory) : null;
+
+  if (link) {
+    const open = (event: React.SyntheticEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      getAdapter()
+        .openFile(link.path, link.line)
+        .catch((err) => {
+          console.error('[MarkdownFileLink] Failed to open file link:', err);
+        });
+    };
+    return (
+      <span
+        className={`${MARKDOWN_LINK_CLASS} cursor-pointer`}
+        role="button"
+        tabIndex={0}
+        title={link.path}
+        onClick={open}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter' || event.key === ' ') open(event);
+        }}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  // In-page anchor (footnotes, TOC): keep it same-tab.
+  if (href && href.startsWith('#')) {
+    return <a href={href} className={MARKDOWN_LINK_CLASS}>{children}</a>;
+  }
+  // Non-local: a normal external web link, unless it's a streaming placeholder
+  // href (`streamdown:incomplete-link`), which stays plain text.
+  if (href && !href.startsWith('streamdown:')) {
+    return (
+      <a href={href} target="_blank" rel="noreferrer" className={MARKDOWN_LINK_CLASS}>
+        {children}
+      </a>
+    );
+  }
+  return <span className={MARKDOWN_LINK_CLASS}>{children}</span>;
+};
+
+/** Streamdown `components` override that routes local file links to the IDE. */
+export const MARKDOWN_COMPONENTS = { a: MarkdownFileLink };

--- a/webview/src/pages/ChatPage/message-renderers/components/MessagePathChip.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/MessagePathChip.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getAdapter } from '../../../../adapters';
 import { useWorkingDir } from '@/contexts/WorkingDirContext';
-import { pathFromToken, isFolderToken, resolveFilePath } from '../utils/tokenizeMessagePaths';
+import { pathFromToken, lineFromToken, isFolderToken, resolveFilePath } from '../utils/tokenizeMessagePaths';
 
 interface Props {
   token: string;
@@ -26,7 +26,7 @@ export const MessagePathChip = (props: Props) => {
     event.stopPropagation();
     const filePath = resolveFilePath(pathFromToken(token), workingDirectory);
     getAdapter()
-      .openFile(filePath)
+      .openFile(filePath, lineFromToken(token))
       .catch((err) => {
         console.error('[MessagePathChip] Failed to open file:', err);
       });

--- a/webview/src/pages/ChatPage/message-renderers/components/__tests__/MessagePathChip.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/__tests__/MessagePathChip.test.tsx
@@ -24,11 +24,18 @@ describe('MessagePathChip', () => {
     expect(screen.getByText('@src/file.ts')).toBeInTheDocument();
   });
 
-  it('파일 토큰 클릭 시 워킹디렉토리와 결합한 절대경로로 openFile을 호출한다', () => {
+  it('파일 토큰 클릭 시 절대경로와 #L 라인을 함께 openFile에 전달한다', () => {
     render(<MessagePathChip token="@src/file.ts#L10-L25" />);
     fireEvent.click(screen.getByText('@src/file.ts#L10-L25'));
     expect(mockOpenFile).toHaveBeenCalledTimes(1);
-    expect(mockOpenFile).toHaveBeenCalledWith('/abs/project/src/file.ts');
+    expect(mockOpenFile).toHaveBeenCalledWith('/abs/project/src/file.ts', 10);
+  });
+
+  it('#L 라인 앵커가 없는 토큰은 line 인자 없이 openFile을 호출한다', () => {
+    render(<MessagePathChip token="@src/file.ts" />);
+    fireEvent.click(screen.getByText('@src/file.ts'));
+    expect(mockOpenFile).toHaveBeenCalledTimes(1);
+    expect(mockOpenFile).toHaveBeenCalledWith('/abs/project/src/file.ts', undefined);
   });
 
   it('파일 토큰은 role=button 으로 클릭 가능하다', () => {

--- a/webview/src/pages/ChatPage/message-renderers/utils/__tests__/markdownFileLink.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/__tests__/markdownFileLink.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseMarkdownFileLink,
+  normalizeDotSegments,
+  resolveMarkdownFileLink,
+  toLocalFileHref,
+} from '../markdownFileLink';
+
+describe('parseMarkdownFileLink', () => {
+  it('parses a POSIX-absolute path with a line', () => {
+    expect(parseMarkdownFileLink('/abs/f.ts#L42')).toEqual({ path: '/abs/f.ts', line: 42 });
+  });
+
+  it('parses a POSIX-absolute path without a line (undefined line → open at top)', () => {
+    expect(parseMarkdownFileLink('/abs/f.ts')).toEqual({ path: '/abs/f.ts', line: undefined });
+  });
+
+  it('takes the range start line from #L10-L25', () => {
+    expect(parseMarkdownFileLink('/abs/f.ts#L10-L25')).toEqual({ path: '/abs/f.ts', line: 10 });
+  });
+
+  it('strips a leading ./ from a relative path', () => {
+    expect(parseMarkdownFileLink('./src/f.ts#L5')).toEqual({ path: 'src/f.ts', line: 5 });
+  });
+
+  it('keeps a ../ relative path', () => {
+    expect(parseMarkdownFileLink('../f.ts')).toEqual({ path: '../f.ts', line: undefined });
+  });
+
+  it('treats a Windows drive-rooted path as local (forward slashes)', () => {
+    expect(parseMarkdownFileLink('C:/proj/f.ts#L42')).toEqual({ path: 'C:/proj/f.ts', line: 42 });
+  });
+
+  it('treats a Windows drive-rooted path as local (backslashes)', () => {
+    expect(parseMarkdownFileLink('C:\\proj\\f.ts')).toEqual({ path: 'C:\\proj\\f.ts', line: undefined });
+  });
+
+  it('restores a slash-prefixed Windows drive href (/C:/… → C:/…)', () => {
+    expect(parseMarkdownFileLink('/C:/proj/f.ts#L4')).toEqual({ path: 'C:/proj/f.ts', line: 4 });
+  });
+
+  it('percent-decodes the path', () => {
+    expect(parseMarkdownFileLink('/abs/my%20file.ts#L3')).toEqual({ path: '/abs/my file.ts', line: 3 });
+  });
+
+  it('returns null for http(s) and mailto URLs', () => {
+    expect(parseMarkdownFileLink('https://example.com/x')).toBeNull();
+    expect(parseMarkdownFileLink('http://example.com')).toBeNull();
+    expect(parseMarkdownFileLink('mailto:a@b.com')).toBeNull();
+  });
+
+  it('returns null for a protocol-relative //host URL', () => {
+    expect(parseMarkdownFileLink('//example.com/x')).toBeNull();
+  });
+
+  it('returns null for a bare #fragment', () => {
+    expect(parseMarkdownFileLink('#section')).toBeNull();
+  });
+
+  it('returns null for a bare relative path (chat markdown always prefixes ./)', () => {
+    expect(parseMarkdownFileLink('src/f.ts')).toBeNull();
+  });
+
+  it('returns null for empty / non-string input', () => {
+    expect(parseMarkdownFileLink('')).toBeNull();
+    // @ts-expect-error runtime guard against a non-string href
+    expect(parseMarkdownFileLink(null)).toBeNull();
+  });
+});
+
+describe('normalizeDotSegments', () => {
+  it('collapses .. against a POSIX root', () => {
+    expect(normalizeDotSegments('/wd/../f.ts')).toBe('/f.ts');
+  });
+
+  it('drops . segments', () => {
+    expect(normalizeDotSegments('/a/b/./c')).toBe('/a/b/c');
+  });
+
+  it('collapses .. against a Windows drive root and normalizes separators', () => {
+    expect(normalizeDotSegments('C:/wd/../f.ts')).toBe('C:/f.ts');
+    expect(normalizeDotSegments('C:\\wd\\..\\f.ts')).toBe('C:/f.ts');
+  });
+
+  it('keeps a leading .. for a relative path (nothing above to pop)', () => {
+    expect(normalizeDotSegments('../f.ts')).toBe('../f.ts');
+    expect(normalizeDotSegments('a/b/../c')).toBe('a/c');
+  });
+
+  it('never escapes above the root', () => {
+    expect(normalizeDotSegments('/a/../../b')).toBe('/b');
+  });
+});
+
+describe('toLocalFileHref', () => {
+  it('leaves a POSIX-absolute path unchanged', () => {
+    expect(toLocalFileHref('/abs/f.ts')).toBe('/abs/f.ts');
+  });
+
+  it('prefixes a Windows drive path with / and forward-slashes it', () => {
+    expect(toLocalFileHref('C:/proj/f.ts')).toBe('/C:/proj/f.ts');
+    expect(toLocalFileHref('C:\\proj\\f.ts')).toBe('/C:/proj/f.ts');
+  });
+
+  it('collapses . / .. segments', () => {
+    expect(toLocalFileHref('/wd/../a/./b.ts')).toBe('/a/b.ts');
+  });
+});
+
+describe('resolveMarkdownFileLink', () => {
+  it('leaves an absolute path unchanged (working dir irrelevant)', () => {
+    expect(resolveMarkdownFileLink('/abs/f.ts#L5', '/wd')).toEqual({ path: '/abs/f.ts', line: 5 });
+  });
+
+  it('joins a ./ relative path against the working dir', () => {
+    expect(resolveMarkdownFileLink('./src/f.ts#L3', '/wd')).toEqual({ path: '/wd/src/f.ts', line: 3 });
+  });
+
+  it('joins and normalizes a ../ relative path', () => {
+    expect(resolveMarkdownFileLink('../f.ts', '/wd/sub')).toEqual({ path: '/wd/f.ts', line: undefined });
+  });
+
+  it('returns the relative path as-is when the working dir is unknown', () => {
+    expect(resolveMarkdownFileLink('./src/f.ts#L3', null)).toEqual({ path: 'src/f.ts', line: 3 });
+  });
+
+  it('returns null for an external link', () => {
+    expect(resolveMarkdownFileLink('https://example.com', '/wd')).toBeNull();
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/utils/__tests__/tokenizeMessagePaths.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/__tests__/tokenizeMessagePaths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { tokenizeMessagePaths, pathFromToken, resolveFilePath } from '../tokenizeMessagePaths';
+import { tokenizeMessagePaths, pathFromToken, lineFromToken, resolveFilePath } from '../tokenizeMessagePaths';
 
 describe('resolveFilePath', () => {
   it('상대경로를 워킹디렉토리와 결합해 절대경로로 만든다', () => {
@@ -10,6 +10,10 @@ describe('resolveFilePath', () => {
   });
   it('이미 절대경로면 그대로 둔다', () => {
     expect(resolveFilePath('/etc/hosts', '/abs/project')).toBe('/etc/hosts');
+  });
+  it('Windows 드라이브 절대경로(C:/…, C:\\…)는 그대로 둔다', () => {
+    expect(resolveFilePath('C:/proj/file.ts', '/abs/project')).toBe('C:/proj/file.ts');
+    expect(resolveFilePath('C:\\proj\\file.ts', '/abs/project')).toBe('C:\\proj\\file.ts');
   });
   it('워킹디렉토리가 없으면 상대경로를 그대로 반환한다', () => {
     expect(resolveFilePath('src/file.ts', null)).toBe('src/file.ts');
@@ -125,5 +129,23 @@ describe('pathFromToken', () => {
 
   it('@ 없는 토큰도 처리한다', () => {
     expect(pathFromToken('src/file.ts')).toBe('src/file.ts');
+  });
+});
+
+describe('lineFromToken', () => {
+  it('#L10에서 라인 번호를 반환한다', () => {
+    expect(lineFromToken('@src/file.ts#L10')).toBe(10);
+  });
+
+  it('#L10-L25 범위에서는 시작 라인을 반환한다', () => {
+    expect(lineFromToken('@src/file.ts#L10-L25')).toBe(10);
+  });
+
+  it('라인 앵커가 없으면 undefined를 반환한다', () => {
+    expect(lineFromToken('@src/file.ts')).toBeUndefined();
+  });
+
+  it('폴더 토큰은 undefined를 반환한다', () => {
+    expect(lineFromToken('@src/utils/')).toBeUndefined();
   });
 });

--- a/webview/src/pages/ChatPage/message-renderers/utils/markdownFileLink.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/markdownFileLink.ts
@@ -1,0 +1,148 @@
+import { LINE_ANCHOR, resolveFilePath } from './tokenizeMessagePaths';
+
+/**
+ * A local file reference parsed out of an assistant markdown link href.
+ * `path` has its `#L` anchor removed and is percent-decoded; `line` is the
+ * 1-based line the caret should move to (undefined → open at the file top).
+ */
+export interface MarkdownFileLink {
+  path: string;
+  line?: number;
+}
+
+/** True for a Windows drive-rooted path (`C:/…` or `C:\…`), matching `joinProjectPath`. */
+function isWindowsAbsolute(href: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(href);
+}
+
+/**
+ * Parse a markdown link href into a local {@link MarkdownFileLink}, or `null`
+ * for external hrefs (which keep normal link behavior).
+ *
+ * Local = POSIX-rooted (`/…`), Windows drive-rooted (`C:/…`, `C:\…`), or relative
+ * (`./…`, `../…`). Protocol (`https:`, `mailto:`) and protocol-relative (`//host`)
+ * URLs are external. The `#L` anchor and a leading `./` are stripped and the path
+ * is percent-decoded to match the on-disk name.
+ */
+export function parseMarkdownFileLink(href: string): MarkdownFileLink | null {
+  if (typeof href !== 'string' || href.length === 0) return null;
+
+  const isPosixAbsolute = href.startsWith('/') && !href.startsWith('//'); // exclude protocol-relative //host
+  const isRelative = href.startsWith('./') || href.startsWith('../');
+  if (!isPosixAbsolute && !isWindowsAbsolute(href) && !isRelative) return null;
+
+  const match = LINE_ANCHOR.exec(href);
+  const line = match ? Number(match[1]) : undefined;
+
+  let path = href.replace(LINE_ANCHOR, '').replace(/^\.\//, '');
+  // A Windows drive path travels as `/C:/…` (leading slash so rehype-sanitize
+  // doesn't parse `C:` as a URL scheme and strip the link); restore `C:/…`.
+  if (/^\/[A-Za-z]:[\\/]/.test(path)) path = path.slice(1);
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    // Malformed percent-escape — keep the raw path rather than throw.
+  }
+
+  return { path, line };
+}
+
+/**
+ * Render a resolved local path as a link href that survives rehype-sanitize.
+ * Forward-slashes it (via {@link normalizeDotSegments}) and prefixes a Windows
+ * drive path with `/` so `C:` is not parsed as a URL scheme (`C:/proj` →
+ * `/C:/proj`); {@link parseMarkdownFileLink} strips that leading `/` back off.
+ */
+export function toLocalFileHref(path: string): string {
+  const normalized = normalizeDotSegments(path);
+  return /^[A-Za-z]:\//.test(normalized) ? `/${normalized}` : normalized;
+}
+
+/**
+ * Collapse `.`/`..` segments in an already-resolved path (POSIX- or
+ * Windows-drive-rooted, or relative) so the IDE file lookup gets a clean path,
+ * e.g. `/wd/../foo.ts` → `/foo.ts`, `C:/wd/../foo.ts` → `C:/foo.ts`. Backslashes
+ * are treated as separators; the result uses forward slashes. A leading `..` is
+ * preserved only for relative paths (there is nothing above the root to pop).
+ */
+export function normalizeDotSegments(p: string): string {
+  if (typeof p !== 'string' || p.length === 0) return p;
+
+  const drive = /^([A-Za-z]:)[\\/]/.exec(p);
+  let prefix = '';
+  let rest = p;
+  if (drive) {
+    prefix = `${drive[1]}/`;
+    rest = p.slice(drive[0].length);
+  } else if (p.startsWith('/')) {
+    prefix = '/';
+    rest = p.slice(1);
+  }
+
+  const out: string[] = [];
+  for (const segment of rest.split(/[\\/]+/)) {
+    if (segment === '' || segment === '.') continue;
+    if (segment === '..') {
+      if (out.length > 0 && out[out.length - 1] !== '..') out.pop();
+      else if (prefix === '') out.push('..'); // keep leading `..` only for relative paths
+    } else {
+      out.push(segment);
+    }
+  }
+
+  return prefix + out.join('/');
+}
+
+/**
+ * Parse and fully resolve a markdown link href into a local file reference
+ * ready for `openFile`, or `null` for external links. Relative paths are joined
+ * against `workingDir` (absolute paths pass through) and `.`/`..` segments are
+ * collapsed.
+ */
+export function resolveMarkdownFileLink(
+  href: string,
+  workingDir: string | null | undefined,
+): MarkdownFileLink | null {
+  const parsed = parseMarkdownFileLink(href);
+  if (!parsed) return null;
+  return {
+    path: normalizeDotSegments(resolveFilePath(parsed.path, workingDir)),
+    line: parsed.line,
+  };
+}
+
+/**
+ * Rewrite local-file link URLs in markdown to sanitize-safe absolute paths.
+ *
+ * rehype-harden resolves `./` relatives against the origin (losing the project
+ * path) and rehype-sanitize drops a bare `C:` as a URL scheme — so resolve local
+ * links to absolute here (relatives joined to `workingDir`) via {@link toLocalFileHref}
+ * (Windows drive carried as `/C:/…`). External / `#` / code-span URLs are left
+ * as-is; with no working dir, relatives fall back to the `./` form.
+ */
+export function normalizeMarkdownLinkUrls(markdown: string, workingDir: string | null | undefined): string {
+  // Mask fenced blocks and inline code so link URLs inside code are never
+  // rewritten (that would corrupt shown code and leak the working directory).
+  const codeSpans: string[] = [];
+  const masked = markdown.replace(
+    /```[\s\S]*?```|~~~[\s\S]*?~~~|`+[^`\n]*?`+/g,
+    (span) => `\u0000${codeSpans.push(span) - 1}\u0000`,
+  );
+
+  // Match markdown links [text](url) but NOT image links ![text](url).
+  const rewritten = masked.replace(
+    /(?<!!)\[([^\]]*)\]\(([^)]+)\)/g,
+    (match, text: string, url: string) => {
+      const isWindowsAbsolute = /^[A-Za-z]:[\\/]/.test(url);
+      // A single-letter "scheme" followed by / or \ is a Windows drive, not a URL scheme.
+      const isExternal = !isWindowsAbsolute
+        && (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(url) || url.startsWith('//') || url.startsWith('#'));
+      if (isExternal) return match;
+      if (url.startsWith('/') || isWindowsAbsolute) return `[${text}](${toLocalFileHref(url)})`;
+      if (workingDir) return `[${text}](${toLocalFileHref(resolveFilePath(url, workingDir))})`;
+      return url.startsWith('./') || url.startsWith('../') ? match : `[${text}](./${url})`;
+    },
+  );
+
+  return rewritten.replace(/\u0000(\d+)\u0000/g, (_, index) => codeSpans[Number(index)]);
+}

--- a/webview/src/pages/ChatPage/message-renderers/utils/tokenizeMessagePaths.ts
+++ b/webview/src/pages/ChatPage/message-renderers/utils/tokenizeMessagePaths.ts
@@ -60,6 +60,14 @@ export function tokenizeMessagePaths(text: string): MessageSegment[] {
 }
 
 /**
+ * Trailing GitHub-style line anchor (`#L10` or a `#L10-L25` range) on a path
+ * token or link href. Capture group 1 is the (1-based) start line. Shared by
+ * the `@`-mention helpers and the assistant markdown-link parser so the
+ * recognized syntax lives in one place.
+ */
+export const LINE_ANCHOR = /#L(\d+)(?:-L\d+)?$/;
+
+/**
  * Normalize an `@`-path token into the path to open in the IDE.
  *
  * Strips the leading `@` and any trailing line range (`#L10` or `#L10-L25`).
@@ -72,7 +80,20 @@ export function tokenizeMessagePaths(text: string): MessageSegment[] {
 export function pathFromToken(token: string): string {
   return token
     .replace(/^@/, '')
-    .replace(/#L\d+(?:-L\d+)?$/, '');
+    .replace(LINE_ANCHOR, '');
+}
+
+/**
+ * The 1-based line from an `@`-token's trailing `#L10`/`#L10-L25` (the range's
+ * start line), or `undefined` when the token carries no line anchor. Forwarded
+ * to `openFile` so the mention navigates to the line, not just the file.
+ *
+ * @example lineFromToken('@src/file.ts#L10-L25') // 10
+ * @example lineFromToken('@src/file.ts')         // undefined
+ */
+export function lineFromToken(token: string): number | undefined {
+  const match = LINE_ANCHOR.exec(token);
+  return match ? Number(match[1]) : undefined;
 }
 
 /**
@@ -89,11 +110,12 @@ export function isFolderToken(token: string): boolean {
  * path, and the backend forwards the path verbatim, so the webview must combine
  * the relative mention with the working directory here.
  *
- * Already-absolute paths (leading `/`) pass through unchanged. When the working
- * directory is unknown the relative path is returned as-is (best effort).
+ * Already-absolute paths pass through unchanged — POSIX (leading `/`) or
+ * Windows drive-rooted (`C:/…`, `C:\…`), matching `joinProjectPath`. When the
+ * working directory is unknown the relative path is returned as-is (best effort).
  */
 export function resolveFilePath(relativePath: string, workingDir: string | null | undefined): string {
-  if (relativePath.startsWith('/')) return relativePath;
+  if (relativePath.startsWith('/') || /^[A-Za-z]:[\\/]/.test(relativePath)) return relativePath;
   if (!workingDir) return relativePath;
-  return `${workingDir.replace(/\/+$/, '')}/${relativePath}`;
+  return `${workingDir.replace(/[\\/]+$/, '')}/${relativePath}`;
 }


### PR DESCRIPTION
## What

Make source-code file references in the chat clickable → open the file in the IDE at the referenced line.

- **Assistant markdown links** to local files (e.g. `[wdd.py:120](/abs/path/wdd.py#L120)` or `[x](./src/x.ts#L10)`) open the file at the line — in both normal messages and reasoning blocks. External links stay normal web links.
- **`@path#L42` mention chips** now forward the line (previously they opened the file at the top).

This fixes the symptom where an assistant file link opened a dead `localhost:<port>/…` tab — Streamdown's default link routes a root-relative href through `window.open`, which resolves against the webview origin.

Closes #209. Addresses the markdown-link part of #183 (plain-text `path:line` detection is out of scope here).

## How

- `MessagePathChip`: parse `#L` off the token and pass it to `openFile(path, line)`.
- `MarkdownFileLink` + `MARKDOWN_COMPONENTS`: a Streamdown `components.a` override, shared by `StreamingMessage` and `ThinkingStreamingMessage`. Local hrefs → a clickable reference calling `openFile(path, line)`; external → normal `<a target="_blank">`; in-page `#` anchors stay same-tab.
- `normalizeMarkdownLinkUrls`: resolve local link URLs to sanitize-safe absolute paths *before* Streamdown, because rehype-harden origin-resolves `./` relatives and rehype-sanitize strips a bare `C:` as a URL scheme. URLs inside code spans / fenced blocks are left verbatim.
- Windows: drive paths are carried as `/C:/…` through sanitize and restored on parse (matching `joinProjectPath`'s drive handling).

The IDE bridge already accepted `openFile(filePath, line?, column?)` and the backend already does `OpenFileDescriptor(project, file, line - 1, col)` (1-based in; opens at top when null) — so this is webview-only, no backend change.

## Tests

Full `pnpm test` suite green. New/updated:
- `markdownFileLink.test.ts` — parse/resolve/normalize incl. Windows drive, `%`-encoding, `#L` ranges, external/`//`/`#` → null.
- `tokenizeMessagePaths.test.ts` — `lineFromToken`, drive-aware `resolveFilePath`.
- `MessagePathChip.test.tsx` — line forwarded to `openFile`.
- `StreamingMessage.file-links.test.tsx` — behavioral, through the real Streamdown sanitize/harden pipeline: local → `openFile(path,line)`, relative resolved against the working dir, Windows drive round-trip, code-span not rewritten, `#`-anchor same-tab, external → no `openFile`.
