### PR TITLE
fix(win32): kill chat CLI tree via Job Object (git-bash orphan gap)

### DIFF
--- a/backend/esbuild.mjs
+++ b/backend/esbuild.mjs
@@ -1,5 +1,5 @@
 import { build } from 'esbuild';
-import { readFileSync } from 'fs';
+import { readFileSync, copyFileSync } from 'fs';
 
 const pkg = JSON.parse(readFileSync('package.json', 'utf-8'));
 
@@ -74,5 +74,11 @@ await build({ ...common, entryPoints: ['src/server.ts'], outfile: 'dist/backend.
 // Terminal account-switch helper, shipped beside backend.mjs in the standalone
 // runtime and invoked by `ccg account …`.
 await build({ ...common, entryPoints: ['src/cli/account.ts'], outfile: 'dist/account-cli.mjs' });
+
+// Ship the win32 Job Object wrapper next to the bundle. It's a runtime asset (not
+// JS to bundle): win-job.ts resolves it via `new URL('./win-job-wrapper.ps1',
+// import.meta.url)`, i.e. beside backend.mjs. Both distributables (plugin
+// syncResources, standalone tgz) copy it from dist/ alongside backend.mjs.
+copyFileSync('src/core/win-job-wrapper.ps1', 'dist/win-job-wrapper.ps1');
 
 console.log('Backend bundled successfully');

--- a/backend/src/core/__tests__/win-job.test.ts
+++ b/backend/src/core/__tests__/win-job.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { buildWin32CmdLine } from '../win-job';
+
+describe('buildWin32CmdLine', () => {
+  it('joins command + args with single spaces (mirrors Node win32 shell:true)', () => {
+    expect(buildWin32CmdLine('claude', ['-p', '--verbose'])).toBe('claude -p --verbose');
+  });
+
+  it('reproduces the chat CLI invocation verbatim (no per-arg re-quoting)', () => {
+    const args = [
+      '-p', '--output-format', 'stream-json', '--input-format', 'stream-json',
+      '--verbose', '--include-partial-messages', '--permission-prompt-tool', 'stdio',
+      '--session-id', '795f99a6-b973-4963-ba19-84f095c1ff74',
+    ];
+    expect(buildWin32CmdLine('claude', args)).toBe(
+      'claude -p --output-format stream-json --input-format stream-json --verbose ' +
+        '--include-partial-messages --permission-prompt-tool stdio ' +
+        '--session-id 795f99a6-b973-4963-ba19-84f095c1ff74',
+    );
+  });
+
+  it('returns the bare command when there are no args', () => {
+    expect(buildWin32CmdLine('claude', [])).toBe('claude');
+  });
+});

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -215,7 +215,10 @@ export async function ensureClaudeProcess(
       CI: 'true',
       CLAUDECODE: undefined,
     },
-  });
+    // win32: route this long-lived chat CLI through a Job Object wrapper so its
+    // whole tree (incl. MSYS/git-bash workers that escape taskkill /F /T) dies with
+    // the backend. POSIX uses the detached process-group above instead.
+  }, targetSessionId);
 
   let stderrBuffer = '';
 

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -12,6 +12,7 @@ import { augmentedPath } from './augmented-path';
 import { resolveWslCwd } from './wsl-path';
 import { execViaCmdArgv } from './win-exec';
 import { pickWin32Launcher } from './which-launcher';
+import { spawnWin32JobCli } from './win-job';
 
 export class Claude {
   private static cliPath: string | null = null;
@@ -91,15 +92,25 @@ export class Claude {
     };
   }
 
