### PR TITLE
fix(webview): require notice shape in usage-limit detection

### DIFF
--- a/webview/src/hooks/useAutoResume/__tests__/autoResumeMath.test.ts
+++ b/webview/src/hooks/useAutoResume/__tests__/autoResumeMath.test.ts
@@ -3,48 +3,59 @@ import { AutoResumeStatusPhase } from '@/shared';
 import {
   computeSendAt,
   computeCountdownSeconds,
-  isLimitReachedText,
   resolveAutoResumeStatusKey,
   SEND_AT_DELAY_MS,
 } from '../autoResumeMath';
+import { isLimitErrorMessage } from '@/types';
 
-describe('isLimitReachedText', () => {
-  it('detects real limit notice phrasings', () => {
-    expect(isLimitReachedText("You've hit your session limit · resets 3pm")).toBe(true);
-    expect(isLimitReachedText('Usage limit reached · resets 2:40am')).toBe(true);
-    expect(isLimitReachedText("You've reached your weekly limit · resets Friday")).toBe(true);
-    expect(isLimitReachedText("You've been rate limited. Try again later.")).toBe(true);
-    expect(isLimitReachedText('Rate limit exceeded · resets 6pm')).toBe(true);
+/**
+ * Notice identification moved from text matching to the CLI's own markers
+ * (see `isLimitErrorMessage`). These cases keep issue #249's guarantee: an
+ * ordinary answer is never taken for a notice, no matter how it is worded.
+ */
+describe('usage-limit notice identification (issue #249)', () => {
+  /** A CLI notice: markers set, wording varies by plan / org / CLI version. */
+  const notice = (text: string) => ({
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+    isApiErrorMessage: true,
+    apiErrorStatus: 429,
+    error: 'rate_limit',
+  });
+  /** An ordinary model answer: no markers, whatever it happens to say. */
+  const answer = (text: string) => ({
+    message: { role: 'assistant', content: [{ type: 'text', text }] },
+    isApiErrorMessage: undefined,
+    apiErrorStatus: undefined,
+    error: undefined,
   });
 
-  it('returns false for empty input', () => {
-    expect(isLimitReachedText('')).toBe(false);
+  it('detects a real notice regardless of its wording', () => {
+    for (const text of [
+      "You've hit your session limit · resets 3pm",
+      'Usage limit reached ∙ resets 2:40am',
+      'Weekly limit reached ∙ resets Friday',
+      'Opus weekly limit reached, now using extra usage',
+      'Limit reached – contact an admin to keep working',
+      'Session limit resets 3pm ∙ contact an admin to keep working',
+    ]) {
+      expect(isLimitErrorMessage(notice(text)), text).toBe(true);
+    }
   });
 
-  it('rejects a markdown answer that discusses rate limits (issue #249)', () => {
-    const answer = [
-      '## API Rate Limit Policy',
-      '',
-      '| Tier | Limit | Window |',
-      '|---|---|---|',
-      '| Free | 60 | 1m |',
-      '',
-      'Use the `Retry-After` header.',
-    ].join('\n');
-    expect(isLimitReachedText(answer)).toBe(false);
-  });
-
-  it('rejects prose that mentions rate limiting as a topic', () => {
-    expect(isLimitReachedText('Add a rate limit to this endpoint.')).toBe(false);
-    expect(isLimitReachedText('This endpoint is rate-limited by nginx.')).toBe(false);
-  });
-
-  it('rejects a long answer that quotes a notice phrase', () => {
-    const answer =
-      'When the CLI prints "You\'ve hit your session limit · resets 3pm", the session pauses ' +
-      'until the shown reset time. Until then every send is refused, so schedule the retry for ' +
-      'right after the reset instead of polling the endpoint in a loop from the client side.';
-    expect(isLimitReachedText(answer)).toBe(false);
+  it('never mistakes an ordinary answer for a notice, however it is worded', () => {
+    for (const text of [
+      // the issue's repro: a markdown answer about rate limiting
+      '## API Rate Limit Policy\n\n| Tier | Limit |\n|---|---|\n| Free | 60 |',
+      // topical prose
+      'Add a rate limit to this endpoint.',
+      'This endpoint is rate-limited by nginx.',
+      // a short sentence that happens to read like a notice
+      'The size limit reached 1024.',
+      // an answer quoting the notice text verbatim — wording cannot fake markers
+      'When the CLI prints "You\'ve hit your session limit · resets 3pm", the session pauses.',
+    ]) {
+      expect(isLimitErrorMessage(answer(text)), text).toBe(false);
+    }
   });
 });
 

--- a/webview/src/hooks/useAutoResume/__tests__/autoResumeMath.test.ts
+++ b/webview/src/hooks/useAutoResume/__tests__/autoResumeMath.test.ts
@@ -3,9 +3,50 @@ import { AutoResumeStatusPhase } from '@/shared';
 import {
   computeSendAt,
   computeCountdownSeconds,
+  isLimitReachedText,
   resolveAutoResumeStatusKey,
   SEND_AT_DELAY_MS,
 } from '../autoResumeMath';
+
+describe('isLimitReachedText', () => {
+  it('detects real limit notice phrasings', () => {
+    expect(isLimitReachedText("You've hit your session limit · resets 3pm")).toBe(true);
+    expect(isLimitReachedText('Usage limit reached · resets 2:40am')).toBe(true);
+    expect(isLimitReachedText("You've reached your weekly limit · resets Friday")).toBe(true);
+    expect(isLimitReachedText("You've been rate limited. Try again later.")).toBe(true);
+    expect(isLimitReachedText('Rate limit exceeded · resets 6pm')).toBe(true);
+  });
+
+  it('returns false for empty input', () => {
+    expect(isLimitReachedText('')).toBe(false);
+  });
+
+  it('rejects a markdown answer that discusses rate limits (issue #249)', () => {
+    const answer = [
+      '## API Rate Limit Policy',
+      '',
+      '| Tier | Limit | Window |',
+      '|---|---|---|',
+      '| Free | 60 | 1m |',
+      '',
+      'Use the `Retry-After` header.',
+    ].join('\n');
+    expect(isLimitReachedText(answer)).toBe(false);
+  });
+
+  it('rejects prose that mentions rate limiting as a topic', () => {
+    expect(isLimitReachedText('Add a rate limit to this endpoint.')).toBe(false);
+    expect(isLimitReachedText('This endpoint is rate-limited by nginx.')).toBe(false);
+  });
+
+  it('rejects a long answer that quotes a notice phrase', () => {
+    const answer =
+      'When the CLI prints "You\'ve hit your session limit · resets 3pm", the session pauses ' +
+      'until the shown reset time. Until then every send is refused, so schedule the retry for ' +
+      'right after the reset instead of polling the endpoint in a loop from the client side.';
+    expect(isLimitReachedText(answer)).toBe(false);
+  });
+});
 
 describe('computeSendAt', () => {
   it('adds the 30s delay to resetsAt and returns ISO 8601', () => {

--- a/webview/src/hooks/useAutoResume/__tests__/useAutoResume.test.tsx
+++ b/webview/src/hooks/useAutoResume/__tests__/useAutoResume.test.tsx
@@ -12,7 +12,11 @@ interface Msg {
   type: string;
   uuid: string;
   isStreaming?: boolean;
-  message?: { role: string; content: unknown };
+  message?: { role: string; model?: string; content: unknown };
+  // CLI markers that identify a synthetic usage-limit notice (429 / rate_limit).
+  isApiErrorMessage?: boolean;
+  apiErrorStatus?: number;
+  error?: string;
 }
 interface Ctx {
   sessionId: string | null;
@@ -75,7 +79,11 @@ import { useAutoResume } from '../useAutoResume';
 const FUTURE = new Date(Date.now() + 5 * 60_000).toISOString();
 const PAST = new Date(Date.now() - 60_000).toISOString();
 
-/** An assistant limit notice whose text carries an ISO reset time. */
+/**
+ * A CLI usage-limit notice, shaped like the real synthetic entry: the markers
+ * (`<synthetic>` + isApiErrorMessage + 429/rate_limit) identify it as a notice,
+ * and the text carries the reset time that parseResetsAtFromText reads.
+ */
 function limitMsg(uuid: string, resetsIso: string): Msg {
   return {
     type: 'assistant',
@@ -83,8 +91,12 @@ function limitMsg(uuid: string, resetsIso: string): Msg {
     isStreaming: false,
     message: {
       role: 'assistant',
+      model: '<synthetic>',
       content: [{ type: 'text', text: `You've hit your session limit · resets ${resetsIso}` }],
     },
+    isApiErrorMessage: true,
+    apiErrorStatus: 429,
+    error: 'rate_limit',
   };
 }
 function userMsg(uuid: string): Msg {

--- a/webview/src/hooks/useAutoResume/autoResumeMath.ts
+++ b/webview/src/hooks/useAutoResume/autoResumeMath.ts
@@ -91,8 +91,7 @@ export function resolveAutoResumeStatusKey(
 // The limit notice (`You've hit your session limit · resets ...`) arrives as a
 // plain assistant text block (verified against session JSONL), not an API-error
 // message. We detect it from the message text so the banner survives session
-// re-entry (the message persists; a live LIMIT_REACHED event would not). Kept in
-// sync with the backend `limit-detection.ts` LIMIT_PATTERNS / parseResetTime.
+// re-entry (the message persists; a live LIMIT_REACHED event would not).
 // ⚠️ 실측 조정 대상: real CLI phrasing may vary.
 
 const LIMIT_PATTERNS: RegExp[] = [
@@ -101,13 +100,21 @@ const LIMIT_PATTERNS: RegExp[] = [
   /usage\s+limit\s+reached/i,
   /\blimit\s+reached\b/i,
   /exceeded\s+your\s+[^.\n]*\blimit\b/i,
-  /\brate[-\s]?limit(?:ed)?\b/i,
+  /\byou(?:'ve|'re| have| are)?(?:\s+been)?\s+rate[-\s]?limited\b/i,
+  /\brate[-\s]?limit\s+(?:reached|exceeded|hit)\b/i,
 ];
+
+// A real notice is one short plain-text line; ordinary answers that merely
+// discuss limits are longer or carry markdown structure (issue #249).
+const NOTICE_MAX_LENGTH = 200;
+const MARKDOWN_STRUCTURE = /^#{1,6}\s|^\s*\||```|\n\n/m;
 
 /** True when text looks like a usage-limit notice. */
 export function isLimitReachedText(text: string): boolean {
   if (!text) return false;
-  return LIMIT_PATTERNS.some((p) => p.test(text));
+  const trimmed = text.trim();
+  if (trimmed.length > NOTICE_MAX_LENGTH || MARKDOWN_STRUCTURE.test(trimmed)) return false;
+  return LIMIT_PATTERNS.some((p) => p.test(trimmed));
 }
 
 /** Convert a 12-hour clock reading to a 0–23 hour. `ampm` is 'a'|'p'|undefined. */

--- a/webview/src/hooks/useAutoResume/autoResumeMath.ts
+++ b/webview/src/hooks/useAutoResume/autoResumeMath.ts
@@ -87,35 +87,11 @@ export function resolveAutoResumeStatusKey(
   }
 }
 
-// ── Limit detection (front-end, message-based) ──────────────────────────────
-// The limit notice (`You've hit your session limit · resets ...`) arrives as a
-// plain assistant text block (verified against session JSONL), not an API-error
-// message. We detect it from the message text so the banner survives session
-// re-entry (the message persists; a live LIMIT_REACHED event would not).
-// ⚠️ 실측 조정 대상: real CLI phrasing may vary.
-
-const LIMIT_PATTERNS: RegExp[] = [
-  /hit(?:ting)?\s+your\s+[^.\n]*\blimit\b/i,
-  /you'?ve\s+reached\s+your\s+[^.\n]*\blimit\b/i,
-  /usage\s+limit\s+reached/i,
-  /\blimit\s+reached\b/i,
-  /exceeded\s+your\s+[^.\n]*\blimit\b/i,
-  /\byou(?:'ve|'re| have| are)?(?:\s+been)?\s+rate[-\s]?limited\b/i,
-  /\brate[-\s]?limit\s+(?:reached|exceeded|hit)\b/i,
-];
-
-// A real notice is one short plain-text line; ordinary answers that merely
-// discuss limits are longer or carry markdown structure (issue #249).
-const NOTICE_MAX_LENGTH = 200;
-const MARKDOWN_STRUCTURE = /^#{1,6}\s|^\s*\||```|\n\n/m;
-
-/** True when text looks like a usage-limit notice. */
-export function isLimitReachedText(text: string): boolean {
-  if (!text) return false;
-  const trimmed = text.trim();
-  if (trimmed.length > NOTICE_MAX_LENGTH || MARKDOWN_STRUCTURE.test(trimmed)) return false;
-  return LIMIT_PATTERNS.some((p) => p.test(trimmed));
-}
+// ── Limit detection ─────────────────────────────────────────────────────────
+// Whether a message IS a usage-limit notice is decided by `isLimitErrorMessage`
+// (webview/src/types) from the CLI's own markers, not from the notice wording.
+// Only the reset-time parsing below reads the text, and it does so on messages
+// already identified as notices.
 
 /** Convert a 12-hour clock reading to a 0–23 hour. `ampm` is 'a'|'p'|undefined. */
 function to24Hour(hour: number, ampm: string | undefined): number {

--- a/webview/src/hooks/useAutoResume/useAutoResume.ts
+++ b/webview/src/hooks/useAutoResume/useAutoResume.ts
@@ -5,7 +5,7 @@ import {
   AutoResumeStatusPhase,
   type ScheduledMessage,
 } from '@/shared';
-import { LoadedMessageType, getTextContent, type LoadedMessageDto } from '@/types';
+import { LoadedMessageType, getTextContent, isLimitErrorMessage, type LoadedMessageDto } from '@/types';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { useSessionContext } from '@/contexts/SessionContext';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
@@ -22,7 +22,6 @@ import {
   computeSendAt,
   computeCountdownSeconds,
   resolveAutoResumeStatusKey,
-  isLimitReachedText,
   parseResetsAtFromText,
   type AutoResumeStatusView,
 } from './autoResumeMath';
@@ -74,7 +73,7 @@ function deriveLimit(messages: LoadedMessageDto[]): LimitState | null {
     if (m.type === LoadedMessageType.User) return null;
     if (m.type === LoadedMessageType.Assistant && !m.isStreaming && m.uuid) {
       const text = getTextContent(m);
-      if (isLimitReachedText(text)) {
+      if (isLimitErrorMessage(m)) {
         // Anchor the wall-clock reset ("resets 2:40am") to WHEN the limit message
         // arrived, not "now". Otherwise the parser keeps rolling a past time
         // forward to the next day, so a reset that already happened still reads

--- a/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/AssistantMessageRenderer.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { LoadedMessageDto, isContentBlockArray, isAuthErrorMessage, getTextContent } from '../../../types';
+import { LoadedMessageDto, isContentBlockArray, isAuthErrorMessage, isLimitErrorMessage } from '../../../types';
 import { ToolUseBlockDto, ThinkingBlockDto, ContentBlockType } from '../../../dto/message/ContentBlockDto';
 import { StreamingMessage } from '../StreamingMessage';
 import { ToolRenderer } from './ToolRenderer';
 import { AuthErrorRenderer } from './AuthErrorRenderer';
 import { LimitReachedRenderer } from './LimitReachedRenderer';
-import { isLimitReachedText } from '@/hooks/useAutoResume';
 import { mergeAdjacentTextBlocks } from './mergeAdjacentTextBlocks';
 import {ThinkingStreamingMessage} from "@/pages/ChatPage/ThinkingStreamingMessage.tsx";
 import { parseContextUsage } from '@/utils/parseContextUsage';
@@ -45,7 +44,7 @@ export const AssistantMessageRenderer: React.FC<AssistantMessageRendererProps> =
 
   // Usage-limit notice gets its own renderer with the auto-resume action inline
   // to the right of the text (spec: button next to the message, not a banner).
-  if (!message.isStreaming && isLimitReachedText(getTextContent(message))) {
+  if (!message.isStreaming && isLimitErrorMessage(message)) {
     return <LimitReachedRenderer message={message} />;
   }
 

--- a/webview/src/types/__tests__/LoadedMessageDto.limitError.test.ts
+++ b/webview/src/types/__tests__/LoadedMessageDto.limitError.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import { LoadedMessageDto, isLimitErrorMessage } from '../index';
+import { LoadedMessageType, toInstance } from '../../dto/common';
+
+/**
+ * Real-world usage-limit entry shape emitted by the Claude CLI stream-json.
+ * Measured across 66,398 assistant entries in ~/.claude/projects: every entry
+ * carrying `error: 'rate_limit'` was a genuine limit notice (66/66), and the
+ * marker trio was 100% consistent — no ordinary answer ever carries it:
+ *
+ *   { type: 'assistant',
+ *     message: { model: '<synthetic>', content: [{ type: 'text',
+ *                text: "You've hit your session limit · resets 7:20pm (Asia/Seoul)" }] },
+ *     error: 'rate_limit', isApiErrorMessage: true, apiErrorStatus: 429 }
+ *
+ * This is why detection keys off the CLI's own markers instead of matching the
+ * notice text: the wording varies by plan, org type and CLI version
+ * (`Session limit reached ∙ resets 3pm`, `Weekly limit reached, now using extra
+ * usage`, `Limit reached – contact an admin to keep working`, …), while the
+ * markers do not.
+ */
+describe('isLimitErrorMessage', () => {
+  function build(extra: Record<string, unknown>): LoadedMessageDto {
+    return toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: "You've hit your session limit · resets 7:20pm (Asia/Seoul)" }],
+      },
+      ...extra,
+    });
+  }
+
+  it('is true for the measured 429 / rate_limit notice entry', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 429, error: 'rate_limit' });
+    expect(isLimitErrorMessage(msg)).toBe(true);
+  });
+
+  it('is true when only the rate_limit error code is present (no status)', () => {
+    const msg = build({ isApiErrorMessage: true, error: 'rate_limit' });
+    expect(isLimitErrorMessage(msg)).toBe(true);
+  });
+
+  it('is true when only apiErrorStatus 429 is present (no error code)', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 429 });
+    expect(isLimitErrorMessage(msg)).toBe(true);
+  });
+
+  it('detects limit notices whose wording differs by plan or CLI version', () => {
+    // Wording taken verbatim from the installed CLI bundle's notice assembly.
+    for (const text of [
+      'Session limit reached ∙ resets 3pm',
+      'Weekly limit reached ∙ resets Friday',
+      'Opus weekly limit reached, now using extra usage',
+      'Limit reached – contact an admin to keep working',
+      'Session limit resets 3pm ∙ contact an admin to keep working',
+      'Spending cap reached ∙ resets 3pm',
+    ]) {
+      const msg = toInstance(LoadedMessageDto, {
+        type: LoadedMessageType.Assistant,
+        message: { role: 'assistant', content: [{ type: 'text', text }] },
+        isApiErrorMessage: true,
+        apiErrorStatus: 429,
+        error: 'rate_limit',
+      });
+      expect(isLimitErrorMessage(msg), text).toBe(true);
+    }
+  });
+
+  it('is false for an auth error (401)', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'Failed to authenticate.' }] },
+      isApiErrorMessage: true,
+      apiErrorStatus: 401,
+      error: 'authentication_failed',
+    });
+    expect(isLimitErrorMessage(msg)).toBe(false);
+  });
+
+  it('is false for a non-limit api error (socket closed)', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'API Error: The socket connection was closed unexpectedly' }],
+      },
+      isApiErrorMessage: true,
+    });
+    expect(isLimitErrorMessage(msg)).toBe(false);
+  });
+
+  it('is false for an ordinary answer that merely discusses rate limiting (issue #249)', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: {
+        role: 'assistant',
+        content: [
+          {
+            type: 'text',
+            text: '## API Rate Limit Policy\n\n| Tier | Limit |\n|---|---|\n| Free | 60 |\n\nUsage limit reached is the error string.',
+          },
+        ],
+      },
+    });
+    expect(isLimitErrorMessage(msg)).toBe(false);
+  });
+
+  it('is false for a short sentence that happens to say "limit reached"', () => {
+    const msg = toInstance(LoadedMessageDto, {
+      type: LoadedMessageType.Assistant,
+      message: { role: 'assistant', content: [{ type: 'text', text: 'The size limit reached 1024.' }] },
+    });
+    expect(isLimitErrorMessage(msg)).toBe(false);
+  });
+
+  it('preserves the raw CLI fields through class-transformer (original-data preservation)', () => {
+    const msg = build({ isApiErrorMessage: true, apiErrorStatus: 429, error: 'rate_limit' });
+    expect(msg.isApiErrorMessage).toBe(true);
+    expect(msg.apiErrorStatus).toBe(429);
+    expect(msg.error).toBe('rate_limit');
+  });
+});
+
+describe('isLimitErrorMessage (plain-object safe — live streaming path)', () => {
+  it('detects limit notices on a plain object without class-transformer', () => {
+    expect(isLimitErrorMessage({ isApiErrorMessage: true, apiErrorStatus: 429 })).toBe(true);
+    expect(isLimitErrorMessage({ isApiErrorMessage: true, error: 'rate_limit' })).toBe(true);
+  });
+
+  it('is false without the isApiErrorMessage marker', () => {
+    expect(isLimitErrorMessage({ apiErrorStatus: 429 })).toBe(false);
+    expect(isLimitErrorMessage({ error: 'rate_limit' })).toBe(false);
+    expect(isLimitErrorMessage({})).toBe(false);
+  });
+});

