### PR TITLE
Reliable Enter newline across keyboard layouts & IME (#215)

### DIFF
--- a/webview/src/config/environment.ts
+++ b/webview/src/config/environment.ts
@@ -44,6 +44,17 @@ export function isMobile(): boolean {
   return /android|iphone|ipad|ipod/.test(userAgent);
 }
 
+/**
+ * True when the client OS is macOS. Used to label the send-modifier as Cmd (⌘)
+ * instead of Ctrl. Browser-only (no SSR): reads `navigator.platform`, falling
+ * back to the user-agent string on engines that leave `platform` empty.
+ */
+export function isMac(): boolean {
+  const platform = navigator.platform ?? '';
+  if (platform) return platform.toUpperCase().includes('MAC');
+  return /mac/i.test(navigator.userAgent);
+}
+
 // ── IDE 테마 ─────────────────────────────────────────
 // JetBrains JCEF 환경에서만 의미 있음. Kotlin이 페이지 로드 시점에 LAF 값을
 // window.__IDE_THEME__ 에 주입하고, LAF가 바뀌면 'ide-theme-changed' 이벤트를 dispatch한다.

--- a/webview/src/i18n/locales/ar/settings.json
+++ b/webview/src/i18n/locales/ar/settings.json
@@ -41,7 +41,7 @@
       "label": "تفعيل الاتجاه من اليمين إلى اليسار (RTL)"
     },
     "useCtrlEnterToSend": {
-      "label": "استخدام Ctrl+Enter للإرسال",
+      "label": "استخدام {{modifier}}+Enter للإرسال",
       "description": "عند التفعيل، استخدم Ctrl/Cmd+Enter لإرسال الطلبات بدلًا من Enter فقط. يتيح هذا استخدام Enter لإنشاء أسطر جديدة."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/de/settings.json
+++ b/webview/src/i18n/locales/de/settings.json
@@ -41,7 +41,7 @@
       "label": "RTL(Right-to-left) aktivieren"
     },
     "useCtrlEnterToSend": {
-      "label": "Mit Strg+Enter senden",
+      "label": "Mit {{modifier}}+Enter senden",
       "description": "Wenn aktiviert, wird Strg/Cmd+Enter statt nur Enter verwendet, um Prompts zu senden. So kann mit Enter ein Zeilenumbruch eingefügt werden."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/en/settings.json
+++ b/webview/src/i18n/locales/en/settings.json
@@ -41,7 +41,7 @@
       "label": "Enable RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "Use Ctrl Enter To Send",
+      "label": "Use {{modifier}}+Enter To Send",
       "description": "When enabled, use Ctrl/Cmd+Enter to send prompts instead of just Enter. This allows Enter to create new lines."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/es/settings.json
+++ b/webview/src/i18n/locales/es/settings.json
@@ -41,7 +41,7 @@
       "label": "Activar RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "Usar Ctrl+Enter para enviar",
+      "label": "Usar {{modifier}}+Enter para enviar",
       "description": "Cuando está activado, usa Ctrl/Cmd+Enter para enviar mensajes en lugar de solo Enter. Esto permite usar Enter para crear nuevas líneas."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/fa/settings.json
+++ b/webview/src/i18n/locales/fa/settings.json
@@ -41,7 +41,7 @@
       "label": "فعال‌سازی RTL (راست‌به‌چپ)"
     },
     "useCtrlEnterToSend": {
-      "label": "استفاده از Ctrl+Enter برای ارسال",
+      "label": "استفاده از {{modifier}}+Enter برای ارسال",
       "description": "وقتی فعال باشد، برای ارسال دستورها به‌جای Enter از Ctrl/Cmd+Enter استفاده کنید. این کار به Enter اجازه می‌دهد خط جدید ایجاد کند."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/fr/settings.json
+++ b/webview/src/i18n/locales/fr/settings.json
@@ -41,7 +41,7 @@
       "label": "Activer RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "Utiliser Ctrl+Entrée pour envoyer",
+      "label": "Utiliser {{modifier}}+Entrée pour envoyer",
       "description": "Lorsque cette option est activée, utilisez Ctrl/Cmd+Entrée pour envoyer les invites au lieu de simplement Entrée. Cela permet à Entrée de créer de nouvelles lignes."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/ja/settings.json
+++ b/webview/src/i18n/locales/ja/settings.json
@@ -41,7 +41,7 @@
       "label": "RTL(Right-to-left) を有効化"
     },
     "useCtrlEnterToSend": {
-      "label": "送信にCtrl+Enterを使用",
+      "label": "送信に{{modifier}}+Enterを使用",
       "description": "有効にすると、Enterだけでなく Ctrl/Cmd+Enter でプロンプトを送信します。Enterキーは改行に使用できるようになります。"
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/ko/settings.json
+++ b/webview/src/i18n/locales/ko/settings.json
@@ -41,7 +41,7 @@
       "label": "RTL(Right-to-left) 켜기"
     },
     "useCtrlEnterToSend": {
-      "label": "Ctrl+Enter로 전송",
+      "label": "{{modifier}}+Enter로 전송",
       "description": "켜면 Enter 대신 Ctrl/Cmd+Enter로 프롬프트를 전송합니다. 이렇게 하면 Enter로 줄바꿈을 넣을 수 있습니다."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/pt/settings.json
+++ b/webview/src/i18n/locales/pt/settings.json
@@ -41,7 +41,7 @@
       "label": "Ativar RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "Usar Ctrl+Enter para enviar",
+      "label": "Usar {{modifier}}+Enter para enviar",
       "description": "Quando ativado, use Ctrl/Cmd+Enter para enviar mensagens em vez de apenas Enter. Isso permite que Enter crie novas linhas."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/ru/settings.json
+++ b/webview/src/i18n/locales/ru/settings.json
@@ -41,7 +41,7 @@
       "label": "Включить RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "Отправлять по Ctrl+Enter",
+      "label": "Отправлять по {{modifier}}+Enter",
       "description": "Если включено, для отправки запроса используется Ctrl/Cmd+Enter вместо просто Enter. Это позволяет создавать новые строки клавишей Enter."
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/zh-TW/settings.json
+++ b/webview/src/i18n/locales/zh-TW/settings.json
@@ -41,7 +41,7 @@
       "label": "啟用 RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "使用 Ctrl+Enter 傳送",
+      "label": "使用 {{modifier}}+Enter 傳送",
       "description": "啟用後,將以 Ctrl/Cmd+Enter 傳送提示,而不只是按 Enter。這樣 Enter 鍵就能用來換行。"
     },
     "focusInputOnEditorContext": {

--- a/webview/src/i18n/locales/zh/settings.json
+++ b/webview/src/i18n/locales/zh/settings.json
@@ -41,7 +41,7 @@
       "label": "启用 RTL(Right-to-left)"
     },
     "useCtrlEnterToSend": {
-      "label": "使用 Ctrl+Enter 发送",
+      "label": "使用 {{modifier}}+Enter 发送",
       "description": "启用后,使用 Ctrl/Cmd+Enter 发送提示,而不是单独按 Enter。这样 Enter 键可用于换行。"
     },
     "focusInputOnEditorContext": {

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/insertNewlineAtCursor.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/insertNewlineAtCursor.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for insertNewlineAtCursor.
+ *
+ * jsdom does not implement `document.execCommand`, so we exercise both paths:
+ *   - execCommand present and succeeding (mocked to return true): the util
+ *     defers to the browser and inserts nothing itself.
+ *   - execCommand absent/failing: the manual fallback inserts a real "\n" text
+ *     node at the caret. We insert a text node (not a <br>) because our composer
+ *     derives its value from `textContent`, where a <br> would contribute no
+ *     newline and silently drop the line break from `value`.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { insertNewlineAtCursor } from '../insertNewlineAtCursor';
+
+// jsdom does not implement document.execCommand at all (the property is absent),
+// so vi.spyOn cannot attach to it. We assign a stub directly per test and remove
+// it afterwards. The shape cast keeps the delete type-safe without `any`.
+type ExecCommandHost = { execCommand?: Document['execCommand'] };
+function setExecCommand(fn: Document['execCommand']): void {
+  (document as ExecCommandHost).execCommand = fn;
+}
+function clearExecCommand(): void {
+  delete (document as ExecCommandHost).execCommand;
+}
+
+function makeEditableWithCaret(text: string): HTMLDivElement {
+  const el = document.createElement('div');
+  el.textContent = text;
+  document.body.appendChild(el);
+
+  const sel = window.getSelection()!;
+  const range = document.createRange();
+  const textNode = el.firstChild ?? el;
+  // Place the caret at the end of the text.
+  range.setStart(textNode, textNode.nodeType === Node.TEXT_NODE ? (textNode as Text).length : 0);
+  range.collapse(true);
+  sel.removeAllRanges();
+  sel.addRange(range);
+  return el;
+}
+
+describe('insertNewlineAtCursor', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    clearExecCommand();
+    vi.restoreAllMocks();
+  });
+
+  it('defers to execCommand when it succeeds (inserts nothing itself)', () => {
+    const el = makeEditableWithCaret('hello');
+    const exec = vi.fn().mockReturnValue(true);
+    setExecCommand(exec as unknown as Document['execCommand']);
+
+    insertNewlineAtCursor();
+
+    expect(exec).toHaveBeenCalledWith('insertLineBreak');
+    // No manual fallback ran, so the DOM text is unchanged by the util.
+    expect(el.textContent).toBe('hello');
+  });
+
+  it('falls back to inserting a "\\n" text node when execCommand returns false', () => {
+    const el = makeEditableWithCaret('hello');
+    setExecCommand(vi.fn().mockReturnValue(false) as unknown as Document['execCommand']);
+
+    insertNewlineAtCursor();
+
+    expect(el.textContent).toBe('hello\n');
+  });
+
+  it('falls back gracefully when execCommand throws (jsdom "not implemented")', () => {
+    const el = makeEditableWithCaret('world');
+    setExecCommand((() => {
+      throw new Error('not implemented');
+    }) as unknown as Document['execCommand']);
+
+    expect(() => insertNewlineAtCursor()).not.toThrow();
+    expect(el.textContent).toBe('world\n');
+  });
+
+  it('is a no-op-safe when execCommand is entirely absent (fallback runs)', () => {
+    const el = makeEditableWithCaret('bye');
+    clearExecCommand(); // simulate real jsdom: no execCommand at all
+
+    expect(() => insertNewlineAtCursor()).not.toThrow();
+    expect(el.textContent).toBe('bye\n');
+  });
+
+  it('inserts the newline at the caret between existing characters', () => {
+    const el = document.createElement('div');
+    el.textContent = 'abcd';
+    document.body.appendChild(el);
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(el.firstChild as Text, 2); // caret between "ab" and "cd"
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    setExecCommand(vi.fn().mockReturnValue(false) as unknown as Document['execCommand']);
+    insertNewlineAtCursor();
+
+    expect(el.textContent).toBe('ab\ncd');
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/useIMEComposition.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/useIMEComposition.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for useIMEComposition — the ref-only source of truth for IME state.
+ *
+ * Why ref-only: under JCEF (embedded Chromium) `KeyboardEvent.isComposing` is
+ * unreliable (false during an active composition, true just after it ends). We
+ * therefore track composition ourselves. State is kept in refs (not React
+ * state) so that fast Hangul typing never triggers a re-render mid-composition,
+ * which under JCEF causes duplicated/stuttered glyphs.
+ *
+ * These tests assert the synchronous transitions and the 100ms fallback that
+ * guarantees the flag cannot get stuck true when an IME abandons a composition
+ * without a trailing input/compositionend event.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useIMEComposition } from '../useIMEComposition';
+
+describe('useIMEComposition', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('compositionStart sets isComposing true synchronously', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    expect(result.current.isComposing()).toBe(false);
+    result.current.handleCompositionStart();
+    expect(result.current.isComposing()).toBe(true);
+  });
+
+  it('compositionEnd sets isComposing false synchronously (no RAF/timer needed)', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.handleCompositionStart();
+    result.current.handleCompositionEnd();
+    // Synchronous: must be false immediately, without advancing timers.
+    expect(result.current.isComposing()).toBe(false);
+  });
+
+  it('keyCode 229 keydown is treated as a composing signal', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.noteKeyDown(229);
+    expect(result.current.isComposing()).toBe(true);
+  });
+
+  it('a non-229 keydown does not flip the composing flag', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.noteKeyDown(13);
+    expect(result.current.isComposing()).toBe(false);
+  });
+
+  it('fallback resets a stuck 229 composing flag after 100ms (abandoned composition)', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.noteKeyDown(229);
+    expect(result.current.isComposing()).toBe(true);
+    // No compositionend / input arrives (IME cancel edge case).
+    vi.advanceTimersByTime(100);
+    expect(result.current.isComposing()).toBe(false);
+  });
+
+  it('compositionStart cancels a pending fallback so a fast next syllable is not reset', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.handleCompositionStart();
+    result.current.handleCompositionEnd(); // schedules a 100ms fallback
+    // A new syllable begins within the fallback window.
+    result.current.handleCompositionStart();
+    expect(result.current.isComposing()).toBe(true);
+    vi.advanceTimersByTime(100);
+    // The stale fallback must NOT have reset the now-active composition.
+    expect(result.current.isComposing()).toBe(true);
+  });
+
+  it('notifyInput cancels a pending 229 fallback (committed input resolves state)', () => {
+    const { result } = renderHook(() => useIMEComposition());
+    result.current.noteKeyDown(229); // composing + schedules fallback
+    result.current.handleCompositionStart(); // real composition confirmed
+    result.current.notifyInput(); // committed input arrives
+    vi.advanceTimersByTime(100);
+    // Still composing because compositionEnd has not fired; the fallback was
+    // cancelled by the committed input rather than wrongly resetting state.
+    expect(result.current.isComposing()).toBe(true);
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
@@ -13,6 +13,8 @@ import {
 } from 'react';
 import { setCaretOffset } from '@/utils/domSelection';
 import { splitIntoSegments } from './segments';
+import { useIMEComposition, type IMEComposition } from './useIMEComposition';
+import { insertNewlineAtCursor } from './insertNewlineAtCursor';
 
 interface Props {
   value: string;
@@ -31,6 +33,14 @@ interface Props {
    * is never chipped. Defaults to an empty list (plain text, no chips).
    */
   highlightTokens?: readonly string[];
+  /**
+   * IME composition state, optionally owned by the parent (ChatInput) so its
+   * keydown handler and this editor agree on a single source of truth. Under
+   * JCEF the native `isComposing` flag is unreliable; this ref-only hook is
+   * authoritative. When omitted, RichInput manages its own instance so it stays
+   * usable standalone.
+   */
+  ime?: IMEComposition;
 }
 
 /**
@@ -80,11 +90,17 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
     className,
     ariaLabel,
     highlightTokens = [],
+    ime: imeProp,
   } = props;
 
   const elRef = useRef<HTMLDivElement>(null);
   const mirrorRef = useRef<HTMLDivElement>(null);
-  const isComposingRef = useRef(false);
+  // Own an IME instance so RichInput works standalone; when the parent supplies
+  // one (ChatInput), use it so keydown and this editor share a single truth.
+  const internalIme = useIMEComposition();
+  const ime = imeProp ?? internalIme;
+  // IME truth lives in the (possibly parent-owned) hook; alias for local reads.
+  const isComposingRef = ime.isComposingRef;
 
   // Live display text that drives the mirror. Unlike `value` (the controlled
   // prop, which is NOT updated mid-IME-composition), this tracks the editable
@@ -142,14 +158,35 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
       // reporting to the parent until compositionend to avoid emitting partial
       // glyphs. The mirror still updates above so the user sees live feedback.
       if (isComposingRef.current) return;
+      // A committed input cancels the IME safety fallback (see useIMEComposition).
+      ime.notifyInput();
       onChange(text);
     },
-    [onChange],
+    [onChange, ime, isComposingRef],
+  );
+
+  // beforeinput safety net (issue #215): under JCEF a non-English-layout Enter
+  // can slip past keydown, so the composer never receives our explicit-newline
+  // handling. `insertParagraph` (the paragraph-break intent) is layout-
+  // independent — catch it here, convert it to a single `\n`, and keep `value`
+  // the single source of truth. Skipped while composing so an IME commit stands.
+  const handleBeforeInput = useCallback(
+    (e: FormEvent<HTMLDivElement>) => {
+      const native = e.nativeEvent as InputEvent;
+      if (native.inputType !== 'insertParagraph') return;
+      if (isComposingRef.current) return;
+      e.preventDefault();
+      insertNewlineAtCursor();
+      const text = elRef.current?.textContent ?? '';
+      setDisplayText(text);
+      onChange(text);
+    },
+    [onChange, isComposingRef],
   );
 
   const handleCompositionStart = useCallback(() => {
-    isComposingRef.current = true;
-  }, []);
+    ime.handleCompositionStart();
+  }, [ime]);
 
   const handleCompositionUpdate = useCallback(
     (e: ReactCompositionEvent<HTMLDivElement>) => {
@@ -162,12 +199,12 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
 
   const handleCompositionEnd = useCallback(
     (e: ReactCompositionEvent<HTMLDivElement>) => {
-      isComposingRef.current = false;
+      ime.handleCompositionEnd();
       const text = e.currentTarget.textContent ?? '';
       setDisplayText(text);
       onChange(text);
     },
-    [onChange],
+    [onChange, ime],
   );
 
   // Keep the mirror's scroll position locked to the editable div so long /
@@ -236,6 +273,7 @@ export const RichInput = forwardRef<HTMLDivElement, Props>((props: Props, ref) =
           .filter(Boolean)
           .join(' ')}
         onInput={handleInput}
+        onBeforeInput={handleBeforeInput}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
         onFocus={onFocus}

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/insertNewlineAtCursor.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/insertNewlineAtCursor.ts
@@ -1,0 +1,46 @@
+/**
+ * Insert a single newline at the current caret position inside a focused
+ * contentEditable, without relying on the browser's default Enter handling.
+ *
+ * Why explicit insertion (issue #215): under JCEF (embedded Chromium) with a
+ * non-English keyboard layout, a plain Enter is frequently swallowed as an IME
+ * "commit" keystroke, so the browser never inserts the line break. Deciding the
+ * newline ourselves and writing it directly is layout-independent and always
+ * produces exactly one `\n`.
+ *
+ * Two paths:
+ *   1. `document.execCommand('insertLineBreak')` — the fast path. In a
+ *      `plaintext-only` editable, Chromium inserts a real `\n` and fires a
+ *      native `input` event so the composer's value sync runs normally.
+ *   2. Manual fallback — when execCommand is unavailable (returns false) or
+ *      throws (jsdom reports "not implemented"). We insert a `\n` TEXT node
+ *      (not a `<br>`): the composer derives `value` from `textContent`, where a
+ *      `<br>` contributes no newline and would silently drop the line break.
+ *
+ * Assumes the target editable is focused so `window.getSelection()` points into
+ * it. No-ops safely when there is no usable selection.
+ */
+export function insertNewlineAtCursor(): void {
+  let handledByBrowser = false;
+  try {
+    handledByBrowser = document.execCommand('insertLineBreak');
+  } catch {
+    handledByBrowser = false;
+  }
+  if (handledByBrowser) return;
+
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+
+  const range = selection.getRangeAt(0);
+  range.deleteContents();
+
+  const newline = document.createTextNode('\n');
+  range.insertNode(newline);
+
+  // Collapse the caret to just after the inserted newline.
+  range.setStartAfter(newline);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+}

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/useIMEComposition.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/useIMEComposition.ts
@@ -1,0 +1,107 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react';
+
+/**
+ * Fallback timeout (ms) that force-clears the composing flag when an IME
+ * abandons a composition without a trailing compositionend/input event.
+ */
+const FALLBACK_RESET_MS = 100;
+
+/** keyCode reported by browsers while an IME is still processing a keystroke. */
+const IME_PROCESS_KEYCODE = 229;
+
+export interface IMEComposition {
+  /** Live truth for "an IME composition is in flight" (ref, never state). */
+  isComposingRef: RefObject<boolean>;
+  /** compositionstart handler: marks composing true synchronously. */
+  handleCompositionStart: () => void;
+  /** compositionend handler: marks composing false synchronously. */
+  handleCompositionEnd: () => void;
+  /** keydown hook: keyCode 229 is treated as a composing signal. */
+  noteKeyDown: (keyCode: number) => void;
+  /** input hook: a committed input cancels the pending safety fallback. */
+  notifyInput: () => void;
+  /** Query: is a composition currently in flight? */
+  isComposing: () => boolean;
+}
+
+/**
+ * useIMEComposition — the single, ref-only source of truth for IME composition
+ * state in the composer.
+ *
+ * Why this exists: under JCEF (embedded Chromium) `KeyboardEvent.isComposing`
+ * is unreliable — it can read false during an active composition and true just
+ * after it ends. Relying on it makes a plain Enter in a non-English layout get
+ * consumed as a composition "commit", so no newline is produced (issue #215).
+ * We therefore track composition ourselves from the composition lifecycle plus
+ * the keyCode-229 signal.
+ *
+ * Why refs, not React state: updating state mid-composition triggers a
+ * re-render, and under JCEF that re-render duplicates/stutters the in-progress
+ * glyphs. All state here lives in refs so composition never causes a render.
+ *
+ * Transitions are synchronous (no requestAnimationFrame): during fast Hangul
+ * typing a deferred reset would race the next compositionstart and briefly
+ * report the wrong state. A short {@link FALLBACK_RESET_MS} timer is the only
+ * async piece, and it exists purely as a safety net for IMEs that abandon a
+ * composition without a trailing event.
+ */
+export function useIMEComposition(): IMEComposition {
+  const isComposingRef = useRef(false);
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearFallback = useCallback(() => {
+    if (fallbackTimerRef.current !== null) {
+      clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleFallback = useCallback(() => {
+    clearFallback();
+    fallbackTimerRef.current = setTimeout(() => {
+      isComposingRef.current = false;
+      fallbackTimerRef.current = null;
+    }, FALLBACK_RESET_MS);
+  }, [clearFallback]);
+
+  const handleCompositionStart = useCallback(() => {
+    // A fresh composition supersedes any pending fallback from a prior one.
+    clearFallback();
+    isComposingRef.current = true;
+  }, [clearFallback]);
+
+  const handleCompositionEnd = useCallback(() => {
+    isComposingRef.current = false;
+    // Safety net: if a keyCode-229 keystroke re-raises the flag right after this
+    // without a real composition, the fallback clears it.
+    scheduleFallback();
+  }, [scheduleFallback]);
+
+  const noteKeyDown = useCallback((keyCode: number) => {
+    if (keyCode !== IME_PROCESS_KEYCODE) return;
+    // The IME is still processing this keystroke — treat as composing, and arm
+    // the fallback so a cancelled composition (no compositionend/input) cannot
+    // leave the flag stuck true.
+    isComposingRef.current = true;
+    scheduleFallback();
+  }, [scheduleFallback]);
+
+  const notifyInput = useCallback(() => {
+    // A committed input means the composition lifecycle is driving state; the
+    // safety fallback is no longer needed and must not fire mid-composition.
+    clearFallback();
+  }, [clearFallback]);
+
+  const isComposing = useCallback(() => isComposingRef.current, []);
+
+  useEffect(() => clearFallback, [clearFallback]);
+
+  return {
+    isComposingRef,
+    handleCompositionStart,
+    handleCompositionEnd,
+    noteKeyDown,
+    notifyInput,
+    isComposing,
+  };
+}

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -34,6 +34,8 @@ import { isMobile } from '@/config/environment';
 import { shouldSubmitOnEnter } from './shouldSubmitOnEnter';
 import { basename } from './basename';
 import { RichInput } from './RichInput';
+import { useIMEComposition } from './RichInput/useIMEComposition';
+import { insertNewlineAtCursor } from './RichInput/insertNewlineAtCursor';
 import { TelemetryConsentBanner } from '../TelemetryConsentBanner';
 import { InputBanner } from '../InputBanner';
 import { FableNoticeBanner } from '../FableNoticeBanner';
@@ -237,6 +239,10 @@ export function ChatInput() {
 
   const modeConfig = INPUT_MODES[mode];
 
+  // IME composition truth (ref-only) shared between this keydown handler and the
+  // RichInput editor. Under JCEF the native `isComposing` flag is unreliable.
+  const ime = useIMEComposition();
+
   const palette = useCommandPalette({ onChange, textareaRef });
 
   const mention = useMention({
@@ -397,8 +403,19 @@ export function ChatInput() {
     initHistory(userTexts);
   }, [currentSessionId, initHistory]);
 
+  const handleRichChange = useCallback((newValue: string) => {
+    onChange(newValue);
+    palette.detectSlashCommand(newValue);
+    const caret = textareaRef.current ? getCaretOffset(textareaRef.current) : newValue.length;
+    mention.detectMention(newValue, caret);
+  }, [onChange, palette, mention, textareaRef]);
+
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
     if (e.key.startsWith('Arrow')) console.log('[KeyDebug:textarea-keydown]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
+
+    // Feed the IME truth: keyCode 229 means the IME is still processing this
+    // keystroke, so mark composition active before any Enter decision runs.
+    ime.noteKeyDown(e.nativeEvent.keyCode);
 
     // JCEF workaround: Cmd+Arrow 처리 후 발생하는 순수 Arrow 유령 이벤트 무시
     const isArrowKey = e.key.startsWith('Arrow');
@@ -448,14 +465,21 @@ export function ChatInput() {
 
     // Enter: submit or newline depending on useCtrlEnterToSend setting.
     // IME composition and mobile guards always apply to the submit path.
-    if (e.key === 'Enter') {
+    // Enter is double-detected (key OR keyCode 13) because non-English layouts
+    // under JCEF can surface it with a non-"Enter" key string (issue #215).
+    const isEnterKey = e.key === 'Enter' || e.nativeEvent.keyCode === 13;
+    if (isEnterKey) {
+      // Combine our composition truth with the native flag: either being set
+      // means "in composition", since JCEF's native flag alone is unreliable.
+      const isIMEComposing = ime.isComposing() || e.nativeEvent.isComposing;
       const willSubmit = shouldSubmitOnEnter(
         {
           key: e.key,
+          keyCode: e.nativeEvent.keyCode,
           shiftKey: e.shiftKey,
           ctrlKey: e.ctrlKey,
           metaKey: e.metaKey,
-          isComposing: e.nativeEvent.isComposing,
+          isComposing: isIMEComposing,
           isMobile: isMobile(),
         },
         claudeSettings.useCtrlEnterToSend ?? false,
@@ -468,8 +492,19 @@ export function ChatInput() {
           clearAttachments();
           setPathTokens([]);
         }
+        return;
       }
-      // When willSubmit is false: do not prevent default — let the textarea handle it natively
+      // Not a submit. Insert a newline explicitly (issue #215): under JCEF a
+      // plain Enter in a non-English layout is otherwise swallowed as an IME
+      // commit and no line break appears. While composing we do NOT touch it —
+      // the composition confirmation owns that keystroke.
+      if (!isIMEComposing) {
+        e.preventDefault();
+        insertNewlineAtCursor();
+        const text = e.currentTarget.textContent ?? '';
+        handleRichChange(text);
+      }
+      return;
     } else if (e.key === 'ArrowUp' && !palette.showSlashCommands) {
       console.log('[KeyDebug:history-up-triggered]');
       // 복수행: 커서가 첫 번째 줄에 있을 때만 히스토리 탐색
@@ -491,14 +526,7 @@ export function ChatInput() {
       e.preventDefault();
       onChange(historyValue);
     }
-  }, [disabled, value, attachments.length, onSubmit, pushToHistory, navigateUp, navigateDown, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend]);
-
-  const handleRichChange = useCallback((newValue: string) => {
-    onChange(newValue);
-    palette.detectSlashCommand(newValue);
-    const caret = textareaRef.current ? getCaretOffset(textareaRef.current) : newValue.length;
-    mention.detectMention(newValue, caret);
-  }, [onChange, palette, mention, textareaRef]);
+  }, [disabled, value, attachments.length, onSubmit, pushToHistory, navigateUp, navigateDown, onChange, palette, mention, cycleMode, clearAttachments, mode, claudeSettings.useCtrlEnterToSend, ime, handleRichChange]);
 
   // Wrap the attachment paste handler so that, when the clipboard carries no
   // image, we insert the plain-text payload ourselves. contentEditable would
@@ -605,6 +633,7 @@ export function ChatInput() {
         <div className="pt-2.5 pb-1.5">
           <RichInput
             ref={textareaRef}
+            ime={ime}
             value={value}
             onChange={handleRichChange}
             onKeyDown={handleKeyDown}

--- a/webview/src/pages/ChatPage/ChatInput/shouldSubmitOnEnter.ts
+++ b/webview/src/pages/ChatPage/ChatInput/shouldSubmitOnEnter.ts
@@ -1,16 +1,28 @@
 /**
- * Pure helper that determines whether a keydown event on the textarea should
+ * Pure helper that determines whether a keydown event on the composer should
  * trigger form submission, based on the useCtrlEnterToSend setting.
  *
  * Extracted for unit-testability without requiring full context setup.
  *
- * @param event - subset of KeyboardEvent properties needed for the decision
+ * Robustness notes (issue #215, JCEF/embedded-Chromium):
+ *   - `isEnterKey` double-detects Enter via `key === 'Enter'` OR `keyCode === 13`.
+ *     Non-English layouts under JCEF can surface Enter with a non-"Enter" key
+ *     string but keyCode 13.
+ *   - `isComposing` is expected to already be the OR of our own composition
+ *     truth and `nativeEvent.isComposing` (JCEF's native flag is unreliable
+ *     alone). It always guards the submit path. While a composition is in
+ *     flight this blocks submit; once it ends (`isComposing` false) a plain
+ *     Enter behaves normally, so typing a CJK glyph then pressing Enter submits
+ *     on the first Enter just like a pasted string does.
+ *
+ * @param event - subset of KeyboardEvent-derived properties for the decision
  * @param useCtrlEnterToSend - value of the ClaudeSettings toggle
  * @returns true when the key combo should submit the prompt
  */
 export function shouldSubmitOnEnter(
   event: {
     key: string;
+    keyCode: number;
     shiftKey: boolean;
     ctrlKey: boolean;
     metaKey: boolean;
@@ -19,17 +31,19 @@ export function shouldSubmitOnEnter(
   },
   useCtrlEnterToSend: boolean,
 ): boolean {
-  // Only applies to the Enter key
-  if (event.key !== 'Enter') return false;
+  // Only applies to the Enter key (double-detected for non-English layouts).
+  const isEnterKey = event.key === 'Enter' || event.keyCode === 13;
+  if (!isEnterKey) return false;
 
-  // IME composition and mobile are always guarded on the submit path
+  // IME composition and mobile are always guarded on the submit path.
   if (event.isComposing || event.isMobile) return false;
 
   if (useCtrlEnterToSend) {
-    // Ctrl/Cmd+Enter sends; Shift+Enter and plain Enter insert newlines
+    // Ctrl/Cmd+Enter sends; Shift+Enter and plain Enter insert newlines.
     return (event.ctrlKey || event.metaKey) && !event.shiftKey;
   } else {
-    // Default: Enter sends, Shift+Enter inserts a newline
-    return !event.shiftKey;
+    // Default: Enter sends, Shift+Enter inserts a newline.
+    if (event.shiftKey) return false;
+    return true;
   }
 }

--- a/webview/src/pages/ChatPage/__tests__/ChatInput.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/ChatInput.test.tsx
@@ -13,6 +13,7 @@ import { shouldSubmitOnEnter } from '../ChatInput/shouldSubmitOnEnter';
 
 const makeEvent = (overrides: Partial<{
   key: string;
+  keyCode: number;
   shiftKey: boolean;
   ctrlKey: boolean;
   metaKey: boolean;
@@ -20,6 +21,7 @@ const makeEvent = (overrides: Partial<{
   isMobile: boolean;
 }> = {}) => ({
   key: 'Enter',
+  keyCode: 13,
   shiftKey: false,
   ctrlKey: false,
   metaKey: false,
@@ -44,6 +46,14 @@ describe('shouldSubmitOnEnter — useCtrlEnterToSend: false (default mode)', () 
 
   it('IME composing → submit NOT called', () => {
     expect(shouldSubmitOnEnter(makeEvent({ isComposing: true }), false)).toBe(false);
+  });
+
+  it('Enter right after a composition ends (isComposing false) → submit called', () => {
+    // Regression guard: typing a CJK glyph then pressing Enter must submit on the
+    // FIRST Enter. The composition is already finished (isComposing=false), so no
+    // recent-composition suppression should swallow this Enter as a newline.
+    // (A prior `isRecentlyComposing` guard caused a spurious first-Enter newline.)
+    expect(shouldSubmitOnEnter(makeEvent({ isComposing: false }), false)).toBe(true);
   });
 
   it('mobile environment → submit NOT called', () => {
@@ -83,7 +93,20 @@ describe('shouldSubmitOnEnter — useCtrlEnterToSend: true', () => {
 
 describe('shouldSubmitOnEnter — non-Enter key', () => {
   it('non-Enter key always returns false regardless of mode', () => {
-    expect(shouldSubmitOnEnter(makeEvent({ key: 'a' }), false)).toBe(false);
-    expect(shouldSubmitOnEnter(makeEvent({ key: 'a' }), true)).toBe(false);
+    // key !== 'Enter' AND keyCode !== 13
+    expect(shouldSubmitOnEnter(makeEvent({ key: 'a', keyCode: 65 }), false)).toBe(false);
+    expect(shouldSubmitOnEnter(makeEvent({ key: 'a', keyCode: 65 }), true)).toBe(false);
+  });
+});
+
+describe('shouldSubmitOnEnter — isEnterKey double detection (keyCode 13)', () => {
+  it('keyCode 13 with non-Enter key string still counts as Enter (non-English layout)', () => {
+    // Non-English layouts under JCEF may surface Enter with a stale/non-"Enter"
+    // key string but keyCode 13. Submit path must still recognize it.
+    expect(shouldSubmitOnEnter(makeEvent({ key: 'Process', keyCode: 13 }), false)).toBe(true);
+  });
+
+  it('key "Enter" with keyCode 0 still counts as Enter', () => {
+    expect(shouldSubmitOnEnter(makeEvent({ key: 'Enter', keyCode: 0 }), false)).toBe(true);
   });
 });

--- a/webview/src/pages/SettingsPage/General/index.tsx
+++ b/webview/src/pages/SettingsPage/General/index.tsx
@@ -12,6 +12,7 @@ import { useSettings } from '@/contexts/SettingsContext';
 import { SettingKey, UiDirection } from '@/types/settings';
 import { useTranslation } from '@/i18n';
 import { isRtlLanguage } from '@/i18n/languageMap';
+import { isMac } from '@/config/environment';
 
 const NOT_SET_VALUE = '__NOT_SET__';
 
@@ -49,6 +50,9 @@ export function GeneralSettings() {
   const currentUiLanguage = isUiNotSet ? NOT_SET_VALUE : ((rawUiLanguage as string) ?? 'english');
 
   const useCtrlEnterToSend = (scopeSettings.useCtrlEnterToSend as boolean | undefined) ?? false;
+  // Label the send-modifier per platform: macOS uses Cmd (⌘), everything else Ctrl.
+  // The handler accepts both (ctrlKey || metaKey); only the label needs to differ.
+  const sendModifier = isMac() ? 'Cmd' : 'Ctrl';
   const focusInputOnEditorContext = (scopeSettings.focusInputOnEditorContext as boolean | undefined) ?? true;
   const respectGitignoreForContext = (scopeSettings.respectGitignoreForContext as boolean | undefined) ?? false;
 
@@ -116,13 +120,13 @@ export function GeneralSettings() {
         <UiDirectionRow />
 
         <SettingRow
-          label={t('general.useCtrlEnterToSend.label')}
+          label={t('general.useCtrlEnterToSend.label', { modifier: sendModifier })}
           description={t('general.useCtrlEnterToSend.description')}
         >
           <ToggleSwitch
             checked={useCtrlEnterToSend}
             onChange={(checked) => updateSetting('useCtrlEnterToSend', checked)}
-            ariaLabel={t('general.useCtrlEnterToSend.label')}
+            ariaLabel={t('general.useCtrlEnterToSend.label', { modifier: sendModifier })}
           />
         </SettingRow>
 


### PR DESCRIPTION
## What
Under JetBrains JCEF, a plain **Enter** in a non-English keyboard layout was consumed as an IME commit, so it never produced a line break — while **Ctrl/Cmd+Enter still sent** the message (#215).

## Why
The composer is a `contentEditable` div (not a `<textarea>`) and it relied on the browser's native Enter handling plus `KeyboardEvent.isComposing`. Under JCEF both are unreliable for non-English layouts.

## Changes
- **Own the IME composition state** (`useIMEComposition`): synchronous `compositionstart`/`end` transitions + a `keyCode 229` signal, ref-only so composition never triggers a re-render (which stutters/duplicates CJK glyphs under JCEF).
- **Double-detect Enter** (`key === 'Enter' || keyCode === 13`) and guard the submit path with our own composition truth **OR** the native flag.
- **Insert the newline explicitly** at the caret (`insertNewlineAtCursor` — `execCommand('insertLineBreak')` with a `\n` text-node fallback) instead of leaving it to native handling, plus a `beforeinput`/`insertParagraph` safety net for keystrokes that slip past keydown.
- **macOS label**: the "Use … Enter To Send" toggle now shows **Cmd** on macOS instead of Ctrl (the handler already accepted `ctrlKey || metaKey`); the modifier is interpolated per platform across all locales.

## Testing
- 1534 webview unit tests pass, including new `useIMEComposition`, `insertNewlineAtCursor`, and `shouldSubmitOnEnter` cases (keyCode 229, isComposing guard, layout-independent Enter).
- Verified in a real browser: Shift+Enter and cmdEnter-mode plain Enter both insert a newline; default-mode Enter sends; **Korean typing followed by Enter sends with no stray newline**.

Closes #215