### PR TITLE
fix(zoom): match numpad keys by code so Ctrl+Insert stays a copy (#268)

### DIFF
--- a/webview/src/hooks/__tests__/useZoomControls.test.ts
+++ b/webview/src/hooks/__tests__/useZoomControls.test.ts
@@ -8,7 +8,7 @@ vi.mock('@/config/environment', () => ({
 let mockIsMac = false;
 
 function keyEvent(init: Partial<KeyboardEvent>): KeyboardEvent {
-  return { key: '', metaKey: false, ctrlKey: false, ...init } as KeyboardEvent;
+  return { key: '', code: '', metaKey: false, ctrlKey: false, shiftKey: false, ...init } as KeyboardEvent;
 }
 
 function wheelEvent(init: Partial<WheelEvent>): WheelEvent {
@@ -40,9 +40,16 @@ describe('hasCmdOrCtrl', () => {
 });
 
 describe('isZoomInKey', () => {
-  it('accepts every spelling of plus', () => {
-    for (const key of ['+', '=', 'Add']) {
+  it('accepts both spellings of the number-row plus', () => {
+    for (const key of ['+', '=']) {
       expect(isZoomInKey(keyEvent({ key, ctrlKey: true }))).toBe(true);
+    }
+  });
+
+  // Matched physically, so it holds under either NumLock state.
+  it('accepts numpad plus by code whatever NumLock reports', () => {
+    for (const key of ['+', 'Add']) {
+      expect(isZoomInKey(keyEvent({ key, code: 'NumpadAdd', ctrlKey: true }))).toBe(true);
     }
   });
 
@@ -56,9 +63,15 @@ describe('isZoomInKey', () => {
 });
 
 describe('isZoomOutKey', () => {
-  it('accepts every spelling of minus', () => {
-    for (const key of ['-', '_', 'Subtract']) {
+  it('accepts both spellings of the number-row minus', () => {
+    for (const key of ['-', '_']) {
       expect(isZoomOutKey(keyEvent({ key, ctrlKey: true }))).toBe(true);
+    }
+  });
+
+  it('accepts numpad minus by code whatever NumLock reports', () => {
+    for (const key of ['-', 'Subtract']) {
+      expect(isZoomOutKey(keyEvent({ key, code: 'NumpadSubtract', ctrlKey: true }))).toBe(true);
     }
   });
 
@@ -68,12 +81,50 @@ describe('isZoomOutKey', () => {
 });
 
 describe('isZoomResetKey', () => {
-  it('accepts CmdOrCtrl+0', () => {
-    expect(isZoomResetKey(keyEvent({ key: '0', ctrlKey: true }))).toBe(true);
+  it('accepts CmdOrCtrl+0 on the number row', () => {
+    expect(isZoomResetKey(keyEvent({ key: '0', code: 'Digit0', ctrlKey: true }))).toBe(true);
   });
 
   it('requires the modifier', () => {
     expect(isZoomResetKey(keyEvent({ key: '0' }))).toBe(false);
+  });
+
+  // Chromium binds zoom-reset to VKEY_0 and VKEY_NUMPAD0. NumLock flips numpad
+  // 0's `key` between '0' and 'Insert', so only `code` catches it both ways.
+  it('accepts numpad 0 by code whatever NumLock reports', () => {
+    for (const key of ['0', 'Insert']) {
+      expect(isZoomResetKey(keyEvent({ key, code: 'Numpad0', ctrlKey: true }))).toBe(true);
+    }
+  });
+
+  // Issue #268: Ctrl+Insert is Chromium's built-in copy. Claiming it for zoom
+  // reset made the handler preventDefault() and silently killed the copy.
+  it('rejects the standalone Insert key so Ctrl+Insert stays a copy', () => {
+    expect(isZoomResetKey(keyEvent({ key: 'Insert', code: 'Insert', ctrlKey: true }))).toBe(false);
+  });
+
+  // Shift+Insert is Chromium's built-in paste. It never carried our modifier,
+  // but pin it down so no future edit starts swallowing it either.
+  it('rejects Shift+Insert so it stays a paste', () => {
+    expect(isZoomResetKey(keyEvent({ key: 'Insert', code: 'Insert', shiftKey: true }))).toBe(false);
+  });
+
+  // Guards the guard: proves the two cases above actually discriminate, by
+  // showing the pre-fix predicate — which keyed off `e.key` — fails them. Kept
+  // inline so the check lives in the test file rather than in a throwaway
+  // experiment against the working tree.
+  it('catches the regression the pre-fix predicate had', () => {
+    const preFix = (e: KeyboardEvent) => hasCmdOrCtrl(e) && (e.key === '0' || e.key === 'Insert');
+
+    const ctrlInsert = keyEvent({ key: 'Insert', code: 'Insert', ctrlKey: true });
+    expect(preFix(ctrlInsert)).toBe(true); // the bug: swallowed, killing the copy
+    expect(isZoomResetKey(ctrlInsert)).toBe(false); // fixed
+
+    // The numpad 0 it was meant to catch never worked with NumLock on, either:
+    // `key` reads '0' there, so the 'Insert' arm was dead weight both ways.
+    const numpad0NumLockOff = keyEvent({ key: 'Insert', code: 'Numpad0', ctrlKey: true });
+    expect(preFix(numpad0NumLockOff)).toBe(true);
+    expect(isZoomResetKey(numpad0NumLockOff)).toBe(true);
   });
 });
 

--- a/webview/src/hooks/useZoomControls.ts
+++ b/webview/src/hooks/useZoomControls.ts
@@ -15,22 +15,45 @@ export function hasCmdOrCtrl(e: KeyboardEvent): boolean {
 }
 
 /**
- * Whether a keydown means "zoom in". Browsers report the `+` key as '=' on an
- * unshifted US layout and as '+' when shifted, and numpad plus as 'Add' on
- * older engines; all spellings count so the gesture works regardless of layout.
+ * Numpad keys are matched on `e.code`, never `e.key` (issue #268).
+ *
+ * `e.key` carries a key's *meaning*, which on the numpad flips with NumLock:
+ * numpad 0 reads '0' while NumLock is on but 'Insert' while it is off. Matching
+ * that spelling therefore misses the numpad half the time and — worse — claims
+ * the standalone Insert key, whose Ctrl+Insert / Shift+Insert are Chromium's
+ * built-in copy/paste (`ui/views/controls/textfield/textfield.cc`, VKEY_INSERT
+ * → COPY/PASTE). Swallowing those broke copying out of the chat.
+ *
+ * `e.code` names the physical key ('Numpad0' vs 'Insert') whatever NumLock says,
+ * mirroring the VKEY_NUMPAD0 / VKEY_INSERT split Chromium itself keys off. Its
+ * accelerator table (`chrome/browser/ui/accelerator_table.cc`) binds zoom to
+ * VKEY_0 / VKEY_NUMPAD0 and never mentions VKEY_INSERT — we match it exactly.
+ */
+
+/**
+ * Whether a keydown means "zoom in" — the number-row plus, reported as '=' on an
+ * unshifted US layout and '+' when shifted, or numpad plus by its physical code.
+ * Mirrors Chromium's VKEY_OEM_PLUS / VKEY_ADD pair.
  */
 export function isZoomInKey(e: KeyboardEvent): boolean {
-  return hasCmdOrCtrl(e) && (e.key === '+' || e.key === '=' || e.key === 'Add');
+  return hasCmdOrCtrl(e) && (e.key === '+' || e.key === '=' || e.code === 'NumpadAdd');
 }
 
-/** Whether a keydown means "zoom out" ('-' or numpad minus). */
+/**
+ * Whether a keydown means "zoom out" — number-row minus or numpad minus,
+ * mirroring Chromium's VKEY_OEM_MINUS / VKEY_SUBTRACT pair.
+ */
 export function isZoomOutKey(e: KeyboardEvent): boolean {
-  return hasCmdOrCtrl(e) && (e.key === '-' || e.key === '_' || e.key === 'Subtract');
+  return hasCmdOrCtrl(e) && (e.key === '-' || e.key === '_' || e.code === 'NumpadSubtract');
 }
 
-/** Whether a keydown means "reset zoom to 100%" — CmdOrCtrl+0, as in browsers. */
+/**
+ * Whether a keydown means "reset zoom to 100%" — CmdOrCtrl+0 on the number row
+ * or on the numpad, mirroring Chromium's VKEY_0 / VKEY_NUMPAD0 pair. The
+ * standalone Insert key is deliberately excluded so Ctrl+Insert stays a copy.
+ */
 export function isZoomResetKey(e: KeyboardEvent): boolean {
-  return hasCmdOrCtrl(e) && (e.key === '0' || e.key === 'Insert');
+  return hasCmdOrCtrl(e) && (e.key === '0' || e.code === 'Numpad0');
 }
 
 /**


### PR DESCRIPTION
Fixes #268.

## The bug

Ctrl+Insert stopped copying in the chat. It is not a shortcut we implement — Chromium provides it, the same way it provides Ctrl+C. We took it away.

The zoom shortcuts added in v0.26.2 (#247) did this:

```ts
export function isZoomResetKey(e: KeyboardEvent): boolean {
  return hasCmdOrCtrl(e) && (e.key === '0' || e.key === 'Insert');
}
```

The `'Insert'` arm was there to catch numpad 0, which reports under that name while NumLock is off. But `e.key` carries a key's *meaning*, not its position — the standalone Insert key reports `'Insert'` too. So Ctrl+Insert matched, the handler called `preventDefault()`, and Chromium's copy was cancelled.

That arm never did its job either: with NumLock **on**, numpad 0 reads `'0'` and was already matched by the first arm. It only ever caught the key it was not supposed to.

## The fix

Match the numpad on `e.code`, which names the physical key regardless of NumLock.

Chromium draws the same line internally, and we now mirror it exactly:

- `chrome/browser/ui/accelerator_table.cc:135-136` binds zoom-reset to `VKEY_0` and `VKEY_NUMPAD0`. `VKEY_INSERT` does not appear anywhere in that file.
- `ui/views/controls/textfield/textfield.cc:2692-2697` handles `VKEY_INSERT` as COPY (with Ctrl) / PASTE (with Shift).

Applied to the plus and minus arms too, replacing the legacy `'Add'` / `'Subtract'` `e.key` spellings with `'NumpadAdd'` / `'NumpadSubtract'` codes.

## Result

- Ctrl+Insert goes back to Chromium as a copy.
- Numpad 0 zoom-reset now works under **both** NumLock states — the behaviour originally intended in #247, which had never actually worked with NumLock on.

## Tests

`webview/src/hooks/__tests__/useZoomControls.test.ts` — 21 passing.

New cases: the standalone Insert key is rejected (Ctrl+Insert and Shift+Insert), numpad 0/plus/minus are accepted by code under both NumLock states.

One case guards the guard — it inlines the pre-fix predicate and asserts it *did* swallow Ctrl+Insert while the current one does not, so the regression tests are proven to discriminate rather than passing vacuously.

Full suite: 215 files / 1963 tests passing, `tsc --noEmit` clean.

## Not covered here

The report also mentions Shift+Insert (paste). Nothing in our code intercepts it — the zoom predicates all require Ctrl.

The likely explanation is that it was a symptom of the same bug: with Ctrl+Insert broken, the clipboard was empty, so pasting had nothing to paste. Worth noting that on Linux the two are not a pair anyway — Ctrl+Insert writes to CLIPBOARD, while Shift+Insert conventionally pastes the PRIMARY selection.

Asked the reporter to re-check once this ships. If paste is still broken with copy working, it is a separate issue and we will investigate then.