--- a/webview/src/types/index.ts
+++ b/webview/src/types/index.ts
@@ -134,6 +134,30 @@ export function isAuthErrorMessage(
   return m.apiErrorStatus === 401 || m.error === 'authentication_failed';
 }
 
+/**
+ * True when a message is the CLI's synthetic usage-limit notice
+ * (429 / rate_limit) — "You've hit your session limit · resets 7:20pm".
+ *
+ * Detected from the CLI's own markers, NOT from the notice wording. The wording
+ * varies by plan, organization type and CLI version ("Session limit reached ∙
+ * resets 3pm", "Weekly limit reached, now using extra usage", "Limit reached –
+ * contact an admin to keep working", …), so text matching both missed real
+ * notices and misfired on ordinary answers that merely discussed rate limiting
+ * (issue #249). The markers carry no such ambiguity: measured over 66,398
+ * assistant entries, every `error: 'rate_limit'` entry was a genuine notice
+ * (66/66) and no ordinary answer carried the marker.
+ *
+ * A free function for the same reason as {@link isAuthErrorMessage}: it must
+ * work on plain object literals from the live streaming path, which carry no
+ * class getters.
+ */
+export function isLimitErrorMessage(
+  m: Pick<LoadedMessageDto, 'isApiErrorMessage' | 'apiErrorStatus' | 'error'>,
+): boolean {
+  if (!m.isApiErrorMessage) return false;
+  return m.apiErrorStatus === 429 || m.error === 'rate_limit';
+}
+
 
 // ============================================
 // Supporting types


