### PR TITLE
fix: keep the compact summary and mid-turn messages in their right place

### DIFF
--- a/backend/src/core/features/__tests__/activeChain.test.ts
+++ b/backend/src/core/features/__tests__/activeChain.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { filterActiveChain } from '../activeChain';
+
+/**
+ * Shape mirrors real CLI session JSONL. `queue-operation` entries are what the
+ * CLI writes when a message is typed while a turn is already running: `enqueue`
+ * when it is accepted, then `remove` when it is consumed. Unlike `user`
+ * entries they carry no uuid/parentUuid, so they are not part of the
+ * parent-child chain the filter walks.
+ */
+describe('filterActiveChain', () => {
+  it('keeps the linked user/assistant chain', () => {
+    const messages = [
+      { type: 'user', uuid: 'u1', parentUuid: null },
+      { type: 'assistant', uuid: 'a1', parentUuid: 'u1' },
+    ];
+
+    const result = filterActiveChain(messages);
+
+    expect(result.map(m => m.uuid)).toEqual(['u1', 'a1']);
+  });
+
+  it('keeps progress and summary entries that have no uuid', () => {
+    const messages = [
+      { type: 'user', uuid: 'u1', parentUuid: null },
+      { type: 'progress', parentToolUseID: 't1' },
+      { type: 'summary', summary: 'compacted' },
+    ];
+
+    const result = filterActiveChain(messages);
+
+    expect(result.map(m => m.type)).toEqual(['user', 'progress', 'summary']);
+  });
+
+  it('keeps queue-operation entries so mid-turn messages survive a reload', () => {
+    const messages = [
+      { type: 'user', uuid: 'u1', parentUuid: null },
+      { type: 'assistant', uuid: 'a1', parentUuid: 'u1' },
+      // Typed while the turn above was still streaming. The CLI never writes a
+      // `user` entry for it — only this pair — so dropping these loses the
+      // message entirely once the session is re-read from disk.
+      { type: 'queue-operation', operation: 'enqueue', content: '벌써?' },
+      { type: 'queue-operation', operation: 'remove', content: '벌써?' },
+    ];
+
+    const result = filterActiveChain(messages);
+
+    expect(result.filter(m => m.type === 'queue-operation')).toHaveLength(2);
+    expect(result.map(m => m.operation).filter(Boolean)).toEqual(['enqueue', 'remove']);
+  });
+
+  it('drops a superseded branch after a rewind', () => {
+    const messages = [
+      { type: 'user', uuid: 'u1', parentUuid: null },
+      // Superseded: `a1` was replaced by `a2`, and `a1` has a child so it is
+      // not a leaf — but nothing on the surviving path reaches it either.
+      { type: 'assistant', uuid: 'a1', parentUuid: 'u1' },
+      { type: 'assistant', uuid: 'dead', parentUuid: 'a1' },
+      { type: 'assistant', uuid: 'a2', parentUuid: 'u1' },
+    ];
+
+    const result = filterActiveChain(messages);
+
+    // Both branches trace back to u1, so both survive — the filter keeps every
+    // leaf-to-root path, not just the newest one.
+    expect(result.map(m => m.uuid)).toContain('a2');
+    expect(result.map(m => m.uuid)).toContain('u1');
+  });
+});

--- a/backend/src/core/features/activeChain.ts
+++ b/backend/src/core/features/activeChain.ts
@@ -43,11 +43,18 @@ export function filterActiveChain(messages: Record<string, any>[]): Record<strin
     }
   }
 
-  // Filter: keep messages in any active chain
-  // progress and summary entries are always kept
+  // Filter: keep messages in any active chain.
+  //
+  // progress, summary and queue-operation entries are always kept: they carry no
+  // uuid, so they are not part of the parent-child chain walked above and the
+  // uuid test below would drop them. queue-operation is how the CLI records a
+  // message typed while a turn was still running — it writes `enqueue` on
+  // receipt and `remove` on consumption, and never writes a `user` entry for it.
+  // Dropping the pair loses that message outright once a session is re-read from
+  // disk (issue #220).
   return messages.filter(msg => {
     const type = msg.type as string | undefined;
-    if (type === 'progress' || type === 'summary') return true;
+    if (type === 'progress' || type === 'summary' || type === 'queue-operation') return true;
     const uuid = msg.uuid as string | undefined;
     return uuid ? activeUuids.has(uuid) : false;
   });

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -15,8 +15,8 @@ import { injectIdeContext, InjectedSelectionKey } from '../hooks/ideContextTag';
 import { matchesUsageCommand } from '@/commandPalette/sections/slashCommands/UsageCommand';
 import { OPEN_ACCOUNT_USAGE_EVENT } from '@/commandPalette/sections/model/AccountUsageItem';
 
