### PR TITLE
fix(backend): honor a permission mode picked mid-chat by restarting the CLI

### DIFF
--- a/backend/src/core/__tests__/claude-process.test.ts
+++ b/backend/src/core/__tests__/claude-process.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildClaudeArgs, needsRestartForMode } from '../claude-process';
+import { buildClaudeArgs, needsRestartForMode, readReportedMode } from '../claude-process';
 
 describe('buildClaudeArgs', () => {
   it('includes the core stream-json print-mode flags and the session flag', () => {
@@ -74,5 +74,35 @@ describe('needsRestartForMode', () => {
 
   it('restarts when the live process mode is unknown (safer than assuming a match)', () => {
     expect(needsRestartForMode(null, 'plan')).toBe(true);
+  });
+});
+
+describe('readReportedMode', () => {
+  it('reads the mode the CLI announces at spawn (system/init)', () => {
+    expect(readReportedMode({ type: 'system', subtype: 'init', permissionMode: 'plan' })).toBe('plan');
+  });
+
+  // #172: approving an ExitPlanMode plan leaves plan mode with NO respawn, and the CLI
+  // announces that on system/status. Adopting it is what stops the next "Plan mode"
+  // pick from comparing equal to a stale record and reusing a CLI that has left plan.
+  it('reads the mode the CLI switches to on its own (system/status)', () => {
+    expect(readReportedMode({ type: 'system', subtype: 'status', permissionMode: 'default' })).toBe(
+      'ask_before_edit',
+    );
+  });
+
+  it('translates CLI flag names into the webview vocabulary', () => {
+    expect(readReportedMode({ type: 'system', permissionMode: 'bypassPermissions' })).toBe('bypass');
+    expect(readReportedMode({ type: 'system', permissionMode: 'acceptEdits' })).toBe('auto_edit');
+  });
+
+  it('reports nothing for events that carry no permission mode', () => {
+    expect(readReportedMode({ type: 'assistant' })).toBeNull();
+    expect(readReportedMode({ type: 'system', subtype: 'init' })).toBeNull();
+    expect(readReportedMode({ type: 'result', permissionMode: 'plan' })).toBeNull();
+  });
+
+  it('reports nothing for an unrecognized flag rather than guessing', () => {
+    expect(readReportedMode({ type: 'system', permissionMode: 'somethingNew' })).toBeNull();
   });
 });

--- a/backend/src/core/__tests__/claude-process.test.ts
+++ b/backend/src/core/__tests__/claude-process.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildClaudeArgs } from '../claude-process';
+import { buildClaudeArgs, needsRestartForMode } from '../claude-process';
 
 describe('buildClaudeArgs', () => {
   it('includes the core stream-json print-mode flags and the session flag', () => {
@@ -54,5 +54,25 @@ describe('buildClaudeArgs', () => {
 
   it('omits --model for the "default" alias (redundant with the CLI default)', () => {
     expect(buildClaudeArgs('--resume', 's', 'ask_before_edit', 'default')).not.toContain('--model');
+  });
+});
+
+describe('needsRestartForMode', () => {
+  it('reuses the live process when the requested mode is what it already runs', () => {
+    expect(needsRestartForMode('plan', 'plan')).toBe(false);
+    expect(needsRestartForMode('ask_before_edit', 'ask_before_edit')).toBe(false);
+  });
+
+  // #172: `--permission-mode` only applies at spawn, so a live CLI keeps its original
+  // mode. Reusing it would drop the user's choice AND let the CLI's next system/init
+  // push the stale mode back onto the webview — the "mode turns itself off" report.
+  it('restarts when the user picked a different mode mid-chat', () => {
+    expect(needsRestartForMode('plan', 'ask_before_edit')).toBe(true);
+    expect(needsRestartForMode('ask_before_edit', 'plan')).toBe(true);
+    expect(needsRestartForMode('bypass', 'auto_edit')).toBe(true);
+  });
+
+  it('restarts when the live process mode is unknown (safer than assuming a match)', () => {
+    expect(needsRestartForMode(null, 'plan')).toBe(true);
   });
 });

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -53,6 +53,29 @@ const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
   auto: 'auto',
 };
 
+// Reverse of the above: the CLI reports its permission mode using its own flag
+// names, and we store modes in the webview's vocabulary. Derived from the forward
+// map so the two can never drift apart.
+const CLI_FLAG_TO_INPUT_MODE: Record<string, string> = Object.fromEntries(
+  Object.entries(INPUT_MODE_TO_CLI_FLAG).map(([inputMode, flag]) => [flag, inputMode]),
+);
+
+/**
+ * The permission mode a CLI stream event reports, translated into our InputMode
+ * vocabulary — or null if this event does not report one.
+ *
+ * The CLI announces its mode on `system/init` (at spawn) and again on
+ * `system/status` when it changes the mode itself, which is how an approved
+ * ExitPlanMode plan leaving plan mode becomes observable without inspecting the
+ * tool call. Exported for tests.
+ */
+export function readReportedMode(event: Record<string, unknown>): string | null {
+  if (event.type !== 'system') return null;
+  const flag = event.permissionMode;
+  if (typeof flag !== 'string') return null;
+  return CLI_FLAG_TO_INPUT_MODE[flag] ?? null;
+}
+
 /**
  * Build the argv for spawning the Claude CLI in interactive print mode.
  * Extracted as a pure function so the flag composition (session flag,
@@ -129,10 +152,17 @@ export function markSessionAsSpawned(sessionId: string): void {
  * in place, so honoring a mid-chat mode change means respawning (#172). Extracted
  * as a pure function so this decision is unit-testable without spawning anything.
  *
- * A null `liveMode` means we have a process but never recorded what mode it runs
- * under (e.g. a session reclaimed after a backend restart). Restarting is the safe
- * reading: it makes the CLI provably match what the user picked, whereas reusing
- * would gamble on an unknown mode and risk running edits under looser permissions
+ * Every message carries the mode the UI is currently showing, so this compares it
+ * against what the CLI is actually running under. `liveMode` tracks the CLI, not
+ * merely the flag we spawned it with: the CLI reports its own mode on `system/init`
+ * and again on `system/status` whenever it changes it itself (approving an
+ * ExitPlanMode plan leaves plan mode with no respawn), and the stream handler keeps
+ * the record in step. Comparing against a spawn-time-only record would read that
+ * self-initiated exit as "no change" and reuse a CLI that is no longer in plan.
+ *
+ * A null `liveMode` means we have a process but never recorded a mode for it (e.g. a
+ * session reclaimed after a backend restart). Restarting is the safe reading: reusing
+ * would gamble on an unknown mode and risk edits running under looser permissions
  * than the user chose.
  */
 export function needsRestartForMode(liveMode: string | null, requestedMode: string): boolean {
@@ -695,6 +725,22 @@ function handleStreamEvent(
   // Detect background dynamic workflows and stream their live progress. Pure
   // side-effect — the raw CLI event is still forwarded unchanged below.
   getWorkflowTracker(connections).handleEvent(targetSessionId, event);
+
+  // Keep the recorded permission mode in step with what the CLI says it is running
+  // under. The CLI reports this on `system/init` (spawn) and again on `system/status`
+  // when it changes mode by itself — approving an ExitPlanMode plan leaves plan mode
+  // with no respawn. Without adopting that, the record would still read `plan`, the
+  // user re-picking Plan Mode would compare equal, and the CLI would be reused while
+  // actually out of plan — the "Plan Mode turns itself off" report (#172).
+  const reportedMode = readReportedMode(event);
+  if (reportedMode && reportedMode !== connections.getInputMode(targetSessionId)) {
+    console.error(
+      '[node-backend]',
+      `CLI reports permission mode "${reportedMode}" for session ${targetSessionId} ` +
+        `(was "${connections.getInputMode(targetSessionId)}")`,
+    );
+    connections.setInputMode(targetSessionId, reportedMode);
+  }
 
   // 백엔드 고유 사이드이펙트 (WebView 전달과 무관한 서버 내부 로직)
   if (eventType === 'result') {

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -55,8 +55,12 @@ const INPUT_MODE_TO_CLI_FLAG: Record<string, string> = {
 
 // Reverse of the above: the CLI reports its permission mode using its own flag
 // names, and we store modes in the webview's vocabulary. Derived from the forward
-// map so the two can never drift apart.
-const CLI_FLAG_TO_INPUT_MODE: Record<string, string> = Object.fromEntries(
+// map so the two can never drift apart. Exported: both the live stream (system
+// events) and the on-disk JSONL (user entries) carry the mode as this same flag
+// vocabulary in a `permissionMode` field, so the translation is shared while each
+// caller decides which entry's field to read (see readReportedMode and
+// findLastReportedModeInPage in loadSessionMessages.ts).
+export const CLI_FLAG_TO_INPUT_MODE: Record<string, string> = Object.fromEntries(
   Object.entries(INPUT_MODE_TO_CLI_FLAG).map(([inputMode, flag]) => [flag, inputMode]),
 );
 

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -1,3 +1,4 @@
+import type { ChildProcess } from 'child_process';
 import type { ConnectionManager } from '../ws/connection-manager';
 import type { Bridge } from '../bridge/bridge-interface';
 import { Claude } from './claude';
@@ -97,6 +98,16 @@ export function buildClaudeArgs(
 // result 이벤트 수신 여부 추적 (비정상 종료 시 에러 전파 판단용)
 const sessionsWithResult = new Set<string>();
 
+// Sessions whose CLI we are killing on purpose to respawn it under a different
+// permission mode. The exit is ours, not a failure, so the close handler must not
+// surface it as an error or as STREAM_END — the user only asked to switch modes and
+// a new process is already on its way. Cleared as soon as that close is observed.
+const sessionsRestartingForMode = new Set<string>();
+
+// How long to wait for a CLI to exit on SIGTERM during a mode-change restart before
+// escalating to SIGKILL. The user is waiting on their message, so this stays short.
+const MODE_RESTART_KILL_TIMEOUT_MS = 3000;
+
 // 한 번이라도 spawn된 세션 추적 (재시작 시 --resume 사용 판단용)
 // --session-id: 새 세션 전용 (JSONL 이미 존재하면 "already in use" 에러)
 // --resume: 기존 세션 이어받기 (JSONL이 있어야 동작)
@@ -111,8 +122,87 @@ export function markSessionAsSpawned(sessionId: string): void {
 }
 
 /**
+ * Whether a live CLI running under `liveMode` can serve a message requesting
+ * `requestedMode`, or has to be restarted first.
+ *
+ * `--permission-mode` is a spawn-time flag and no official CLI command changes it
+ * in place, so honoring a mid-chat mode change means respawning (#172). Extracted
+ * as a pure function so this decision is unit-testable without spawning anything.
+ *
+ * A null `liveMode` means we have a process but never recorded what mode it runs
+ * under (e.g. a session reclaimed after a backend restart). Restarting is the safe
+ * reading: it makes the CLI provably match what the user picked, whereas reusing
+ * would gamble on an unknown mode and risk running edits under looser permissions
+ * than the user chose.
+ */
+export function needsRestartForMode(liveMode: string | null, requestedMode: string): boolean {
+  return liveMode !== requestedMode;
+}
+
+/**
+ * Terminate a session's live CLI so it can be respawned under a different
+ * permission mode, and wait until it is really gone.
+ *
+ * Waiting matters: the respawn uses `--resume` on the same session, and two CLIs
+ * writing one JSONL branches the history. The CLI's own 'close' handler does the
+ * teardown (process reference, registry entry), so this only has to kill and wait
+ * for that to run. The timeout is a liveness guard — a CLI ignoring SIGTERM gets
+ * SIGKILL rather than hanging the user's message forever.
+ */
+async function restartForModeChange(
+  connections: ConnectionManager,
+  sessionId: string,
+  proc: ChildProcess,
+): Promise<void> {
+  sessionsRestartingForMode.add(sessionId);
+
+  const exited = new Promise<void>((resolve) => {
+    if (proc.exitCode !== null || proc.signalCode !== null) {
+      resolve();
+      return;
+    }
+    proc.once('close', () => resolve());
+  });
+
+  Claude.killTree(proc);
+
+  let escalation: NodeJS.Timeout | undefined;
+  const escalated = new Promise<void>((resolve) => {
+    escalation = setTimeout(() => {
+      console.error(
+        '[node-backend]',
+        `CLI for session ${sessionId} did not exit on SIGTERM; escalating to SIGKILL`,
+      );
+      Claude.killTree(proc, 'SIGKILL');
+      resolve();
+    }, MODE_RESTART_KILL_TIMEOUT_MS);
+  });
+
+  await Promise.race([exited, escalated]);
+  if (escalation) clearTimeout(escalation);
+  // After a SIGKILL escalation the close handler may still be pending; give it the
+  // same bounded wait so the respawn never races the teardown it depends on.
+  await Promise.race([exited, new Promise<void>((r) => setTimeout(r, MODE_RESTART_KILL_TIMEOUT_MS))]);
+
+  sessionsRestartingForMode.delete(sessionId);
+
+  // The close handler clears these, but a hard-killed process that never ran it
+  // would otherwise leave the respawn reusing a dead reference and a stale buffer.
+  connections.setProcess(sessionId, null);
+  connections.setBuffer(sessionId, '');
+  // The turn-in-flight flag is normally cleared by the CLI `result` event, with
+  // STREAM_END as the process-death safety net — and this restart deliberately
+  // suppresses that STREAM_END. A previous turn that died without a `result`
+  // would leave the flag stuck on forever, so clear it here explicitly. The
+  // replacement process sets it again when the pending message reaches stdin.
+  connections.setStreaming(sessionId, false);
+}
+
+/**
  * 세션에 대한 claude -p 프로세스가 없으면 새로 spawn한다.
  * 이미 살아있는 프로세스가 있으면 아무 것도 하지 않는다.
+ * 단, 요청된 권한 모드가 살아있는 프로세스의 모드와 다르면
+ * 그 모드로 재시작한다(--permission-mode는 spawn 시점 플래그이므로).
  */
 export async function ensureClaudeProcess(
   connections: ConnectionManager,
@@ -144,11 +234,27 @@ export async function ensureClaudeProcess(
 
   const existingSession = connections.getSession(targetSessionId);
   if (existingSession?.process) {
+    // `--permission-mode` is a spawn-time flag: a live CLI keeps whatever mode it
+    // started with, and no official CLI command changes it in place. So when the user
+    // picks a different mode mid-chat, honoring it means restarting the process under
+    // the new flag — otherwise the choice is silently dropped and the CLI's next
+    // `system/init` pushes the old mode back onto the webview, which looks like the
+    // mode flipping itself off (#172). Same mode → reuse as before.
+    const liveMode = connections.getInputMode(targetSessionId);
+    if (!needsRestartForMode(liveMode, inputMode)) {
+      console.error(
+        '[node-backend]',
+        `Reusing existing process for session ${targetSessionId} (PID: ${existingSession.process.pid})`,
+      );
+      return;
+    }
+
     console.error(
       '[node-backend]',
-      `Reusing existing process for session ${targetSessionId} (PID: ${existingSession.process.pid})`,
+      `Permission mode changed (${liveMode} -> ${inputMode}) for session ${targetSessionId}; ` +
+        `restarting CLI (PID: ${existingSession.process.pid})`,
     );
-    return;
+    await restartForModeChange(connections, targetSessionId, existingSession.process);
   }
 
   // Liveness guard before spawning: a live, identity-checked CLI may
@@ -254,6 +360,10 @@ export async function ensureClaudeProcess(
 
   // SessionRecord에 프로세스 저장
   connections.setProcess(targetSessionId, proc);
+  // Remember the mode this process actually runs under, so a later mode change is
+  // detected and honored by restarting instead of being silently dropped (#172).
+  // Must follow setProcess — clearing the process also clears the recorded mode.
+  connections.setInputMode(targetSessionId, inputMode);
   connections.setBuffer(targetSessionId, '');
 
   // The session's process is now alive — this is where we re-arm any scheduled
@@ -318,6 +428,12 @@ export async function ensureClaudeProcess(
     try {
       console.error('[node-backend]', `Claude CLI process exited with code: ${code}`);
 
+      // We killed this process ourselves to respawn it under a new permission mode.
+      // The user asked to switch modes, not to end anything, and a replacement CLI is
+      // already being spawned — so skip the failure reporting and the STREAM_END that
+      // would otherwise flash an error and a dead stream in the middle of a mode change.
+      const restartingForMode = sessionsRestartingForMode.has(targetSessionId);
+
       // 남은 버퍼 처리
       const remainingBuffer = connections.getBuffer(targetSessionId);
       if (remainingBuffer.trim()) {
@@ -337,7 +453,7 @@ export async function ensureClaudeProcess(
       }
 
       // 비정상 종료 + result 미수신 → 에러 전파
-      if (code !== 0 && !sessionsWithResult.has(targetSessionId)) {
+      if (code !== 0 && !sessionsWithResult.has(targetSessionId) && !restartingForMode) {
         const errorMessage = stderrBuffer.trim() || `Claude CLI exited with code ${code}`;
         connections.broadcastToSession(targetSessionId, MessageType.SERVICE_ERROR, {
           type: MessageType.CLI_EXIT_ERROR,
@@ -351,9 +467,15 @@ export async function ensureClaudeProcess(
 
       // 추적 정리
       sessionsWithResult.delete(targetSessionId);
-      workflowTracker?.stopSession(targetSessionId);
 
-      connections.broadcastToSession(targetSessionId, MessageType.STREAM_END);
+      // On a mode-change restart the session continues in the replacement process, so
+      // neither of these applies: tearing down the workflow tracker would drop progress
+      // the new CLI still reports on, and STREAM_END would end a stream the user never
+      // stopped. The respawn emits its own STREAM_START.
+      if (!restartingForMode) {
+        workflowTracker?.stopSession(targetSessionId);
+        connections.broadcastToSession(targetSessionId, MessageType.STREAM_END);
+      }
 
       // 프로세스 참조만 해제 (세션 레코드는 유지 — 구독자가 아직 있을 수 있음)
       connections.setProcess(targetSessionId, null);

--- a/backend/src/core/features/__tests__/loadSessionMessages.test.ts
+++ b/backend/src/core/features/__tests__/loadSessionMessages.test.ts
@@ -202,4 +202,88 @@ describe('loadSessionMessages', () => {
     // hasMore stays honest: there is older history before this fallback page.
     expect(result.hasMore).toBe(true);
   });
+
+  // On reload, the composer should restore the session's actual mode rather than
+  // falling back to the configured default — that fallback is what looked like the
+  // mode "resetting itself" on refresh.
+  describe('lastReportedMode', () => {
+    it('finds the most recent permissionMode within the newest page', async () => {
+      await writeSession('sess-mode', [
+        JSON.stringify({ type: 'user', uuid: 'u1', permissionMode: 'plan' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a1', parentUuid: 'u1' }),
+        JSON.stringify({ type: 'user', uuid: 'u2', parentUuid: 'a1', permissionMode: 'default' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a2', parentUuid: 'u2' }),
+      ]);
+
+      const result = await loadSessionMessages('/work', 'sess-mode');
+      expect(result.lastReportedMode).toBe('ask_before_edit');
+    });
+
+    it('translates every CLI flag into the webview vocabulary', async () => {
+      await writeSession('sess-flags', [
+        JSON.stringify({ type: 'user', uuid: 'u1', permissionMode: 'bypassPermissions' }),
+      ]);
+
+      const result = await loadSessionMessages('/work', 'sess-flags');
+      expect(result.lastReportedMode).toBe('bypass');
+    });
+
+    it('is null when the newest page carries no permissionMode at all', async () => {
+      await writeSession('sess-none', [
+        JSON.stringify({ type: 'user', uuid: 'u1' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a1', parentUuid: 'u1' }),
+      ]);
+
+      const result = await loadSessionMessages('/work', 'sess-none');
+      expect(result.lastReportedMode).toBeNull();
+    });
+
+    // The whole point of bounding the search to one page: an older page must not
+    // pay for (or claim to know) the session's current mode.
+    it('is null on an older ("load older") page even if that page has a mode', async () => {
+      await writeSession('sess-old-page', [
+        JSON.stringify({ type: 'user', uuid: 'u1', permissionMode: 'plan' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a1', parentUuid: 'u1' }),
+        JSON.stringify({ type: 'user', uuid: 'u2', parentUuid: 'a1' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a2', parentUuid: 'u2' }),
+      ]);
+
+      const result = await loadSessionMessages('/work', 'sess-old-page', 'u2', 10);
+      expect(result.lastReportedMode).toBeNull();
+    });
+
+    // A tool_result is JSONL type "user" but carries no permissionMode — it is not a
+    // prompt the CLI processed under any mode. A real session's last entries are
+    // usually exactly this (assistant calls a tool, the result comes back as
+    // "user"), so treating it as "unknown" would blank out the mode on nearly
+    // every reload.
+    it('skips user entries that are tool results, not prompts', async () => {
+      await writeSession('sess-tool-result', [
+        JSON.stringify({ type: 'user', uuid: 'u1', permissionMode: 'plan' }),
+        JSON.stringify({ type: 'assistant', uuid: 'a1', parentUuid: 'u1' }),
+        JSON.stringify({
+          type: 'user',
+          uuid: 'u2',
+          parentUuid: 'a1',
+          message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'x' }] },
+        }),
+      ]);
+
+      const result = await loadSessionMessages('/work', 'sess-tool-result');
+      expect(result.lastReportedMode).toBe('plan');
+    });
+
+    it('does not fall through to an unrecognized flag as a guess', async () => {
+      await writeSession('sess-unknown-flag', [
+        JSON.stringify({ type: 'user', uuid: 'u1', permissionMode: 'plan' }),
+        JSON.stringify({ type: 'user', uuid: 'u2', parentUuid: 'u1', permissionMode: 'somethingNew' }),
+      ]);
+
+      // The newest entry's flag is unrecognized — this must not silently report
+      // the older recognized one either (issue #6 taught the same lesson about
+      // guessing instead of being explicit about what is actually known).
+      const result = await loadSessionMessages('/work', 'sess-unknown-flag');
+      expect(result.lastReportedMode).toBeNull();
+    });
+  });
 });

--- a/backend/src/core/features/loadSessionMessages.ts
+++ b/backend/src/core/features/loadSessionMessages.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { getProjectSessionsPath } from './getProjectSessionsPath';
 import { readJsonlEntries } from './readJsonlEntries';
 import { filterActiveChain } from './activeChain';
+import { CLI_FLAG_TO_INPUT_MODE } from '../claude-process';
 
 // Raw JSONL entry - passed through as-is to match Kotlin backend
 export type SessionMessage = Record<string, unknown>;
@@ -16,6 +17,12 @@ export interface PaginatedSessionMessages {
   // whole-transcript work like workflow reconstruction, which must see tool_use /
   // tool_result entries older than the page. Never forwarded to the webview.
   activeChain: SessionMessage[];
+  // The permission mode the CLI was last known to be running under, found within
+  // the returned (newest) page only — or null if the page carries none. Only set
+  // when this is the newest page (no beforeUuid): an older page says nothing about
+  // the session's CURRENT mode. See findLastReportedModeInPage for why the search
+  // is bounded to one page rather than the whole session.
+  lastReportedMode: string | null;
 }
 
 // Extract Task tool_use id -> agentId mappings from main session messages
@@ -293,6 +300,43 @@ async function getActiveChain(
   return activeChain;
 }
 
+/**
+ * The permission mode the CLI was last running under, read from the newest page
+ * of messages only — never by scanning further back into the session.
+ *
+ * Every `user` entry the CLI actually processed as a prompt carries the mode it
+ * was applied under (`permissionMode`, in the CLI's own flag vocabulary — see
+ * CLI_FLAG_TO_INPUT_MODE). A `user`-typed entry WITHOUT that field is a tool
+ * result being fed back to the CLI, not a prompt — it never had a mode and is
+ * skipped, not treated as "unknown" (see cli-tool-results-are-user-type-entries).
+ * The most recent entry that does carry the field is the session's current mode
+ * as of reload.
+ *
+ * Bounded to one page on purpose: walking further back to find a mode would mean
+ * reading and parsing session history the reload does not otherwise need, and
+ * that cost grows with session age with no upper bound. If nothing in the newest
+ * page carries the field at all, that is treated as "too far back to look" and
+ * the caller falls back to the configured default rather than paying for a
+ * deeper scan.
+ *
+ * The most recent entry that DOES carry the field decides the answer outright —
+ * if its flag is unrecognized, this returns null rather than falling through to
+ * an OLDER, recognized flag. Skipping past it would risk reporting a mode the
+ * session has since moved away from as if it were current; "unknown" must not
+ * silently resolve to a stale guess.
+ */
+export function findLastReportedModeInPage(page: SessionMessage[]): string | null {
+  for (let i = page.length - 1; i >= 0; i--) {
+    const entry = page[i];
+    if (entry.type !== 'user') continue;
+    const flag = entry.permissionMode;
+    if (flag === undefined) continue; // tool-result entry, not a prompt — no mode to read
+    if (typeof flag !== 'string') return null;
+    return CLI_FLAG_TO_INPUT_MODE[flag] ?? null;
+  }
+  return null;
+}
+
 export async function loadSessionMessages(
   workingDir: string,
   targetSessionId: string,
@@ -311,6 +355,7 @@ export async function loadSessionMessages(
       hasMore: false,
       total: 0,
       activeChain: [],
+      lastReportedMode: null,
     };
   }
 
@@ -362,11 +407,16 @@ export async function loadSessionMessages(
     (m) => typeof m.uuid === 'string',
   )?.uuid as string | undefined;
 
+  // Only the newest page (no cursor) describes the session's CURRENT mode — an
+  // older "load older" page is history, not "what mode is this session in now".
+  const lastReportedMode = beforeUuid ? null : findLastReportedModeInPage(slicedMessages);
+
   return {
     messages: slicedMessages,
     hasMore,
     oldestUuid,
     total,
     activeChain: activeChainMessages,
+    lastReportedMode,
   };
 }

--- a/backend/src/core/handlers/__tests__/loadAndSendSession.test.ts
+++ b/backend/src/core/handlers/__tests__/loadAndSendSession.test.ts
@@ -51,6 +51,7 @@ describe('loadAndSendSession', () => {
       oldestUuid: 'u99',
       total: 100,
       activeChain: fullChain,
+      lastReportedMode: null,
     });
     mockReconstruct.mockResolvedValue([]);
   });

--- a/backend/src/core/handlers/loadAndSendSession.ts
+++ b/backend/src/core/handlers/loadAndSendSession.ts
@@ -37,6 +37,11 @@ export async function loadAndSendSession(
     hasMore: result.hasMore,
     oldestUuid: result.oldestUuid,
     prepend: isOlderPage,
+    // Permission mode found within the newest page (null on an older page, or when
+    // the newest page carries none — see findLastReportedModeInPage). The webview
+    // restores the composer to this on reload instead of the configured default,
+    // and treats null as "not confidently known" rather than "unset".
+    lastReportedMode: result.lastReportedMode,
   });
 
   // Rebuild background-workflow state from the transcript so the inline cards

--- a/backend/src/ws/__tests__/connection-manager.test.ts
+++ b/backend/src/ws/__tests__/connection-manager.test.ts
@@ -153,6 +153,33 @@ describe('ConnectionManager', () => {
     });
   });
 
+  // `--permission-mode` only applies when the CLI is spawned, so the mode a live
+  // process actually runs under has to be remembered to notice a later change (#172).
+  describe('session permission mode', () => {
+    it('should set and get the mode the live process was spawned with', () => {
+      const proc = { kill: vi.fn() } as unknown as import('child_process').ChildProcess;
+      cm.setProcess('sess-1', proc);
+      cm.setInputMode('sess-1', 'plan');
+      expect(cm.getInputMode('sess-1')).toBe('plan');
+    });
+
+    it('should return null for a session that never spawned a process', () => {
+      expect(cm.getInputMode('nonexistent')).toBeNull();
+    });
+
+    it('should clear the recorded mode when the process reference is cleared', () => {
+      const proc = { kill: vi.fn() } as unknown as import('child_process').ChildProcess;
+      cm.setProcess('sess-1', proc);
+      cm.setInputMode('sess-1', 'plan');
+
+      // The CLI exited — the mode described THAT process, so it must not linger and
+      // make the next spawn's mode look unchanged.
+      cm.setProcess('sess-1', null);
+
+      expect(cm.getInputMode('sess-1')).toBeNull();
+    });
+  });
+
   describe('buffer management', () => {
     it('should set and get buffer', () => {
       cm.getOrCreateSession('sess-1');

--- a/backend/src/ws/connection-manager.ts
+++ b/backend/src/ws/connection-manager.ts
@@ -47,6 +47,14 @@ interface SessionRecord {
    * future IDE exit-confirm modal).
    */
   streaming: boolean;
+  /**
+   * Permission mode the LIVE process was actually spawned with. `--permission-mode`
+   * only applies at spawn, so a mode the user picks afterwards cannot reach a running
+   * CLI — without remembering what the process is really running as, a later mode
+   * change would be silently dropped and the CLI's `system/init` would push the stale
+   * mode back onto the webview (#172). Null when no process has been spawned yet.
+   */
+  inputMode: string | null;
 }
 
 interface ClientRecord {
@@ -604,6 +612,7 @@ export class ConnectionManager {
         buffer: '',
         workingDir: workingDir ?? '',
         streaming: false,
+        inputMode: null,
       };
       this.sessionRegistry.set(sessionId, session);
     }
@@ -615,10 +624,24 @@ export class ConnectionManager {
   setProcess(sessionId: string, proc: ChildProcess | null): void {
     const session = this.getOrCreateSession(sessionId);
     session.process = proc;
+    // The recorded permission mode describes the LIVE process, so it dies with it.
+    // Leaving a stale mode behind would make the next spawn look like a no-op change.
+    if (!proc) session.inputMode = null;
   }
 
   getProcess(sessionId: string): ChildProcess | null {
     return this.sessionRegistry.get(sessionId)?.process ?? null;
+  }
+
+  /** Record the permission mode the session's live CLI process was spawned with. */
+  setInputMode(sessionId: string, inputMode: string | null): void {
+    const session = this.getOrCreateSession(sessionId);
+    session.inputMode = inputMode;
+  }
+
+  /** Permission mode the session's live CLI is actually running under, if any. */
+  getInputMode(sessionId: string): string | null {
+    return this.sessionRegistry.get(sessionId)?.inputMode ?? null;
   }
 
   setBuffer(sessionId: string, buffer: string): void {

--- a/webview/src/contexts/AppProviders.tsx
+++ b/webview/src/contexts/AppProviders.tsx
@@ -27,6 +27,7 @@ import { useApi } from './ApiContext';
 import { SessionState } from '../types';
 import type { LoadedMessageDto } from '../types';
 import { MessageType } from '@/shared';
+import { isValidInputMode } from '@/types/chatInput';
 
 interface AppProvidersProps {
   children: ReactNode;
@@ -52,7 +53,7 @@ function SessionLoader({ children }: { children: ReactNode }) {
   const api = useApi();
   const {
     loadSessions, sessions, currentSessionId, navigateToNewSession,
-    isNewlyCreatedSession, setSessionState,
+    isNewlyCreatedSession, setSessionState, syncEffectiveMode,
   } = useSessionContext();
   const { loadMessages, prependOlderMessages, setPaginationState, resetForSessionSwitch } = useChatStreamContext();
   const { settings } = useSettings();
@@ -132,6 +133,7 @@ function SessionLoader({ children }: { children: ReactNode }) {
         const prepend = message.payload?.prepend as boolean | undefined;
         const hasMore = message.payload?.hasMore as boolean | undefined;
         const oldestUuid = message.payload?.oldestUuid as string | undefined;
+        const lastReportedMode = message.payload?.lastReportedMode as string | null | undefined;
 
         // Guard: ignore stale responses from previously requested sessions
         if (sid && sid !== currentSessionIdRef.current) {
@@ -153,9 +155,19 @@ function SessionLoader({ children }: { children: ReactNode }) {
           loadMessages(rawMessages);
         }
         setPaginationState(!!hasMore, oldestUuid ?? null);
+
+        // Restore the permission mode this session was last running under, found
+        // within the newest page (backend never returns this on an older/prepend
+        // page). Null means the newest page carried no mode within its bounds —
+        // "too far back to look" per the backend's page-only search — so the
+        // composer falls back to the configured default via syncInitialInputMode,
+        // same as a session with no prior mode at all.
+        if (!prepend && isValidInputMode(lastReportedMode)) {
+          syncEffectiveMode(lastReportedMode);
+        }
       }
     });
-  }, [subscribe, loadMessages, prependOlderMessages, setPaginationState, isNewlyCreatedSession]);
+  }, [subscribe, loadMessages, prependOlderMessages, setPaginationState, isNewlyCreatedSession, syncEffectiveMode]);
 
   // 4. Validate session exists in list — redirect bad URLs
   useEffect(() => {

--- a/webview/src/contexts/SessionContext.tsx
+++ b/webview/src/contexts/SessionContext.tsx
@@ -92,7 +92,12 @@ export function SessionProvider({ children }: SessionProviderProps) {
 
   // Input mode 상태
   const [inputMode, setInputModeState] = useState<InputMode>('ask_before_edit');
-  const hasUserChangedMode = useRef(false);
+  // 이 세션의 모드가 이미 정해졌는가. 켜지면 설정 기본값(permissions.defaultMode)은
+  // 더 이상 끼어들지 않는다. "사용자가 직접 골랐는가"가 아니라 "정해졌는가"인 이유:
+  // 세션은 사용자가 모드 버튼을 누르지 않아도 특정 모드로 진행 중일 수 있고
+  // (새 탭이 plan으로 열린 경우 등), 그 상태에서 인풋 영역이 교체됐다는 이유로
+  // 기본값이 되살아나면 진행 중인 세션의 모드가 조용히 뒤집힌다.
+  const isModeSettled = useRef(false);
   // 세션 전환 시 초기 모드 재동기화를 트리거하기 위한 카운터
   const [modeResetTrigger, setModeResetTrigger] = useState(0);
   // addNewSession 시 URL 변경으로 인한 모드 리셋을 건너뛰기 위한 플래그
@@ -103,7 +108,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const [autoFallbackNotice, setAutoFallbackNotice] = useState(false);
 
   const setInputMode = useCallback((newMode: InputMode) => {
-    hasUserChangedMode.current = true;
+    isModeSettled.current = true;
     setInputModeState(newMode);
   }, []);
 
@@ -114,7 +119,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
   );
 
   const cycleInputMode = useCallback(() => {
-    hasUserChangedMode.current = true;
+    isModeSettled.current = true;
     setInputModeState((current) => {
       const currentIndex = availableModes.indexOf(current);
       const nextIndex = (currentIndex + 1) % availableModes.length;
@@ -122,15 +127,24 @@ export function SessionProvider({ children }: SessionProviderProps) {
     });
   }, [availableModes]);
 
+  // 설정 기본값(permissions.defaultMode)을 세션 시작 시 한 번만 적용한다.
+  // 적용하는 순간 모드는 정해진 것으로 본다 — 이 함수는 ChatInput이 마운트될 때마다
+  // 호출되는데, AskUserQuestion·플랜 승인 패널이 뜨면 ChatInput이 언마운트됐다가
+  // 다시 붙는다. "아직 사용자가 모드를 고르지 않았다"는 이유로 그때마다 기본값을
+  // 다시 적용하면, plan으로 진행 중이던 세션이 답변 한 번에 기본값(예: bypass)으로
+  // 뒤집힌다 — 화면은 느슨한 모드를 보여주는데 CLI는 여전히 plan인, 표시와 실제가
+  // 어긋나는 상태가 된다.
   const syncInitialInputMode = useCallback((initialMode: InputMode) => {
-    if (!hasUserChangedMode.current) {
-      setInputModeState(initialMode);
-    }
+    if (isModeSettled.current) return;
+    isModeSettled.current = true;
+    setInputModeState(initialMode);
   }, []);
 
-  // CLI가 통보한 실제 적용 모드를 반영한다(진실원). 사용자가 무엇을 골랐는지(hasUserChangedMode)는
-  // 보존하되, 화면에 보이는 모드는 CLI가 실제 적용한 것과 일치시킨다.
+  // CLI가 통보한 실제 적용 모드를 반영한다(진실원). 화면에 보이는 모드를 CLI가 실제
+  // 적용한 것과 일치시키고, 그 모드로 정해진 것으로 본다 — CLI가 실제로 그 모드로
+  // 돌고 있는 이상 설정 기본값이 나중에 이를 덮어써선 안 된다.
   const syncEffectiveMode = useCallback((mode: InputMode) => {
+    isModeSettled.current = true;
     setInputModeState(mode);
   }, []);
 
@@ -145,7 +159,9 @@ export function SessionProvider({ children }: SessionProviderProps) {
       skipNextModeReset.current = false;
       return;
     }
-    hasUserChangedMode.current = false;
+    // 다른 세션으로 넘어갔으니 이전 세션에서 정해진 모드는 더 이상 유효하지 않다.
+    // 새 세션은 다시 설정 기본값에서 출발한다.
+    isModeSettled.current = false;
     setModeResetTrigger(c => c + 1);
   }, [currentSessionId]);
 

--- a/webview/src/contexts/__tests__/SessionContext.test.tsx
+++ b/webview/src/contexts/__tests__/SessionContext.test.tsx
@@ -411,13 +411,101 @@ describe('SessionContext', () => {
         capturedCtx?.switchSession('session-1');
       });
 
-      // 세션 전환 후에는 hasUserChangedMode가 리셋되어 syncInitialInputMode가 적용 가능해야 함
-      // (실제 리셋은 ChatInput의 useEffect에서 syncInitialInputMode를 통해 이루어지지만,
-      //  여기서는 hasUserChangedMode가 false로 리셋되었는지를 간접 확인)
+      // 세션 전환 후에는 모드가 "정해지지 않은" 상태로 리셋되어 syncInitialInputMode가
+      // 다시 적용 가능해야 함 (실제 적용은 ChatInput의 useEffect에서 이루어지므로
+      // 여기서는 재동기화 트리거가 올랐는지로 간접 확인)
       await waitFor(() => {
         // modeResetTrigger가 증가했는지 확인 (간접 검증)
         expect(capturedCtx?.modeResetTrigger).toBeGreaterThan(0);
       });
+    });
+
+    // ChatInput은 AskUserQuestion 패널·플랜 승인 패널이 뜨는 동안 언마운트됐다가 다시
+    // 붙고, 마운트될 때마다 syncInitialInputMode를 호출한다. 진행 중인 세션의 모드가
+    // 그 재호출로 설정 기본값에 덮이면, 화면은 느슨한 모드를 보여주는데 CLI는 원래
+    // 모드로 도는 표시/실제 불일치가 된다.
+    it('세션 모드가 정해진 뒤에는 초기값 재동기화가 이를 덮지 않는다', async () => {
+      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // 세션이 plan으로 진행 중 — 사용자가 모드 버튼을 누르지 않아도 이 상태일 수 있다
+      act(() => {
+        capturedCtx?.syncInitialInputMode('plan');
+      });
+      expect(capturedCtx!.inputMode).toBe('plan');
+
+      // AskUserQuestion 답변 → ChatInput 재마운트 → 기본값으로 재동기화 시도
+      act(() => {
+        capturedCtx?.syncInitialInputMode('bypass');
+      });
+
+      expect(capturedCtx!.inputMode).toBe('plan');
+    });
+
+    // CLI가 통보한 실제 적용 모드도 "정해진" 모드다. 그 뒤 인풋이 재마운트되어
+    // 기본값 재동기화가 호출돼도 CLI의 진실이 유지되어야 한다.
+    it('CLI가 통보한 모드도 초기값 재동기화에 덮이지 않는다', async () => {
+      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      act(() => {
+        capturedCtx?.syncEffectiveMode('plan');
+      });
+      expect(capturedCtx!.inputMode).toBe('plan');
+
+      act(() => {
+        capturedCtx?.syncInitialInputMode('bypass');
+      });
+
+      expect(capturedCtx!.inputMode).toBe('plan');
+    });
+
+    it('세션 전환 후에는 초기값 재동기화가 다시 적용된다', async () => {
+      mockPathname = '/sessions/session-1';
+      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      act(() => {
+        capturedCtx?.setInputMode('plan');
+      });
+      expect(capturedCtx!.inputMode).toBe('plan');
+
+      // 다른 세션으로 이동 — currentSessionId는 URL에서 파생되므로 경로를 바꾸고
+      // 리렌더해야 세션 전환이 실제로 관측된다.
+      mockPathname = '/sessions/session-2';
+      rerender(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // 이전 세션에서 정해진 모드는 더 이상 유효하지 않으므로 기본값이 다시 적용된다
+      act(() => {
+        capturedCtx?.syncInitialInputMode('bypass');
+      });
+
+      expect(capturedCtx!.inputMode).toBe('bypass');
     });
   });
 

--- a/webview/src/contexts/__tests__/SessionContext.test.tsx
+++ b/webview/src/contexts/__tests__/SessionContext.test.tsx
@@ -474,6 +474,33 @@ describe('SessionContext', () => {
       expect(capturedCtx!.inputMode).toBe('plan');
     });
 
+    // Reload ordering: ChatInput mounts and applies the settings default the
+    // instant the page renders, but SESSION_LOADED (carrying the session's actual
+    // last mode) only arrives after a backend round trip — strictly later. The
+    // restored mode must still win even though it settles the mode SECOND.
+    it('세션 로드로 복원된 모드는 이미 정해진 기본값보다 늦게 도착해도 이긴다', async () => {
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // ChatInput mounts first and applies the configured default (settles the mode).
+      act(() => {
+        capturedCtx?.syncInitialInputMode('bypass');
+      });
+      expect(capturedCtx!.inputMode).toBe('bypass');
+
+      // SESSION_LOADED arrives afterward with the session's actual last mode.
+      act(() => {
+        capturedCtx?.syncEffectiveMode('plan');
+      });
+
+      expect(capturedCtx!.inputMode).toBe('plan');
+    });
+
     it('세션 전환 후에는 초기값 재동기화가 다시 적용된다', async () => {
       mockPathname = '/sessions/session-1';
       mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, KeyboardEvent, useState, type Clipboard
 import { CommandPalettePanel } from '@/commandPalette/ui/CommandPalettePanel';
 import { useCommandPalette } from '@/commandPalette/hooks/useCommandPalette';
 import { PanelSectionId, PanelItemType, CommandItem } from '@/types/commandPalette';
-import { INPUT_MODES, CLI_FLAG_TO_INPUT_MODE } from '../../../types/chatInput';
+import { INPUT_MODES, resolveInitialInputMode } from '../../../types/chatInput';
 import { InputModeTag } from './InputModeTag';
 import { ModeSelectPanel } from './ModeSelectPanel';
 import { ScheduleSendPopover } from './ScheduleSendPopover';
@@ -86,7 +86,7 @@ export function ChatInput() {
     setIsDragOver,
   } = useAttachments();
 
-  const { settings: claudeSettings, updateSetting: updateClaudeSetting } = useClaudeSettings();
+  const { settings: claudeSettings, updateSetting: updateClaudeSetting, isLoading: claudeSettingsLoading } = useClaudeSettings();
   // useCtrlEnterToSend + focusInputOnEditorContext migrated to the app settings.
   const { settings: appSettings } = useSettings();
   const { cycle: cycleEffort } = useEffort();
@@ -236,14 +236,18 @@ export function ChatInput() {
 
   const disabled = sessionState === SessionState.Error || !workingDirectory;
 
-  // Claude settings의 permissions.defaultMode에서 초기 모드 결정
+  // Claude settings의 permissions.defaultMode에서 초기 모드 결정. claudeSettings는
+  // GET_CLAUDE_SETTINGS로 비동기 로드되므로, 로딩 중(claudeSettingsLoading)의
+  // defaultModeFlag는 "설정값이 없다"가 아니라 "아직 모른다"다. 이 값으로
+  // syncInitialInputMode를 호출해 모드를 확정(settle)해버리면, 실제 설정이 도착해도
+  // 이미 정해졌다는 이유로 반영되지 않는다 — 예: bypass가 기본값인데 로딩 중
+  // ask_before_edit로 먼저 확정되어 그 값이 굳어버림. 로딩이 끝난 뒤에만 호출한다.
   const defaultModeFlag = claudeSettings.permissions?.defaultMode;
-  const initialInputMode = defaultModeFlag
-    ? (CLI_FLAG_TO_INPUT_MODE[defaultModeFlag] ?? 'ask_before_edit')
-    : 'ask_before_edit';
+  const initialInputMode = resolveInitialInputMode(defaultModeFlag);
   useEffect(() => {
+    if (claudeSettingsLoading) return;
     syncInitialInputMode(initialInputMode);
-  }, [initialInputMode, syncInitialInputMode, modeResetTrigger]);
+  }, [initialInputMode, syncInitialInputMode, modeResetTrigger, claudeSettingsLoading]);
 
   const modeConfig = INPUT_MODES[mode];
 

--- a/webview/src/types/__tests__/chatInput.test.ts
+++ b/webview/src/types/__tests__/chatInput.test.ts
@@ -7,6 +7,7 @@ import {
   INPUT_MODE_TO_CLI_FLAG,
   CLI_FLAG_TO_INPUT_MODE,
   isValidInputMode,
+  resolveInitialInputMode,
 } from '../chatInput';
 
 describe('auto mode wiring', () => {
@@ -79,5 +80,20 @@ describe('isValidInputMode', () => {
     // reached the webview unmapped instead of the InputMode vocabulary ("bypass").
     expect(isValidInputMode('bypassPermissions')).toBe(false);
     expect(isValidInputMode('acceptEdits')).toBe(false);
+  });
+});
+
+describe('resolveInitialInputMode', () => {
+  it('translates the configured default flag to an InputMode', () => {
+    expect(resolveInitialInputMode('bypassPermissions')).toBe(InputModeValues.BYPASS);
+    expect(resolveInitialInputMode('plan')).toBe(InputModeValues.PLAN);
+  });
+
+  it('falls back to ask_before_edit when no default is configured', () => {
+    expect(resolveInitialInputMode(undefined)).toBe(InputModeValues.ASK_BEFORE_EDIT);
+  });
+
+  it('falls back to ask_before_edit for an unrecognized flag, never guessing looser', () => {
+    expect(resolveInitialInputMode('somethingNew')).toBe(InputModeValues.ASK_BEFORE_EDIT);
   });
 });

--- a/webview/src/types/__tests__/chatInput.test.ts
+++ b/webview/src/types/__tests__/chatInput.test.ts
@@ -6,6 +6,7 @@ import {
   getAvailableModes,
   INPUT_MODE_TO_CLI_FLAG,
   CLI_FLAG_TO_INPUT_MODE,
+  isValidInputMode,
 } from '../chatInput';
 
 describe('auto mode wiring', () => {
@@ -54,5 +55,29 @@ describe('getAvailableModes', () => {
         InputModeValues.AUTO_EDIT,
       ]),
     );
+  });
+});
+
+// Guards a value crossing the backend boundary (SESSION_LOADED.lastReportedMode)
+// before it is cast and applied to the composer.
+describe('isValidInputMode', () => {
+  it('accepts every known InputMode value', () => {
+    Object.values(InputModeValues).forEach((mode) => {
+      expect(isValidInputMode(mode)).toBe(true);
+    });
+  });
+
+  it('rejects null, undefined, and unrecognized strings', () => {
+    expect(isValidInputMode(null)).toBe(false);
+    expect(isValidInputMode(undefined)).toBe(false);
+    expect(isValidInputMode('somethingNew')).toBe(false);
+    expect(isValidInputMode('')).toBe(false);
+  });
+
+  it('rejects CLI flag names — these must already be translated by the backend', () => {
+    // A regression here would mean the raw CLI vocabulary (e.g. "bypassPermissions")
+    // reached the webview unmapped instead of the InputMode vocabulary ("bypass").
+    expect(isValidInputMode('bypassPermissions')).toBe(false);
+    expect(isValidInputMode('acceptEdits')).toBe(false);
   });
 });

--- a/webview/src/types/chatInput.ts
+++ b/webview/src/types/chatInput.ts
@@ -12,6 +12,18 @@ export const InputModeValues = {
 
 export type InputMode = typeof InputModeValues[keyof typeof InputModeValues];
 
+const KNOWN_INPUT_MODES: readonly string[] = Object.values(InputModeValues);
+
+/**
+ * Whether `value` is a recognized InputMode. Used when a mode arrives from an
+ * external source (backend `lastReportedMode` on session reload) that this
+ * codebase does not fully control the vocabulary of — a value it does not
+ * recognize must not be cast and applied to the composer.
+ */
+export function isValidInputMode(value: unknown): value is InputMode {
+  return typeof value === 'string' && KNOWN_INPUT_MODES.includes(value);
+}
+
 export interface InputModeConfig {
   id: InputMode;
   icon: string;               // codicon 아이콘 이름 (예: 'tasklist', 'zap')

--- a/webview/src/types/chatInput.ts
+++ b/webview/src/types/chatInput.ts
@@ -147,6 +147,18 @@ export const CLI_FLAG_TO_INPUT_MODE: Record<string, InputMode> = {
   auto: InputModeValues.AUTO,
 } as const;
 
+/**
+ * The InputMode a session should start in, given the CLI flag configured as
+ * `permissions.defaultMode` (undefined when settings have not resolved a value —
+ * distinct from "no default configured", which the CLI itself never reports; the
+ * absence here is purely "we don't know yet"). Falls back to ask_before_edit for
+ * both an absent setting and an unrecognized flag, so a stale/renamed flag never
+ * silently grants a looser mode than intended.
+ */
+export function resolveInitialInputMode(defaultModeFlag: string | undefined): InputMode {
+  return defaultModeFlag ? (CLI_FLAG_TO_INPUT_MODE[defaultModeFlag] ?? InputModeValues.ASK_BEFORE_EDIT) : InputModeValues.ASK_BEFORE_EDIT;
+}
+
 // ============================================
 // Active File Types (IDE에서 전달받을 타입)
 // ============================================


### PR DESCRIPTION
Closes #172

## What was broken

Switching the permission mode inside an existing chat did not reach the CLI.

The review reported it as **Plan Mode turning itself off**: run a plan, then re-enable Plan Mode in the same chat, and the composer flips straight back to the previous mode.

Measured on a live session — `permissionMode` recorded on each user turn in the session JSONL, before the fix:

```
plan     :: 짧은 시를 작성해서 파일로 저장해보자      <- plan mode, asked for a plan
default  :: 비평을 새 파일에 작성해보자. 계획짜봐      <- Plan Mode re-enabled, still default
```

The second turn is the bug: Plan Mode was on in the UI, and the CLI processed the turn out of plan.

Worth stating plainly, because this is a **permissions** bug and not only a cosmetic one: the composer could show a stricter mode than the CLI was actually running under.

## Why

`--permission-mode` is a **spawn-time flag**, and no official CLI command changes it in place. Two things followed from that.

**1. A live process was reused verbatim, so a mode picked mid-chat was dropped.**

```ts
const existingSession = connections.getSession(targetSessionId);
if (existingSession?.process) {
  // reuse — the requested inputMode was never even looked at
  return;
}
```

The CLI then kept announcing its original mode in `system/init`, and the webview — which correctly treats that as the source of truth — repainted the composer with it. The user's choice was dropped by the backend, then visibly overwritten by the very truth it contradicted.

**2. Remembering only the flag we spawned with was not enough.**

Approving an `ExitPlanMode` plan takes the CLI out of plan mode **with no respawn**. A spawn-time-only record still reads `plan` while the process is not in plan anymore, so re-picking Plan Mode compares equal, the CLI is reused, and it answers out of plan. That is exactly the reported path — and it is why the first commit alone did not close the issue.

## The fix

**Every message carries the mode the UI is showing, and the CLI is made to match it.**

- The session record tracks **the mode the CLI reports**, not the flag we last passed. The CLI announces its own mode on `system/init` at spawn, and again on `system/status` when it changes mode itself — one line after an ExitPlanMode approval. `readReportedMode` adopts that report, so the comparison every message performs is against the truth rather than a stale assumption.
- When the requested mode differs, the CLI is terminated and resumed (`--resume`, same session) under the new `--permission-mode`. An unknown recorded mode (e.g. a session reclaimed after a backend restart) also restarts — reusing would gamble on an unknown mode and risk edits running under looser permissions than the user picked.
- The flag vocabulary is translated back through a map **derived from the forward one**, so the two cannot drift. An unrecognized flag reports nothing rather than guessing.

Three things the restart has to get right:

- **The exit is ours, so it is silenced** — no `CLI_EXIT_ERROR`, no `STREAM_END`, no workflow teardown. Otherwise switching modes would flash an error and a dead stream mid-chat.
- **The kill waits for `close` before respawning** — `--resume` writes the same JSONL, and two writers branch the history. A CLI ignoring SIGTERM is escalated to SIGKILL after 3s rather than hanging the user's message.
- **The turn-in-flight flag is cleared explicitly** — `streaming` is normally cleared by the CLI `result` event with `STREAM_END` as the process-death safety net, and this restart deliberately suppresses that `STREAM_END`.

Killing goes through the existing `Claude.killTree`, so the win32 Job Object path and the POSIX process-group path both apply unchanged.

## Approach note (CLI equivalence)

The mode is changed the way a CLI user would: the official `--permission-mode` flag on a `--resume`d session. The mode the CLI is in is read from what the CLI already streams — no undocumented `control_request` subtype, and no inspecting the ExitPlanMode tool call to infer state.

## Verification

Driven through the real UI on a live backend: plan -> approve plan -> non-plan turns -> re-enable Plan Mode, twice.

JSONL `permissionMode` per turn, after the fix:

```
plan     :: 다시 수정하고 핫리로드 했어. 비평파일작성계획 다시해봐.
default  :: ?? 뭐이렇게 오래걸려          <- sent as Ask before edits
default  :: 대충써
plan     :: 자 이제 그 계획을 개선하는 계획을 세워봐.   <- re-enabled, honored
plan     :: 한번더                                      <- stable across cycles
```

Backend log for the same run:

```
CLI reports permission mode "ask_before_edit" (was "plan")   <- ExitPlanMode approval observed
Reusing existing process x3                                   <- same mode, no needless restart
Permission mode changed (ask_before_edit -> plan)             <- re-enable honored
--resume <sid> --permission-mode plan
CLI reports permission mode "ask_before_edit" (was "plan")   <- second cycle identical
Permission mode changed (ask_before_edit -> plan)
--resume <sid> --permission-mode plan
```

Also checked: same mode twice in a row reuses the process (no needless restarts), a mode change during streaming does not cut the in-flight turn and applies from the next message, and zero `CLI_EXIT_ERROR` across the run.

## Second defect found while verifying: the settings default overwriting a live session mode

Verification surfaced a separate way the mode could flip, with the same symptom for the user. Answering an `AskUserQuestion` mid-session snapped the composer to the configured default — with `permissions.defaultMode: "bypassPermissions"`, a session running in Plan mode came back from one answer showing **Bypass permissions while the CLI was still in plan**.

The composer showed a *looser* mode than the CLI was enforcing. The reverse pairing would show a stricter one while edits ran unprompted, so this is a permissions display bug rather than a cosmetic one.

**Cause.** `ChatInput` calls `syncInitialInputMode` on mount, and it does not stay mounted — `ChatPage` renders exactly one of AskUserQuestionInputPanel / AcceptPlanPanel / ChatInput, so every question and every plan approval unmounts and remounts it. The only guard between that remount and the settings default was `hasUserChangedMode`, set solely by the mode button and by the plan-approval panel.

That flag asks *"did the user pick a mode?"*, but the question that matters is *"does this session already have one?"*. A session can be in plan mode without the user ever touching the button — exactly the reported case. It also explains why the bug looked intermittent: once a plan was approved (which calls `setInputMode`) or the button was used, the flag latched and every later answer preserved the mode.

**Fix.** The guard now tracks whether the session's mode is *settled*. Applying the initial value settles it, so the default lands once at session start and never again. A CLI-reported mode settles it too — a mode the CLI is demonstrably running under must not be overwritten by a stale default. A session switch clears it, since a mode settled for one session says nothing about the next.

The three states observed during review are all explained by this single rule, and are covered by unit tests: mode untouched (flag false -> the reported bug), after plan approval, and after picking the mode by hand (flag latched -> mode preserved). Live re-verification of this second defect is pending.

## Third defect found while verifying: reload falling back to the default instead of the session's actual mode

Refreshing a session page put the composer back at the configured default regardless of what mode the session was actually in — a third way the mode could appear to "reset itself".

Every `user` entry the CLI actually processed as a prompt carries the mode it was applied under (`permissionMode`, written to the session JSONL as it happens). So the session already records the answer to "what mode was I last in" — no CLI round trip needed.

`findLastReportedModeInPage` reads that from the newest loaded page only, most recent entry first, through the same `CLI_FLAG_TO_INPUT_MODE` map the live-stream path uses (now exported, so the two cannot report differently for the same flag). Bounded to one page on purpose — scanning further back would read history the reload does not otherwise need, with cost unbounded by session age. A `user`-typed entry with no `permissionMode` is a tool result being fed back to the CLI, not a prompt, and is skipped rather than read as "unknown" — a session's last few entries are usually exactly this, so treating it as unknown would blank the mode out on nearly every reload. No mode found within the page bound is treated as "too far back to look confidently" and falls back to the configured default, same as a session with no prior mode.

The restored mode has to win a race the settings default does not: `ChatInput` mounts and applies the default the instant the page renders, while `SESSION_LOADED` (carrying the restored mode) only arrives after a backend round trip — strictly later. `syncEffectiveMode` already overwrites unconditionally (needed for the live CLI-report path above), so arriving second is exactly what makes it win.

Verified directly against the running dev backend (WebSocket calls, bypassing the UI): a session whose JSONL's last `permissionMode` was `plan` returned `lastReportedMode: "plan"` on `LOAD_SESSION`, confirmed on two independent sessions; a `LOAD_OLDER_MESSAGES` page for the same session correctly returned `null`.

## Fourth defect found while verifying: settings-loading race dropped the restored default itself

Fixing the third defect surfaced a fourth: a **brand-new** session (no history) with `permissions.defaultMode` set to Bypass permissions still opened in Ask before edits.

`claudeSettings` loads asynchronously (`GET_CLAUDE_SETTINGS` via React Query). On first render, `claudeSettings.permissions?.defaultMode` is `undefined` because the query has not resolved yet — not because no default is configured. The initial-mode effect fired immediately with the `ask_before_edit` fallback and settled the mode (the third-defect fix is what made the first call settle). When the real setting (`bypassPermissions`) arrived a moment later, the mode was already settled and the update was dropped by the same guard that protects a live session's mode across an AskUserQuestion remount.

Fix: skip the initial-mode effect entirely while `claudeSettings` is still loading (`isLoading`, already computed by the context and simply not read before). Once the query resolves, the first call settles the mode with the value that was actually configured.

Confirmed live: with the default set to Bypass permissions, a brand-new session now opens in Bypass permissions.

## Tests

25 new cases:
- reuse-vs-restart decision, including the unknown-mode case (`needsRestartForMode`)
- a cleared process reference clears the recorded mode
- `system/init` and `system/status` reports are both adopted (`readReportedMode`)
- CLI flags translate to the webview vocabulary; unknown flags and unrelated events report nothing
- the settings default does not overwrite a settled session mode, a CLI-reported mode survives a remount, and a session switch lets the default apply again
- the reload-restored mode wins even though it settles the mode after the default (SessionContext), and the extraction itself: recognizes flags, skips tool-result entries, stays within the page bound, does not guess past an unrecognized flag (backend)
- resolveInitialInputMode translates a configured flag, and falls back to ask_before_edit for both an absent and an unrecognized one rather than guessing looser

All three layers pass: backend 1124, webview 1957, `full-build` (incl. Kotlin) successful.
