### PR TITLE
fix: place CLI-sent messages by the CLI's clock, not by arrival

### DIFF
--- a/backend/src/core/features/telemetry.test.ts
+++ b/backend/src/core/features/telemetry.test.ts
@@ -50,11 +50,23 @@ function mockCommonDeps() {
   }));
 }
 
+/** 직전 테스트가 로드한 telemetry 모듈. resetModules 전에 비워내기 위해 붙잡아 둔다. */
+let loadedTelemetry: typeof import('./telemetry') | null = null;
+
 async function loadTelemetry(
   profile: TestProfile,
   apiKey: string,
   fetchImpl?: (input: string, init: { body: string }) => Promise<unknown>,
 ) {
+  // inFlight는 모듈 스코프 상태라 resetModules()가 새 인스턴스에 빈 Set을 만든다. 직전
+  // 테스트의 전송이 아직 떠 있는 채로 리셋하면, 그 전송을 기다려 줄 주체가 사라진다 —
+  // 새 인스턴스의 flushTelemetry()는 자기 빈 Set만 보고 즉시 반환하고, 뒤늦게 끝난 옛
+  // 전송이 새 테스트의 fetchMock에 얹혀 "보내지 않아야 할 때 1번 호출됨"으로 터진다.
+  // 리셋 전에 옛 인스턴스를 직접 비워, 전송이 자기 인스턴스보다 오래 살지 못하게 한다.
+  if (loadedTelemetry) {
+    await loadedTelemetry.flushTelemetry();
+    loadedTelemetry = null;
+  }
   vi.resetModules();
   // hoisted environment mock의 CCG_RYBBIT_API_KEY getter가 반환할 값을 이 파일에 주입한다
   // (process.env 전역을 건드리지 않음 — 상단 mock 주석 참고).
@@ -67,6 +79,7 @@ async function loadTelemetry(
   const fetchMock = vi.fn(fetchImpl ?? (async () => ({ ok: true })));
   vi.stubGlobal('fetch', fetchMock);
   const mod = await import('./telemetry');
+  loadedTelemetry = mod;
   return {
     trackEvent: mod.trackEvent,
     trackError: mod.trackError,
@@ -75,6 +88,13 @@ async function loadTelemetry(
     fetchMock,
   };
 }
+
+// 각 테스트가 끝나면 그 테스트가 띄운 전송을 그 자리에서 비운다. 테스트 본문이
+// flushTelemetry()를 부르지 않고 끝나는 경우(전송을 기대하지 않는 케이스)에도 전송이
+// 다음 테스트로 새지 않도록 하는 안전망 — loadTelemetry의 리셋 전 드레인과 짝을 이룬다.
+afterEach(async () => {
+  if (loadedTelemetry) await loadedTelemetry.flushTelemetry();
+});
 
 describe('telemetry consent gating', () => {
   afterEach(async () => {

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -1123,4 +1123,177 @@ describe('useChatStream', () => {
       expect(getTextContent(after[after.length - 1])).toContain('part two');
     });
   });
+
+  describe('CLI가 턴 도중 보낸 메시지 위치 (Stop hook 피드백, issue #211)', () => {
+    // 실제 CLI가 Stop hook 실행 후 내보내는 엔트리 모양.
+    // isCompactSummary도 isVisibleInTranscriptOnly도 없고, isSynthetic만 붙는다.
+    const STOP_HOOK_TEXT =
+      'Stop hook feedback:\n[resume]: the goal remains in-progress, not complete.';
+
+    const emitStopHookFeedback = (
+      emit: (type: string, payload: Record<string, unknown>) => void,
+      opts: { uuid: string; timestamp: string; text?: string },
+    ) => {
+      emit(MessageType.CLI_EVENT, {
+        type: 'user',
+        uuid: opts.uuid,
+        timestamp: opts.timestamp,
+        isSynthetic: true,
+        message: { role: 'user', content: opts.text ?? STOP_HOOK_TEXT },
+      });
+    };
+
+    it('늦게 도착해도 CLI timestamp 자리에 삽입된다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      // 훅 피드백보다 나중 시각의 메시지가 이미 화면에 있다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'later',
+          timestamp: '2026-07-26T20:50:30.000Z',
+          message: { role: 'user', content: 'next iteration' },
+        });
+      });
+
+      // 훅 피드백은 그보다 이른 시각인데 뒤늦게 도착한다.
+      act(() => {
+        emitStopHookFeedback(emit, {
+          uuid: 'stop-1',
+          timestamp: '2026-07-26T20:50:03.297Z',
+        });
+      });
+
+      // 맨 끝이 아니라 시간순 제자리(앞)에 놓여야 한다.
+      const contents = result.current.messages.map(m => m.message?.content);
+      expect(contents).toEqual([STOP_HOOK_TEXT, 'next iteration']);
+    });
+
+    it('사이클을 반복해도 화면 하단에 쌓이지 않는다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      // 이터레이션 3회: 각 훅 피드백 뒤에 다음 턴의 결과가 이어진다.
+      const cycles = [
+        { hookTs: '2026-07-26T20:50:03.000Z', turnTs: '2026-07-26T20:50:10.000Z' },
+        { hookTs: '2026-07-26T20:51:03.000Z', turnTs: '2026-07-26T20:51:10.000Z' },
+        { hookTs: '2026-07-26T20:52:03.000Z', turnTs: '2026-07-26T20:52:10.000Z' },
+      ];
+
+      cycles.forEach((c, i) => {
+        act(() => {
+          emitStopHookFeedback(emit, {
+            uuid: `stop-${i}`,
+            timestamp: c.hookTs,
+            text: `HOOK-${i}`,
+          });
+        });
+        act(() => {
+          emit(MessageType.CLI_EVENT, {
+            type: 'user',
+            uuid: `turn-${i}`,
+            timestamp: c.turnTs,
+            message: { role: 'user', content: `TURN-${i}` },
+          });
+        });
+      });
+
+      // 훅 피드백이 끝에 몰리지 않고 각 사이클 사이에 번갈아 놓인다.
+      expect(result.current.messages.map(m => m.message?.content)).toEqual([
+        'HOOK-0', 'TURN-0', 'HOOK-1', 'TURN-1', 'HOOK-2', 'TURN-2',
+      ]);
+    });
+
+    it('이후 델타가 훅 피드백을 아래로 밀지 않는다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        result.current.addUserMessage('go');
+      });
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part one ' } },
+        });
+      });
+      act(() => flushRAF());
+
+      const assistantIndex = 1;
+      const beforeText = getTextContent(result.current.messages[assistantIndex]);
+
+      // 턴이 아직 스트리밍 중인데 훅 피드백이 도착한다.
+      act(() => {
+        emitStopHookFeedback(emit, {
+          uuid: 'stop-mid',
+          timestamp: new Date(Date.now() + 1000).toISOString(),
+        });
+      });
+      const hookIndex = result.current.messages.length - 1;
+      expect(getTextContent(result.current.messages[hookIndex])).toBe(STOP_HOOK_TEXT);
+
+      // 응답이 계속 스트리밍된다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part two' } },
+        });
+      });
+      act(() => flushRAF());
+
+      // 훅 피드백 위 버블은 더 이상 자라지 않고, 새 텍스트는 그 아래에 쌓인다.
+      expect(getTextContent(result.current.messages[assistantIndex])).toBe(beforeText);
+      expect(getTextContent(result.current.messages[hookIndex])).toBe(STOP_HOOK_TEXT);
+      const after = result.current.messages.slice(hookIndex + 1);
+      expect(after.length).toBeGreaterThan(0);
+      expect(getTextContent(after[after.length - 1])).toContain('part two');
+    });
+
+    it('tool_result는 자기 버블이 없으므로 assistant 버블을 쪼개지 않는다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        result.current.addUserMessage('go');
+      });
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part one ' } },
+        });
+      });
+      act(() => flushRAF());
+
+      const assistantIndex = 1;
+      expect(result.current.isStreaming).toBe(true);
+
+      // 도구 결과가 도착해도 스트리밍은 계속되어야 한다.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'user',
+          uuid: 'tr-1',
+          timestamp: new Date(Date.now() + 1000).toISOString(),
+          message: {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: 'ok' }],
+          },
+        });
+      });
+
+      expect(result.current.isStreaming).toBe(true);
+
+      // 이후 델타는 원래 버블에 계속 누적된다 (새 버블로 갈라지지 않는다).
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { delta: { type: 'text_delta', text: 'part two' } },
+        });
+      });
+      act(() => flushRAF());
+
+      expect(getTextContent(result.current.messages[assistantIndex])).toContain('part one');
+      expect(getTextContent(result.current.messages[assistantIndex])).toContain('part two');
+    });
+  });
 });

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -15,6 +15,37 @@ interface ModelUsageEntry {
 }
 
 /**
+ * Whether a CLI `user` entry will occupy a row of its own in the transcript.
+ *
+ * Most `user` entries the CLI streams mid-turn are plumbing: a `tool_result`
+ * belongs to the tool call that requested it, and a skill-expanded prompt
+ * belongs to the Skill invocation — `mergeToolResults` folds both into the
+ * tool_use above and drops the standalone bubble. What is left is a plain text
+ * entry the CLI authored on its own behalf, such as a Stop hook's feedback,
+ * which does get its own bubble.
+ *
+ * Used to decide whether inserting the entry should close off the streaming
+ * assistant message above it; splitting that bubble for an entry that renders
+ * nothing would leave a visible seam for no reason.
+ */
+function rendersAsOwnBubble(message: LoadedMessageDto): boolean {
+  // Folded into its Skill tool_use by mergeToolResults.
+  if (message.sourceToolUseID) return false;
+
+  const content = message.message?.content;
+  if (typeof content === 'string') return content.trim().length > 0;
+  if (!Array.isArray(content)) return false;
+
+  // A tool_result block is folded into the tool call that requested it.
+  if (content.some(b => b.type === ContentBlockType.ToolResult)) return false;
+
+  return content.some(
+    b => (b.type === ContentBlockType.Text && (b as TextBlockDto).text?.trim())
+      || b.type === ContentBlockType.Image,
+  );
+}
+
+/**
  * Resolve modelUsage entry for the currently running model.
  * The CLI's modelUsage dict may be keyed by a form that differs slightly
  * from the `model` string in the same result event (e.g. `claude-opus-4-7`
@@ -302,6 +333,34 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     return assistantMessageId;
   }, [generateMessageId, appendMessage, startStreaming]);
 
+  // Close off the assistant message that is currently streaming, so whatever we
+  // insert next lands *below* it and stays put.
+  //
+  // An assistant turn renders as a single element. While it is still open every
+  // delta makes it taller, which pushes anything already sitting beneath it
+  // further down the screen — the message appears to slide away from where it
+  // belongs (#220 for a message the user typed, #211 for a Stop hook's feedback
+  // arriving mid-turn). Sealing here means later deltas open a fresh assistant
+  // bubble underneath, leaving the inserted message anchored where it landed.
+  //
+  // No-op when nothing is streaming, so callers can seal unconditionally.
+  const sealStreamingAssistant = useCallback(() => {
+    const streamingId = streamingMessageIdRef.current;
+    if (!streamingId) return;
+    if (pendingTextRef.current || pendingThinkingRef.current || pendingInputJsonRef.current) {
+      flushPendingDeltas();
+    }
+    updateMessage(streamingId, { isStreaming: false });
+    streamingMessageIdRef.current = null;
+    setStreamingMessageId(null);
+    activeBlockIndexRef.current = -1;
+    activeTextBlockIndexRef.current = -1;
+    activeThinkingBlockIndexRef.current = -1;
+    activeToolUseBlockIndexRef.current = -1;
+    turnStartBlockCountRef.current = 0;
+    accumulatedInputJsonRef.current = '';
+  }, [flushPendingDeltas, updateMessage, setStreamingMessageId]);
+
   // End streaming helper
   const endStreaming = useCallback(() => {
     // Flush any remaining delta (including input JSON)
@@ -385,27 +444,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     // 스트리밍 중이면 사용자 메시지만 추가 (assistant placeholder 생성 스킵).
     // 백엔드 전송은 ChatStreamContext가 담당한다.
     if (isStreaming) {
-      // Seal the assistant message that is still streaming above this one. An
-      // assistant turn renders as a single element, so if we let it keep
-      // growing it pushes this bubble further down the screen with every delta
-      // — the message the user just typed appears to slide away from where they
-      // typed it (#220). Cutting the message here means subsequent deltas open
-      // a fresh assistant bubble *below* this one, so it stays put.
-      const streamingId = streamingMessageIdRef.current;
-      if (streamingId) {
-        if (pendingTextRef.current || pendingThinkingRef.current || pendingInputJsonRef.current) {
-          flushPendingDeltas();
-        }
-        updateMessage(streamingId, { isStreaming: false });
-        streamingMessageIdRef.current = null;
-        setStreamingMessageId(null);
-        activeBlockIndexRef.current = -1;
-        activeTextBlockIndexRef.current = -1;
-        activeThinkingBlockIndexRef.current = -1;
-        activeToolUseBlockIndexRef.current = -1;
-        turnStartBlockCountRef.current = 0;
-        accumulatedInputJsonRef.current = '';
-      }
+      sealStreamingAssistant();
       return;
     }
 
@@ -958,23 +997,38 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
           // stamping the arrival time here would strand late-arriving CLI-internal
           // entries — notably the compact summary, which the CLI emits after the
           // assistant messages that follow it — at the end of the list (#220).
+          const cliTimestamp = (cliEvent as any).timestamp as string | undefined;
           const userMessage: LoadedMessageDto = {
             type: LoadedMessageType.User,
             uuid: (cliEvent as any).uuid || generateMessageId(),
-            timestamp: (cliEvent as any).timestamp ?? new Date().toISOString(),
+            timestamp: cliTimestamp ?? new Date().toISOString(),
             message: userMsg as unknown as LoadedMessageDto['message'],
             sourceToolUseID,
             isSynthetic: (cliEvent as any).isSynthetic === true ? true : undefined,
             isCompactSummary: (cliEvent as any).isCompactSummary === true ? true : undefined,
             isVisibleInTranscriptOnly: (cliEvent as any).isVisibleInTranscriptOnly === true ? true : undefined,
           };
-          // The compact summary is the one `user` event that genuinely arrives out
-          // of order — the CLI emits it after the assistant messages that follow
-          // it — so it needs the timestamp sort to land back in place. Everything
-          // else (tool_results, skill prompts) arrives in the order it belongs in
-          // and is appended as it comes, which keeps it next to the message it
-          // answers even when the user sends mid-turn.
-          appendMessage(userMessage, !userMessage.isCompactSummary);
+          // Anything the CLI stamped belongs where its clock says, not where it
+          // happened to arrive. The compact summary was the first case we hit
+          // (#220), but it is not the only one: a Stop hook's feedback is emitted
+          // as a synthetic `user` entry when the hook fires, yet reaches us after
+          // the next turn has already started, so arrival order pins it to the
+          // bottom and it accumulates there over repeated cycles (#211). Sorting
+          // on the CLI timestamp covers both, and every future CLI-internal entry
+          // that arrives late, without needing a flag per kind.
+          //
+          // Entries with no CLI timestamp are ours, not the CLI's — they have no
+          // clock to sort by, so they keep arrival order (see appendMessage).
+          appendMessage(userMessage, !cliTimestamp);
+
+          // A CLI entry that renders as its own bubble mid-turn needs the open
+          // assistant message closed off, or every following delta pushes it
+          // down the screen (#211). Tool results and skill prompts are folded
+          // into the tool call above by mergeToolResults, so they never occupy
+          // a row of their own and must not split the bubble.
+          if (rendersAsOwnBubble(userMessage)) {
+            sealStreamingAssistant();
+          }
         }
         return;
       }


### PR DESCRIPTION
Fixes #211.

Under a repeating directive like `/goal`, the summary a Stop hook emits at the end of each cycle piled up at the bottom of the screen instead of staying where that cycle ended. After a few iterations the transcript was all summary and the active work sat below the fold.

## What it actually is

Not a Stop-hook-specific renderer. That box is an ordinary `user` bubble — there is no dedicated component and no sticky CSS, so its position is decided entirely by insertion order.

Measured against a live CLI (a Stop hook installed for the probe, then removed), the entry arrives as:

```
type=user  ts=2026-07-26T20:50:03.297Z  isSynthetic=true
keys: type,message,parent_tool_use_id,session_id,uuid,timestamp,isSynthetic
text: "Stop hook feedback: [resume]: ..."
```

No `isCompactSummary`, no `isVisibleInTranscriptOnly`.

## Two causes, both general

**Ordering.** #228 restored the compact summary by sorting it on the CLI's timestamp, but scoped that to `isCompactSummary` and routed every other `user` entry to arrival order. The hook's feedback carries a real timestamp and neither flag, so it took the arrival path and pinned itself to the end.

A flag whitelist structurally misses cases nobody has hit yet — each new kind needs a human to add a flag. This replaces it with the property that actually separates the two groups:

| entry | placement |
|---|---|
| CLI stamped a timestamp | insert by the CLI's clock |
| no CLI timestamp (we composed it locally) | keep arrival order |

That covers the compact summary, this hook, and any future CLI-internal entry that arrives late, without a flag per kind.

**Drift.** An assistant turn renders as one element, so anything inserted beneath it while it is still open is pushed down by every delta. #228 sealed the open bubble when the user types; the same is needed when the CLI sends an entry that occupies a row of its own. The sealing block is lifted into `sealStreamingAssistant` and shared by both paths.

Not every CLI `user` entry should seal: `mergeToolResults` folds tool results and skill-expanded prompts into the tool call above, so they never get their own row and sealing for them would split the assistant bubble for nothing. `rendersAsOwnBubble` gates that.

## Verification

The two bug-reproducing tests were confirmed to fail without the fix, so they are not vacuous:

- ordering — got `['next iteration', …]`, the feedback pinned to the bottom
- drift — got `'part one part two'`, the bubble above still growing

Two further tests guard behaviour that must not regress (repeated cycles stay interleaved; a `tool_result` does not split the bubble).

All three layers pass: `wv-test` 1633 (188 files), `be-test` 931, Kotlin `test` BUILD SUCCESSFUL. `wv-lint`, `be-lint` and `full-build` clean. No Kotlin files are touched by this PR.

## Unrelated defect fixed along the way

`telemetry.test.ts` failed intermittently while verifying this — fail/pass/pass on identical code. It was not flakiness. `inFlight` is module state, so `vi.resetModules()` gives each test a fresh empty set; a send still running from the previous test had nothing left to await it and landed on the next test's `fetchMock`, breaking the consent-gating assertion. The giveaway was the leaked payload carrying a real installation uuid rather than the mocked `test-uuid`, which meant a genuine send had escaped.

The previous module instance is now drained before the reset, with an `afterEach` safety net. 8/8 green afterwards, and the full backend suite green on two consecutive runs.