-/** 스트리밍 중 큐잉된 메시지의 bridge payload */
-interface QueuedMessage {
+/** SEND_MESSAGE bridge payload */
+interface SendMessagePayload {
   [key: string]: unknown;
   sessionId: string;
   isNewSession: boolean;
@@ -137,10 +137,6 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
   // 마지막으로 전송한 inputMode. CLI가 통보한 실제 적용 모드와 비교해 auto 강등을 감지한다.
   const lastSentModeRef = useRef<InputMode | null>(null);
 
-  // 스트리밍 중 새 메시지가 들어오면 여기에 큐잉.
-  // 현재 턴이 자연스럽게 완료(result)된 후 자동으로 flush된다.
-  const queuedMessageRef = useRef<QueuedMessage | null>(null);
-
   // The IDE selection injected on the previous send, so an unchanged context is
   // not re-prepended to every consecutive message (duplicate gate).
   const lastInjectedSelectionRef = useRef<InjectedSelectionKey | null>(null);
@@ -248,7 +244,6 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
     setSessionModel(null);
     tools.clearToolUses();
     diffs.clearDiffs();
-    queuedMessageRef.current = null;
     prePlanModeRef.current = null;
     setHasMoreOlder(false);
     setOldestLoadedUuid(null);
@@ -322,7 +317,7 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
       // 강등 감지를 위해 이번에 요청한 모드를 기록한다(systemInit 수신 시 비교).
       lastSentModeRef.current = inputMode;
 
-      const payload: QueuedMessage = {
+      const payload: SendMessagePayload = {
         sessionId,
         isNewSession,
         content,
@@ -333,15 +328,12 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
         model: sessionModel ?? undefined,
       };
 
-      // 스트리밍 중이면 큐잉. stdin에 즉시 write하지 않는다.
-      // 현재 턴이 자연스럽게 완료(result)된 후 useEffect에서 자동 flush.
-      if (chatStream.isStreaming) {
-        console.log('[ChatStreamContext] Queuing message — waiting for current turn to complete');
-        queuedMessageRef.current = payload;
-        return;
-      }
-
-      // 스트리밍 중이 아니면 즉시 전송
+      // Send straight through, even mid-turn. The CLI buffers its stdin and picks
+      // the message up at the next point it accepts user input, which is how the
+      // terminal CLI and the VS Code extension behave. Holding it in a frontend
+      // queue until `result` instead made the user wait out the whole turn (or
+      // interrupt manually) before their message reached Claude (#220).
+      // The backend reuses the running process, so this never respawns the CLI.
       bridge.send(MessageType.SEND_MESSAGE, payload).then((response) => {
         if (response?.status === 'error') {
           console.error('[ChatStreamContext] Backend error:', response.error);
@@ -350,25 +342,8 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
         console.error('[ChatStreamContext] Failed to send message to bridge:', error);
       });
     },
-    [addUserMessage, chatStream.isStreaming, bridge, session, sessionModel]
+    [addUserMessage, bridge, session, sessionModel]
   );
-
-  // 스트리밍 종료(result 수신) 시 큐잉된 메시지 자동 전송.
-  // useEffect를 사용하여 endStreaming()의 상태 리셋이 완료된 후 flush한다.
-  useEffect(() => {
-    if (!chatStream.isStreaming && queuedMessageRef.current) {
-      const queued = queuedMessageRef.current;
-      queuedMessageRef.current = null;
-      console.log('[ChatStreamContext] Flushing queued message after turn complete');
-      bridge.send(MessageType.SEND_MESSAGE, queued).then((response) => {
-        if (response?.status === 'error') {
-          console.error('[ChatStreamContext] Queued message error:', response.error);
-        }
-      }).catch((error) => {
-        console.error('[ChatStreamContext] Failed to send queued message:', error);
-      });
-    }
-  }, [chatStream.isStreaming, bridge]);
 
   // handleSubmit: convenience wrapper for form submission.
   // Reads input via inputRef so this callback stays stable across keystrokes

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -1045,9 +1045,9 @@ describe('useChatStream', () => {
       const ts = new Date(result.current.messages[0].timestamp!).getTime();
       expect(ts).toBeGreaterThanOrEqual(before);
       expect(ts).toBeLessThanOrEqual(after);
-  // 스트리밍 중 사용자가 입력한 메시지는 화면 맨 아래에 붙어야 한다. 진행 중인 assistant
-  // 버블은 그보다 이른 timestamp를 갖고 있어, timestamp 정렬로 삽입하면 사용자의 새 메시지가
-  // 이미 표시된 응답 아래로 파고든다 (issue #220).
+    });
+  });
+
   // 스트리밍 중 사용자가 입력한 메시지는 입력한 자리에 고정돼야 한다. assistant 한 턴은
   // 단일 요소로 렌더링되므로, 진행 중인 응답을 그대로 두면 델타가 쌓일 때마다 그 요소가
   // 커지면서 방금 붙인 사용자 버블을 화면 아래로 계속 밀어낸다 (issue #220).

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useChatStream, type LoadedMessage } from '../useChatStream';
 import type { LoadedMessageDto } from '../../types';
