### PR TITLE
fix(settings): keep // in string values from breaking settings parsing (#7)

### DIFF
--- a/backend/src/core/features/__tests__/settings.test.ts
+++ b/backend/src/core/features/__tests__/settings.test.ts
@@ -485,6 +485,42 @@ export default {
       expect(result.fontSize).toBe(14);
     });
 
+    // Regression #7: a string value containing `//` (e.g. a WSL UNC path like
+    // //wsl.localhost/...) must NOT be treated as a line comment. Previously the
+    // comment stripper ate the rest of the line, JSON.parse threw, and the whole
+    // settings object silently fell back to defaults — dropping the user's saved
+    // hostMode ("tool-window") down to "editor-tab".
+    it('should preserve settings when a string value contains // (WSL UNC path)', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(`export default {
+  // Claude CLI 실행 파일 경로
+  cliPath: "//wsl.localhost/Ubuntu/home/yhk/.local/bin/claude",
+  // 채팅을 띄우는 자리
+  hostMode: "tool-window",
+  theme: "dark",
+};
+`);
+
+      const result = await readSettingsFile();
+      expect(result.cliPath).toBe('//wsl.localhost/Ubuntu/home/yhk/.local/bin/claude');
+      expect(result.hostMode).toBe('tool-window');
+      expect(result.theme).toBe('dark');
+    });
+
+    // Same hazard inside a value that also contains block-comment markers.
+    it('should preserve a string value containing /* */ markers', async () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(`export default {
+  terminalApp: "wt /* not a comment */ --profile",
+  hostMode: "tool-window",
+};
+`);
+
+      const result = await readSettingsFile();
+      expect(result.terminalApp).toBe('wt /* not a comment */ --profile');
+      expect(result.hostMode).toBe('tool-window');
+    });
+
     it('should merge parsed values with defaults for missing keys', async () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFile.mockResolvedValue(`export default { theme: "dark" };`);

--- a/backend/src/core/features/settings.ts
+++ b/backend/src/core/features/settings.ts
@@ -84,6 +84,56 @@ function generateSettingsContent(settings: Record<string, unknown>): string {
   return lines.join('\n') + '\n';
 }
 
+/**
+ * Strip `//` line comments and block comments from the settings JS source, but
+ * NEVER when the marker sits inside a string literal. A value such as
+ * "//wsl.localhost/..." (a WSL UNC path a user may enter for cliPath/nodePath)
+ * must survive intact — otherwise JSON.parse throws and the whole settings
+ * object silently falls back to defaults, dropping the user's saved hostMode
+ * down to "editor-tab" (regression #7).
+ */
+function stripJsComments(src: string): string {
+  let out = '';
+  let inString = false;
+  let quote = '';
+  for (let i = 0; i < src.length; i++) {
+    const ch = src[i];
+    if (inString) {
+      out += ch;
+      if (ch === '\\') {
+        // preserve the escaped character verbatim
+        i++;
+        if (i < src.length) out += src[i];
+        continue;
+      }
+      if (ch === quote) inString = false;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      inString = true;
+      quote = ch;
+      out += ch;
+      continue;
+    }
+    const next = src[i + 1];
+    if (ch === '/' && next === '/') {
+      // line comment → drop to end of line, keep the newline
+      while (i < src.length && src[i] !== '\n') i++;
+      if (i < src.length) out += '\n';
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      // block comment → drop through the closing marker
+      i += 2;
+      while (i < src.length && !(src[i] === '*' && src[i + 1] === '/')) i++;
+      i++; // skip '*'; the loop's i++ skips '/'
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
 export async function readSettingsFile(): Promise<Record<string, unknown>> {
   try {
     if (!existsSync(SETTINGS_FILE)) {
@@ -95,11 +145,9 @@ export async function readSettingsFile(): Promise<Record<string, unknown>> {
 
     const raw = await readFile(SETTINGS_FILE, 'utf-8');
 
-    // Strip block comments
-    let stripped = raw.replace(/\/\*[\s\S]*?\*\//g, '');
-
-    // Strip line comments (preserving strings)
-    stripped = stripped.replace(/\/\/[^\n]*/g, '');
+    // Strip comments in a string-literal-aware way so a value like
+    // "//wsl.localhost/..." (WSL UNC path) is never mistaken for a comment (#7).
+    let stripped = stripJsComments(raw);
 
     // Remove `export default` prefix and trailing semicolon
     stripped = stripped.replace(/^\s*export\s+default\s*/, '').replace(/;\s*$/, '').trim();


### PR DESCRIPTION
## Problem (regression, #7)
On WSL2, users reported chat opening in the **Panel** (editor tab) even though **Sidebar** (tool-window) was selected. Reproduced and root-caused:

`readSettingsFile` strips comments from `settings.js` with a regex that removes `//` **even inside string literals**. A `cliPath`/`nodePath` such as `"//wsl.localhost/..."` (a WSL UNC path a user can enter in Settings → CLI) makes `JSON.parse` throw. The `catch` returns `DEFAULT_SETTINGS`, silently resetting `hostMode` to `"editor-tab"` (Panel) and dropping the user's Sidebar choice.

## Fix
Parse `//` line comments and block comments in a **string-literal-aware** way (character scan) so values containing `//` or comment markers survive intact.

## Tests
- New regression tests: `//` (WSL UNC path) and `/* */` markers inside string values preserve `hostMode`/`cliPath`.
- `settings.test.ts`: 64/64 pass. No parser regressions.

## Follow-up (separate PR)
Defense-in-depth: on a genuine parse failure, avoid overwriting the file with defaults (prevents silent loss for already-corrupted files). Existing affected users must re-select Preferred Location once.

Refs #7