### PR TITLE
Empty message bubbles: the guard, the cause, and a trail for both

### DIFF
--- a/webview/src/hooks/__tests__/useChatStream.test.ts
+++ b/webview/src/hooks/__tests__/useChatStream.test.ts
@@ -1578,3 +1578,224 @@ describe('useChatStream', () => {
     });
   });
 });
+
+/**
+ * A turn that runs tools does not end at `result`: the CLI keeps going and
+ * emits a NEW assistant message per continuation, each with its own
+ * `message.id`. The streaming placeholder, however, lives until `result`.
+ *
+ * Both messages therefore resolved to the same placeholder, and the second
+ * payload replaced the first one's blocks instead of following them — taking
+ * that turn's `tool_use` with it. The matching `tool_result` still arrived,
+ * found no tool call to fold into, and rendered as a bubble with nothing in it,
+ * one per overwritten turn (issue #232).
+ *
+ * The session logs attached to the issue are what pinned this down: streamed,
+ * 14 standalone tool_results whose tool_use_id matched none of the 236 tool_use
+ * blocks present; reloaded, the same 14 ids all present, each on its own
+ * assistant entry. Same data, so nothing was lost in transport — only the live
+ * assembly collapsed them.
+ */
+describe('useChatStream — one assistant entry per CLI message id (issue #232)', () => {
+  function toolUseIdsIn(messages: LoadedMessage[]): string[] {
+    return messages.flatMap(m => {
+      const content = m.message?.content;
+      if (!Array.isArray(content)) return [];
+      return content
+        .filter((b): b is typeof b & { id: string } => b.type === 'tool_use')
+        .map(b => b.id);
+    });
+  }
+
+  /**
+   * Streams one assistant turn that calls a single tool, as the CLI does.
+   *
+   * `content_block_start` matters as much as the payload: it is what opens the
+   * streaming placeholder, and the overwrite only happens while one is open. A
+   * turn built from `message_start` + the final payload alone never reproduced
+   * the bug, because the placeholder was already closed and the second turn
+   * took the append path regardless.
+   */
+  function emitToolTurn(
+    emit: (type: string, payload: Record<string, unknown>) => void,
+    apiMessageId: string,
+    toolUseId: string,
+  ) {
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: apiMessageId } },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 0,
+        content_block: { type: 'tool_use', id: toolUseId, name: 'Bash', input: {} },
+      },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'assistant',
+      message: {
+        id: apiMessageId,
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: toolUseId, name: 'Bash', input: { command: 'ls' } }],
+      },
+    });
+  }
+
+  /**
+   * A full turn: text streamed as deltas and confirmed by a payload, then a
+   * tool call under the SAME message id — the shape the session logs show, where
+   * one id spans several `assistant` events.
+   */
+  function emitTextThenToolTurn(
+    emit: (type: string, payload: Record<string, unknown>) => void,
+    apiMessageId: string,
+    text: string,
+    toolUseId: string,
+  ) {
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: { type: 'message_start', message: { id: apiMessageId } },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: { type: 'content_block_start', index: 0, content_block: { type: 'text', text: '' } },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: { delta: { type: 'text_delta', text } },
+    });
+    flushRAF();
+    emit(MessageType.CLI_EVENT, {
+      type: 'assistant',
+      message: { id: apiMessageId, role: 'assistant', content: [{ type: 'text', text }] },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'stream_event',
+      event: {
+        type: 'content_block_start',
+        index: 1,
+        content_block: { type: 'tool_use', id: toolUseId, name: 'Bash', input: {} },
+      },
+    });
+    emit(MessageType.CLI_EVENT, {
+      type: 'assistant',
+      message: {
+        id: apiMessageId,
+        role: 'assistant',
+        content: [
+          { type: 'text', text },
+          { type: 'tool_use', id: toolUseId, name: 'Bash', input: { command: 'ls' } },
+        ],
+      },
+    });
+  }
+
+  it('keeps an earlier turn\'s tool_use when the next turn arrives', () => {
+    const { bridge, emit } = createMockBridge();
+    const { result } = renderHook(() => useChatStream({ bridge }));
+
+    // One `act`, as the CLI delivers it: the turns arrive back to back with no
+    // render committed in between, which is the state the placeholder is open
+    // in. Splitting them across two `act` calls lets React close the stream
+    // first, and then the second turn appends no matter what — the bug cannot
+    // reproduce and the test proves nothing.
+    act(() => {
+      emitToolTurn(emit, 'msg_first', 'toolu_first');
+      emitToolTurn(emit, 'msg_second', 'toolu_second');
+      flushRAF();
+    });
+
+    // Before the fix the second payload overwrote the first, leaving only
+    // `toolu_second` — and stranding `toolu_first`'s result as an empty bubble.
+    expect(toolUseIdsIn(result.current.messages)).toEqual(['toolu_first', 'toolu_second']);
+  });
+
+  it('gives each CLI message id its own entry, so a tool_result finds its call', () => {
+    const { bridge, emit } = createMockBridge();
+    const { result } = renderHook(() => useChatStream({ bridge }));
+
+    // Five continuations of one turn, the shape the reported session had.
+    const ids = ['a', 'b', 'c', 'd', 'e'];
+    act(() => {
+      ids.forEach(id => emitToolTurn(emit, `msg_${id}`, `toolu_${id}`));
+      flushRAF();
+    });
+
+    expect(toolUseIdsIn(result.current.messages)).toEqual(ids.map(id => `toolu_${id}`));
+
+    // Every tool_result now has a tool_use to fold into — the property whose
+    // absence *is* the empty bubble.
+    const present = new Set(toolUseIdsIn(result.current.messages));
+    ids.forEach(id => expect(present.has(`toolu_${id}`)).toBe(true));
+  });
+
+  it('does not repeat text when a message spans several assistant events', () => {
+    // The first attempt at this fix sealed on the `assistant` payload instead of
+    // `message_start`. By then the message's deltas were already in the entry,
+    // so the next payload re-added the same text under a fresh entry and every
+    // line of the reply appeared twice on screen. Sealing on `message_start` —
+    // before any delta of the new message arrives — is what keeps each block in
+    // exactly one entry.
+    const { bridge, emit } = createMockBridge();
+    const { result } = renderHook(() => useChatStream({ bridge }));
+
+    act(() => {
+      emitTextThenToolTurn(emit, 'msg_first', 'HELLO', 'toolu_first');
+      emitTextThenToolTurn(emit, 'msg_second', 'WORLD', 'toolu_second');
+      flushRAF();
+    });
+
+    const texts = result.current.messages.flatMap(m => {
+      const content = m.message?.content;
+      if (!Array.isArray(content)) return [];
+      return content
+        .filter((b): b is typeof b & { text: string } => b.type === 'text')
+        .map(b => b.text)
+        .filter(t => t !== '');
+    });
+
+    expect(texts).toEqual(['HELLO', 'WORLD']);
+    // Both tool calls survive too — the defect this fix exists for.
+    expect(toolUseIdsIn(result.current.messages)).toEqual(['toolu_first', 'toolu_second']);
+  });
+
+  it('does not split a turn whose deltas keep arriving under one message id', () => {
+    // The seal keys on the id CHANGING, not on every assistant event. Text
+    // deltas and their final payload all carry one id, and splitting there
+    // would scatter a single reply across several bubbles.
+    const { bridge, emit } = createMockBridge();
+    const { result } = renderHook(() => useChatStream({ bridge }));
+
+    act(() => {
+      emit(MessageType.CLI_EVENT, {
+        type: 'stream_event',
+        event: { type: 'message_start', message: { id: 'msg_same' } },
+      });
+      emit(MessageType.CLI_EVENT, {
+        type: 'stream_event',
+        event: { delta: { type: 'text_delta', text: 'first' } },
+      });
+      emit(MessageType.CLI_EVENT, {
+        type: 'stream_event',
+        event: { delta: { type: 'text_delta', text: ' and second' } },
+      });
+      emit(MessageType.CLI_EVENT, {
+        type: 'assistant',
+        message: {
+          id: 'msg_same',
+          role: 'assistant',
+          content: [{ type: 'text', text: 'first and second' }],
+        },
+      });
+      flushRAF();
+    });
+
+    const assistantEntries = result.current.messages.filter(
+      m => m.type === LoadedMessageType.Assistant,
+    );
+    expect(assistantEntries).toHaveLength(1);
+    expect(getTextContent(assistantEntries[0] as LoadedMessageDto)).toContain('first and second');
+  });
+});