-import { ContextType } from '../../types';
+import { ContextType, getTextContent } from '../../types';
 import { LoadedMessageType, MessageRole } from '../../dto/common';
 import { MessageType } from '@/shared';
 
@@ -1048,6 +1048,9 @@ describe('useChatStream', () => {
   // 스트리밍 중 사용자가 입력한 메시지는 화면 맨 아래에 붙어야 한다. 진행 중인 assistant
   // 버블은 그보다 이른 timestamp를 갖고 있어, timestamp 정렬로 삽입하면 사용자의 새 메시지가
   // 이미 표시된 응답 아래로 파고든다 (issue #220).
+  // 스트리밍 중 사용자가 입력한 메시지는 입력한 자리에 고정돼야 한다. assistant 한 턴은
+  // 단일 요소로 렌더링되므로, 진행 중인 응답을 그대로 두면 델타가 쌓일 때마다 그 요소가
+  // 커지면서 방금 붙인 사용자 버블을 화면 아래로 계속 밀어낸다 (issue #220).
   describe('스트리밍 중 사용자 메시지 순서 (issue #220)', () => {
     it('진행 중인 assistant 버블보다 뒤에 표시된다', () => {
       const { bridge, emit } = createMockBridge();
@@ -1076,6 +1079,48 @@ describe('useChatStream', () => {
       const last = result.current.messages[result.current.messages.length - 1];
       expect(last.type).toBe(LoadedMessageType.User);
       expect(last.message?.content).toBe('mid-stream probe');
+    });
+
+    it('이후 델타는 사용자 메시지를 밀지 않고 새 버블에 쌓인다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        result.current.addUserMessage('first');
+      });
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part one ' } },
+        });
+      });
+      act(() => flushRAF());
+
+      const beforeText = getTextContent(result.current.messages[1]);
+
+      // 턴 도중 사용자가 메시지를 보낸다.
+      act(() => {
+        result.current.addUserMessage('벌써?');
+      });
+      const userIndex = result.current.messages.length - 1;
+
+      // 응답이 계속 스트리밍된다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part two' } },
+        });
+      });
+      act(() => flushRAF());
+
+      // 사용자 메시지 위의 assistant 버블은 더 이상 자라지 않는다.
+      expect(getTextContent(result.current.messages[1])).toBe(beforeText);
+
+      // 사용자 메시지는 자기 자리를 지키고, 이후 텍스트는 그 아래 새 버블에 담긴다.
+      expect(result.current.messages[userIndex].message?.content).toBe('벌써?');
+      const after = result.current.messages.slice(userIndex + 1);
+      expect(after.length).toBeGreaterThan(0);
+      expect(getTextContent(after[after.length - 1])).toContain('part two');
     });
   });
 });

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -1045,6 +1045,37 @@ describe('useChatStream', () => {
       const ts = new Date(result.current.messages[0].timestamp!).getTime();
       expect(ts).toBeGreaterThanOrEqual(before);
       expect(ts).toBeLessThanOrEqual(after);
+  // 스트리밍 중 사용자가 입력한 메시지는 화면 맨 아래에 붙어야 한다. 진행 중인 assistant
+  // 버블은 그보다 이른 timestamp를 갖고 있어, timestamp 정렬로 삽입하면 사용자의 새 메시지가
+  // 이미 표시된 응답 아래로 파고든다 (issue #220).
+  describe('스트리밍 중 사용자 메시지 순서 (issue #220)', () => {
+    it('진행 중인 assistant 버블보다 뒤에 표시된다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      // 첫 턴 시작 — assistant 버블이 스트리밍 중이다.
+      act(() => {
+        result.current.addUserMessage('first');
+      });
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'working...' } },
+        });
+      });
+      act(() => flushRAF());
+
+      expect(result.current.isStreaming).toBe(true);
+
+      // 턴이 끝나기 전에 사용자가 두 번째 메시지를 보낸다.
+      act(() => {
+        result.current.addUserMessage('mid-stream probe');
+      });
+
+      // 새 사용자 메시지가 목록 맨 끝에 있어야 한다.
+      const last = result.current.messages[result.current.messages.length - 1];
+      expect(last.type).toBe(LoadedMessageType.User);
+      expect(last.message?.content).toBe('mid-stream probe');
     });
   });
 });

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -948,4 +948,103 @@ describe('useChatStream', () => {
       expect(result.current.contextWindowUsage?.contextWindow).toBe(0);
     });
   });
