### PR TITLE
fix(settings): honor project scope for path/app settings and Preferred Location (#7)

### DIFF
--- a/backend/src/bridge/__tests__/browser-bridge-open-file.test.ts
+++ b/backend/src/bridge/__tests__/browser-bridge-open-file.test.ts
@@ -8,7 +8,7 @@ vi.mock('child_process', () => ({
 }));
 
 vi.mock('../../core/features/settings', () => ({
-  readSettingsFile: vi.fn(),
+  readMergedSettings: vi.fn(),
 }));
 
 vi.mock('../../core/features/detectEditors', () => ({
@@ -16,7 +16,7 @@ vi.mock('../../core/features/detectEditors', () => ({
 }));
 
 import { execFile, spawn } from 'child_process';
-import { readSettingsFile } from '../../core/features/settings';
+import { readMergedSettings } from '../../core/features/settings';
 import { detectInstalledEditors } from '../../core/features/detectEditors';
 import { BrowserBridge, OPEN_FILES_WITH_CUSTOM } from '../browser-bridge';
 
@@ -41,7 +41,7 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
   it('launches the configured editor via execFile -a on macOS when openFilesWith is set', async () => {
     setPlatform('darwin');
-    vi.mocked(readSettingsFile).mockResolvedValue({ openFilesWith: 'Cursor', openFilesWithCustom: null });
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { openFilesWith: 'Cursor', openFilesWithCustom: null }, overrides: [] });
     vi.mocked(detectInstalledEditors).mockResolvedValue([
       { id: 'cursor', name: 'Cursor', path: '/Applications/Cursor.app' },
     ]);
@@ -60,7 +60,7 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
   it('launches the configured editor via spawn directly on linux when openFilesWith is set', async () => {
     setPlatform('linux');
-    vi.mocked(readSettingsFile).mockResolvedValue({ openFilesWith: 'code', openFilesWithCustom: null });
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { openFilesWith: 'code', openFilesWithCustom: null }, overrides: [] });
     vi.mocked(detectInstalledEditors).mockResolvedValue([
       { id: 'vscode', name: 'code', path: '/usr/bin/code' },
     ]);
@@ -77,7 +77,7 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
   it('launches the configured editor via spawn on windows when openFilesWith is set', async () => {
     setPlatform('win32');
-    vi.mocked(readSettingsFile).mockResolvedValue({ openFilesWith: 'code', openFilesWithCustom: null });
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { openFilesWith: 'code', openFilesWithCustom: null }, overrides: [] });
     vi.mocked(detectInstalledEditors).mockResolvedValue([
       { id: 'vscode', name: 'code', path: 'C:\\Program Files\\Code\\Code.exe' },
     ]);
@@ -93,7 +93,7 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
   it('falls back to the OS default opener when openFilesWith is null', async () => {
     setPlatform('darwin');
-    vi.mocked(readSettingsFile).mockResolvedValue({ openFilesWith: null, openFilesWithCustom: null });
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { openFilesWith: null, openFilesWithCustom: null }, overrides: [] });
 
     const bridge = new BrowserBridge();
     await bridge.openFile('/tmp/file.ts');
@@ -104,7 +104,7 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
   it('falls back to the OS default opener when the configured editor is not among detected editors', async () => {
     setPlatform('darwin');
-    vi.mocked(readSettingsFile).mockResolvedValue({ openFilesWith: 'SomeUninstalledEditor', openFilesWithCustom: null });
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { openFilesWith: 'SomeUninstalledEditor', openFilesWithCustom: null }, overrides: [] });
     vi.mocked(detectInstalledEditors).mockResolvedValue([
       { id: 'cursor', name: 'Cursor', path: '/Applications/Cursor.app' },
     ]);
@@ -122,10 +122,10 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
     it('expands %TARGET_PATH% and launches the custom executable via spawn', async () => {
       setPlatform('linux');
-      vi.mocked(readSettingsFile).mockResolvedValue({
+      vi.mocked(readMergedSettings).mockResolvedValue({ settings: {
         openFilesWith: OPEN_FILES_WITH_CUSTOM,
         openFilesWithCustom: { path: '/usr/local/bin/subl', arguments: '%TARGET_PATH%' },
-      });
+      }, overrides: [] });
 
       const bridge = new BrowserBridge();
       await bridge.openFile('/tmp/file.ts');
@@ -139,10 +139,10 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
     it('expands %TARGET_PATH% among multiple arguments, preserving quoted tokens', async () => {
       setPlatform('linux');
-      vi.mocked(readSettingsFile).mockResolvedValue({
+      vi.mocked(readMergedSettings).mockResolvedValue({ settings: {
         openFilesWith: OPEN_FILES_WITH_CUSTOM,
         openFilesWithCustom: { path: '/usr/local/bin/subl', arguments: '--wait "%TARGET_PATH%"' },
-      });
+      }, overrides: [] });
 
       const bridge = new BrowserBridge();
       await bridge.openFile('/tmp/my file.ts');
@@ -156,10 +156,10 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
     it('launches a .app custom path via execFile -a on macOS', async () => {
       setPlatform('darwin');
-      vi.mocked(readSettingsFile).mockResolvedValue({
+      vi.mocked(readMergedSettings).mockResolvedValue({ settings: {
         openFilesWith: OPEN_FILES_WITH_CUSTOM,
         openFilesWithCustom: { path: '/Applications/Sublime Text.app', arguments: '%TARGET_PATH%' },
-      });
+      }, overrides: [] });
 
       const bridge = new BrowserBridge();
       await bridge.openFile('/tmp/file.ts');
@@ -173,10 +173,10 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
     it('defaults the argument template to %TARGET_PATH% when arguments is empty', async () => {
       setPlatform('linux');
-      vi.mocked(readSettingsFile).mockResolvedValue({
+      vi.mocked(readMergedSettings).mockResolvedValue({ settings: {
         openFilesWith: OPEN_FILES_WITH_CUSTOM,
         openFilesWithCustom: { path: '/usr/local/bin/subl', arguments: '' },
-      });
+      }, overrides: [] });
 
       const bridge = new BrowserBridge();
       await bridge.openFile('/tmp/file.ts');
@@ -189,15 +189,70 @@ describe('BrowserBridge.openFile — openFilesWith setting', () => {
 
     it('falls back to the OS default opener when $custom is selected but no custom.path is configured', async () => {
       setPlatform('darwin');
-      vi.mocked(readSettingsFile).mockResolvedValue({
+      vi.mocked(readMergedSettings).mockResolvedValue({ settings: {
         openFilesWith: OPEN_FILES_WITH_CUSTOM,
         openFilesWithCustom: null,
-      });
+      }, overrides: [] });
 
       const bridge = new BrowserBridge();
       await bridge.openFile('/tmp/file.ts');
 
       expect(execFile).toHaveBeenCalledWith('open', ['/tmp/file.ts'], expect.any(Function));
     });
+  });
+});
+
+
+// The CLI equivalence principle: anything a user could set per project from the
+// terminal must be settable per project from the GUI. Which editor opens a file
+// and which terminal is launched are ordinary per-project choices, so these reads
+// go through readMergedSettings(workingDir) — global values still apply when a
+// project sets nothing (issue #7).
+describe('BrowserBridge — per-project app settings', () => {
+  let originalPlatform: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(detectInstalledEditors).mockResolvedValue([]);
+    originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+  });
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('openFile honors a project-scoped editor', async () => {
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { openFilesWith: 'Cursor', openFilesWithCustom: null },
+      overrides: ['openFilesWith'],
+    });
+    vi.mocked(detectInstalledEditors).mockResolvedValue([
+      { id: 'cursor', name: 'Cursor', path: '/Applications/Cursor.app' },
+    ]);
+
+    const bridge = new BrowserBridge();
+    await bridge.openFile('/home/u/proj/file.ts', undefined, undefined, '/home/u/proj');
+
+    expect(readMergedSettings).toHaveBeenCalledWith('/home/u/proj');
+    expect(execFile).toHaveBeenCalledWith(
+      'open',
+      ['-a', '/Applications/Cursor.app', '/home/u/proj/file.ts'],
+      expect.anything(),
+    );
+  });
+
+  it('openTerminal resolves the terminal app for the project it opens in', async () => {
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { terminalApp: 'iTerm' },
+      overrides: ['terminalApp'],
+    });
+
+    const bridge = new BrowserBridge();
+    // The launch itself shells out (AppleScript/spawn); we only pin that the
+    // settings lookup is scoped to this project.
+    await bridge.openTerminal('/home/u/proj').catch(() => undefined);
+
+    expect(readMergedSettings).toHaveBeenCalledWith('/home/u/proj');
   });
 });

--- a/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
+++ b/backend/src/bridge/__tests__/jetbrains-bridge.test.ts
@@ -198,6 +198,101 @@ describe('JetBrainsBridge connect-time hostMode push', () => {
     expect(msg?.method).toBe(MessageType.HOST_MODE_CHANGED);
     expect(msg?.params).toEqual({ hostMode: 'tool-window' });
   });
+
+  // An IDE announces the projects it serves only AFTER the socket is up, so the
+  // connect-time push above can only carry the global value. Once the roots
+  // arrive we know which project's settings apply, so the merged value must be
+  // pushed again — otherwise a project that overrides hostMode never takes
+  // effect on the IDE side (issue #7).
+  it('re-pushes the merged hostMode once the client announces its project roots', async () => {
+    vi.spyOn(settings, 'readSettingsFile').mockResolvedValue({ hostMode: 'editor-tab' });
+    vi.spyOn(settings, 'readMergedSettings').mockResolvedValue({
+      settings: { hostMode: 'tool-window' },
+      overrides: ['hostMode'],
+    });
+
+    const bridge = new JetBrainsBridge();
+    const ws = createMockWs();
+    bridge.addRpcClient(ws as never);
+    await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());
+    ws.send.mockClear();
+
+    registerRoots(ws, ['/home/u/proj']);
+
+    await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());
+    const msg = sentMessage(ws);
+    expect(msg?.method).toBe(MessageType.HOST_MODE_CHANGED);
+    expect(msg?.params).toEqual({ hostMode: 'tool-window' });
+    expect(settings.readMergedSettings).toHaveBeenCalledWith('/home/u/proj');
+  });
+
+  it('does not re-push when the client announces no roots', async () => {
+    vi.spyOn(settings, 'readSettingsFile').mockResolvedValue({ hostMode: 'editor-tab' });
+    const merged = vi.spyOn(settings, 'readMergedSettings');
+
+    const bridge = new JetBrainsBridge();
+    const ws = createMockWs();
+    bridge.addRpcClient(ws as never);
+    await vi.waitFor(() => expect(ws.send).toHaveBeenCalled());
+    ws.send.mockClear();
+
+    registerRoots(ws, []);
+
+    expect(merged).not.toHaveBeenCalled();
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+});
+
+// A project-scoped hostMode must reach only the IDE windows serving that
+// project. Pushing it to every client would flip the chat host in unrelated
+// projects — the same "my setting changed by itself" symptom issue #7 reports.
+describe('JetBrainsBridge.pushHostMode project targeting', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.spyOn(settings, 'readSettingsFile').mockResolvedValue({ hostMode: 'editor-tab' });
+  });
+
+  it('pushes to only the clients serving the given project root', async () => {
+    const bridge = new JetBrainsBridge();
+    const a = createMockWs();
+    const b = createMockWs();
+    bridge.addRpcClient(a as never);
+    bridge.addRpcClient(b as never);
+    await vi.waitFor(() => {
+      expect(a.send).toHaveBeenCalled();
+      expect(b.send).toHaveBeenCalled();
+    });
+    registerRoots(a, ['/home/u/alpha']);
+    registerRoots(b, ['/home/u/beta']);
+    a.send.mockClear();
+    b.send.mockClear();
+
+    bridge.pushHostModeForProject('tool-window', '/home/u/alpha');
+
+    expect(sentMessage(a)?.params).toEqual({ hostMode: 'tool-window' });
+    expect(b.send).not.toHaveBeenCalled();
+  });
+
+  it('falls back to every client when no project path is given', async () => {
+    const bridge = new JetBrainsBridge();
+    const a = createMockWs();
+    const b = createMockWs();
+    bridge.addRpcClient(a as never);
+    bridge.addRpcClient(b as never);
+    await vi.waitFor(() => {
+      expect(a.send).toHaveBeenCalled();
+      expect(b.send).toHaveBeenCalled();
+    });
+    registerRoots(a, ['/home/u/alpha']);
+    registerRoots(b, ['/home/u/beta']);
+    a.send.mockClear();
+    b.send.mockClear();
+
+    bridge.pushHostModeForProject('tool-window', undefined);
+
+    expect(sentMessage(a)?.params).toEqual({ hostMode: 'tool-window' });
+    expect(sentMessage(b)?.params).toEqual({ hostMode: 'tool-window' });
+  });
 });
 
 describe('redactRpcLog', () => {

--- a/backend/src/bridge/bridge-interface.ts
+++ b/backend/src/bridge/bridge-interface.ts
@@ -1,5 +1,10 @@
 export interface Bridge {
-  openFile(path: string, line?: number, column?: number): Promise<void>;
+  /**
+   * [workingDir] is the project the request came from, so the "open files with"
+   * setting can be resolved per project (global value when the project sets none).
+   * Optional: callers with no project context still get the global behaviour.
+   */
+  openFile(path: string, line?: number, column?: number, workingDir?: string): Promise<void>;
   openDiff(params: {
     filePath: string;
     oldContent: string;

--- a/backend/src/bridge/browser-bridge.ts
+++ b/backend/src/bridge/browser-bridge.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from 'child_process';
 import type { Bridge } from './bridge-interface';
-import { readSettingsFile } from '../core/features/settings';
+import { readMergedSettings } from '../core/features/settings';
 import { Claude } from '../core/claude';
 import { detectInstalledEditors } from '../core/features/detectEditors';
 import {
@@ -20,8 +20,10 @@ export const OPEN_FILES_WITH_CUSTOM = '$custom';
 export class BrowserBridge implements Bridge {
   // line/column are accepted for interface parity but can't be honored by the OS
   // opener (xdg-open/open/explorer) — line focus is a JetBrains-mode feature.
-  async openFile(path: string, _line?: number, _column?: number): Promise<void> {
-    const settings = await readSettingsFile();
+  async openFile(path: string, _line?: number, _column?: number, workingDir?: string): Promise<void> {
+    // Per-project first, global as the fallback: which editor opens a file is an
+    // ordinary per-project choice, the same one a terminal user makes (issue #7).
+    const { settings } = await readMergedSettings(workingDir);
     const openFilesWith = settings['openFilesWith'] as string | null;
     const custom = settings['openFilesWithCustom'] as
       | { path?: string; arguments?: string }
@@ -311,7 +313,9 @@ if ($dialog.ShowDialog() -eq 'OK') {
   }
 
   async openTerminal(workingDir: string): Promise<void> {
-    const settings = await readSettingsFile();
+    // The terminal is opened *in* this project, so its choice is resolved per
+    // project too — global still applies when the project sets none (issue #7).
+    const { settings } = await readMergedSettings(workingDir);
     const terminalApp = settings['terminalApp'] as string | null;
 
     // Resolve via Claude.which() (augmented PATH + PATHEXT-correct launcher on

--- a/backend/src/bridge/jetbrains-bridge.ts
+++ b/backend/src/bridge/jetbrains-bridge.ts
@@ -1,7 +1,7 @@
 import type { Bridge } from './bridge-interface';
 import type { WebSocket } from 'ws';
 import { extractRoutingPath, selectRpcClientIndex } from './rpc-routing';
-import { readSettingsFile } from '../core/features/settings';
+import { readSettingsFile, readMergedSettings } from '../core/features/settings';
 import { MessageType } from '../shared';
 
 interface JsonRpcRequest {
@@ -93,7 +93,13 @@ export class JetBrainsBridge implements Bridge {
         // Built-in: an IDE advertising the project roots it serves. Handled here
         // (not via notificationHandlers) because it is bound to *this* socket.
         if (notification.method === MessageType.REGISTER_PROJECT_ROOTS) {
-          this.clientRoots.set(ws, parseProjectRoots(notification.params));
+          const roots = parseProjectRoots(notification.params);
+          this.clientRoots.set(ws, roots);
+          // Now that we know which project this IDE serves, re-push hostMode using
+          // the *merged* value. The connect-time push above could only read the
+          // global file — the roots had not been announced yet — so a project that
+          // overrides hostMode would otherwise never reach the IDE (issue #7).
+          this.pushMergedHostMode(ws, roots[0]);
           return;
         }
         const handler = this.notificationHandlers.get(notification.method);
@@ -205,6 +211,42 @@ export class JetBrainsBridge implements Bridge {
    */
   pushHostMode(hostMode: string, target?: WebSocket): void {
     this.notify(MessageType.HOST_MODE_CHANGED, { hostMode }, target);
+  }
+
+  /**
+   * Push a saved `hostMode` to the IDE windows that serve [projectPath].
+   *
+   * A project-scoped save must not reach unrelated projects: flipping the chat
+   * host in a window the user never touched is exactly the "my setting changed
+   * by itself" symptom of issue #7. With no [projectPath] (a global save) every
+   * client is addressed, as before.
+   */
+  pushHostModeForProject(hostMode: string, projectPath?: string): void {
+    if (!projectPath) {
+      this.pushHostMode(hostMode);
+      return;
+    }
+    for (const ws of this.rpcClients) {
+      if ((this.clientRoots.get(ws) ?? []).includes(projectPath)) {
+        this.pushHostMode(hostMode, ws);
+      }
+    }
+  }
+
+  /**
+   * Read the effective (global + project) hostMode and push it to one socket.
+   * Fire-and-forget: a settings read failure must never break RPC handling.
+   */
+  private pushMergedHostMode(ws: WebSocket, projectPath?: string): void {
+    if (!projectPath) return;
+    readMergedSettings(projectPath)
+      .then(({ settings }) => {
+        const hostMode = typeof settings.hostMode === 'string' ? settings.hostMode : 'editor-tab';
+        this.pushHostMode(hostMode, ws);
+      })
+      .catch((err) => {
+        console.error('[node-backend]', 'Failed to push merged hostMode:', err);
+      });
   }
 
   async openFile(path: string, line?: number, column?: number): Promise<void> {

--- a/backend/src/core/__tests__/claude.test.ts
+++ b/backend/src/core/__tests__/claude.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 // Mock readSettingsFile to avoid file system access
 vi.mock('../features/settings', () => ({
   readSettingsFile: vi.fn().mockResolvedValue({ cliPath: null }),
+  readMergedSettings: vi.fn().mockResolvedValue({ settings: { cliPath: null }, overrides: [] }),
   resolveClaudeConfigDirOverride: vi.fn().mockResolvedValue(null),
 }));
 
@@ -254,5 +255,74 @@ describe('Claude', () => {
       await expect(Claude.exec(['mcp', 'add-json', 'srv', withPercent], { shell: false }))
         .resolves.not.toThrow();
     });
+  });
+});
+
+// CLI equivalence (CLAUDE.md): a terminal user can point a project at a specific
+// claude binary, so the GUI must allow it too. `cliPath` therefore resolves through
+// the merged (global + project) settings for the active working directory.
+//
+// process.env and the resolved launcher are single shared slots on the backend, so
+// — exactly like CLAUDE_CONFIG_DIR before it (#123) — the value is projected when a
+// context LOADS rather than being cached per call site. applyConfigDir is that
+// load-time hook and already runs on every entry point, so the CLI path rides along.
+describe('Claude.applyConfigDir — per-project cliPath', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('projects the project-scoped cliPath onto Claude.command', async () => {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { cliPath: '/home/u/proj/.bin/claude' },
+      overrides: ['cliPath'],
+    });
+
+    await Claude.applyConfigDir('/home/u/proj');
+
+    expect(Claude.command).toBe('/home/u/proj/.bin/claude');
+    expect(readMergedSettings).toHaveBeenCalledWith('/home/u/proj');
+  });
+
+  it('falls back to the global cliPath when the project sets none', async () => {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { cliPath: '/usr/local/bin/claude' },
+      overrides: [],
+    });
+
+    await Claude.applyConfigDir('/home/u/other');
+
+    expect(Claude.command).toBe('/usr/local/bin/claude');
+  });
+
+  it('falls back to a bare "claude" when nothing is configured', async () => {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { cliPath: null },
+      overrides: [],
+    });
+
+    await Claude.applyConfigDir('/home/u/plain');
+
+    expect(Claude.command).toBe('claude');
+  });
+
+  it('drops a stale win32 launcher cache when the project changes the CLI', async () => {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { cliPath: '/a/claude' },
+      overrides: ['cliPath'],
+    });
+    await Claude.applyConfigDir('/proj-a');
+    await Claude.which(); // populates the win32 resolved-path cache
+
+    vi.mocked(readMergedSettings).mockResolvedValue({
+      settings: { cliPath: '/b/claude' },
+      overrides: ['cliPath'],
+    });
+    await Claude.applyConfigDir('/proj-b');
+
+    expect(Claude.command).toBe('/b/claude');
   });
 });

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -6,7 +6,7 @@ import {
   type SpawnOptions,
   type ExecFileOptions,
 } from 'child_process';
-import { readSettingsFile, resolveClaudeConfigDirOverride } from './features/settings';
+import { readMergedSettings, resolveClaudeConfigDirOverride } from './features/settings';
 import { getStrippableAuthEnvKeys } from './features/claude-settings';
 import { augmentedPath } from './augmented-path';
 import { resolveWslCwd } from './wsl-path';
@@ -27,10 +27,7 @@ export class Claude {
 
   /** Load cliPath from settings. Call at server start or on settings change. */
   static async refresh(workingDir?: string): Promise<void> {
-    const settings = await readSettingsFile();
-    Claude.cliPath = (settings.cliPath as string) || null;
     Claude.initialized = true;
-    Claude.resolvedWin32Path = null;
     await Claude.applyConfigDir(workingDir);
   }
 
@@ -49,6 +46,20 @@ export class Claude {
    * Priority: settings env (project > global) > inherited startup env > ~/.claude.
    */
   static async applyConfigDir(workingDir?: string): Promise<void> {
+    // `cliPath` rides along on the same load-time projection. A terminal user can
+    // point a project at a specific claude binary, so the GUI must allow it too
+    // (CLI equivalence, CLAUDE.md) — hence the merged read rather than the global
+    // file. Like process.env below, the resolved command is a single shared slot,
+    // so it is re-projected whenever a context loads instead of being cached per
+    // call site; that is what keeps a project-scoped value from leaking backend-wide.
+    const { settings } = await readMergedSettings(workingDir);
+    const nextCliPath = (settings.cliPath as string) || null;
+    if (nextCliPath !== Claude.cliPath) {
+      Claude.cliPath = nextCliPath;
+      // The win32 launcher cache was resolved from the previous binary.
+      Claude.resolvedWin32Path = null;
+    }
+
     const override = await resolveClaudeConfigDirOverride(workingDir);
     if (override) {
       process.env.CLAUDE_CONFIG_DIR = override;

--- a/backend/src/core/handlers/__tests__/openFile.test.ts
+++ b/backend/src/core/handlers/__tests__/openFile.test.ts
@@ -45,7 +45,7 @@ describe('openFileHandler — browser client routes to the IDE when one is attac
 
     await openFileHandler(connId, openFileMessage(), connections, browser, bridges);
 
-    expect(jetbrains.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5);
+    expect(jetbrains.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5, undefined);
     expect(browser.openFile).not.toHaveBeenCalled();
   });
 
@@ -57,7 +57,7 @@ describe('openFileHandler — browser client routes to the IDE when one is attac
 
     await openFileHandler(connId, openFileMessage(), connections, browser, bridges);
 
-    expect(browser.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5);
+    expect(browser.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5, undefined);
     expect(jetbrains.openFile).not.toHaveBeenCalled();
   });
 
@@ -70,7 +70,7 @@ describe('openFileHandler — browser client routes to the IDE when one is attac
     // For a JCEF connection the caller passes the JetBrains bridge as `bridge`.
     await openFileHandler(connId, openFileMessage(), connections, jetbrains, bridges);
 
-    expect(jetbrains.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5);
+    expect(jetbrains.openFile).toHaveBeenCalledWith('/abs/src/x.ts', 42, 5, undefined);
     expect(browser.openFile).not.toHaveBeenCalled();
   });
 

--- a/backend/src/core/handlers/__tests__/saveSettings.test.ts
+++ b/backend/src/core/handlers/__tests__/saveSettings.test.ts
@@ -22,9 +22,11 @@ function createMockConnections() {
   } as unknown as ConnectionManager;
 }
 
-/** A bridge stub that exposes pushHostMode, like JetBrainsBridge does. */
+/** A bridge stub that exposes the hostMode push, like JetBrainsBridge does. */
 function createJetBrainsBridge() {
-  return { pushHostMode: vi.fn() } as unknown as Bridge & { pushHostMode: (m: string) => void };
+  return { pushHostModeForProject: vi.fn() } as unknown as Bridge & {
+    pushHostModeForProject: (m: string, p?: string) => void;
+  };
 }
 
 describe('saveSettingsHandler hostMode push', () => {
@@ -46,7 +48,30 @@ describe('saveSettingsHandler hostMode push', () => {
     };
     await saveSettingsHandler('conn-1', message, connections, bridge);
 
-    expect(bridge.pushHostMode).toHaveBeenCalledWith('tool-window');
+    expect(bridge.pushHostModeForProject).toHaveBeenCalledWith('tool-window', undefined);
+  });
+
+  // A project-scoped save must be addressed to that project's IDE windows only,
+  // so the working directory is carried through to the push (issue #7).
+  it('carries the project path when hostMode is saved at project scope', async () => {
+    const connections = createMockConnections();
+    const bridge = createJetBrainsBridge();
+    vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'ok' });
+
+    const message: IPCMessage = {
+      type: MessageType.SAVE_SETTINGS,
+      payload: {
+        key: 'hostMode',
+        value: 'tool-window',
+        scope: 'project',
+        workingDir: '/home/u/proj',
+      },
+      timestamp: 0,
+      requestId: 'req-5',
+    };
+    await saveSettingsHandler('conn-1', message, connections, bridge);
+
+    expect(bridge.pushHostModeForProject).toHaveBeenCalledWith('tool-window', '/home/u/proj');
   });
 
   it('does not push when a non-hostMode setting is saved', async () => {
@@ -62,7 +87,7 @@ describe('saveSettingsHandler hostMode push', () => {
     };
     await saveSettingsHandler('conn-1', message, connections, bridge);
 
-    expect(bridge.pushHostMode).not.toHaveBeenCalled();
+    expect(bridge.pushHostModeForProject).not.toHaveBeenCalled();
   });
 
   it('does not push when the hostMode save fails', async () => {
@@ -78,12 +103,12 @@ describe('saveSettingsHandler hostMode push', () => {
     };
     await saveSettingsHandler('conn-1', message, connections, bridge);
 
-    expect(bridge.pushHostMode).not.toHaveBeenCalled();
+    expect(bridge.pushHostModeForProject).not.toHaveBeenCalled();
   });
 
-  it('is a no-op for a bridge without pushHostMode (browser mode)', async () => {
+  it('is a no-op for a bridge without the hostMode push (browser mode)', async () => {
     const connections = createMockConnections();
-    const browserBridge = {} as Bridge; // no pushHostMode
+    const browserBridge = {} as Bridge; // no pushHostModeForProject
     vi.mocked(saveSettingToScope).mockResolvedValue({ status: 'ok' });
 
     const message: IPCMessage = {
@@ -92,7 +117,7 @@ describe('saveSettingsHandler hostMode push', () => {
       timestamp: 0,
       requestId: 'req-4',
     };
-    // Must not throw even though the bridge lacks pushHostMode.
+    // Must not throw even though the bridge lacks pushHostModeForProject.
     await expect(
       saveSettingsHandler('conn-1', message, connections, browserBridge),
     ).resolves.toBeUndefined();

--- a/backend/src/core/handlers/openFile.ts
+++ b/backend/src/core/handlers/openFile.ts
@@ -18,6 +18,9 @@ export async function openFileHandler(
   const rawColumn = message.payload?.column;
   const line = typeof rawLine === 'number' ? rawLine : undefined;
   const column = typeof rawColumn === 'number' ? rawColumn : undefined;
+  // The project this open came from, so "open files with" resolves per project.
+  const rawWorkingDir = message.payload?.workingDir;
+  const workingDir = typeof rawWorkingDir === 'string' ? rawWorkingDir : undefined;
 
   if (filePath) {
     // Fail fast with feedback when the target does not exist: a clicked reference
@@ -34,6 +37,7 @@ export async function openFileHandler(
         filePath,
         line,
         column,
+        workingDir,
       );
     } catch (err) {
       console.error('[node-backend]', 'Failed to open file:', err);

--- a/backend/src/core/handlers/saveSettings.ts
+++ b/backend/src/core/handlers/saveSettings.ts
@@ -18,17 +18,24 @@ export async function saveSettingsHandler(
 
   const result = await saveSettingToScope(key, value, scope, workingDir);
 
+  // Re-resolve against the scope that was just written, so a project-scoped CLI
+  // path takes effect for that project instead of re-reading only the global one.
   if (result.status === 'ok' && key === 'cliPath') {
-    await Claude.refresh();
+    await Claude.refresh(workingDir);
   }
 
   // Push the new hostMode to the IDE so Kotlin's cache stays in sync and chat windows
   // route to the chosen host immediately. The backend owns settings; Kotlin no longer
   // reads the file for hostMode (it diverges from the JVM home on WSL2 — issue #7).
-  // Only the JetBrains bridge exposes pushHostMode; browser mode has no IDE to notify.
+  // Only the JetBrains bridge exposes the push; browser mode has no IDE to notify.
+  //
+  // Scope matters: a project-scoped save is addressed to the windows serving that
+  // project only. Broadcasting it would flip the chat host in unrelated projects.
   if (result.status === 'ok' && key === 'hostMode' && typeof value === 'string') {
-    const pushable = bridge as Bridge & { pushHostMode?: (hostMode: string) => void };
-    pushable.pushHostMode?.(value);
+    const pushable = bridge as Bridge & {
+      pushHostModeForProject?: (hostMode: string, projectPath?: string) => void;
+    };
+    pushable.pushHostModeForProject?.(value, scope === 'project' ? workingDir : undefined);
   }
 
   // Broadcast merged settings after save

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/NodeProcessManager.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.application.ApplicationNamesInfo
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.EnvironmentUtil
+import com.github.yhk1038.claudecodegui.settings.ProjectSettingsReader
 import com.github.yhk1038.claudecodegui.settings.SettingsManager
 import com.github.yhk1038.claudecodegui.toolwindow.realization.LoadingPhase
 import kotlinx.coroutines.*
@@ -46,6 +47,13 @@ class NodeProcessManager(
     private val wslDistro: String? = null,
     /** Linux working directory inside [wslDistro] (the project root's `/home/...` path). */
     private val wslCwd: String? = null,
+    /**
+     * The IDE project root this backend serves. Used to resolve a project-scoped
+     * `nodePath` before the backend (the usual source of truth) exists to be asked —
+     * see [findNodeExecutable] and ProjectSettingsReader. Null = no project context,
+     * in which case only the global setting applies.
+     */
+    private val projectRoot: String? = null,
     /**
      * Invoked as [start] advances through its blocking sub-steps (node discovery,
      * shell-PATH capture, resource extraction, waiting for the PORT line) so the panel
@@ -490,14 +498,18 @@ class NodeProcessManager(
      */
     private fun findNodeExecutable(): String? {
         // 0. User-configured override from settings (highest priority — #22).
-        //    Read straight from ~/.claude-code-gui/settings.js: this runs BEFORE the
-        //    backend is spawned, so we can't ask the backend. SettingsManager reads
-        //    the file synchronously and findNodeExecutable already runs off the EDT.
+        //    Read straight from the settings files: this runs BEFORE the backend is
+        //    spawned, so we can't ask the backend. Both reads are synchronous and
+        //    findNodeExecutable already runs off the EDT.
         //    Lets users on `n`/`nvm` pin an exact node when PATH holds an incompatible
         //    one, and provides a recovery path that survives a non-bootable backend.
-        NodeExecutableResolver.normalizeConfiguredNodePath(
-            SettingsManager.getInstance().get("nodePath")?.jsonPrimitive?.contentOrNull
-        )?.let { configured ->
+        //
+        //    Project scope wins over global, matching the backend's merge order: a
+        //    terminal user can pin a project to one node (`.nvmrc` and friends), so
+        //    the GUI must allow the same (CLI equivalence, CLAUDE.md — issue #7).
+        val configuredNodePath = ProjectSettingsReader.read(projectRoot, "nodePath")
+            ?: SettingsManager.getInstance().get("nodePath")?.jsonPrimitive?.contentOrNull
+        NodeExecutableResolver.normalizeConfiguredNodePath(configuredNodePath)?.let { configured ->
             val file = File(configured)
             if (file.exists() && file.canExecute()) {
                 logger.info("Found node via settings nodePath: $configured")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/NodeBackendService.kt
@@ -240,6 +240,9 @@ class NodeBackendService : Disposable {
                 requestedPort = lastPort,
                 wslDistro = wsl?.distro,
                 wslCwd = wsl?.linuxPath,
+                // So a project-scoped `nodePath` is honoured when picking the node
+                // that launches this backend (issue #7).
+                projectRoot = basePath,
                 onProgress = ::emitProgress,
                 // Unified restart signal: when the backend self-exits with RESTART_EXIT_CODE
                 // (and not via dispose), respawn it on the same port. restart() is

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/ProjectSettingsReader.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/ProjectSettingsReader.kt
@@ -1,0 +1,52 @@
+package com.github.yhk1038.claudecodegui.settings
+
+import com.intellij.openapi.diagnostic.Logger
+import kotlinx.serialization.json.*
+import java.io.File
+
+/**
+ * Reads a single value out of a project's own settings file
+ * (`<project>/.claude-code-gui/settings.json`, plain JSON — the same file the Node
+ * backend writes for project scope).
+ *
+ * **Why the IDE reads this at all.** The backend is the single source of truth for
+ * settings (CLAUDE.md), so the IDE normally asks it. `nodePath` is the one exception:
+ * it decides which `node` *launches* that backend, so it must be resolved before any
+ * backend exists to ask (#22). Honouring the project scope for it therefore requires
+ * the IDE to look at the project file directly.
+ *
+ * Keep this narrow. It is a single-key lookup with no merge policy of its own — the
+ * caller falls back to the global value when this returns null — precisely so the
+ * backend's merge rules are not duplicated on the Kotlin side.
+ */
+object ProjectSettingsReader {
+
+    private val logger = Logger.getInstance(ProjectSettingsReader::class.java)
+
+    private val lenientJson = Json {
+        isLenient = true
+        ignoreUnknownKeys = true
+    }
+
+    /**
+     * The string value of [key] in [projectPath]'s settings file, or null when the
+     * project sets nothing (no file, no key, JSON null, or a non-string value).
+     *
+     * Never throws: a corrupt project file must not stop the backend from launching —
+     * the caller simply falls back to the global setting.
+     */
+    fun read(projectPath: String?, key: String): String? {
+        if (projectPath.isNullOrBlank()) return null
+
+        val file = File(File(projectPath, ".claude-code-gui"), "settings.json")
+        if (!file.isFile) return null
+
+        return try {
+            val root = lenientJson.parseToJsonElement(file.readText()) as? JsonObject ?: return null
+            (root[key] as? JsonPrimitive)?.takeIf { it.isString }?.content?.takeIf { it.isNotBlank() }
+        } catch (e: Exception) {
+            logger.warn("Ignoring unreadable project settings: ${file.absolutePath}", e)
+            null
+        }
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsManager.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsManager.kt
@@ -47,17 +47,7 @@ class SettingsManager {
     )
 
     /** 기본값 맵 (순서 보존) */
-    private val defaults: LinkedHashMap<String, JsonElement> = linkedMapOf(
-        "cliPath" to JsonNull,
-        "nodePath" to JsonNull,
-        "theme" to JsonPrimitive("system"),
-        "fontSize" to JsonPrimitive(13),
-        "lineHeight" to JsonPrimitive(1.6),
-        "debugMode" to JsonPrimitive(false),
-        "logLevel" to JsonPrimitive("info"),
-        "terminalApp" to JsonNull,
-        "hostMode" to JsonPrimitive("editor-tab")
-    )
+    private val defaults: LinkedHashMap<String, JsonElement> get() = LinkedHashMap(DEFAULTS)
 
     /**
      * 설정 파일이 없으면 기본값으로 생성하고, 설정을 로드한다.
@@ -102,7 +92,7 @@ class SettingsManager {
      * @return 저장 성공 여부
      */
     fun save(): Boolean = synchronized(lock) {
-        saveInternal()
+        saveInternal(emptyMap())
     }
 
     /**
@@ -122,8 +112,7 @@ class SettingsManager {
      * @return 저장 성공 여부
      */
     fun set(key: String, value: JsonElement): Boolean = synchronized(lock) {
-        cachedSettings[key] = value
-        saveInternal()
+        saveInternal(mapOf(key to value))
     }
 
     /**
@@ -133,8 +122,7 @@ class SettingsManager {
      * @return 저장 성공 여부
      */
     fun setAll(entries: Map<String, JsonElement>): Boolean = synchronized(lock) {
-        entries.forEach { (k, v) -> cachedSettings[k] = v }
-        saveInternal()
+        saveInternal(entries)
     }
 
     /**
@@ -198,15 +186,43 @@ class SettingsManager {
     }
 
     /**
-     * 현재 캐시를 파일에 저장하는 내부 구현.
+     * [edits]를 디스크의 현재 내용 위에 얹어 저장하는 내부 구현.
      * lock 내부에서만 호출되므로 자체 동기화 없음.
+     *
+     * 백엔드가 설정의 유일 진실원이므로(CLAUDE.md), **인메모리 캐시를 그대로 직렬화하지
+     * 않고 디스크를 먼저 읽어 그 위에 변경분만 얹는다.** 캐시만 믿고 파일을 통째로 새로
+     * 쓰면 이 클래스가 선언하지 않은 백엔드 전용 키 14개(`hostMode`, `openSettingsAs`,
+     * `uiLanguage` 등)가 전부 사라진다. 사용자가 IDE 설정 화면(Settings → Tools →
+     * Claude Code)에서 CLI Path 하나만 저장해도 "Sidebar" 선택이 조용히 "editor-tab"으로
+     * 되돌아가던 원인이다(이슈 #7).
+     *
+     * 파일이 존재하는데 파싱에 실패하면 **저장을 거부한다.** 안에 무엇이 들어 있는지
+     * 모르는 채로 기본값을 덮어쓰면 사용자 설정이 영구 소실되기 때문이다. 저장 실패는
+     * 호출자에게 false로 전달되어 표면화된다.
      */
-    private fun saveInternal(): Boolean {
+    private fun saveInternal(edits: Map<String, JsonElement>): Boolean {
         return try {
             settingsDir.toFile().mkdirs()  // 안전장치
-            val content = JsSettingsParser.generate(cachedSettings, commentMap)
-            settingsFile.writeText(content)
+
+            val onDisk: Map<String, JsonElement> = if (settingsFile.exists()) {
+                try {
+                    JsSettingsParser.parse(settingsFile.readText())
+                } catch (e: Exception) {
+                    logger.error(
+                        "Refusing to overwrite unparseable settings file: ${settingsFile.absolutePath}",
+                        e
+                    )
+                    return false
+                }
+            } else {
+                emptyMap()
+            }
+
+            val merged = mergeForWrite(onDisk, edits)
+            settingsFile.writeText(JsSettingsParser.generate(merged, commentMap))
+            cachedSettings = LinkedHashMap(merged)
             lastModified = settingsFile.lastModified()
+            isLoaded = true
             true
         } catch (e: Exception) {
             logger.error("Failed to save settings", e)
@@ -228,5 +244,40 @@ class SettingsManager {
 
     companion object {
         fun getInstance(): SettingsManager = service()
+
+        /**
+         * IDE 쪽이 아는 설정 키의 기본값. 백엔드의 `DEFAULT_SETTINGS`(23개)와 달리
+         * 여기에는 이 플러그인의 설정 화면이 편집하는 키만 있다. **이 목록이 파일에
+         * 쓸 키의 전체 집합이 아니라는 점이 핵심이다** — 나머지는 디스크에서 읽어
+         * 보존한다. [mergeForWrite] 참조.
+         */
+        private val DEFAULTS: LinkedHashMap<String, JsonElement> = linkedMapOf(
+            "cliPath" to JsonNull,
+            "nodePath" to JsonNull,
+            "theme" to JsonPrimitive("system"),
+            "fontSize" to JsonPrimitive(13),
+            "lineHeight" to JsonPrimitive(1.6),
+            "debugMode" to JsonPrimitive(false),
+            "logLevel" to JsonPrimitive("info"),
+            "terminalApp" to JsonNull,
+            "hostMode" to JsonPrimitive("editor-tab")
+        )
+
+        /**
+         * 파일에 쓸 최종 맵을 만든다: `IDE 기본값 < 디스크의 현재 값 < 이번 변경분`.
+         *
+         * 디스크 값이 기본값을 이기므로 이 클래스가 모르는 백엔드 전용 키가 그대로
+         * 살아남고, 변경분이 마지막이므로 사용자가 방금 고친 값이 반영된다. 순수 함수라
+         * IntelliJ 서비스 컨테이너 없이 단위 테스트할 수 있다(SettingsFileMergeTest).
+         */
+        fun mergeForWrite(
+            onDisk: Map<String, JsonElement>,
+            edits: Map<String, JsonElement>,
+        ): LinkedHashMap<String, JsonElement> {
+            val merged = LinkedHashMap(DEFAULTS)
+            merged.putAll(onDisk)
+            merged.putAll(edits)
+            return merged
+        }
     }
 }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/ProjectSettingsReaderTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/ProjectSettingsReaderTest.kt
@@ -1,0 +1,78 @@
+package com.github.yhk1038.claudecodegui.settings
+
+import kotlinx.serialization.json.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * The IDE reads `nodePath` itself, before any backend exists to ask (#22). To honour
+ * the project scope it therefore has to look at the project's own settings file the
+ * same way the backend's `readMergedSettings` does — project value wins, global is
+ * the fallback.
+ *
+ * This is deliberately the ONLY settings key the IDE resolves per project: every
+ * other consumer runs after the backend is up and asks it instead (CLAUDE.md — the
+ * backend is the single source of truth).
+ */
+class ProjectSettingsReaderTest {
+
+    @TempDir
+    lateinit var tmp: Path
+
+    private fun writeProjectSettings(projectRoot: Path, json: String) {
+        val dir = projectRoot.resolve(".claude-code-gui")
+        Files.createDirectories(dir)
+        Files.writeString(dir.resolve("settings.json"), json)
+    }
+
+    @Test
+    fun `reads a value from the project settings file`() {
+        writeProjectSettings(tmp, """{ "nodePath": "/proj/.bin/node" }""")
+
+        val value = ProjectSettingsReader.read(tmp.toString(), "nodePath")
+
+        assertEquals("/proj/.bin/node", value)
+    }
+
+    @Test
+    fun `returns null when the project sets nothing, so the caller falls back to global`() {
+        writeProjectSettings(tmp, """{ "cliPath": "/proj/.bin/claude" }""")
+
+        assertNull(ProjectSettingsReader.read(tmp.toString(), "nodePath"))
+    }
+
+    @Test
+    fun `returns null when the project has no settings file at all`() {
+        assertNull(ProjectSettingsReader.read(tmp.toString(), "nodePath"))
+    }
+
+    @Test
+    fun `returns null for a blank or missing project path`() {
+        assertNull(ProjectSettingsReader.read(null, "nodePath"))
+        assertNull(ProjectSettingsReader.read("", "nodePath"))
+    }
+
+    @Test
+    fun `a corrupt project file is ignored rather than crashing the backend launch`() {
+        writeProjectSettings(tmp, "{ this is not json")
+
+        assertNull(ProjectSettingsReader.read(tmp.toString(), "nodePath"))
+    }
+
+    @Test
+    fun `a JSON null is treated as unset`() {
+        writeProjectSettings(tmp, """{ "nodePath": null }""")
+
+        assertNull(ProjectSettingsReader.read(tmp.toString(), "nodePath"))
+    }
+
+    @Test
+    fun `a non-string value is ignored`() {
+        writeProjectSettings(tmp, """{ "nodePath": 42 }""")
+
+        assertNull(ProjectSettingsReader.read(tmp.toString(), "nodePath"))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsFileMergeTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/settings/SettingsFileMergeTest.kt
@@ -1,0 +1,100 @@
+package com.github.yhk1038.claudecodegui.settings
+
+import kotlinx.serialization.json.*
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+/**
+ * Regression guard for issue #7: an IDE-side settings write must not erase keys the
+ * IDE does not know about.
+ *
+ * The Node backend owns the settings schema (23 keys). [SettingsManager] declares
+ * only the 9 its own Settings dialog edits. Serializing a write from the IDE's map
+ * alone therefore drops every backend-only key — `hostMode` among them — silently
+ * resetting a user's "Sidebar" choice to "editor-tab" the moment they save a CLI
+ * path from Settings → Tools → Claude Code.
+ *
+ * [SettingsManager.mergeForWrite] is the seam that fixes this: it folds the pending
+ * edits onto whatever is already on disk. These tests pin that contract without
+ * needing the IntelliJ service container.
+ */
+class SettingsFileMergeTest {
+
+    /** A settings.js as the Node backend writes it — carries backend-only keys. */
+    private val backendWritten = """
+        // ~/.claude-code-gui/settings.js
+        export default {
+          cliPath: null,
+          hostMode: "tool-window",
+          openSettingsAs: "overlay",
+          uiLanguage: "korean",
+          autoResumeOnLimit: true,
+        };
+    """.trimIndent()
+
+    @Test
+    fun `edits fold onto the on-disk values instead of replacing them`() {
+        val onDisk = JsSettingsParser.parse(backendWritten)
+
+        val merged = SettingsManager.mergeForWrite(
+            onDisk = onDisk,
+            edits = mapOf("cliPath" to JsonPrimitive("/usr/local/bin/claude")),
+        )
+
+        // The edit landed.
+        assertEquals(JsonPrimitive("/usr/local/bin/claude"), merged["cliPath"])
+        // Every backend-only key survived.
+        assertEquals(JsonPrimitive("tool-window"), merged["hostMode"])
+        assertEquals(JsonPrimitive("overlay"), merged["openSettingsAs"])
+        assertEquals(JsonPrimitive("korean"), merged["uiLanguage"])
+        assertEquals(JsonPrimitive(true), merged["autoResumeOnLimit"])
+    }
+
+    @Test
+    fun `a full write-out round-trip keeps every backend-only key`() {
+        val onDisk = JsSettingsParser.parse(backendWritten)
+        val merged = SettingsManager.mergeForWrite(
+            onDisk = onDisk,
+            edits = mapOf("nodePath" to JsonPrimitive("/usr/local/bin/node")),
+        )
+
+        val reparsed = JsSettingsParser.parse(JsSettingsParser.generate(merged, emptyMap()))
+
+        assertEquals(JsonPrimitive("/usr/local/bin/node"), reparsed["nodePath"])
+        assertEquals(JsonPrimitive("tool-window"), reparsed["hostMode"])
+        assertEquals(JsonPrimitive("korean"), reparsed["uiLanguage"])
+    }
+
+    @Test
+    fun `keys missing from disk fall back to defaults, never dropped`() {
+        // A file written by an older build that predates a key still yields that key,
+        // so generate() does not emit a file with holes in it.
+        val onDisk = JsSettingsParser.parse("""export default { hostMode: "tool-window" };""")
+
+        val merged = SettingsManager.mergeForWrite(onDisk = onDisk, edits = emptyMap())
+
+        assertEquals(JsonPrimitive("tool-window"), merged["hostMode"])
+        assertTrue(merged.containsKey("theme"))
+        assertTrue(merged.containsKey("fontSize"))
+    }
+
+    @Test
+    fun `an empty disk map yields the IDE defaults`() {
+        val merged = SettingsManager.mergeForWrite(onDisk = emptyMap(), edits = emptyMap())
+
+        assertEquals(JsonPrimitive("editor-tab"), merged["hostMode"])
+        assertEquals(JsonPrimitive("system"), merged["theme"])
+    }
+
+    @Test
+    fun `edits win over both disk and defaults`() {
+        val onDisk = JsSettingsParser.parse("""export default { theme: "dark" };""")
+
+        val merged = SettingsManager.mergeForWrite(
+            onDisk = onDisk,
+            edits = mapOf("theme" to JsonPrimitive("light")),
+        )
+
+        assertEquals(JsonPrimitive("light"), merged["theme"])
+    }
+}

--- a/webview/src/adapters/BrowserAdapter.ts
+++ b/webview/src/adapters/BrowserAdapter.ts
@@ -3,6 +3,7 @@ import type { IdeAdapter } from './IdeAdapter';
 import { getBridge } from '../api/bridge/Bridge';
 import { assertFileOpened } from './openFileResult';
 import { Route, routeToPath } from '../router';
+import { readWorkingDirFromUrl } from '@/contexts/workingDirParam';
 
 /**
  * Browser Adapter
@@ -60,7 +61,16 @@ export class BrowserAdapter implements IdeAdapter {
   }
 
   async openFile(filePath: string, line?: number, column?: number): Promise<void> {
-    const res = await getBridge().request(MessageType.OPEN_FILE, { filePath, line, column });
+    // Carry the project so the backend can resolve "open files with" per project
+    // (issue #7). Read from the URL: openFile is called from many renderers that
+    // do not thread the working directory down.
+    const workingDir = readWorkingDirFromUrl();
+    const res = await getBridge().request(MessageType.OPEN_FILE, {
+      filePath,
+      line,
+      column,
+      workingDir,
+    });
     assertFileOpened(res, filePath);
     console.log('[BrowserAdapter] Sent OPEN_FILE request:', filePath, line ?? '');
   }

--- a/webview/src/adapters/JetBrainsAdapter.ts
+++ b/webview/src/adapters/JetBrainsAdapter.ts
@@ -3,6 +3,7 @@ import type { IdeAdapter } from './IdeAdapter';
 import { getBridge } from '../api/bridge/Bridge';
 import { assertFileOpened } from './openFileResult';
 import { type Route, routeToPath } from '../router';
+import { readWorkingDirFromUrl } from '@/contexts/workingDirParam';
 
 /**
  * JetBrains IDE Adapter
@@ -36,7 +37,16 @@ export class JetBrainsAdapter implements IdeAdapter {
   }
 
   async openFile(filePath: string, line?: number, column?: number): Promise<void> {
-    const res = await getBridge().request(MessageType.OPEN_FILE, { filePath, line, column });
+    // Carry the project so the backend can resolve "open files with" per project
+    // (issue #7). Read from the URL: openFile is called from many renderers that
+    // do not thread the working directory down.
+    const workingDir = readWorkingDirFromUrl();
+    const res = await getBridge().request(MessageType.OPEN_FILE, {
+      filePath,
+      line,
+      column,
+      workingDir,
+    });
     assertFileOpened(res, filePath);
     console.log('[JetBrainsAdapter] Sent OPEN_FILE via WebSocket bridge:', filePath, line ?? '');
   }

--- a/webview/src/contexts/WorkingDirContext.tsx
+++ b/webview/src/contexts/WorkingDirContext.tsx
@@ -4,6 +4,7 @@ import { useBridgeContext } from '@/contexts/BridgeContext';
 import { useApi } from '@/contexts/ApiContext';
 import { Route, routeToPath, withWorkingDir } from '@/router/routes';
 import { MessageType } from '@/shared';
+import { WORKING_DIR_PARAM_KEY } from './workingDirParam';
 
 interface WorkingDirContextValue {
   workingDirectory: string | null;
@@ -23,7 +24,7 @@ interface Props {
   children: ReactNode;
 }
 
-export const WORKING_DIR_PARAM_KEY = 'workingDir';
+export { WORKING_DIR_PARAM_KEY, readWorkingDirFromUrl } from './workingDirParam';
 
 export function WorkingDirProvider(props: Props) {
   const { children } = props;

--- a/webview/src/contexts/workingDirParam.ts
+++ b/webview/src/contexts/workingDirParam.ts
@@ -1,0 +1,23 @@
+/**
+ * The `workingDir` URL parameter, isolated from the React context that consumes it.
+ *
+ * The bridge adapters need the active project to tell the backend which project an
+ * `openFile` belongs to, so per-project settings apply (issue #7). They run outside
+ * React and so cannot use `useWorkingDir` — and importing WorkingDirContext from an
+ * adapter drags the whole context module (and its api/bridge imports) into a cycle
+ * that breaks module init. Keeping the parameter name and the URL read here, with no
+ * imports of its own, lets both sides share one definition safely.
+ */
+
+export const WORKING_DIR_PARAM_KEY = 'workingDir';
+
+/**
+ * The current working directory read straight off the URL, or undefined when there
+ * is none (the project selector). Applies the same trailing-slash normalization the
+ * provider does, so the value matches the `projectPath` the backend indexes by.
+ */
+export function readWorkingDirFromUrl(): string | undefined {
+  const raw = new URLSearchParams(window.location.search).get(WORKING_DIR_PARAM_KEY);
+  if (!raw) return undefined;
+  return raw.replace(/\/+$/, '') || raw;
+}

--- a/webview/src/pages/SettingsPage/Cli/index.tsx
+++ b/webview/src/pages/SettingsPage/Cli/index.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { SettingSection, SettingRow, ScopeGuard } from '../common';
+import { SettingSection, SettingRow } from '../common';
 import { Select, type SelectOption } from '@/components/Select';
 import { useSettings } from '@/contexts/SettingsContext';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
@@ -33,7 +33,7 @@ function toSelectValue(app: string | null, terminals: TerminalInfo[]): string {
 
 export function CliSettings() {
   const { t } = useTranslation('settings');
-  const { settings, updateSetting, scope } = useSettings();
+  const { settings, updateSetting } = useSettings();
   const { send } = useBridge();
   const isJetBrainsEnv = isJetBrains();
   const { settings: claudeSettings, updateSetting: updateClaudeSetting } = useClaudeSettings();
@@ -127,49 +127,45 @@ export function CliSettings() {
     <div>
       <h2 className="text-xl font-semibold text-text-primary mb-6">{t('nav.cli')}</h2>
 
-      <ScopeGuard supportedScope="global" currentScope={scope}>
-        <SettingSection title={t('cli.openFilesWith.title')}>
-          <OpenFilesWithRow />
-        </SettingSection>
-      </ScopeGuard>
+      <SettingSection title={t('cli.openFilesWith.title')}>
+        <OpenFilesWithRow />
+      </SettingSection>
 
-      <ScopeGuard supportedScope="global" currentScope={scope}>
-        <SettingSection title={t('cli.terminal.title')}>
-          <SettingRow
-            label={t('cli.terminal.app.label')}
-            description={
-              isJetBrainsEnv
-                ? t('cli.terminal.app.jetbrainsDescription')
-                : t('cli.terminal.app.description')
-            }
-          >
-            {isJetBrainsEnv ? (
-              <span className="text-sm text-text-tertiary">{t('cli.terminal.app.jetbrainsValue')}</span>
-            ) : loading ? (
-              <span className="text-sm text-text-tertiary">{t('cli.terminal.app.detecting')}</span>
-            ) : (
-              <div className="flex items-center gap-2">
-                <Select
-                  value={selectValue}
-                  options={terminalOptions}
-                  ariaLabel={t('cli.terminal.app.label')}
-                  onChange={handleSelectChange}
-                  className="bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary"
+      <SettingSection title={t('cli.terminal.title')}>
+        <SettingRow
+          label={t('cli.terminal.app.label')}
+          description={
+            isJetBrainsEnv
+              ? t('cli.terminal.app.jetbrainsDescription')
+              : t('cli.terminal.app.description')
+          }
+        >
+          {isJetBrainsEnv ? (
+            <span className="text-sm text-text-tertiary">{t('cli.terminal.app.jetbrainsValue')}</span>
+          ) : loading ? (
+            <span className="text-sm text-text-tertiary">{t('cli.terminal.app.detecting')}</span>
+          ) : (
+            <div className="flex items-center gap-2">
+              <Select
+                value={selectValue}
+                options={terminalOptions}
+                ariaLabel={t('cli.terminal.app.label')}
+                onChange={handleSelectChange}
+                className="bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary"
+              />
+              {selectValue === CUSTOM_MARKER && (
+                <input
+                  type="text"
+                  value={customInput}
+                  onChange={(e) => handleCustomInput(e.target.value)}
+                  placeholder={t('cli.terminal.app.customPlaceholder')}
+                  className="w-40 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
                 />
-                {selectValue === CUSTOM_MARKER && (
-                  <input
-                    type="text"
-                    value={customInput}
-                    onChange={(e) => handleCustomInput(e.target.value)}
-                    placeholder={t('cli.terminal.app.customPlaceholder')}
-                    className="w-40 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
-                  />
-                )}
-              </div>
-            )}
-          </SettingRow>
-        </SettingSection>
-      </ScopeGuard>
+              )}
+            </div>
+          )}
+        </SettingRow>
+      </SettingSection>
 
       <SettingSection title={t('cli.model.title')}>
         <SettingRow
@@ -192,51 +188,49 @@ export function CliSettings() {
         </SettingRow>
       </SettingSection>
 
-      <ScopeGuard supportedScope="global" currentScope={scope}>
-        <SettingSection title={t('cli.path.title')}>
-          <SettingRow
-            label={t('cli.path.label')}
-            description={t('cli.path.description')}
-          >
-            <div className="flex flex-col items-end gap-1">
-              <input
-                type="text"
-                value={settings[SettingKey.CLI_PATH] || ''}
-                onChange={(e) => updateSetting(SettingKey.CLI_PATH, e.target.value || null)}
-                placeholder={t('cli.path.placeholder')}
-                className="w-64 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
-              />
-              {detectedCliPath && !settings[SettingKey.CLI_PATH] && (
-                <span className="text-xs text-text-tertiary truncate max-w-64" title={detectedCliPath}>
-                  {detectedCliPath}
-                </span>
-              )}
-            </div>
-          </SettingRow>
-        </SettingSection>
+      <SettingSection title={t('cli.path.title')}>
+        <SettingRow
+          label={t('cli.path.label')}
+          description={t('cli.path.description')}
+        >
+          <div className="flex flex-col items-end gap-1">
+            <input
+              type="text"
+              value={settings[SettingKey.CLI_PATH] || ''}
+              onChange={(e) => updateSetting(SettingKey.CLI_PATH, e.target.value || null)}
+              placeholder={t('cli.path.placeholder')}
+              className="w-64 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
+            />
+            {detectedCliPath && !settings[SettingKey.CLI_PATH] && (
+              <span className="text-xs text-text-tertiary truncate max-w-64" title={detectedCliPath}>
+                {detectedCliPath}
+              </span>
+            )}
+          </div>
+        </SettingRow>
+      </SettingSection>
 
-        <SettingSection title={t('cli.nodePath.title')}>
-          <SettingRow
-            label={t('cli.nodePath.label')}
-            description={t('cli.nodePath.description')}
-          >
-            <div className="flex flex-col items-end gap-1">
-              <input
-                type="text"
-                value={settings[SettingKey.NODE_PATH] || ''}
-                onChange={(e) => updateSetting(SettingKey.NODE_PATH, e.target.value || null)}
-                placeholder={t('cli.nodePath.placeholder')}
-                className="w-64 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
-              />
-              {detectedNodePath && !settings[SettingKey.NODE_PATH] && (
-                <span className="text-xs text-text-tertiary truncate max-w-64" title={detectedNodePath}>
-                  {detectedNodePath}
-                </span>
-              )}
-            </div>
-          </SettingRow>
-        </SettingSection>
-      </ScopeGuard>
+      <SettingSection title={t('cli.nodePath.title')}>
+        <SettingRow
+          label={t('cli.nodePath.label')}
+          description={t('cli.nodePath.description')}
+        >
+          <div className="flex flex-col items-end gap-1">
+            <input
+              type="text"
+              value={settings[SettingKey.NODE_PATH] || ''}
+              onChange={(e) => updateSetting(SettingKey.NODE_PATH, e.target.value || null)}
+              placeholder={t('cli.nodePath.placeholder')}
+              className="w-64 bg-surface-overlay border border-border-default rounded-lg px-3 py-1.5 text-sm text-text-primary placeholder-text-tertiary"
+            />
+            {detectedNodePath && !settings[SettingKey.NODE_PATH] && (
+              <span className="text-xs text-text-tertiary truncate max-w-64" title={detectedNodePath}>
+                {detectedNodePath}
+              </span>
+            )}
+          </div>
+        </SettingRow>
+      </SettingSection>
     </div>
   );
 }


### PR DESCRIPTION
## Problem

Five settings were locked to a single machine-wide value — **Claude CLI path, Node.js path, terminal app, "open files with", and its custom command**. The Settings screen greyed them out on the **Project** tab with an "Only available as a global setting" tooltip.

Nothing about them requires global scope. Each consumer simply called `readSettingsFile()` (the global file) and never looked at the project's own, so a value written to a project's `settings.json` saved "successfully" and then did nothing. A terminal user has always been free to point one project at a different `node` (`.nvmrc` and friends) or a different `claude` binary, so the GUI must allow the same — CLI equivalence is this project's baseline.

Two related defects surfaced while tracing that:

- **Preferred Location (`hostMode`) accepted a per-project value that never took effect.** An IDE announces which project roots it serves *after* the RPC socket is up, so the connect-time push could only ever carry the global value.
- **A project-scoped `hostMode` save was broadcast to every IDE window**, flipping the chat host in unrelated projects — the "my setting changed by itself" symptom reported in #7.
- **`SettingsManager.saveInternal` rewrote the settings file from the 9 keys the IDE knows**, discarding the other 14 (`hostMode`, `openSettingsAs`, `uiLanguage`, …). Saving a CLI path from *Settings → Tools → Claude Code* silently reset the user's sidebar choice, interface language, chat pagination, and more, with no warning. On WSL2 it also wrote to the Windows home while the backend read the Linux one.

## Fix

**Per-project resolution.** Each consumer now reads `readMergedSettings(workingDir)`:

| Setting | How |
|---|---|
| terminal app, open-files-with, custom command | Resolved per call in `browser-bridge`. `openTerminal` already receives the working directory; `openFile` gains a `workingDir` argument, supplied by the adapters from the URL (its 20+ call sites in renderers do not thread it down). |
| `cliPath` | `Claude.cliPath` is a **static field shared by every project this backend serves**, so a naive per-call read would leak across projects. It is re-projected on context load in `applyConfigDir` — the same escape hatch `CLAUDE_CONFIG_DIR` uses (#123) — and the win32 launcher cache is invalidated when it changes. |
| `nodePath` | Decides which `node` **launches** the backend, so it cannot be resolved by asking the backend (circular). `ProjectSettingsReader` gives the IDE a narrow, read-only, single-key lookup into the project file, with no merge policy of its own. Deliberately the only settings key the IDE resolves on its own; every other consumer still asks the backend. |

**Preferred Location.** The merged value is re-pushed as soon as `REGISTER_PROJECT_ROOTS` arrives, and `pushHostModeForProject` addresses only the sockets serving that project (all clients when the save was global).

**IDE-side writes.** `saveInternal` reads the file first and folds the pending edits onto it (`mergeForWrite`), leaving unknown keys intact. When the file exists but cannot be parsed, the save is **refused** rather than replacing content of unknown value with defaults — a failed save is recoverable, a silently erased one is not.

The three `<ScopeGuard supportedScope="global">` wrappers in Settings → CLI are removed, so the Project tab now accepts these settings. The component itself is kept for future use.

## Tests

TDD throughout — each change landed on a failing test first.

- `ProjectSettingsReaderTest` (7): project value wins, null/missing/blank/corrupt/non-string all fall back to global without throwing, so a bad project file never blocks backend launch.
- `SettingsFileMergeTest` (5): backend-only keys survive an IDE write; edits win over disk, disk wins over IDE defaults.
- `jetbrains-bridge.test` (+3): merged re-push on roots announcement, no re-push when roots are empty, project-targeted vs. broadcast push.
- `claude.test` (+4): project `cliPath` projection, global fallback, bare-`claude` fallback, stale win32 launcher cache dropped.
- `browser-bridge-open-file.test` (+2), `saveSettings.test` (+1): per-project lookups are scoped to the right project.

All three layers pass: backend 1044, webview 1739 (198 files), Kotlin green, `full-build` clean, both `tsc --noEmit` clean.

## Notes

- **No behaviour change for existing users.** A project that sets nothing keeps using the global value.
- Path joins use `path.join()` / `File(parent, child)` throughout, so WSL2 UNC roots and Windows separators are handled by the platform rather than by string concatenation.
- One trap worth recording: importing `WorkingDirContext` from an adapter pulls `api/bridge` into a module cycle and breaks init (`Right-hand side of 'instanceof' is not an object`, 9 webview suites down). The URL parameter now lives in a dependency-free `contexts/workingDirParam.ts` that both sides import.

Closes #7