--- a/webview/src/hooks/useChatStream.ts
+++ b/webview/src/hooks/useChatStream.ts
@@ -163,6 +163,12 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
   const activeThinkingBlockIndexRef = useRef<number>(-1);     // content 배열 내 현재 활성 thinking 블록 인덱스
   const activeToolUseBlockIndexRef = useRef<number>(-1);      // content 배열 내 현재 활성 tool_use 블록 인덱스
   const turnStartBlockCountRef = useRef<number>(0);           // 현재 턴 시작 시 content 배열의 길이 (병합 기준점)
+  // CLI `message.id` the streaming placeholder currently stands for. The CLI
+  // starts a NEW assistant message per turn while the placeholder lives until
+  // `result`, so without this the second turn's payload overwrote the first
+  // one's blocks — taking its tool_use with it, and stranding the tool_result
+  // that referenced it as an empty bubble (issue #232).
+  const streamingApiMessageIdRef = useRef<string | null>(null);
   const devModeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const devModeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastSkillToolUseIdRef = useRef<string | null>(null);    // Skill tool_result의 tool_use_id 추적 (isSynthetic 매칭용)
@@ -415,6 +421,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     activeToolUseBlockIndexRef.current = -1;
     turnStartBlockCountRef.current = 0;
     accumulatedInputJsonRef.current = '';
+    streamingApiMessageIdRef.current = null;
   }, [flushPendingDeltas, updateMessage, setStreamingMessageId]);
 
   // End streaming helper
@@ -443,6 +450,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     activeToolUseBlockIndexRef.current = -1;
     turnStartBlockCountRef.current = 0;
     accumulatedInputJsonRef.current = '';
+    streamingApiMessageIdRef.current = null;
   }, [flushPendingDeltas, updateMessage]);
 
   // addUserMessage - 로컬 상태 조작만 (bridge.send 하지 않음)
@@ -644,6 +652,7 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
     setIsStreaming(false);
     setStreamingMessageId(null);
     streamingMessageIdRef.current = null;
+    streamingApiMessageIdRef.current = null;
     controlRequestPendingRef.current = false;
     pendingTextRef.current = '';
     pendingThinkingRef.current = '';
@@ -735,6 +744,38 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
 
         const streamEventType = innerEvent.type as string | undefined;
         const delta = innerEvent.delta as Record<string, unknown> | undefined;