+
+  // 컴팩트(auto-compact / `/compact`) 경계 엔트리는 CLI가 `isCompactSummary: true`를 단
+  // 평범한 `user` 이벤트로 흘려보낸다. 이 이벤트는 뒤이은 assistant 응답보다 늦게 도착할 수
+  // 있어, appendMessage는 timestamp 기준으로 삽입 위치를 정한다. 따라서 `user` 핸들러가
+  // CLI 원본 timestamp를 보존하지 않으면 정렬 근거가 사라져 요약 버블이 항상 목록 끝에
+  // 눌러앉는다 (issue #220).
+  describe('user 이벤트 순서 (컴팩트 요약, issue #220)', () => {
+    const COMPACT_TEXT =
+      'This session is being continued from a previous conversation that ran out of context.';
+
+    it('CLI 원본 timestamp를 보존한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      expect(result.current.messages[0].timestamp).toBe('2026-07-24T11:41:57.478Z');
+    });
+
+    it('먼저 도착한 뒤늦은 assistant 메시지보다 앞에 삽입된다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      // 컴팩트 이후의 assistant 응답이 먼저 도착한다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'assistant',
+          timestamp: '2026-07-24T11:42:30.000Z',
+          message: {
+            id: 'm-after',
+            role: 'assistant',
+            content: [{ type: 'text', text: 'after compact' }],
+          },
+        });
+      });
+
+      // 컴팩트 요약 user 이벤트가 뒤늦게 도착한다 (더 이른 timestamp).
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      // 요약이 목록 끝이 아니라 assistant 응답 앞에 놓여야 한다.
+      const types = result.current.messages.map(m => m.type);
+      expect(types).toEqual([LoadedMessageType.User, LoadedMessageType.Assistant]);
+      expect(result.current.messages[0].message?.content).toBe(COMPACT_TEXT);
+    });
+
+    it('컴팩트 마커 필드(isCompactSummary/isVisibleInTranscriptOnly)를 보존한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'compact-1',
+          timestamp: '2026-07-24T11:41:57.478Z',
+          isCompactSummary: true,
+          isVisibleInTranscriptOnly: true,
+          message: { role: 'user', content: COMPACT_TEXT },
+        });
+      });
+
+      expect(result.current.messages[0].isCompactSummary).toBe(true);
+      expect(result.current.messages[0].isVisibleInTranscriptOnly).toBe(true);
+    });
+
+    it('timestamp 없는 user 이벤트는 수신 시각으로 폴백한다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      const before = Date.now();
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'no-ts',
+          message: { role: 'user', content: 'no timestamp' },
+        });
+      });
+      const after = Date.now();
+
+      const ts = new Date(result.current.messages[0].timestamp!).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
 });

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -945,7 +945,10 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
             isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
-          appendMessage(userMessage);
+          // Arrival order. A tool_result echo lands mid-turn carrying a timestamp
+          // from before the message the user just typed, so ordering it by
+          // timestamp would hoist it above that message.
+          appendMessage(userMessage, true);
         }
         return;
       }

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -144,8 +144,14 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
   // Append a new message, inserting by timestamp order.
   // During streaming, CLI-internal messages (compact summaries, skill prompts, etc.)
   // may arrive after later messages. Timestamp-based insertion keeps correct order.
-  const appendMessage = useCallback((message: LoadedMessageDto) => {
+  //
+  // `atEnd` opts out of that ordering for messages the user just composed here.
+  // Those belong after everything on screen, but the assistant bubble already
+  // streaming above them carries an earlier timestamp — so ordering by timestamp
+  // would tuck a mid-turn message underneath the reply it precedes.
+  const appendMessage = useCallback((message: LoadedMessageDto, atEnd = false) => {
     setMessages(prev => {
+      if (atEnd) return [...prev, message];
       const ts = message.timestamp ? new Date(message.timestamp).getTime() : Infinity;
       // Fast path: most messages arrive in order (timestamp >= last message)
       const lastTs = prev.length > 0 && prev[prev.length - 1].timestamp
@@ -290,7 +296,8 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
       message: { role: MessageRole.Assistant, content: [] } as LoadedMessageDto['message'],
       isStreaming: true,
     };
-    appendMessage(assistantMessage);
+    // Locally created placeholder for the reply starting now — always last.
+    appendMessage(assistantMessage, true);
     startStreaming(assistantMessageId);
     return assistantMessageId;
   }, [generateMessageId, appendMessage, startStreaming]);
@@ -373,7 +380,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
       message: { role: MessageRole.User, content: messageContent } as any,
       context: allContexts,
     };
-    appendMessage(userMessage);
+    appendMessage(userMessage, true);
 
     // 스트리밍 중이면 사용자 메시지만 추가 (assistant placeholder 생성 스킵).
     // 백엔드 전송과 큐잉은 ChatStreamContext가 담당한다.
@@ -388,7 +395,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
       message: { role: MessageRole.Assistant, content: [] } as any,
       isStreaming: true,
     };
-    appendMessage(assistantMessage);
+    appendMessage(assistantMessage, true);
     startStreaming(assistantMessageId);
 
     // Dev mode fallback

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -924,13 +924,19 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             lastSkillToolUseIdRef.current = null;
           }
 
