### PR TITLE
fix: keep the compact summary in place by preserving the CLI's timestamp

### DIFF
--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -948,4 +948,103 @@ describe('useChatStream', () => {
       expect(result.current.contextWindowUsage?.contextWindow).toBe(0);
     });
   });
+
+  // 컴팩트(auto-compact / `/compact`) 경계 엔트리는 CLI가 `isCompactSummary: true`를 단
+  // 평범한 `user` 이벤트로 흘려보낸다. 이 이벤트는 뒤이은 assistant 응답보다 늦게 도착할 수
+  // 있어, appendMessage는 timestamp 기준으로 삽입 위치를 정한다. 따라서 `user` 핸들러가
+  // CLI 원본 timestamp를 보존하지 않으면 정렬 근거가 사라져 요약 버블이 항상 목록 끝에
+  // 눌러앉는다 (issue #220).
+  describe('user 이벤트 순서 (컴팩트 요약, issue #220)', () => {
+    const COMPACT_TEXT =
+      'This session is being continued from a previous conversation that ran out of context.';
+
+    it('CLI 원본 timestamp를 보존한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      expect(result.current.messages[0].timestamp).toBe('2026-07-24T11:41:57.478Z');
+    });
+
+    it('먼저 도착한 뒤늦은 assistant 메시지보다 앞에 삽입된다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      // 컴팩트 이후의 assistant 응답이 먼저 도착한다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'assistant',
+          timestamp: '2026-07-24T11:42:30.000Z',
+          message: {
+            id: 'm-after',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'after compact' }],
+          },
+        });
+      });
+
+      // 컴팩트 요약 user 이벤트가 뒤늦게 도착한다 (더 이른 timestamp).
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      // 요약이 목록 끝이 아니라 assistant 응답 앞에 놓여야 한다.
+      const types = result.current.messages.map(m => m.type);
+      expect(types).toEqual([LoadedMessageType.User, LoadedMessageType.Assistant]);
+      expect(result.current.messages[0].message?.content).toBe(COMPACT_TEXT);
+    });
+
+    it('컴팩트 마커 필드(isCompactSummary/isVisibleInTranscriptOnly)를 보존한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          isVisibleInTranscriptOnly: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      expect(result.current.messages[0].isCompactSummary).toBe(true);
+      expect(result.current.messages[0].isVisibleInTranscriptOnly).toBe(true);
+    });
+
+    it('timestamp 없는 user 이벤트는 수신 시각으로 폴백한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      const before = Date.now();
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'no-ts',
+          message: { role: 'user', content: 'no timestamp' },
+        });
+      });
+      const after = Date.now();
+
+      const ts = new Date(result.current.messages[0].timestamp!).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
 });

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -924,13 +924,19 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             lastSkillToolUseIdRef.current = null;
           }
 
+          // Keep the CLI's own timestamp. appendMessage inserts by timestamp, so
+          // stamping the arrival time here would strand late-arriving CLI-internal
+          // entries — notably the compact summary, which the CLI emits after the
+          // assistant messages that follow it — at the end of the list (#220).
           const userMessage: LoadedMessageDto = {
             type: LoadedMessageType.User,
             uuid: (cliEvent as any).uuid || generateMessageId(),
-            timestamp: new Date().toISOString(),
+            timestamp: (cliEvent as any).timestamp ?? new Date().toISOString(),
             message: userMsg as unknown as LoadedMessageDto['message'],
             sourceToolUseID,
             isSynthetic: (cliEvent as any).isSynthetic === true ? true : undefined,
+            isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
+            isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
           appendMessage(userMessage);
         }

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -88,6 +88,13 @@ export class LoadedMessageDto {
   summary?: string;
   leafUuid?: string;
 
+  // Compact-boundary flags. When a conversation is compacted (auto-compact or
+  // `/compact`), the CLI emits the carried-over summary as an ordinary `user`
+  // entry carrying these flags — not as a `summary` entry. Preserved verbatim
+  // from the CLI so the boundary stays identifiable downstream.
+  isCompactSummary?: boolean;
+  isVisibleInTranscriptOnly?: boolean;
+
   // metadata
   slug?: string;
   sessionId?: string;


### PR DESCRIPTION
Fixes the compact-summary bubble sticking to the bottom of the conversation, reported in #220.

## The defect

When a conversation is compacted (auto-compact or `/compact`), the CLI emits the carried-over summary as an ordinary `user` entry flagged `isCompactSummary` — not as a `summary` entry — and it can arrive *after* the assistant messages that follow it.

`appendMessage` already inserts by timestamp to absorb exactly that reordering; its comment says so:

> During streaming, CLI-internal messages (compact summaries, skill prompts, etc.) may arrive after later messages. Timestamp-based insertion keeps correct order.

But the `user` handler overwrote the CLI's timestamp with the arrival time, so the summary always compared as the newest entry and pinned itself to the end of the list, with later replies rendering above it. Reloading the session fixed it because the JSONL path never rewrites timestamps — which is why the bug looked cosmetic and survived since early March.

The handler was also the odd one out: `progress` and both sub-agent handlers already preserve the original timestamp.

## The fix

Preserve the CLI timestamp, falling back to now when absent, and carry the `isCompactSummary` / `isVisibleInTranscriptOnly` flags through instead of dropping them. Sorting behaviour is untouched.

Those two flags were previously lost at every layer — no code read them — so this also restores them under the original-data preservation rule.

## Verification

Confirmed against a real compact boundary in a session file:

```
type: user
isCompactSummary: True
isVisibleInTranscriptOnly: True
timestamp: 2026-07-24T11:41:57.478Z
```

Tests were written first and failed on the exact symptom — order came back `['assistant', 'user']`. After the fix:

- `wv-test` 1621 passed
- `wv-lint` clean
- `be-test` 927 passed

Closes #220