-  static spawn(args: string[], options?: SpawnOptions): ChildProcess {
+  /**
+   * Spawn `claude`. Pass `win32JobSessionId` ONLY for the long-lived chat CLI: on
+   * win32 it routes the spawn through a Job Object wrapper so the whole CLI tree —
+   * including MSYS/git-bash workers that reparent out of the taskkill /F /T tree —
+   * is torn down when the wrapper (or the backend) dies. The sessionId rides along
+   * so the on-disk registry's orphan sweep can find and kill that wrapper. Short-
+   * lived spawns (auth, /usage, config) omit it and keep the plain shell path.
+   */
+  static spawn(args: string[], options?: SpawnOptions, win32JobSessionId?: string): ChildProcess {
+    const cwd = resolveWslCwd(options?.cwd);
+    const env = { ...Claude.env, ...options?.env };
+    if (process.platform === 'win32' && win32JobSessionId) {
+      return spawnWin32JobCli(Claude.command, args, win32JobSessionId, { ...options, cwd, env });
+    }
     return cpSpawn(Claude.command, args, {
       ...options,
-      cwd: resolveWslCwd(options?.cwd),
+      cwd,
       shell: options?.shell ?? (process.platform === 'win32'),
-      env: {
-        ...Claude.env,
-        ...options?.env,
-      },
+      env,
     });
   }
 
@@ -130,9 +141,10 @@ export class Claude {
     args: string[],
     workingDir?: string,
     options?: SpawnOptions,
+    win32JobSessionId?: string,
   ): Promise<ChildProcess> {
     const stripEnv = await Claude.authStripEnv(workingDir);
-    return Claude.spawn(args, { ...options, env: { ...options?.env, ...stripEnv } });
+    return Claude.spawn(args, { ...options, env: { ...options?.env, ...stripEnv } }, win32JobSessionId);
   }
 
   /**

--- a/backend/src/core/win-job-wrapper.ps1
+++ b/backend/src/core/win-job-wrapper.ps1
@@ -1,0 +1,76 @@
+# CCG win32 chat-CLI job wrapper.
+#
+# Why this exists: win32 has no process groups. `taskkill /F /T` walks the LIVE
+# parent-child tree, but git-bash (MSYS) spawns its worker processes under a
+# short-lived fork helper that exits immediately, detaching the worker from the
+# cmd->claude->bash tree (children even reparent to ppid 1). Windows never
+# reparents to a reaper, so those workers become invisible orphans that keep
+# running (and billing). POSIX avoids this by launching the CLI detached as a
+# process-group leader and signalling the whole group (see claude.ts killTree).
+#
+# A Windows Job Object is the kernel equivalent of a process group: every
+# descendant of a job member stays in the job regardless of PPID reparenting.
+# This wrapper creates a job with JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, launches the
+# real chat CLI inside it, then holds the job handle for the CLI's lifetime. When
+# the backend kills THIS process (or the backend itself dies), the last job handle
+# closes and the kernel tears down the ENTIRE tree — the MSYS orphans included.
+#
+# Contract with the backend (claude.ts / win-job.ts):
+#   - $env:CCG_JOB_CMDLINE holds the exact `cmd /d /s /c` command line to run.
+#   - argv[0] (if present) is the sessionId, carried ONLY so the on-disk registry's
+#     sessionId-keyed orphan sweep can find and kill THIS wrapper. The wrapper
+#     itself ignores it.
+#   - MUST be silent on stdout: the backend reads the child's stdout as the chat
+#     stream-json protocol. Only genuine errors go to stderr.
+$ErrorActionPreference = 'Stop'
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public static class CcgJobNative {
+  [DllImport("kernel32.dll", SetLastError=true)] public static extern IntPtr CreateJobObject(IntPtr a, string name);
+  [DllImport("kernel32.dll", SetLastError=true)] public static extern bool SetInformationJobObject(IntPtr job, int infoClass, IntPtr info, uint len);
+  [DllImport("kernel32.dll", SetLastError=true)] public static extern bool AssignProcessToJobObject(IntPtr job, IntPtr process);
+}
+"@
+
+$cmdline = $env:CCG_JOB_CMDLINE
+if ([string]::IsNullOrEmpty($cmdline)) {
+  [Console]::Error.WriteLine('[ccg-job] CCG_JOB_CMDLINE not set')
+  exit 210
+}
+
+# Create the job + set KILL_ON_JOB_CLOSE. If any of this fails we still launch the
+# CLI (degrading to the pre-job behavior) rather than break chat — a missing job
+# only reopens the orphan gap, it never blocks the user.
+$job = [CcgJobNative]::CreateJobObject([IntPtr]::Zero, $null)
+if ($job -ne [IntPtr]::Zero) {
+  # JOBOBJECT_EXTENDED_LIMIT_INFORMATION is 144 bytes on x64: BASIC_LIMIT(64) +
+  # IO_COUNTERS(48) + 4x SIZE_T memory fields(32). LimitFlags sits at offset 16.
+  $size = 144
+  $buf = [Runtime.InteropServices.Marshal]::AllocHGlobal($size)
+  try {
+    for ($i = 0; $i -lt $size; $i++) { [Runtime.InteropServices.Marshal]::WriteByte($buf, $i, 0) }
+    [Runtime.InteropServices.Marshal]::WriteInt32($buf, 16, 0x2000)  # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+    # JobObjectExtendedLimitInformation = 9
+    [void][CcgJobNative]::SetInformationJobObject($job, 9, $buf, $size)
+  } finally {
+    [Runtime.InteropServices.Marshal]::FreeHGlobal($buf)
+  }
+}
+
+$psi = New-Object Diagnostics.ProcessStartInfo
+$psi.FileName = 'cmd.exe'
+# cmd resolves the claude launcher via PATHEXT exactly as the pre-job spawn did.
+$psi.Arguments = '/d /s /c "' + $cmdline + '"'
+# Inherit our std handles so the child's stdio is the backend's pipes, byte-for-byte.
+$psi.UseShellExecute = $false
+$proc = [Diagnostics.Process]::Start($psi)
+
+# Put the CLI (and thus every descendant) in the job. Non-fatal on failure.
+if ($job -ne [IntPtr]::Zero) {
+  [void][CcgJobNative]::AssignProcessToJobObject($job, $proc.Handle)
+}
+
+$proc.WaitForExit()
+exit $proc.ExitCode

--- a/backend/src/core/win-job.ts
+++ b/backend/src/core/win-job.ts
@@ -1,0 +1,58 @@
+import { spawn as cpSpawn, type ChildProcess, type SpawnOptions } from 'child_process';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+/**
+ * win32 chat-CLI spawn through a Job Object wrapper — the Windows equivalent of the
+ * POSIX "detached process-group leader + signal the whole group" design.
+ *
+ * The problem it solves: `taskkill /F /T` walks the LIVE parent-child tree, but
+ * git-bash (MSYS) launches its workers under a fork helper that exits immediately,
+ * detaching them from the cmd->claude->bash tree (they even reparent to ppid 1).
+ * Windows never reparents to a reaper, so those workers survive every tree-kill as
+ * headless orphans that keep running and billing. A Job Object with
+ * KILL_ON_JOB_CLOSE keeps every descendant in the job regardless of PPID
+ * reparenting; killing the wrapper (or the backend dying) closes the job handle and
+ * the kernel tears the whole tree down. See win-job-wrapper.ps1 for the mechanism.
+ */
+
+/**
+ * The exact `cmd /d /s /c "<...>"` payload. Mirrors Node's own win32 shell:true
+ * construction: command + args joined by spaces with NO per-arg re-quoting, wrapped
+ * as a single verbatim string by the wrapper. Reproducing that byte-for-byte keeps
+ * the CLI's argv identical to the pre-job spawn (chat args are simple tokens).
+ */
+export function buildWin32CmdLine(command: string, args: string[]): string {
+  return [command, ...args].join(' ');
+}
+
+/** Absolute path to the shipped wrapper, resolved next to the running bundle. */
+export function jobWrapperPath(): string {
+  return fileURLToPath(new URL('./win-job-wrapper.ps1', import.meta.url));
+}
+
+/**
+ * Spawn the chat CLI inside a Job Object. `sessionId` is passed as a wrapper argv
+ * token ONLY so the on-disk registry's sessionId-keyed orphan sweep can find and
+ * kill this wrapper (its death closes the job). If the wrapper asset is missing for
+ * any reason, fall back to the plain shell spawn so chat never breaks — a missing
+ * job only reopens the orphan gap, it must never block the user.
+ */
+export function spawnWin32JobCli(
+  command: string,
+  args: string[],
+  sessionId: string,
+  options: SpawnOptions,
+): ChildProcess {
+  const wrapper = jobWrapperPath();
+  if (!existsSync(wrapper)) {
+    console.error('[node-backend]', `Job wrapper not found at ${wrapper} — spawning without a job (orphan guard degraded)`);
+    return cpSpawn(command, args, { ...options, shell: true });
+  }
+  const cmdline = buildWin32CmdLine(command, args);
+  return cpSpawn(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', wrapper, sessionId],
+    { ...options, shell: false, env: { ...options.env, CCG_JOB_CMDLINE: cmdline } },
+  );
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -377,8 +377,10 @@ tasks {
         dependsOn("buildWebviewFrontend", "buildNodeBackend")
         inputs.dir(file("webview/dist"))
         inputs.file(file("backend/dist/backend.mjs"))
+        inputs.file(file("backend/dist/win-job-wrapper.ps1"))
         outputs.dir(file("src/main/resources/webview"))
         outputs.file(file("src/main/resources/backend/backend.mjs"))
+        outputs.file(file("src/main/resources/backend/win-job-wrapper.ps1"))
         doLast {
             // WebView 정적 파일 동기화 (stale 파일 방지를 위해 기존 디렉토리 삭제 후 복사)
             file("src/main/resources/webview").deleteRecursively()
@@ -386,10 +388,11 @@ tasks {
                 from(file("webview/dist"))
                 into(file("src/main/resources/webview"))
             }
-            // Node.js 백엔드 번들 복사
+            // Node.js 백엔드 번들 복사 (+ win32 Job Object 래퍼 자산)
             file("src/main/resources/backend").mkdirs()
             copy {
                 from(file("backend/dist/backend.mjs"))
+                from(file("backend/dist/win-job-wrapper.ps1"))
                 into(file("src/main/resources/backend"))
             }
         }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -209,9 +209,10 @@ case "${1:-}" in
     mkdir -p "$stage/webview"
     cp "$ROOT/backend/dist/backend.mjs" "$stage/"
     cp "$ROOT/backend/dist/account-cli.mjs" "$stage/"
+    cp "$ROOT/backend/dist/win-job-wrapper.ps1" "$stage/"
     cp -R "$ROOT/webview/dist/." "$stage/webview/"
     out="$ROOT/dist/claude-code-gui-standalone-v$version.tgz"
-    tar -czf "$out" -C "$stage" account-cli.mjs backend.mjs webview
+    tar -czf "$out" -C "$stage" account-cli.mjs backend.mjs win-job-wrapper.ps1 webview
     rm -rf "$stage"
     echo "Created: $out"
     ;;

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractor.kt
@@ -290,6 +290,12 @@ class PluginResourceExtractor(
         val target = File(backendDirTarget, BACKEND_ENTRY)
         target.parentFile?.mkdirs()
         stream.use { input -> target.outputStream().use { input.copyTo(it) } }
+        // win32 Job Object wrapper, shipped beside backend.mjs (win-job.ts resolves it
+        // there). Best-effort: if the asset is missing, win-job.ts falls back to a plain
+        // spawn (degraded orphan guard), so its absence must not abort extraction.
+        resourceAnchor.getResourceAsStream("/backend/$WIN_JOB_WRAPPER")?.use { input ->
+            File(backendDirTarget, WIN_JOB_WRAPPER).outputStream().use { input.copyTo(it) }
+        }
     }
 
     private fun extractWebview(webviewTarget: File) {
@@ -438,6 +444,7 @@ class PluginResourceExtractor(
         private const val WEBVIEW_SUBDIR = "webview"
         private const val BACKEND_SUBDIR = "backend"
         private const val BACKEND_ENTRY = "backend.mjs"
+        private const val WIN_JOB_WRAPPER = "win-job-wrapper.ps1"
         private const val LOCK_NAME = ".lock"
         /** Prefix for the sibling temp dir an extraction unpacks into before the atomic rename. */
         private const val TMP_PREFIX = ".tmp-"


### PR DESCRIPTION
## The gap (found during Windows field-testing of #187/#254)

win32 has no process groups, so `Claude.killTree` falls back to `taskkill /F /T`, which walks the **live** parent-child (PPID) tree. But git-bash (MSYS) launches the actual worker of a Bash-tool command under a short-lived fork helper that exits immediately, **detaching the worker from the `cmd → claude → bash` tree** (its grandchildren even reparent to ppid 1). Windows never reparents to a reaper, so `taskkill /T` can no longer reach those workers — they survive every session teardown as **headless, still-billing orphans**.

Reproduced twice on a real Windows machine with a real `claude`: a long-running Bash-tool child kept running (and spawning grandchildren) after its session was torn down; directly targeting the real pid killed it, confirming the tree-walk — not the process — was the gap. This is exactly the orphan class #187 set out to close, still open for git-bash grandchildren. (POSIX is unaffected: the CLI is spawned detached as a process-group leader and `kill(-pgid)` reaches the whole group regardless of reparenting.)

## The fix — a Windows Job Object (the kernel equivalent of a POSIX process group)

Route the long-lived chat CLI (win32 only) through a PowerShell **Job Object** wrapper. Every descendant of a job member stays in the job regardless of PPID reparenting, and `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` tears the whole tree down when the wrapper (or the backend) dies — restoring the POSIX "detached group + `kill(-pgid)`" semantics Windows otherwise lacks.

- **`win-job-wrapper.ps1`** — creates the job, runs `cmd /d /s /c <cmdline>` with **inherited stdio** (byte-transparent for the stream-json chat protocol), assigns it to the job, holds the handle. Silent on stdout. Degrades to a plain spawn if the job APIs fail, so chat never breaks.
- **`win-job.ts`** — `buildWin32CmdLine` (mirrors Node's `shell:true` join verbatim) + `spawnWin32JobCli` (falls back to a plain spawn if the wrapper asset is missing).
- **`Claude.spawn`/`spawnAuthed`** take an opt-in `win32JobSessionId`; only the chat spawn passes it. The sessionId rides as a wrapper argv token so the registry's sessionId-keyed orphan sweep can still find and kill the wrapper (its death closes the job). Short-lived spawns (auth, `/usage`, config) keep the plain path. **POSIX unchanged.**
- Ships the wrapper beside `backend.mjs`: esbuild copy, gradle `syncResources`, standalone tgz, and plugin JAR extraction (best-effort).

## Verification (real `claude`, run-ide sandbox)

- **M1-b (the gap)**: chat streams normally through the wrapper; on session close the job tears down the whole tree including the git-bash worker that previously orphaned. Kill lands well inside claude's Bash-tool timeout, ruling out timeout-driven cleanup.
- **Backend hard-death & port reclaim**: the job also closes the orphan on a backend SIGKILL (stdin-EOF → CLI exit → wrapper exit → job close) and on standalone port reclaim (`taskkill /F /T` of the stale backend → wrapper death → job close).
- Backend test suite: **no new failures** vs `main` on Windows (the 17 pre-existing failures are POSIX/mac-only path tests); adds 3 passing `win-job` unit tests.

Targeting **0.26.5**.