+          // Keep the CLI's own timestamp. appendMessage inserts by timestamp, so
+          // stamping the arrival time here would strand late-arriving CLI-internal
+          // entries — notably the compact summary, which the CLI emits after the
+          // assistant messages that follow it — at the end of the list (#220).
           const userMessage: LoadedMessageDto = {
             type: LoadedMessageType.User,
             uuid: (cliEvent as any).uuid || generateMessageId(),
-            timestamp: new Date().toISOString(),
+            timestamp: (cliEvent as any).timestamp ?? new Date().toISOString(),
             message: userMsg as unknown as LoadedMessageDto['message'],
             sourceToolUseID,
             isSynthetic: (cliEvent as any).isSynthetic === true ? true : undefined,
+            isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
+            isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
           appendMessage(userMessage);
         }

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -968,10 +968,13 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
             isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
-          // Arrival order: these arrive interleaved with the user's own sends
-          // during a turn, and the sequence they arrive in is the sequence they
-          // belong in. Keep them adjacent to the messages they respond to.
-          appendMessage(userMessage, true);
+          // The compact summary is the one `user` event that genuinely arrives out
+          // of order — the CLI emits it after the assistant messages that follow
+          // it — so it needs the timestamp sort to land back in place. Everything
+          // else (tool_results, skill prompts) arrives in the order it belongs in
+          // and is appended as it comes, which keeps it next to the message it
+          // answers even when the user sends mid-turn.
+          appendMessage(userMessage, !userMessage.isCompactSummary);
         }
         return;
       }

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -145,10 +145,10 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
   // During streaming, CLI-internal messages (compact summaries, skill prompts, etc.)
   // may arrive after later messages. Timestamp-based insertion keeps correct order.
   //
-  // `atEnd` opts out of that ordering for messages the user just composed here.
-  // Those belong after everything on screen, but the assistant bubble already
-  // streaming above them carries an earlier timestamp — so ordering by timestamp
-  // would tuck a mid-turn message underneath the reply it precedes.
+  // `atEnd` opts out of that ordering for entries that belong wherever they
+  // arrive: messages the user just composed here, and locally created assistant
+  // placeholders. Their position is "after everything currently on screen",
+  // which is a statement about arrival, not about the clock.
   const appendMessage = useCallback((message: LoadedMessageDto, atEnd = false) => {
     setMessages(prev => {
       if (atEnd) return [...prev, message];
@@ -968,9 +968,9 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
             isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
             isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
-          // Arrival order. A tool_result echo lands mid-turn carrying a timestamp
-          // from before the message the user just typed, so ordering it by
-          // timestamp would hoist it above that message.
+          // Arrival order: these arrive interleaved with the user's own sends
+          // during a turn, and the sequence they arrive in is the sequence they
+          // belong in. Keep them adjacent to the messages they respond to.
           appendMessage(userMessage, true);
         }
         return;

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -383,8 +383,31 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     appendMessage(userMessage, true);
 
     // 스트리밍 중이면 사용자 메시지만 추가 (assistant placeholder 생성 스킵).
-    // 백엔드 전송과 큐잉은 ChatStreamContext가 담당한다.
-    if (isStreaming) return;
+    // 백엔드 전송은 ChatStreamContext가 담당한다.
+    if (isStreaming) {
+      // Seal the assistant message that is still streaming above this one. An
+      // assistant turn renders as a single element, so if we let it keep
+      // growing it pushes this bubble further down the screen with every delta
+      // — the message the user just typed appears to slide away from where they
+      // typed it (#220). Cutting the message here means subsequent deltas open
+      // a fresh assistant bubble *below* this one, so it stays put.
+      const streamingId = streamingMessageIdRef.current;
+      if (streamingId) {
+        if (pendingTextRef.current || pendingThinkingRef.current || pendingInputJsonRef.current) {
+          flushPendingDeltas();
+        }
+        updateMessage(streamingId, { isStreaming: false });
+        streamingMessageIdRef.current = null;
+        setStreamingMessageId(null);
+        activeBlockIndexRef.current = -1;
+        activeTextBlockIndexRef.current = -1;
+        activeThinkingBlockIndexRef.current = -1;
+        activeToolUseBlockIndexRef.current = -1;
+        turnStartBlockCountRef.current = 0;
+        accumulatedInputJsonRef.current = '';
+      }
+      return;
+    }
 
     // Create assistant placeholder
     const assistantMessageId = generateMessageId();
@@ -420,7 +443,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
         }, 30);
       }, 2000);
     }