+
+        // message_start: the CLI begins a NEW assistant message.
+        //
+        // A turn that runs tools does not stop at one message — the CLI keeps
+        // going and starts another for each continuation. The placeholder,
+        // though, lives until `result`, so every message resolved to the same
+        // entry and each payload replaced the previous message's blocks instead
+        // of following them. What that dropped was the finished message's
+        // `tool_use`; its `tool_result` still arrived, found no tool call to
+        // fold into, and was left as a bubble with nothing in it — one per
+        // overwritten message, which is why they appeared in runs (issue #232).
+        //
+        // Sealing belongs here and not on the `assistant` payload: this event
+        // arrives before any of the new message's deltas, so the entry closes on
+        // exactly the content that belongs to it. Sealing on the payload instead
+        // let the following deltas keep flowing into the entry that was just
+        // closed, which both corrupted it and re-rendered the same text under
+        // the next one.
+        if (streamEventType === 'message_start') {
+          const startedApiMessageId = (innerEvent.message as { id?: string } | undefined)?.id;
+          if (
+            startedApiMessageId
+            && streamingApiMessageIdRef.current
+            && startedApiMessageId !== streamingApiMessageIdRef.current
+          ) {
+            sealStreamingAssistant();
+          }
+          if (startedApiMessageId) streamingApiMessageIdRef.current = startedApiMessageId;
+          // Falls through: the event carries no delta, so the handlers below are
+          // no-ops for it, and returning here would be a behaviour change beyond
+          // the seal.
+        }
 
         // content_block_start: 새로운 content block 시작
         if (streamEventType === 'content_block_start') {
@@ -938,6 +979,20 @@ export function useChatStream(options: UseChatStreamOptions): UseChatStreamRetur
         // with no partial stream_events — result's endStreaming() nulls
         // streamingMessageIdRef.current in between. Reading the ref inside the callback
         // would then match nothing and drop the finished content (#196).
+        // A turn that runs tools does not end at `result` — the CLI keeps going,
+        // and every continuation is a NEW assistant message with its own
+        // `message.id`. The placeholder, though, lives until `result`, so both
+        // messages resolved to the same `streamingId` and the second payload
+        // replaced the first one's blocks instead of following them.
+        //
+        // What was lost that way was the earlier turn's `tool_use`. Its
+        // `tool_result` still arrived, found no tool call to fold into, and was
+        // left as a bubble with nothing in it — one per overwritten turn, which
+        // is why they came in runs (issue #232). Reloading the session fixed it,
+        // because the JSONL keeps each assistant message as its own entry.
+        //
+        // So a new `message.id` seals the placeholder and starts a fresh entry:
+        // the same shape the reload path produces, arrived at live.
         const streamingId = streamingMessageIdRef.current;
         if (streamingId) {
           // Flush any pending deltas before replacing

--- a/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
@@ -12,6 +12,7 @@ import { MessagePathChip } from './components/MessagePathChip';
 import { InterruptedMessageRenderer } from './InterruptedMessageRenderer';
 import { NotificationLine } from './NotificationMessageRenderer';
 import { MessageBox } from './components/MessageBox';
+import { IfVisible, hasVisibleGlyph } from './components/IfVisible';
 import { toolResultText } from './ToolRenderers/common/toolStatus';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { modelChangeTarget } from '@/types/models';
@@ -85,25 +86,32 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
     }
   }
 
-  // Render command-name style messages
-  if (parsedContent.commandName) {
+  // Render command-name style messages.
+  //
+  // The leading `/` is decoration, so it cannot vouch for the entry: a name made
+  // only of invisible characters would render as a lone slash in a box, which
+  // `IfVisible` rightly counts as visible. Require the name itself to have a
+  // glyph, and let a nameless entry fall through to the paths below.
+  if (hasVisibleGlyph(parsedContent.commandName)) {
     return (
-      <div className="group py-2 px-4">
-        <div className="flex items-start gap-2">
-          <div className="min-w-0">
-            <MessageBox>
-              <div className="text-text-primary/80 text-[1rem] leading-relaxed whitespace-pre-wrap break-words">
-                <span className="text-text-primary/50">{'/'}</span>{parsedContent.commandName}
-                {parsedContent.text && (
-                  <span className="text-text-primary/50">{' '}{parsedContent.text}</span>
-                )}
-              </div>
-            </MessageBox>
-            {allContexts.length > 0 && <ContextPills context={allContexts} />}
+      <IfVisible extra={allContexts.length > 0 || imageBlocks.length > 0}>
+        <div className="group py-2 px-4">
+          <div className="flex items-start gap-2">
+            <div className="min-w-0">
+              <MessageBox>
+                <div className="text-text-primary/80 text-[1rem] leading-relaxed whitespace-pre-wrap break-words">
+                  <span className="text-text-primary/50">{'/'}</span>{parsedContent.commandName}
+                  {parsedContent.text && (
+                    <span className="text-text-primary/50">{' '}{parsedContent.text}</span>
+                  )}
+                </div>
+              </MessageBox>
+              {allContexts.length > 0 && <ContextPills context={allContexts} />}
+            </div>
+            <MessageActions copied={copied} onCopy={handleCopy} />
           </div>
-          <MessageActions copied={copied} onCopy={handleCopy} />
         </div>
-      </div>
+      </IfVisible>
     );
   }
 
@@ -130,57 +138,56 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   // in v0.26.4). So read the result's own text and render THAT; an entry with no
   // output protects nothing and is dropped like any other empty message.
   const unmergedToolResultText = toolResultText(message).trim();
-  const hasAnythingToShow = parsedContent.text.trim() !== ''
-    || imageBlocks.length > 0
-    || allContexts.length > 0
-    || unmergedToolResultText !== '';
-  if (!hasAnythingToShow) return null;
 
   // Show the tool's output as plain preformatted text. This is the fallback path
   // for a result whose tool card is not on screen, so it deliberately stays
   // simple — the rich per-tool renderers need the tool_use that is missing here.
   if (!parsedContent.text.trim() && unmergedToolResultText) {
     return (
+      <IfVisible extra={allContexts.length > 0}>
+        <div className="group pt-2 pb-4 px-4 space-y-2.5">
+          <div className="flex items-start gap-2">
+            <div className="min-w-0">
+              <MessageBox>
+                <div className="text-text-primary/80 text-[1rem] leading-[1.5] whitespace-pre-wrap break-words">
+                  {unmergedToolResultText}
+                </div>
+              </MessageBox>
+            </div>
+          </div>
+          {allContexts.length > 0 && <ContextPills context={allContexts} />}
+        </div>
+      </IfVisible>
+    );
+  }
+
+  return (
+    <IfVisible extra={imageBlocks.length > 0 || allContexts.length > 0}>
       <div className="group pt-2 pb-4 px-4 space-y-2.5">
         <div className="flex items-start gap-2">
           <div className="min-w-0">
             <MessageBox>
               <div className="text-text-primary/80 text-[1rem] leading-[1.5] whitespace-pre-wrap break-words">
-                {unmergedToolResultText}
+                {tokenizeMessagePaths(parsedContent.text).map((seg, idx) =>
+                  seg.isPath ? (
+                    <MessagePathChip key={idx} token={seg.text} />
+                  ) : (
+                    <React.Fragment key={idx}>{seg.text}</React.Fragment>
+                  ),
+                )}
               </div>
             </MessageBox>
           </div>
+
+          {/*<MessageActions copied={copied} onCopy={handleCopy} />*/}
         </div>
+
+        {imageBlocks.length > 0 && (
+            <ImageAttachments images={imageBlocks} />
+        )}
+
         {allContexts.length > 0 && <ContextPills context={allContexts} />}
       </div>
-    );
-  }
-
-  return (
-    <div className="group pt-2 pb-4 px-4 space-y-2.5">
-      <div className="flex items-start gap-2">
-        <div className="min-w-0">
-          <MessageBox>
-            <div className="text-text-primary/80 text-[1rem] leading-[1.5] whitespace-pre-wrap break-words">
-              {tokenizeMessagePaths(parsedContent.text).map((seg, idx) =>
-                seg.isPath ? (
-                  <MessagePathChip key={idx} token={seg.text} />
-                ) : (
-                  <React.Fragment key={idx}>{seg.text}</React.Fragment>
-                ),
-              )}
-            </div>
-          </MessageBox>
-        </div>
-
-        {/*<MessageActions copied={copied} onCopy={handleCopy} />*/}
-      </div>
-
-      {imageBlocks.length > 0 && (
-          <ImageAttachments images={imageBlocks} />
-      )}
-
-      {allContexts.length > 0 && <ContextPills context={allContexts} />}
-    </div>
+    </IfVisible>
   );
 };

