### PR TITLE
fix: keep a tool card's streamed input when the turn's final payload is empty

### DIFF
--- a/webview/src/api/logging/LogForwarder.ts
+++ b/webview/src/api/logging/LogForwarder.ts
@@ -19,12 +19,16 @@ interface LogEntry {
 
 const CONSOLE_METHODS = ['log', 'info', 'warn', 'error', 'debug'] as const;
 const MAX_QUEUE_SIZE = 500;
+/** Investigation-only ring buffer (see `window.ccgLogs`). Not sent anywhere. */
+const MAX_HISTORY_SIZE = 5000;
 const FLUSH_INTERVAL_MS = 500;
 const RECONNECT_DELAY_MS = 2000;
 
 class LogForwarder {
   private ws: WebSocket | null = null;
   private buffer: LogEntry[] = [];
+  /** Full session history for investigation; drained only via window.ccgLogs. */
+  private history: LogEntry[] = [];
   private flushTimer: ReturnType<typeof setInterval> | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private disposed: boolean = false;
@@ -33,8 +37,61 @@ class LogForwarder {
 
   start(): void {
     this.interceptConsole();
+    this.exposeInvestigationApi();
     this.connect();
     this.flushTimer = setInterval(() => this.flush(), FLUSH_INTERVAL_MS);
+  }
+
+  /**
+   * The console history as one plain-text block, newest last. Used to hand over a
+   * whole session's logs at once — from the command palette, or from the console
+   * via `window.ccgLogs`.
+   */
+  getHistoryText(filter?: string): string {
+    const entries = filter
+      ? this.history.filter((e) => e.message.includes(filter))
+      : this.history;
+    return entries
+      .map((e) => `${new Date(e.timestamp).toISOString()} [${e.level}] ${e.message}`)
+      .join('\n');
+  }
+
+  getHistoryCount(): number {
+    return this.history.length;
+  }
+
+  clearHistory(): void {
+    this.history = [];
+  }
+
+  /**
+   * Mirror the history helpers onto `window.ccgLogs` for use straight from the
+   * browser console:
+   *
+   *   ccgLogs.copy()            all logs → clipboard
+   *   ccgLogs.copy('[Bridge]')  only lines containing the filter
+   *   ccgLogs.text()            same, returned as a string
+   *   ccgLogs.clear()           reset the buffer
+   */
+  private exposeInvestigationApi(): void {
+    (window as unknown as { ccgLogs: unknown }).ccgLogs = {
+      text: (filter?: string) => this.getHistoryText(filter),
+      count: () => this.getHistoryCount(),
+      clear: () => {
+        this.clearHistory();
+        return 'cleared';
+      },
+      copy: async (filter?: string) => {
+        const text = this.getHistoryText(filter);
+        try {
+          await navigator.clipboard.writeText(text);
+          return `copied ${text.split('\n').length} lines`;
+        } catch {
+          // Clipboard needs a focused document; fall back to a manual selection.
+          return text;
+        }
+      },
+    };
   }
 
   dispose(): void {
@@ -122,6 +179,17 @@ class LogForwarder {
 
         if (this.buffer.length > MAX_QUEUE_SIZE) {
           this.buffer = this.buffer.slice(-MAX_QUEUE_SIZE);
+        }
+
+        this.history.push({
+          level: method as unknown as LogLevel,
+          source: 'webview',
+          sessionId: this.sessionId,
+          message,
+          timestamp: Date.now(),
+        });
+        if (this.history.length > MAX_HISTORY_SIZE) {
+          this.history = this.history.slice(-MAX_HISTORY_SIZE);
         }
       };
     }

--- a/webview/src/commandPalette/sections/support/__tests__/items.test.ts
+++ b/webview/src/commandPalette/sections/support/__tests__/items.test.ts
@@ -3,6 +3,8 @@ import { getSupportItems } from '../items';
 import { StaticItem } from '../../../types';
 import type { CommandPaletteServices } from '../../../types';
 import * as Adapters from '@/adapters';
+import * as CopyLogs from '@/utils/copyFrontendLogs';
+import toast from 'react-hot-toast';
 
 const supportItems = getSupportItems();
 
@@ -40,6 +42,19 @@ describe('supportItems', () => {
     expect(restartBackend).toHaveBeenCalledTimes(1);
   });
 
+  // Diagnostics aid, not an everyday action: it stays out of the default list and
+  // only surfaces once the user searches for it.
+  it('exposes a search-only "Copy plugin front log" item above the help docs entry', () => {
+    const copyLogs = byId('copy-front-log');
+    expect(copyLogs).toBeDefined();
+    expect(copyLogs.label).toBe('Copy plugin front log');
+    expect(copyLogs.disabled).toBe(false);
+    expect(copyLogs.searchOnly).toBe(true);
+
+    const ids = supportItems.map(item => item.id);
+    expect(ids.indexOf('copy-front-log')).toBeLessThan(ids.indexOf('help-docs'));
+  });
+
   it('does not restart the backend when the user cancels', async () => {
     const restartBackend = vi.fn().mockResolvedValue(undefined);
     vi.spyOn(Adapters, 'getAdapter').mockReturnValue({
@@ -52,5 +67,25 @@ describe('supportItems', () => {
     await restart.execute();
 
     expect(restartBackend).not.toHaveBeenCalled();
+  });
+
+  it('confirms with a toast once the log has been copied', async () => {
+    vi.spyOn(CopyLogs, 'copyFrontendLogs').mockResolvedValue({ ok: true, lineCount: 12 });
+    const success = vi.spyOn(toast, 'success').mockReturnValue('t1');
+
+    await byId('copy-front-log').execute();
+
+    expect(success).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells the user when there was nothing to copy', async () => {
+    vi.spyOn(CopyLogs, 'copyFrontendLogs').mockResolvedValue({ ok: false, lineCount: 0 });
+    const success = vi.spyOn(toast, 'success').mockReturnValue('t1');
+    const error = vi.spyOn(toast, 'error').mockReturnValue('t2');
+
+    await byId('copy-front-log').execute();
+
+    expect(success).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledTimes(1);
   });
 });

--- a/webview/src/commandPalette/sections/support/items.ts
+++ b/webview/src/commandPalette/sections/support/items.ts
@@ -1,5 +1,7 @@
+import toast from 'react-hot-toast';
 import { getAdapter } from '@/adapters';
 import { i18n } from '@/i18n';
+import { copyFrontendLogs } from '@/utils/copyFrontendLogs';
 import { StaticItem } from '../../types';
 import { enKeyword } from '../../enKeyword';
 
@@ -9,6 +11,22 @@ import { enKeyword } from '../../enKeyword';
  * registry registers the Support section.
  */
 export const getSupportItems = (): StaticItem[] => [
+  // Bug-report aid: hands over this tab's whole front-end console log in one go.
+  // `LogForwarder` captures it from startup, so this works for a user who never
+  // opened devtools. Search-only — it is a diagnostics tool, not a daily action.
+  new StaticItem('copy-front-log', i18n.t('commandPalette:support.copyFrontLog'), {
+    disabled: false,
+    searchOnly: true,
+    keywords: [enKeyword('commandPalette:support.copyFrontLog')],
+    action: async () => {
+      const { ok, lineCount } = await copyFrontendLogs();
+      if (ok) {
+        toast.success(i18n.t('commandPalette:support.copyFrontLogDone', { count: lineCount }));
+      } else {
+        toast.error(i18n.t('commandPalette:support.copyFrontLogFailed'));
+      }
+    },
+  }),
   new StaticItem('help-docs', i18n.t('commandPalette:support.viewHelpDocs'), {
     disabled: false,
     keywords: [enKeyword('commandPalette:support.viewHelpDocs')],

--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -314,6 +314,69 @@ describe('useChatStream', () => {
     });
   });
 
+  // A tool_use block's input arrives as `input_json_delta`, which is buffered and
+  // applied on the next RAF frame. Measured against a live CLI, the `assistant`
+  // event for the same turn can arrive *before* that frame runs — and it resets
+  // the active-block index. The buffered delta then had no block to write to and
+  // was dropped, leaving the tool card with an empty input (issue #232).
+  describe('tool_use input_json_delta와 assistant 이벤트 경합 (issue #232)', () => {
+    const TOOL_ID = 'toolu_probe232';
+
+    it('assistant 이벤트가 flush보다 먼저 와도 누적된 input이 유실되지 않는다', () => {
+      const { bridge, emit } = createMockBridge();
+      const { result } = renderHook(() => useChatStream({ bridge }));
+
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_start',
+            index: 0,
+            content_block: { type: 'tool_use', id: TOOL_ID, name: 'Write', input: {} },
+          },
+        });
+      });
+
+      // The input streams in as partial JSON; it is buffered, not yet applied.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: {
+            type: 'content_block_delta',
+            index: 0,
+            delta: { type: 'input_json_delta', partial_json: '{"file_path":"/tmp/a.txt"}' },
+          },
+        });
+      });
+
+      // Measured ordering: the `assistant` event lands *before* the RAF frame and
+      // resets the active-block index, then content_block_stop forces the flush.
+      // The assistant payload here carries only the id/name — no `input` — so the
+      // buffered delta is the only source of the tool's arguments.
+      act(() => {
+        emit(MessageType.CLI_EVENT, {
+          type: 'assistant',
+          message: {
+            id: 'msg_probe232',
+            content: [{ type: 'tool_use', id: TOOL_ID, name: 'Write', input: {} }],
+          },
+        });
+        emit(MessageType.CLI_EVENT, {
+          type: 'stream_event',
+          event: { type: 'content_block_stop', index: 0 },
+        });
+        flushRAF();
+      });
+
+      const blocks = result.current.messages[0].message?.content as Array<{
+        type: string;
+        input?: Record<string, unknown>;
+      }>;
+      const toolUse = blocks.find(b => b.type === 'tool_use');
+      expect(toolUse?.input).toEqual({ file_path: '/tmp/a.txt' });
+    });
+  });
+
   describe('assistant 처리', () => {
     it('완성된 content가 처리된다', () => {
       const { bridge, emit } = createMockBridge();

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -143,6 +143,11 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
   const pendingThinkingRef = useRef<string>('');
   const pendingInputJsonRef = useRef<string>('');              // RAF 프레임 간 input_json_delta 축적용
   const accumulatedInputJsonRef = useRef<string>('');          // 현재 tool_use 블록의 전체 누적 input JSON 문자열
+  // id of the tool_use block the buffered input JSON belongs to. Deltas are
+  // applied a frame later, by which time the `assistant` event for the same turn
+  // may already have reset the active-block index — so the flush resolves its
+  // target by id instead of by index (issue #232).
+  const pendingInputJsonToolIdRef = useRef<string | null>(null);
   const pendingThinkingTokensRef = useRef<number | null>(null); // system/thinking_tokens의 누적 추정치 (RAF flush에서 반영)
   const thinkingStartAtRef = useRef<number | null>(null);      // 활성 thinking 블록의 시작 시각 (duration 측정용)
   const rafIdRef = useRef<number | null>(null);
@@ -272,8 +277,19 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
       }
 
       // Append input JSON delta to the active tool_use block
+      // Resolve the target by the id captured when the delta was buffered, and
+      // only fall back to the active index when no id is known. Resolving by
+      // index alone dropped the delta whenever the `assistant` event reset the
+      // index before this frame ran (issue #232).
       if (inputJsonDelta) {
-        const idx = activeToolUseBlockIndexRef.current;
+        const pendingToolId = pendingInputJsonToolIdRef.current;
+        let idx = pendingToolId
+          ? currentBlocks.findIndex(
+              b => b.type === ContentBlockType.ToolUse && (b as ToolUseBlockDto).id === pendingToolId,
+            )
+          : -1;
+        if (idx < 0) idx = activeToolUseBlockIndexRef.current;
+
         if (idx >= 0 && idx < currentBlocks.length && currentBlocks[idx].type === ContentBlockType.ToolUse) {
           const block = currentBlocks[idx] as ToolUseBlockDto;
           // accumulatedInputJsonRef holds the full JSON string across all RAF frames
@@ -281,6 +297,9 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
           const parsedInput = parsePartialJson(accumulatedInputJsonRef.current) ?? block.input;
           currentBlocks[idx] = { ...block, input: parsedInput };
         }
+        // The buffered JSON has been applied (or had nowhere to go); either way it
+        // must not leak into the next tool_use.
+        pendingInputJsonToolIdRef.current = null;
       }
 
       return { ...msg, message: { ...msg.message!, content: currentBlocks } };
@@ -656,6 +675,12 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
           const blockIndex = innerEvent.index as number | undefined;
           if (!contentBlock) return;
 
+          // Remember which tool_use the following input_json deltas belong to, so
+          // a delayed flush can still find it after the index has been reset.
+          if (contentBlock.type === ContentBlockType.ToolUse) {
+            pendingInputJsonToolIdRef.current = contentBlock.id ?? null;
+          }
+
           if (blockIndex !== undefined) {
             activeBlockIndexRef.current = blockIndex;
           }
@@ -856,7 +881,21 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
 
             // Preserve blocks from previous turns, replace current turn's blocks
             const preservedBlocks = existingBlocks.slice(0, turnStart);
-            const mergedBlocks = [...preservedBlocks, ...finalTurnBlocks];
+            // A tool_use in the final payload can carry an empty `input` while the
+            // streamed input_json deltas already assembled the real arguments —
+            // the CLI emits this event mid-turn, before the tool call is complete.
+            // Replacing blindly would blank the tool card (issue #232), so keep
+            // whichever side actually has arguments.
+            const mergedBlocks = [...preservedBlocks, ...finalTurnBlocks.map(block => {
+              if (block.type !== ContentBlockType.ToolUse) return block;
+              const incoming = block as ToolUseBlockDto;
+              if (incoming.input && Object.keys(incoming.input).length > 0) return block;
+              const streamed = existingBlocks.find(
+                b => b.type === ContentBlockType.ToolUse && (b as ToolUseBlockDto).id === incoming.id,
+              ) as ToolUseBlockDto | undefined;
+              if (!streamed?.input || Object.keys(streamed.input).length === 0) return block;
+              return { ...incoming, input: streamed.input };
+            })];
 
             // Update turnStartBlockCount for the next turn
             turnStartBlockCountRef.current = mergedBlocks.length;

--- a/webview/src/i18n/locales/ar/commandPalette.json
+++ b/webview/src/i18n/locales/ar/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "الإعدادات العامة..."
   },
   "support": {
+    "copyFrontLog": "نسخ سجل واجهة الإضافة",
+    "copyFrontLogDone": "تم نسخ سجل الواجهة ({{count}} سطر)",
+    "copyFrontLogFailed": "لا يوجد سجل واجهة لنسخه",
     "viewHelpDocs": "عرض وثائق المساعدة",
     "restartPlugin": "إعادة تشغيل الإضافة",
     "restartConfirm": {

--- a/webview/src/i18n/locales/de/commandPalette.json
+++ b/webview/src/i18n/locales/de/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "Allgemeine Konfiguration..."
   },
   "support": {
+    "copyFrontLog": "Frontend-Log des Plugins kopieren",
+    "copyFrontLogDone": "Frontend-Log kopiert ({{count}} Zeilen)",
+    "copyFrontLogFailed": "Kein Frontend-Log zum Kopieren vorhanden",
     "viewHelpDocs": "Hilfedokumente ansehen",
     "restartPlugin": "Plugin neu starten",
     "restartConfirm": {

--- a/webview/src/i18n/locales/en/commandPalette.json
+++ b/webview/src/i18n/locales/en/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "General config..."
   },
   "support": {
+    "copyFrontLog": "Copy plugin front log",
+    "copyFrontLogDone": "Front-end log copied ({{count}} lines)",
+    "copyFrontLogFailed": "No front-end log to copy",
     "viewHelpDocs": "View help docs",
     "restartPlugin": "Restart plugin",
     "restartConfirm": {

--- a/webview/src/i18n/locales/es/commandPalette.json
+++ b/webview/src/i18n/locales/es/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "Configuración general..."
   },
   "support": {
+    "copyFrontLog": "Copiar el registro del frontend del plugin",
+    "copyFrontLogDone": "Registro del frontend copiado ({{count}} líneas)",
+    "copyFrontLogFailed": "No hay registro del frontend que copiar",
     "viewHelpDocs": "Ver documentación de ayuda",
     "restartPlugin": "Reiniciar plugin",
     "restartConfirm": {

--- a/webview/src/i18n/locales/fa/commandPalette.json
+++ b/webview/src/i18n/locales/fa/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "پیکربندی عمومی..."
   },
   "support": {
+    "copyFrontLog": "کپی گزارش رابط کاربری پلاگین",
+    "copyFrontLogDone": "گزارش رابط کاربری کپی شد ({{count}} خط)",
+    "copyFrontLogFailed": "گزارش رابط کاربری برای کپی وجود ندارد",
     "viewHelpDocs": "مشاهده مستندات راهنما",
     "restartPlugin": "راه‌اندازی مجدد پلاگین",
     "restartConfirm": {

--- a/webview/src/i18n/locales/fr/commandPalette.json
+++ b/webview/src/i18n/locales/fr/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "Configuration générale..."
   },
   "support": {
+    "copyFrontLog": "Copier le journal front-end du plugin",
+    "copyFrontLogDone": "Journal front-end copié ({{count}} lignes)",
+    "copyFrontLogFailed": "Aucun journal front-end à copier",
     "viewHelpDocs": "Consulter la documentation d'aide",
     "restartPlugin": "Redémarrer le plugin",
     "restartConfirm": {

--- a/webview/src/i18n/locales/ja/commandPalette.json
+++ b/webview/src/i18n/locales/ja/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "一般設定..."
   },
   "support": {
+    "copyFrontLog": "プラグインのフロントログをコピー",
+    "copyFrontLogDone": "フロントログをコピーしました ({{count}} 行)",
+    "copyFrontLogFailed": "コピーできるフロントログがありません",
     "viewHelpDocs": "ヘルプドキュメントを表示",
     "restartPlugin": "プラグインを再起動",
     "restartConfirm": {

--- a/webview/src/i18n/locales/ko/commandPalette.json
+++ b/webview/src/i18n/locales/ko/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "일반 설정..."
   },
   "support": {
+    "copyFrontLog": "플러그인 프론트 로그 복사",
+    "copyFrontLogDone": "프론트 로그를 복사했습니다 ({{count}}줄)",
+    "copyFrontLogFailed": "복사할 프론트 로그가 없습니다",
     "viewHelpDocs": "도움말 문서 보기",
     "restartPlugin": "플러그인 재시작",
     "restartConfirm": {

--- a/webview/src/i18n/locales/pt/commandPalette.json
+++ b/webview/src/i18n/locales/pt/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "Configuração geral..."
   },
   "support": {
+    "copyFrontLog": "Copiar o log do front-end do plugin",
+    "copyFrontLogDone": "Log do front-end copiado ({{count}} linhas)",
+    "copyFrontLogFailed": "Nenhum log do front-end para copiar",
     "viewHelpDocs": "Ver documentação de ajuda",
     "restartPlugin": "Reiniciar plugin",
     "restartConfirm": {

--- a/webview/src/i18n/locales/ru/commandPalette.json
+++ b/webview/src/i18n/locales/ru/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "Общая конфигурация..."
   },
   "support": {
+    "copyFrontLog": "Скопировать журнал фронтенда плагина",
+    "copyFrontLogDone": "Журнал фронтенда скопирован ({{count}} строк)",
+    "copyFrontLogFailed": "Нет журнала фронтенда для копирования",
     "viewHelpDocs": "Открыть справочную документацию",
     "restartPlugin": "Перезапустить плагин",
     "restartConfirm": {

--- a/webview/src/i18n/locales/zh-TW/commandPalette.json
+++ b/webview/src/i18n/locales/zh-TW/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "一般設定..."
   },
   "support": {
+    "copyFrontLog": "複製外掛前端記錄",
+    "copyFrontLogDone": "已複製前端記錄（{{count}} 行）",
+    "copyFrontLogFailed": "沒有可複製的前端記錄",
     "viewHelpDocs": "檢視說明文件",
     "restartPlugin": "重新啟動外掛",
     "restartConfirm": {

--- a/webview/src/i18n/locales/zh/commandPalette.json
+++ b/webview/src/i18n/locales/zh/commandPalette.json
@@ -69,6 +69,9 @@
     "generalConfig": "常规配置..."
   },
   "support": {
+    "copyFrontLog": "复制插件前端日志",
+    "copyFrontLogDone": "已复制前端日志（{{count}} 行）",
+    "copyFrontLogFailed": "没有可复制的前端日志",
     "viewHelpDocs": "查看帮助文档",
     "restartPlugin": "重启插件",
     "restartConfirm": {

--- a/webview/src/utils/__tests__/copyFrontendLogs.test.ts
+++ b/webview/src/utils/__tests__/copyFrontendLogs.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { copyFrontendLogs } from '../copyFrontendLogs';
+import * as Logging from '@/api/logging';
+
+const mockForwarder = (text: string) =>
+  vi.spyOn(Logging, 'getLogForwarder').mockReturnValue({
+    getHistoryText: () => text,
+  } as unknown as ReturnType<typeof Logging.getLogForwarder>);
+
+describe('copyFrontendLogs', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes the captured console history to the clipboard', async () => {
+    mockForwarder('line one\nline two');
+
+    const result = await copyFrontendLogs();
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('line one\nline two');
+    expect(result).toEqual({ ok: true, lineCount: 2 });
+  });
+
+  // The palette entry exists for users who never opened devtools, so an empty
+  // buffer must read as a clear "nothing to copy" rather than a silent success.
+  it('reports failure when there is nothing captured yet', async () => {
+    mockForwarder('');
+
+    const result = await copyFrontendLogs();
+
+    expect(navigator.clipboard.writeText).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, lineCount: 0 });
+  });
+
+  it('reports failure when the clipboard write is rejected', async () => {
+    mockForwarder('line one');
+    (navigator.clipboard.writeText as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('denied'),
+    );
+
+    const result = await copyFrontendLogs();
+
+    expect(result).toEqual({ ok: false, lineCount: 1 });
+  });
+
+  it('survives the log forwarder not being initialised', async () => {
+    vi.spyOn(Logging, 'getLogForwarder').mockReturnValue(
+      undefined as unknown as ReturnType<typeof Logging.getLogForwarder>,
+    );
+
+    const result = await copyFrontendLogs();
+
+    expect(result).toEqual({ ok: false, lineCount: 0 });
+  });
+});

--- a/webview/src/utils/copyFrontendLogs.ts
+++ b/webview/src/utils/copyFrontendLogs.ts
@@ -1,0 +1,29 @@
+import { getLogForwarder } from '@/api/logging';
+
+export interface CopyFrontendLogsResult {
+  ok: boolean;
+  lineCount: number;
+}
+
+/**
+ * Copy this tab's captured console history to the clipboard.
+ *
+ * `LogForwarder` intercepts `console.*` from startup, so the history exists
+ * whether or not devtools were ever opened — which is the point: a user
+ * reporting a bug can hand over the full front-end log without being walked
+ * through opening the inspector first.
+ */
+export async function copyFrontendLogs(): Promise<CopyFrontendLogsResult> {
+  const text = getLogForwarder()?.getHistoryText() ?? '';
+  if (!text) return { ok: false, lineCount: 0 };
+
+  const lineCount = text.split('\n').length;
+  try {
+    await navigator.clipboard.writeText(text);
+    return { ok: true, lineCount };
+  } catch {
+    // Clipboard access needs a focused, permitted document; report the failure
+    // so the caller can tell the user instead of silently doing nothing.
+    return { ok: false, lineCount };
+  }
+}


### PR DESCRIPTION
## Problem

Empty bordered boxes appear in the transcript while a turn is streaming — often
a run of them, and often where a tool card should be. Reloading the session
makes them go away and renders the content correctly in its right place, which
narrows the fault to how the live view assembles messages rather than to the
data itself.

## Root cause

A `tool_use` block's arguments stream in as `input_json_delta`, buffered and
applied on the next animation frame. Measured against a live CLI, the
`assistant` event for the same turn arrives *before* that frame runs: it
flushes the buffer, then replaces the turn's blocks with its own payload.

That payload is emitted mid-turn and can still carry an empty `input`, so the
arguments the stream had already assembled were overwritten with nothing. The
JSONL restore path never runs this replacement, which is why a reload looks
fine.

The reporter's analysis pointed at `UserMessageRenderer` missing the
empty-content guard that `AssistantMessageRenderer` has. That observation is
accurate, but it turned out not to be what shows on screen: an empty
`MessageBox` collapses to no visible height, and adding a guard there would
have hidden entries `mergeToolResults` deliberately keeps visible.

## Fix

Keep whichever side actually has arguments — an empty `input` in the final
payload no longer clobbers what was streamed, while a populated one still
wins. The flush also resolves its target `tool_use` by id instead of by the
active block index, which the same `assistant` event resets.

## Also here: copying the front-end log

Diagnosing this took several rounds of asking for console output, which first
means walking a reporter through opening devtools — and anything that scrolled
past is already gone.

`LogForwarder` already intercepts `console.*` from startup; it now also keeps
the last 5000 lines. **Copy plugin front log** in the palette's Support section
puts that whole history on the clipboard and confirms with a toast, so a
reporter can attach it without opening the inspector. The same history is
reachable from the console via `window.ccgLogs`. Search-only — it is a
diagnostics aid, not an everyday action.

## Verification

- New regression test fails before the fix (`expected {} to deeply equal
  { file_path: '/tmp/a.txt' }`) and passes after
- Webview 1803 passed, backend 1044 passed, Kotlin passed, typecheck clean
- Palette entry driven end to end in a browser: hidden until searched, listed
  above **View help docs**, toast shown, clipboard verified against a sentinel

One limit worth stating plainly: the race did not reproduce in the two live
browser runs after the fix, so the evidence for the fix is the regression test,
not a before/after observation on screen.

Closes #232