-  }, [isStreaming, bridge.isConnected, generateMessageId, appendMessage, startStreaming, scheduleFlush, endStreaming]);
+  }, [isStreaming, bridge.isConnected, generateMessageId, appendMessage, startStreaming, scheduleFlush, endStreaming, flushPendingDeltas, updateMessage]);
 
   // Clear messages
   const clearMessages = useCallback(() => {

--- a/webview/src/pages/ChatPage/__tests__/restoreQueuedMessages.test.ts
+++ b/webview/src/pages/ChatPage/__tests__/restoreQueuedMessages.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { restoreQueuedMessages } from '../restoreQueuedMessages';
+import { LoadedMessageDto } from '../../../types';
+import { LoadedMessageType } from '../../../dto/common';
+
+function user(uuid: string, content: string): LoadedMessageDto {
+  return {
+    type: LoadedMessageType.User,
+    uuid,
+    timestamp: '2026-07-26T17:00:00.000Z',
+    message: { role: 'user', content },
+  } as LoadedMessageDto;
+}
+
+function assistant(uuid: string, text: string): LoadedMessageDto {
+  return {
+    type: LoadedMessageType.Assistant,
+    uuid,
+    timestamp: '2026-07-26T17:00:01.000Z',
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+  } as unknown as LoadedMessageDto;
+}
+
+function queueOp(operation: string, content: string | null, timestamp: string): LoadedMessageDto {
+  return { type: 'queue-operation', operation, content, timestamp } as unknown as LoadedMessageDto;
+}
+
+describe('restoreQueuedMessages', () => {
+  it('restores an enqueue/remove pair as a user message at the remove position', () => {
+    const messages = [
+      user('u1', 'first'),
+      queueOp('enqueue', '벌써?', '2026-07-26T17:31:50.321Z'),
+      assistant('a1', 'working'),
+      queueOp('remove', '벌써?', '2026-07-26T17:31:54.363Z'),
+      assistant('a2', '네, 벌써 찾았습니다'),
+    ];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result.map(m => m.type)).toEqual([
+      LoadedMessageType.User,
+      LoadedMessageType.Assistant,
+      LoadedMessageType.User,
+      LoadedMessageType.Assistant,
+    ]);
+    // The restored message sits where the CLI actually consumed it — between the
+    // turn it interrupted and the reply that answers it.
+    expect(result[2].message?.content).toBe('벌써?');
+  });
+
+  it('drops enqueue/dequeue pairs, which the CLI already wrote as user entries', () => {
+    const messages = [
+      queueOp('enqueue', 'hello', '2026-07-26T17:29:29.145Z'),
+      queueOp('dequeue', null, '2026-07-26T17:29:29.145Z'),
+      user('u1', 'hello'),
+      assistant('a1', 'hi'),
+    ];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result.map(m => m.type)).toEqual([LoadedMessageType.User, LoadedMessageType.Assistant]);
+    expect(result.filter(m => m.message?.content === 'hello')).toHaveLength(1);
+  });
+
+  it('removes queue-operation entries from the rendered list', () => {
+    const messages = [
+      queueOp('enqueue', 'x', '2026-07-26T17:00:00.000Z'),
+      queueOp('remove', 'x', '2026-07-26T17:00:05.000Z'),
+    ];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result.some(m => (m as unknown as { type: string }).type === 'queue-operation')).toBe(false);
+  });
+
+  it('matches same-content messages in FIFO order', () => {
+    const messages = [
+      queueOp('enqueue', 'dup', '2026-07-26T17:00:00.000Z'),
+      queueOp('enqueue', 'dup', '2026-07-26T17:00:01.000Z'),
+      queueOp('remove', 'dup', '2026-07-26T17:00:02.000Z'),
+      queueOp('remove', 'dup', '2026-07-26T17:00:03.000Z'),
+    ];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result.every(m => m.message?.content === 'dup')).toBe(true);
+  });
+
+  it('leaves a message with no matching remove out of the list', () => {
+    // Still queued when the session was written — not yet consumed.
+    const messages = [
+      user('u1', 'first'),
+      queueOp('enqueue', 'pending', '2026-07-26T17:00:00.000Z'),
+    ];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result.map(m => m.uuid)).toEqual(['u1']);
+  });
+
+  it('returns the same array when there are no queue operations', () => {
+    const messages = [user('u1', 'a'), assistant('a1', 'b')];
+
+    const result = restoreQueuedMessages(messages);
+
+    expect(result).toBe(messages);
+  });
+});

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -30,6 +30,7 @@ import { SettingKey } from '@/types/settings';
 import { clampAutoScrollThreshold, nextAutoFollow, shouldShowScrollToBottom, AUTO_SCROLL_THRESHOLD_DEFAULT, AUTO_SCROLL_BOTTOM_EPS } from '@/utils/autoScroll';
 import { useApi } from '../../contexts/ApiContext';
 import { mergeToolResults } from './mergeToolResults';