--- a/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
@@ -12,6 +12,7 @@ import { MessagePathChip } from './components/MessagePathChip';
 import { InterruptedMessageRenderer } from './InterruptedMessageRenderer';
 import { NotificationLine } from './NotificationMessageRenderer';
 import { MessageBox } from './components/MessageBox';
+import { toolResultText } from './ToolRenderers/common/toolStatus';
 import { useCliConfig } from '@/contexts/CliConfigContext';
 import { modelChangeTarget } from '@/types/models';
 import type { ModelInfo } from '@/types/slashCommand';
@@ -115,19 +116,45 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   // into a context pill, or an empty content array. Several in a row read as a
   // column of blank chips.
   //
-  // A `tool_result` entry is deliberately NOT covered here. It renders empty for
-  // a different reason — `mergeToolResults` folds it into the tool card above —
-  // and when that merge cannot happen (the tool_use sits on a not-yet-loaded
-  // page) the entry is what keeps the tool's output reachable. Hiding it here
-  // would drop that output silently, which `mergeToolResults` takes care to
-  // avoid. The mirror of the guard in `AssistantMessageRenderer`.
-  const hasToolResult = isContentBlockArray(message.message?.content)
-    && message.message.content.some(b => b.type === ContentBlockType.ToolResult);
+  // A `tool_result` entry is kept for a different reason — `mergeToolResults`
+  // folds it into the tool card above, and when that merge cannot happen (the
+  // tool_use sits on a not-yet-loaded page) this entry is what keeps the tool's
+  // output reachable. Hiding it would drop that output silently, which
+  // `mergeToolResults` takes care to avoid. The mirror of the guard in
+  // `AssistantMessageRenderer`.
+  //
+  // What matters is the OUTPUT, not the mere presence of a tool_result block.
+  // `getTextContent` only collects text blocks, so it returns '' here; keeping
+  // the entry on `hasToolResult` alone drew a bordered box around that empty
+  // string — a bare 18x9px pill that showed nothing (issue #232, still present
+  // in v0.26.4). So read the result's own text and render THAT; an entry with no
+  // output protects nothing and is dropped like any other empty message.
+  const unmergedToolResultText = toolResultText(message).trim();
   const hasAnythingToShow = parsedContent.text.trim() !== ''
     || imageBlocks.length > 0
     || allContexts.length > 0
-    || hasToolResult;
+    || unmergedToolResultText !== '';
   if (!hasAnythingToShow) return null;
