### PR TITLE
fix(backend): 426 for non-WebSocket (h2c) upgrades instead of a silent destroy (#191)

### DIFF
--- a/backend/src/ws/__tests__/ws-server-auth.test.ts
+++ b/backend/src/ws/__tests__/ws-server-auth.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { WebSocket } from 'ws';
+import net from 'net';
 import { startWebSocketServer, AUTH_SUBPROTOCOL } from '../ws-server';
 import { LogWebSocketServer } from '../../logging/log-ws';
 import { authToken } from '../../config/environment';
@@ -169,6 +170,47 @@ describe('ws-server auth (Sec-WebSocket-Protocol token)', () => {
         body,
       });
       expect(res.status).toBe(200);
+    });
+  });
+
+  // Non-WebSocket `Upgrade` requests (issue #191) — e.g. h2c (HTTP/2 cleartext),
+  // which `java.net.http.HttpClient` sends by default. Node routes every
+  // `Upgrade`-bearing request to the 'upgrade' handler, bypassing the normal
+  // request handler entirely, so this must be answered explicitly (426) rather
+  // than silently destroyed. `ws`/`fetch` can't send arbitrary Upgrade headers,
+  // so we drive this with a raw net.Socket.
+  describe('non-WebSocket upgrade (h2c)', () => {
+    function sendRawUpgrade(rawUpgradeValue: string): Promise<string> {
+      return new Promise((resolve, reject) => {
+        const socket = net.connect(port, '127.0.0.1', () => {
+          socket.write(
+            `GET / HTTP/1.1\r\n` +
+              `Host: 127.0.0.1:${port}\r\n` +
+              `Origin: ${ALLOWED_ORIGIN}\r\n` +
+              `Connection: Upgrade, HTTP2-Settings\r\n` +
+              `Upgrade: ${rawUpgradeValue}\r\n` +
+              `HTTP2-Settings: AAMAAABkAAQCAAAAAAIAAAAA\r\n` +
+              `\r\n`,
+          );
+        });
+        let data = '';
+        socket.on('data', (chunk) => {
+          data += chunk.toString();
+          socket.end();
+        });
+        socket.on('close', () => resolve(data));
+        socket.on('error', reject);
+      });
+    }
+
+    it('receives an explicit 426, not a silent connection destroy', async () => {
+      const response = await sendRawUpgrade('h2c');
+      expect(response).toMatch(/^HTTP\/1\.1 426 Upgrade Required/);
+    });
+
+    it('is case-insensitive when checking the Upgrade header value', async () => {
+      const response = await sendRawUpgrade('H2C');
+      expect(response).toMatch(/^HTTP\/1\.1 426 Upgrade Required/);
     });
   });
 

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -497,6 +497,20 @@ export function startWebSocketServer(
     httpServer.on('upgrade', (request, socket, head) => {
       const url = request.url;
 
+      // Non-WebSocket upgrade guard (issue #191). Node routes EVERY request
+      // carrying an `Upgrade` header to this handler, not just WebSocket
+      // upgrades — e.g. h2c (HTTP/2 cleartext), which `java.net.http.HttpClient`
+      // sends by default. Such requests have no Sec-WebSocket-Protocol token, so
+      // they used to die on the token check below with a bare socket.destroy()
+      // and no response. Reply 426 so the client sees an explicit status and can
+      // fall back to HTTP/1.1 instead of the connection dying mid-read.
+      const upgradeHeader = (request.headers.upgrade ?? '').toLowerCase();
+      if (upgradeHeader !== 'websocket') {
+        socket.write('HTTP/1.1 426 Upgrade Required\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
       // Origin 검증 — /ws, /rpc, /logs 공통. Origin은 인증이 아니라 CSWSH 방어
       // 하드닝 레이어로 그대로 유지한다(약화 금지). 실제 인증은 아래 토큰이 담당.
       const origin = request.headers.origin;


### PR DESCRIPTION
Fixes #191.

## The bug

Node routes **every** request carrying an `Upgrade` header to the WebSocket `upgrade` handler in `backend/src/ws/ws-server.ts`, skipping the normal `request` pipeline entirely. A non-WebSocket upgrade — notably **h2c** (HTTP/2 cleartext), which `java.net.http.HttpClient` negotiates **by default** (`Version.HTTP_2`) — carries no `Sec-WebSocket-Protocol` token, so it fell through to the auth check and had its socket closed. The client's `GET /version` / static-bundle request never reached the request handler; it just died mid-read.

So any h2c-capable client (any JVM integration using `HttpClient` with defaults) is broken against every plain-HTTP endpoint the backend serves. `curl` (without `--http2`) and browsers work only because they don't attempt the cleartext upgrade.

We had already sidestepped this on **our** side by forcing HTTP/1.1 in `BackendStatusClient` (the status/pairing client's mandatory-`HTTP_1_1` comment documents exactly this). This PR fixes the **server-side root cause** so external standard clients work too — in line with the project's baseline that standard tooling should reach our endpoints.

## The fix

Guard the `upgrade` handler up front: if the `Upgrade` header value is not `websocket` (case-insensitive), reply `426 Upgrade Required` + `Connection: close` and destroy — an explicit status the client can act on (fall back to HTTP/1.1) instead of a silent teardown. Normal WebSocket upgrades (`/ws`, `/rpc`, `/logs`) are untouched.

## Tests

Two new cases in `ws-server-auth.test.ts` drive a raw h2c upgrade over `net.Socket` (`ws`/`fetch` can't send arbitrary Upgrade headers) and assert the `426` response, including a case-insensitive `H2C` variant.

Backend build + full suite green: **1107 passed** (8 skipped), 100 test files.

## OS scope

Server-side upgrade handling is Node-runtime-level with no `process.platform`/win32 branches on this path, and h2c is a client-side protocol negotiation, not an OS behavior. No Windows-specific field-testing required (unlike #187/#254/#257, which had explicit win32 branches).

Targeting **0.26.5**.