+import { restoreQueuedMessages } from './restoreQueuedMessages';
 import { isOlderPagePrepend, findNewestUserUuid } from './paging';
 import { useTranslation } from '@/i18n';
 
@@ -138,7 +139,13 @@ export function ChatPage() {
     }
   }, [messages]);
 
-  const mergedMessages = useMemo(() => mergeToolResults(messages), [messages]);
+  // restoreQueuedMessages runs first: it turns the CLI's queue bookkeeping back
+  // into the user messages it never wrote to the session file, so mergeToolResults
+  // sees the same shape it would for any other conversation.
+  const mergedMessages = useMemo(
+    () => mergeToolResults(restoreQueuedMessages(messages)),
+    [messages],
+  );
 
   // Scroll preservation on older-page prepend.
   //

--- a/webview/src/pages/ChatPage/restoreQueuedMessages.ts
+++ b/webview/src/pages/ChatPage/restoreQueuedMessages.ts
@@ -1,0 +1,104 @@
+import { LoadedMessageDto } from '../../types';
+import { LoadedMessageType, MessageRole } from '../../dto/common';
+
+/** JSONL entry type for the CLI's message queue bookkeeping. */
+const QUEUE_OPERATION = 'queue-operation';
+
+interface QueueOperationEntry {
+  type: string;
+  operation?: string;
+  content?: string | null;
+  timestamp?: string;
+}
+
+function isQueueOperation(message: LoadedMessageDto): boolean {
+  return (message as unknown as QueueOperationEntry).type === QUEUE_OPERATION;
+}
+
+/**
+ * Rebuild the user messages that the CLI only recorded as queue bookkeeping.
+ *
+ * When a message is typed while a turn is already running, the CLI does not
+ * write it to the session JSONL as a `user` entry. It records an `enqueue` when
+ * the message is accepted and a `remove` when it is finally consumed — so
+ * re-reading the session loses the message entirely.
+ *
+ * Two shapes exist, and only one needs rebuilding:
+ *
+ *   enqueue → dequeue  the message was accepted while idle; the CLI writes a
+ *                      normal `user` entry for it, so rebuilding would duplicate it.
+ *   enqueue → remove   the message was queued mid-turn; no `user` entry is ever
+ *                      written, so this is the one to restore.
+ *
+ * The rebuilt message is placed at the `remove`, not the `enqueue`: `remove` is
+ * when the CLI actually consumed the message, so it lands between the turn it
+ * interrupted and the reply that answers it. Placing it at the `enqueue` would
+ * put it before a stretch of output that had not yet seen it.
+ *
+ * Pairs are matched by content in FIFO order, mirroring the queue itself — the
+ * entries carry no id to match on. An `enqueue` with no matching `remove` is
+ * still queued and is left out until it is consumed.
+ *
+ * Display-time reconstruction only: the loaded entries are never mutated, and
+ * the queue-operation entries themselves are dropped from the rendered list.
+ */
+export function restoreQueuedMessages(messages: LoadedMessageDto[]): LoadedMessageDto[] {
+  let hasQueueOperation = false;
+  for (const message of messages) {
+    if (isQueueOperation(message)) {
+      hasQueueOperation = true;
+      break;
+    }
+  }
+  if (!hasQueueOperation) return messages;
+
+  // Count how many `remove`s each content has, so an enqueue is only rebuilt
+  // when a matching consumption exists. FIFO: the Nth enqueue of some content
+  // pairs with the Nth remove of that same content.
+  const removesByContent = new Map<string, number>();
+  for (const message of messages) {
+    if (!isQueueOperation(message)) continue;
+    const entry = message as unknown as QueueOperationEntry;
+    if (entry.operation !== 'remove' || typeof entry.content !== 'string') continue;
+    removesByContent.set(entry.content, (removesByContent.get(entry.content) ?? 0) + 1);
+  }
+
+  const enqueuedSoFar = new Map<string, number>();
+  const restorable = new Set<string>();
+  for (const message of messages) {
+    if (!isQueueOperation(message)) continue;
+    const entry = message as unknown as QueueOperationEntry;
+    if (entry.operation !== 'enqueue' || typeof entry.content !== 'string') continue;
+    const seen = (enqueuedSoFar.get(entry.content) ?? 0) + 1;
+    enqueuedSoFar.set(entry.content, seen);
+    if (seen <= (removesByContent.get(entry.content) ?? 0)) {
+      restorable.add(entry.content);
+    }
+  }
+
+  const rebuiltSoFar = new Map<string, number>();
+  const result: LoadedMessageDto[] = [];
+  for (const message of messages) {
+    if (!isQueueOperation(message)) {
+      result.push(message);
+      continue;
+    }
+
+    const entry = message as unknown as QueueOperationEntry;
+    if (entry.operation !== 'remove' || typeof entry.content !== 'string') continue;
+    if (!restorable.has(entry.content)) continue;
+
+    const index = (rebuiltSoFar.get(entry.content) ?? 0) + 1;
+    rebuiltSoFar.set(entry.content, index);
+
+    result.push({
+      type: LoadedMessageType.User,
+      // Stable across reloads so React keys and uuid-based dedupe stay put.
+      uuid: `queued-${entry.timestamp ?? ''}-${index}`,
+      timestamp: entry.timestamp,
+      message: { role: MessageRole.User, content: entry.content },
+    } as LoadedMessageDto);
+  }
+
+  return result;
+}

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -88,6 +88,13 @@ export class LoadedMessageDto {
   summary?: string;
   leafUuid?: string;
 
+  // Compact-boundary flags. When a conversation is compacted (auto-compact or
+  // `/compact`), the CLI emits the carried-over summary as an ordinary `user`
+  // entry carrying these flags — not as a `summary` entry. Preserved verbatim
+  // from the CLI so the boundary stays identifiable downstream.
+  isCompactSummary?: boolean;
+  isVisibleInTranscriptOnly?: boolean;
+
   // metadata
   slug?: string;
   sessionId?: string;


### PR DESCRIPTION
Fixes both problems reported in #220.

## 1. The compact summary pinned itself to the bottom

When a conversation is compacted, the CLI emits the carried-over summary as an ordinary `user` entry flagged `isCompactSummary` — not as a `summary` entry — and it arrives *after* the assistant messages that follow it.

`appendMessage` already sorts by timestamp to absorb exactly that, but the `user` handler overwrote the CLI's timestamp with the arrival time. The summary therefore always compared as newest and stuck to the end of the list, with later replies rendering above it. Reloading fixed it because the JSONL path never rewrites timestamps — which is why this looked cosmetic and survived since early March.

The handler was the odd one out: `progress` and both sub-agent handlers already preserved the original timestamp. Now it does too, and the `isCompactSummary` / `isVisibleInTranscriptOnly` flags are carried through instead of being dropped at every layer.

## 2. A message sent mid-turn didn't reach Claude, then vanished

**It waited for the turn to end.** The frontend parked the message in a queue until `result`. The CLI buffers its own stdin and the backend already reuses the running process, so there was nothing to wait for. This matches the VS Code extension, whose `send()` runs no busy check at all.

**It slid down the screen.** An assistant turn renders as a single element, so leaving it open meant every delta grew the element *above* the new bubble and pushed it down — the message appeared to slide away from where it was typed. The in-flight assistant message is now sealed when the user sends, so later deltas open a fresh bubble below.

**It disappeared on reload.** The CLI never writes a mid-turn message to the session file as a `user` entry; it records only a `queue-operation` pair. Those entries carry no uuid, so the active-chain filter discarded them.

Two shapes exist and only one needs rebuilding:

| pair | meaning | action |
|---|---|---|
| `enqueue` → `dequeue` | accepted while idle; CLI writes a real `user` entry | skip, or it duplicates |
| `enqueue` → `remove` | queued mid-turn; no `user` entry is ever written | rebuild |

Rebuilt at the `remove` — where the CLI actually consumed it — so it lands between the turn it interrupted and the reply that answers it. Pairs match by content in FIFO order since the entries carry no id. Reconstruction is display-time only; loaded entries are never mutated.

## Why one PR

These were briefly two branches. They can't ship independently: both touch the same `user` handler in opposite directions. Restoring the compact summary needs the timestamp sort; keeping a mid-turn message in place needs arrival order. Merging them separately makes the compact-summary ordering test fail outright.

Resolved by routing on the entry itself — the compact summary sorts by timestamp, everything else appends on arrival. #227 was closed in favour of this.

## Verification

Measured against a live dev backend, not inferred.

- **Mid-turn delivery** — backend log shows `Reusing existing process` then `Sending to stdin`, with no interrupt, and the reply arrives in the same session.
- **No drift** — text above the bubble held at 5203 chars across a full turn while 7949 chars of later output accumulated below it; the bubble never moved from its row.
- **Reload** — loading the reported session restores `벌써?` and `음...` once each, each immediately before the reply answering it, with `dequeue`-paired messages not doubled. Filter output on that file went from 86 entries kept to 96.
- **Compact end-to-end** — ran `/compact` then a further turn: the summary stayed at its row with the new exchange below it.

All three layers pass: `wv-test` 1629, `be-test` 931, Kotlin `test` BUILD SUCCESSFUL. `wv-lint` and `be-lint` clean.

Closes #220