+
+  // Show the tool's output as plain preformatted text. This is the fallback path
+  // for a result whose tool card is not on screen, so it deliberately stays
+  // simple — the rich per-tool renderers need the tool_use that is missing here.
+  if (!parsedContent.text.trim() && unmergedToolResultText) {
+    return (
+      <div className="group pt-2 pb-4 px-4 space-y-2.5">
+        <div className="flex items-start gap-2">
+          <div className="min-w-0">
+            <MessageBox>
+              <div className="text-text-primary/80 text-[1rem] leading-[1.5] whitespace-pre-wrap break-words">
+                {unmergedToolResultText}
+              </div>
+            </MessageBox>
+          </div>
+        </div>
+        {allContexts.length > 0 && <ContextPills context={allContexts} />}
+      </div>
+    );
+  }
 
   return (
     <div className="group pt-2 pb-4 px-4 space-y-2.5">

--- a/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/UserMessageRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { LoadedMessageDto, getTextContent, isContentBlockArray } from '../../../types';
-import type { ImageBlockDto } from '../../../dto/message/ContentBlockDto';
+import type { ImageBlockDto, ToolResultBlockDto } from '../../../dto/message/ContentBlockDto';
 import { ContentBlockType } from '../../../dto/message/ContentBlockDto';
 import { useCopyToClipboard } from './hooks/useCopyToClipboard';
 import { ContextPills } from './components/ContextPills';
@@ -36,6 +36,18 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
     const content = message.message?.content;
     if (!isContentBlockArray(content)) return [];
     return content.filter((b): b is ImageBlockDto => b.type === ContentBlockType.Image);
+  }, [message.message?.content]);
+
+  // Labels this entry in the hidden-bubble trail `IfVisible` keeps. A
+  // tool_result that reaches this renderer at all is one `mergeToolResults`
+  // could not fold into its tool card, so its tool_use_id is the thread back to
+  // what went missing — the identifier worth carrying when the bubble is
+  // dropped. Entries of other kinds have no such handle and are counted anonymously.
+  const debugId = useMemo(() => {
+    const content = message.message?.content;
+    if (!isContentBlockArray(content)) return undefined;
+    const block = content.find(b => b.type === ContentBlockType.ToolResult);
+    return block ? (block as ToolResultBlockDto).tool_use_id : undefined;
   }, [message.message?.content]);
 
   const handleCopy = () => {
@@ -94,7 +106,7 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   // glyph, and let a nameless entry fall through to the paths below.
   if (hasVisibleGlyph(parsedContent.commandName)) {
     return (
-      <IfVisible extra={allContexts.length > 0 || imageBlocks.length > 0}>
+      <IfVisible extra={allContexts.length > 0 || imageBlocks.length > 0} debugId={debugId}>
         <div className="group py-2 px-4">
           <div className="flex items-start gap-2">
             <div className="min-w-0">
@@ -144,7 +156,7 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   // simple — the rich per-tool renderers need the tool_use that is missing here.
   if (!parsedContent.text.trim() && unmergedToolResultText) {
     return (
-      <IfVisible extra={allContexts.length > 0}>
+      <IfVisible extra={allContexts.length > 0} debugId={debugId}>
         <div className="group pt-2 pb-4 px-4 space-y-2.5">
           <div className="flex items-start gap-2">
             <div className="min-w-0">
@@ -162,7 +174,7 @@ export const UserMessageRenderer: React.FC<UserMessageRendererProps> = ({ messag
   }
 
   return (
-    <IfVisible extra={imageBlocks.length > 0 || allContexts.length > 0}>
+    <IfVisible extra={imageBlocks.length > 0 || allContexts.length > 0} debugId={debugId}>
       <div className="group pt-2 pb-4 px-4 space-y-2.5">
         <div className="flex items-start gap-2">
           <div className="min-w-0">

--- a/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
@@ -77,4 +77,47 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
     );
     expect(container.innerHTML).not.toBe('');
   });
+
+  // The guard above kept the entry visible but rendered `parsedContent.text`,
+  // which is empty for a tool_result — so the "kept" entry was a bare bordered
+  // pill and the output it was meant to protect never reached the screen. The
+  // reporter hit this on a 110-minute / 258-turn session, where an unpaired
+  // tool_result is far more likely.
+  it('shows the actual output of an unmerged tool_result, not an empty pill', () => {
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([
+          { type: 'tool_result', tool_use_id: 'call_1', content: 'REAL OUTPUT' },
+        ])}
+      />,
+    );
+    expect(container.textContent).toContain('REAL OUTPUT');
+  });
+
+  it('shows output when the tool_result content is a text-block array', () => {
+    // Task-style results arrive as blocks rather than a bare string.
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([
+          {
+            type: 'tool_result',
+            tool_use_id: 'call_1',
+            content: [{ type: 'text', text: 'BLOCK OUTPUT' }],
+          },
+        ])}
+      />,
+    );
+    expect(container.textContent).toContain('BLOCK OUTPUT');
+  });
+
+  it('renders nothing for a tool_result that carries no output at all', () => {
+    // With no text to show, the entry protects nothing — an empty pill is the
+    // very symptom of issue #232.
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'call_1', content: '' }])}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
 });

--- a/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
@@ -66,23 +66,11 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
     expect(container.textContent).toContain('hello');
   });
 