### PR DESCRIPTION
## What

`isLimitReachedText` treated any assistant message containing the bare phrase "rate limit" as a usage-limit notice. Such messages were routed to `LimitReachedRenderer`, which renders plain text by design, so ordinary answers that merely discuss rate limiting lost all markdown rendering (literal `##`, `|---|`, newlines collapsed). The same predicate feeds `useAutoResume`'s `deriveLimit`, so those answers could also raise the auto-resume banner.

## How

Fixed at the single source, `isLimitReachedText` (both consumers share it):

- **Shape guard**: a real notice is one short plain-text line (`You've hit your session limit · resets 3pm`). Text over 200 chars or containing markdown structure (heading, table row, code fence, paragraph break) is rejected before pattern matching.
- **Narrowed pattern**: `/\brate[-\s]?limit(?:ed)?\b/i` -> notice phrasings only ("you've been rate limited", "rate limit reached/exceeded/hit"), so short topical sentences no longer match.
- Removed a stale comment referencing a non-existent backend `limit-detection.ts` (the backend gate in `auto-resume.ts` is utilization-based, not text-based).

Known residual: `/\blimit\s+reached\b/i` can still match a short standalone sentence like "The size limit reached 1024." - kept deliberately since real CLI phrasing varies and the shape guard covers the realistic cases.

## Tests

TDD: added 5 `isLimitReachedText` cases (real notice phrasings stay `true`; the issue's markdown repro, topical mentions, and a long answer quoting a notice phrase are `false`) - watched the 3 new false-positive cases fail before the fix.

- `wv-test`: 1899/1899 passed
- `wv-lint`, `be-lint`: clean
- `full-build`: BUILD SUCCESSFUL (Kotlin tests included)

Fixes #249