-  it('keeps a tool_result entry visible so unmerged tool output is not lost', () => {
-    // mergeToolResults normally folds this into the tool card above. When it
-    // cannot (the tool_use is on a not-yet-loaded page) the entry must survive,
-    // or the tool's output disappears silently.
-    const { container } = render(
-      <UserMessageRenderer
-        message={userMessage([{ type: 'tool_result', tool_use_id: 'call_1', content: 'output' }])}
-      />,
-    );
-    expect(container.innerHTML).not.toBe('');
-  });
-
-  // The guard above kept the entry visible but rendered `parsedContent.text`,
-  // which is empty for a tool_result — so the "kept" entry was a bare bordered
-  // pill and the output it was meant to protect never reached the screen. The
-  // reporter hit this on a 110-minute / 258-turn session, where an unpaired
-  // tool_result is far more likely.
+  // The v0.26.4 guard kept a tool_result visible but rendered
+  // `parsedContent.text`, which is empty for one — so the "kept" entry was a bare
+  // bordered pill and the output it was meant to protect never reached the
+  // screen. The reporter hit this on a 110-minute / 258-turn session, where an
+  // unpaired tool_result is far more likely.
   it('shows the actual output of an unmerged tool_result, not an empty pill', () => {
     const { container } = render(
       <UserMessageRenderer
@@ -119,5 +107,87 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
       />,
     );
     expect(container.innerHTML).toBe('');
+  });
+});
+
+/**
+ * The rule is about what a human sees, not about what a string contains.
+ *
+ * Guarding case by case did not hold: `''` was covered, then `<system-reminder>`,
+ * then `tool_result` — and a zero-width space still drew a box, because
+ * `String.trim()` does not consider one to be whitespace. Worse, the
+ * `commandName` branch returned *above* the guard, so it was never checked at
+ * all. Every new invisible character and every new branch was another leak.
+ *
+ * So the check moved to the single exit and asks about the rendered output. The
+ * cases below are examples of that rule, not the rule itself.
+ *
+ * Escapes, not literals: these characters are invisible in an editor, so a
+ * pasted one would be unreviewable — and a stray one breaks the parse outright.
+ */
+const INVISIBLE: Array<[string, string]> = [
+  ['zero-width space', '​'],
+  ['zero-width non-joiner', '‌'],
+  ['zero-width joiner', '‍'],
+  ['left-to-right mark', '‎'],
+  ['right-to-left mark', '‏'],
+  ['word joiner', '⁠'],
+  ['soft hyphen', '­'],
+  ['BOM / zero-width no-break', '﻿'],
+  ['non-breaking space', ' '],
+  ['ideographic space', '　'],
+  ['hangul filler', 'ㅤ'],
+  ['variation selector', '️'],
+  ['bidi override', '‮'],
+  ['ordinary whitespace', '   \n\t  '],
+  ['a mix of several', '​ ­⁠﻿\n'],
+];
+
+describe('UserMessageRenderer — nothing visible means nothing rendered', () => {
+  it.each(INVISIBLE)('renders nothing for plain text that is only a %s', (_name, ch) => {
+    const { container } = render(<UserMessageRenderer message={userMessage(ch)} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it.each(INVISIBLE)('renders nothing for a tool_result that is only a %s', (_name, ch) => {
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'c1', content: ch }])}
+      />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it.each(INVISIBLE)('renders nothing for a command name that is only a %s', (_name, ch) => {
+    // This branch used to return above the guard, so it was never checked.
+    const { container } = render(
+      <UserMessageRenderer message={userMessage(`<command-name>${ch}</command-name>`)} />,
+    );
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('still renders text that merely contains an invisible character', () => {
+    // The rule drops what is invisible, not what is merely unusual.
+    const { container } = render(<UserMessageRenderer message={userMessage('a​b')} />);
+    expect(container.textContent).toContain('a');
+    expect(container.textContent).toContain('b');
+  });
+
+  it('still renders a real command name', () => {
+    const { container } = render(
+      <UserMessageRenderer message={userMessage('<command-name>/clear</command-name>')} />,
+    );
+    expect(container.textContent).toContain('clear');
+  });
+
+  it('keeps an image-only message, which has no glyphs by nature', () => {
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([
+          { type: 'image', source: { type: 'base64', media_type: 'image/png', data: 'iVBOR' } },
+        ])}
+      />,
+    );
+    expect(container.innerHTML).not.toBe('');
   });
 });

--- a/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/UserMessageRenderer.emptyBubble.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from '@testing-library/react';
 import { LoadedMessageDto } from '../../../../types';
 import { LoadedMessageType, toInstance } from '../../../../dto/common';
@@ -25,6 +25,26 @@ function renderedBox(container: HTMLElement): Element | null {
   return container.querySelector('.bg-surface-hover.border');
 }
 
+/**
+ * Asserts the entry puts nothing on screen.
+ *
+ * Not `innerHTML === ''`: `IfVisible` keeps its wrapper mounted and collapses it
+ * with `display: none`, so the subtree stays in the DOM on purpose. It has to —
+ * the wrapper holds the `ref` the visibility check reads `textContent` from, and
+ * dropping it would freeze the verdict at the first render, so an entry whose
+ * content arrives later could never come back. The wrapper also carries the
+ * `data-ccg-would-be-empty` trail that keeps "how often would this have been an
+ * empty bubble?" answerable in production.
+ *
+ * What matters to the user is that nothing is painted, which is what this checks.
+ */
+function expectNothingVisible(container: HTMLElement): void {
+  const wrapper = container.firstElementChild as HTMLElement | null;
+  if (wrapper === null) return; // rendered literally nothing — also fine
+  expect(container.children).toHaveLength(1);
+  expect(wrapper.style.display).toBe('none');
+}
+
 describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
   it('renders nothing when the content is only a system-reminder', () => {
     const { container } = render(
@@ -32,17 +52,17 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
         message={userMessage('<system-reminder>The user named this session "x".</system-reminder>')}
       />,
     );
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it('renders nothing when the content is an empty block array', () => {
     const { container } = render(<UserMessageRenderer message={userMessage([])} />);
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it('renders nothing when the content is an empty string', () => {
     const { container } = render(<UserMessageRenderer message={userMessage('   ')} />);
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it('renders nothing when an ide_opened_file tag leaves no text behind', () => {
@@ -53,9 +73,10 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
         message={userMessage('<ide_opened_file>The user opened the file /tmp/a.ts in the IDE.</ide_opened_file>')}
       />,
     );
-    // A context pill is real content, so the entry still renders — what must not
-    // happen is an empty box with no pill.
-    if (container.innerHTML !== '') {
+    // A context pill is real content, so the entry may still render — what must
+    // not happen is an empty box with no pill.
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    if (wrapper && wrapper.style.display !== 'none') {
       expect(container.textContent).toContain('a.ts');
     }
   });
@@ -106,7 +127,7 @@ describe('UserMessageRenderer — empty bubble guard (issue #232)', () => {
         message={userMessage([{ type: 'tool_result', tool_use_id: 'call_1', content: '' }])}
       />,
     );
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 });
 
@@ -146,7 +167,7 @@ const INVISIBLE: Array<[string, string]> = [
 describe('UserMessageRenderer — nothing visible means nothing rendered', () => {
   it.each(INVISIBLE)('renders nothing for plain text that is only a %s', (_name, ch) => {
     const { container } = render(<UserMessageRenderer message={userMessage(ch)} />);
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it.each(INVISIBLE)('renders nothing for a tool_result that is only a %s', (_name, ch) => {
@@ -155,7 +176,7 @@ describe('UserMessageRenderer — nothing visible means nothing rendered', () =>
         message={userMessage([{ type: 'tool_result', tool_use_id: 'c1', content: ch }])}
       />,
     );
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it.each(INVISIBLE)('renders nothing for a command name that is only a %s', (_name, ch) => {
@@ -163,7 +184,7 @@ describe('UserMessageRenderer — nothing visible means nothing rendered', () =>
     const { container } = render(
       <UserMessageRenderer message={userMessage(`<command-name>${ch}</command-name>`)} />,
     );
-    expect(container.innerHTML).toBe('');
+    expectNothingVisible(container);
   });
 
   it('still renders text that merely contains an invisible character', () => {
@@ -188,6 +209,83 @@ describe('UserMessageRenderer — nothing visible means nothing rendered', () =>
         ])}
       />,
     );
-    expect(container.innerHTML).not.toBe('');
+    // `not.toBe('')` would pass on the collapsed wrapper alone, so assert the
+    // wrapper is actually shown — an image has no glyph, and `extra` is what
+    // keeps it from being mistaken for an empty bubble.
+    const wrapper = container.firstElementChild as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper!.style.display).not.toBe('none');
+  });
+});
+
+/**
+ * Hiding the bubble solves the symptom but erases the evidence: once the box is
+ * gone, "this build is fixed" and "these conditions never arose" look identical
+ * on screen. The trail is what tells them apart — it survives the fix, so a run
+ * with `count > 0` and no visible box is proof the guard did the work, while
+ * `count === 0` means the case simply did not come up.
+ *
+ * It is deliberately left on in production: a reporter's console is often the
+ * only place the defect can be observed at all.
+ */
+describe('UserMessageRenderer — the hidden bubble leaves a trail', () => {
+  function trail(): { count: number; ids: string[] } | undefined {
+    return (window as unknown as { ccgEmptyBubbles?: { count: number; ids: string[] } })
+      .ccgEmptyBubbles;
+  }
+
+  beforeEach(() => {
+    delete (window as unknown as { ccgEmptyBubbles?: unknown }).ccgEmptyBubbles;
+  });
+
+  it('counts a bubble it hid, and records the tool_use_id it belonged to', () => {
+    render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'toolu_abc', content: '' }])}
+      />,
+    );
+    expect(trail()?.count).toBe(1);
+    expect(trail()?.ids).toContain('toolu_abc');
+  });
+
+  it('marks the hidden element so it can be found in the DOM', () => {
+    const { container } = render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'toolu_abc', content: '' }])}
+      />,
+    );
+    const marked = container.querySelector('[data-ccg-would-be-empty="toolu_abc"]');
+    expect(marked).not.toBeNull();
+    expect((marked as HTMLElement).style.display).toBe('none');
+  });
+
+  it('does not count an entry that renders normally', () => {
+    render(<UserMessageRenderer message={userMessage('hello')} />);
+    expect(trail()?.count ?? 0).toBe(0);
+  });
+
+  it('counts one occurrence per bubble, not one per render', () => {
+    // The visibility check runs in an effect on every render; a re-render must
+    // not inflate the tally, or the number stops meaning "times this happened".
+    const message = userMessage([{ type: 'tool_result', tool_use_id: 'toolu_abc', content: '' }]);
+    const { rerender } = render(<UserMessageRenderer message={message} />);
+    rerender(<UserMessageRenderer message={message} />);
+    rerender(<UserMessageRenderer message={message} />);
+    expect(trail()?.count).toBe(1);
+  });
+
+  it('accumulates across separate empty bubbles', () => {
+    render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'toolu_1', content: '' }])}
+      />,
+    );
+    render(
+      <UserMessageRenderer
+        message={userMessage([{ type: 'tool_result', tool_use_id: 'toolu_2', content: '' }])}
+      />,
+    );
+    expect(trail()?.count).toBe(2);
+    expect(trail()?.ids).toEqual(['toolu_1', 'toolu_2']);
   });
 });

--- a/webview/src/pages/ChatPage/message-renderers/components/IfVisible.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/IfVisible.tsx
@@ -1,0 +1,80 @@
+import React, { useLayoutEffect, useRef, useState } from 'react';
+
+/**
+ * Renders `children` only when they put something a human can actually see on
+ * the screen.
+ *
+ * The rule this enforces — "never draw an empty user bubble" — kept leaking
+ * because it was checked case by case on the way in: first `''`, then
+ * `<system-reminder>`, then `tool_result`, and a zero-width space still drew a
+ * box because `String.trim()` does not treat one as whitespace. Every new
+ * invisible character, and every new branch added above the check, was another
+ * leak (issue #232, reopened twice).
+ *
+ * So the question is asked once, at the exit, about the rendered result rather
+ * than about the input: after mount, does this subtree contain any visible
+ * glyph? If not, it is removed. That holds no matter which branch produced it or
+ * what the content was made of.
+ *
+ * `extra` marks content that is legitimately glyph-less — an image attachment, a
+ * context pill — so it survives the check.
+ */
+interface IfVisibleProps {
+  children: React.ReactNode;
+  /** True when non-text content (images, pills) makes this worth showing. */
+  extra?: boolean;
+}
+
+/**
+ * Characters that occupy no visual space. Stripping these is what separates
+ * "the string is non-empty" from "the user can see something".
+ *
+ * Written as escapes on purpose: the literal characters are invisible in an
+ * editor, so a pasted one would be unreviewable — and a stray one breaks the
+ * parse outright.
+ */
+const INVISIBLE = new RegExp(
+  '[' +
+    '\\s' + // ordinary whitespace, incl. NBSP and ideographic space
+    '\\u00AD' + // soft hyphen
+    '\\u034F' + // combining grapheme joiner
+    '\\u061C' + // arabic letter mark
+    '\\u115F\\u1160' + // hangul choseong/jungseong fillers
+    '\\u17B4\\u17B5' + // khmer inherent vowels
+    '\\u180B-\\u180E' + // mongolian variation selectors, vowel separator
+    '\\u200B-\\u200F' + // zero-width space/non-joiner/joiner, LRM, RLM
+    '\\u202A-\\u202E' + // bidi embedding and override controls
+    '\\u2060-\\u2064' + // word joiner, invisible operators
+    '\\u206A-\\u206F' + // deprecated formatting controls
+    '\\u3164' + // hangul filler
+    '\\uFE00-\\uFE0F' + // variation selectors
+    '\\uFEFF' + // zero-width no-break space (BOM)
+    '\\uFFA0' + // halfwidth hangul filler
+    ']',
+  'g',
+);
+
+/** True when `text` contains at least one character a human can see. */
+export function hasVisibleGlyph(text: string | null | undefined): boolean {
+  return (text ?? '').replace(INVISIBLE, '') !== '';
+}
+
+export const IfVisible: React.FC<IfVisibleProps> = ({ children, extra = false }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [hidden, setHidden] = useState(false);
+
+  // useLayoutEffect so the removal happens before the browser paints — an empty
+  // bubble must never flash on screen.
+  useLayoutEffect(() => {
+    if (extra) {
+      setHidden(false);
+      return;
+    }
+    setHidden(!hasVisibleGlyph(ref.current?.textContent));
+  });
+
+  if (hidden) return null;
+  // `display: contents` keeps this wrapper out of the layout entirely, so the
+  // children lay out exactly as they did before the gate existed.
+  return <div ref={ref} style={{ display: 'contents' }}>{children}</div>;
+};

--- a/webview/src/pages/ChatPage/message-renderers/components/IfVisible.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/IfVisible.tsx
@@ -23,6 +23,39 @@ interface IfVisibleProps {
   children: React.ReactNode;
   /** True when non-text content (images, pills) makes this worth showing. */
   extra?: boolean;
+  /**
+   * Identifies the entry for the debugging trail below, e.g. the `tool_use_id`
+   * of a tool_result that found no tool card to fold into. Optional: an entry
+   * with nothing to identify it still gets counted, just without an id.
+   */
+  debugId?: string;
+}
+
+/**
+ * Records an entry this gate removed, so "how often would an empty bubble have
+ * appeared here?" stays answerable after the bubble itself is gone.
+ *
+ * Both trails are deliberately left on in production. They cost one attribute
+ * and one array entry per hidden bubble, are invisible to the user, and are the
+ * only way to tell "the defect is fixed" apart from "the conditions never
+ * occurred" — including on a reporter's machine, where the console is all we
+ * get. See `ccgLogs` for the same reasoning applied to logs.
+ *
+ *   document.querySelectorAll('[data-ccg-would-be-empty]')   where, in the DOM
+ *   window.ccgEmptyBubbles                                   how many, and which ids
+ */
+const WOULD_BE_EMPTY_ATTR = 'data-ccg-would-be-empty';
+
+interface EmptyBubbleTrail {
+  count: number;
+  ids: string[];
+}
+
+function recordWouldBeEmpty(debugId: string | undefined): void {
+  const w = window as unknown as { ccgEmptyBubbles?: EmptyBubbleTrail };
+  const trail = (w.ccgEmptyBubbles ??= { count: 0, ids: [] });
+  trail.count += 1;
+  if (debugId) trail.ids.push(debugId);
 }
 
 /**
@@ -59,9 +92,12 @@ export function hasVisibleGlyph(text: string | null | undefined): boolean {
   return (text ?? '').replace(INVISIBLE, '') !== '';
 }
 
-export const IfVisible: React.FC<IfVisibleProps> = ({ children, extra = false }) => {
+export const IfVisible: React.FC<IfVisibleProps> = ({ children, extra = false, debugId }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [hidden, setHidden] = useState(false);
+  // The effect below runs on every render, but one bubble is one occurrence —
+  // a re-render (or StrictMode's double invoke) must not inflate the tally.
+  const counted = useRef(false);
 
   // useLayoutEffect so the removal happens before the browser paints — an empty
   // bubble must never flash on screen.
@@ -70,11 +106,15 @@ export const IfVisible: React.FC<IfVisibleProps> = ({ children, extra = false })
       setHidden(false);
       return;
     }
-    setHidden(!hasVisibleGlyph(ref.current?.textContent));
+    const isEmpty = !hasVisibleGlyph(ref.current?.textContent);
+    if (isEmpty && !counted.current) {
+      counted.current = true;
+      recordWouldBeEmpty(debugId);
+    }
+    setHidden(isEmpty);
   });
 
-  if (hidden) return null;
   // `display: contents` keeps this wrapper out of the layout entirely, so the
   // children lay out exactly as they did before the gate existed.
-  return <div ref={ref} style={{ display: 'contents' }}>{children}</div>;
+  return <div ref={ref} {...{ [WOULD_BE_EMPTY_ATTR]: debugId ?? '' }} style={{ display: hidden ? 'none' : 'contents' }}>{children}</div>;
 };


### PR DESCRIPTION
The empty bubbles in #232 were two problems wearing one symptom: a rule that
kept leaking, and a cause that kept producing things for it to leak on. This
addresses both.

## The cause

A turn that runs tools does not end at `result`. The CLI keeps going and starts
a new assistant message per continuation, each with its own `message.id`. The
streaming placeholder, though, lives until `result` — so every message resolved
to the same entry, and each payload replaced the previous message's blocks
instead of following them.

What that dropped was the finished message's `tool_use`. Its `tool_result` still
arrived, found no tool call to fold into, and was left as a bubble with nothing
in it — one per overwritten message, which is why they appeared in runs rather
than singly.

Two session logs attached to the issue settled it:

| | standalone `tool_result` | their `tool_use` present |
|---|---|---|
| streamed | 14 | 0 of 14 (out of 236 tool_use blocks) |
| same point, after reload | 0 | 14 of 14, each on its own entry |

Same data both times, so nothing was lost in transport — only the live assembly
collapsed many messages into one. `message_start` now seals the placeholder when
the id changes, and the next block opens a fresh entry: the shape the reload
path already produces.

The seal belongs there and not on the `assistant` payload. By the time a payload
arrives, its message's deltas are already in the entry, so sealing there let the
following deltas keep flowing into the entry just closed — splicing one
message's text onto another's — while the next payload re-rendered the same text
under a new entry, printing every line of the reply twice.

## The rule

"Never draw an empty user bubble" was checked case by case on the way in: `''`,
then `<system-reminder>`, then `tool_result`. A zero-width space still drew a box
because `String.trim()` does not treat one as whitespace, and the `commandName`
branch returned *above* the check, so it was never checked at all. Every new
invisible character and every new branch was another leak.

So the question moved to the single exit and is asked about the rendered result:
does this subtree contain a glyph a human can see? If not, it is removed —
regardless of which branch produced it or what the content was made of.

Also here: an unmerged `tool_result` now renders its actual output. The earlier
guard kept such entries visible so tool output would not be lost, but the render
path drew `parsedContent.text` — always `''` for a tool_result — so it never
surfaced the output it existed to protect.

## The trail

Hiding the bubble solves the symptom but erases the evidence. Once the box is
gone, "this build is fixed" and "these conditions never arose" look identical on
screen, so a report of "I still see them" cannot be checked against a build that
claims otherwise.

The gate therefore records what it removed: a `data-ccg-would-be-empty` attribute
on the collapsed wrapper, carrying the `tool_use_id` when the entry is a
tool_result that found no tool card, and a running `window.ccgEmptyBubbles` tally.
Neither is visible to the user, and both stay on in production — a reporter's
console is often the only place the defect can be observed at all, the same
reasoning already applied to `ccgLogs`.

## Verification

`wv-test` 2515 ✓ (265 files) · `tsc --noEmit` ✓

Each fix was checked by disabling it and confirming the tests fail:

| disabled | failing tests |
|---|---|
| the seal | 3 |
| seal moved back to the `assistant` payload | 3 |
| the trail's per-bubble guard | 3 |

Reproducing the overwrite in a test needed the placeholder to actually be open —
`content_block_start` is what opens it — and both messages to arrive inside one
`act`. Split across two, React closes the stream in between and the second
message appends regardless, so the test passes with or without the fix.

Closes #232
