### PR TITLE
fix: apply the permission mode and model the user configured (#264, #265)

### DIFF
--- a/backend/src/core/__tests__/claude-process.test.ts
+++ b/backend/src/core/__tests__/claude-process.test.ts
@@ -40,6 +40,15 @@ describe('buildClaudeArgs', () => {
     expect(buildClaudeArgs('--session-id', 's', 'nonsense')).not.toContain('--permission-mode');
   });
 
+  // #264: `--permission-mode default` names the ask-before-edits mode; it does not
+  // mean "use whatever settings say". Handing it to a caller that has no mode to ask
+  // for would override the user's configured `permissions.defaultMode` with the
+  // strictest mode. Omitting the flag entirely is what lets the CLI read its own
+  // settings — the same thing the user gets running `claude` in a terminal.
+  it('omits --permission-mode when no mode is requested, so the CLI reads its own settings', () => {
+    expect(buildClaudeArgs('--session-id', 's', undefined)).not.toContain('--permission-mode');
+  });
+
   it('pins an explicitly selected model via --model (adjacent value)', () => {
     const args = buildClaudeArgs('--resume', 's', 'ask_before_edit', 'opus[1m]');
     const i = args.indexOf('--model');
@@ -74,6 +83,13 @@ describe('needsRestartForMode', () => {
 
   it('restarts when the live process mode is unknown (safer than assuming a match)', () => {
     expect(needsRestartForMode(null, 'plan')).toBe(true);
+  });
+
+  // A message that asks for no particular mode is not a mode change — killing a
+  // working CLI to respawn an identical one would interrupt the session for nothing.
+  it('reuses the live process when the message requests no mode at all', () => {
+    expect(needsRestartForMode('plan', undefined)).toBe(false);
+    expect(needsRestartForMode(null, undefined)).toBe(false);
   });
 });
 

--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -88,7 +88,7 @@ export function readReportedMode(event: Record<string, unknown>): string | null 
 export function buildClaudeArgs(
   sessionFlag: string,
   targetSessionId: string,
-  inputMode: string,
+  inputMode: string | undefined,
   model?: string,
 ): string[] {
   const args: string[] = [
@@ -105,7 +105,11 @@ export function buildClaudeArgs(
     targetSessionId,
   ];
 
-  const cliFlag = INPUT_MODE_TO_CLI_FLAG[inputMode];
+  // No requested mode means nothing has established one for this session yet, so
+  // the CLI is left to read its own `permissions.defaultMode`. Passing a flag here
+  // would override that setting rather than defer to it — `--permission-mode
+  // default` names the ask-before-edits mode, it does not mean "follow settings".
+  const cliFlag = inputMode ? INPUT_MODE_TO_CLI_FLAG[inputMode] : undefined;
   if (cliFlag) {
     args.push('--permission-mode', cliFlag);
   }
@@ -169,7 +173,14 @@ export function markSessionAsSpawned(sessionId: string): void {
  * would gamble on an unknown mode and risk edits running under looser permissions
  * than the user chose.
  */
-export function needsRestartForMode(liveMode: string | null, requestedMode: string): boolean {
+export function needsRestartForMode(
+  liveMode: string | null,
+  requestedMode: string | undefined,
+): boolean {
+  // No requested mode is not a mode to compare against — it means the sender has
+  // no mode to ask for, so whatever the live CLI is already running under stands.
+  // Restarting here would tear down a working process to spawn an identical one.
+  if (!requestedMode) return false;
   return liveMode !== requestedMode;
 }
 
@@ -243,7 +254,7 @@ export async function ensureClaudeProcess(
   connectionId: string,
   workingDir: string,
   targetSessionId: string,
-  inputMode: string,
+  inputMode: string | undefined,
   bridge: Bridge,
   model?: string,
 ): Promise<void> {
@@ -397,7 +408,10 @@ export async function ensureClaudeProcess(
   // Remember the mode this process actually runs under, so a later mode change is
   // detected and honored by restarting instead of being silently dropped (#172).
   // Must follow setProcess — clearing the process also clears the recorded mode.
-  connections.setInputMode(targetSessionId, inputMode);
+  // Spawning without a requested mode leaves this null: the CLI picked the mode
+  // from its own settings, and it reports that choice on `system/init`, which is
+  // what fills the record in.
+  connections.setInputMode(targetSessionId, inputMode ?? null);
   connections.setBuffer(targetSessionId, '');
 
   // The session's process is now alive — this is where we re-arm any scheduled

--- a/backend/src/core/handlers/sendMessage.ts
+++ b/backend/src/core/handlers/sendMessage.ts
@@ -23,7 +23,9 @@ export async function sendMessageHandler(
     });
     return;
   }
-  const inputMode = message.payload?.inputMode as string;
+  // Absent means nothing has established a mode for this session yet — the CLI
+  // then reads its own `permissions.defaultMode` rather than being handed one.
+  const inputMode = message.payload?.inputMode as string | undefined;
   const model = message.payload?.model as string | undefined;
   // 새 세션 여부는 webview가 판정해 payload로 알려준다. webview가 새 세션에도 sessionId를
   // 미리 생성해 보내므로(ChatStreamContext), 백엔드에서 sessionId 유무로는 판정할 수 없다.

--- a/backend/src/core/handlers/startSession.ts
+++ b/backend/src/core/handlers/startSession.ts
@@ -20,7 +20,9 @@ export async function startSessionHandler(
     });
     return;
   }
-  const inputMode = (message.payload?.inputMode as string) || 'ask_before_edit';
+  // Absent means the webview has no mode to ask for yet — the CLI then reads its
+  // own `permissions.defaultMode` instead of being handed a substitute here.
+  const inputMode = message.payload?.inputMode as string | undefined;
 
   try {
     if (sessionId) {

--- a/webview/src/__tests__/chat-streaming.integration.test.tsx
+++ b/webview/src/__tests__/chat-streaming.integration.test.tsx
@@ -38,7 +38,9 @@ const mockSession = {
   isLoading: false,
   workingDirectory: '/test',
   inputMode: 'ask_before_edit' as const,
-  modeResetTrigger: 0,
+  // 컴포저가 CLI에 요구할 모드. 이 테스트들은 모드가 이미 정해진 세션에서 출발하므로
+  // inputMode와 같은 값으로 둔다.
+  requestedInputMode: 'ask_before_edit' as string | null,
   autoModeAvailable: false,
   autoFallbackNotice: false,
   loadSessions: vi.fn(),
@@ -55,7 +57,6 @@ const mockSession = {
   addNewSession: vi.fn(),
   setInputMode: vi.fn(),
   cycleInputMode: vi.fn(),
-  syncInitialInputMode: vi.fn(),
   syncEffectiveMode: vi.fn(),
   setAutoModeAvailable: vi.fn(),
   notifyAutoFallback: vi.fn(),
@@ -152,6 +153,7 @@ describe('채팅 스트리밍 통합 테스트', () => {
     // Reset mocks
     vi.clearAllMocks();
     bridgeHandlers.clear();
+    mockSession.requestedInputMode = 'ask_before_edit';
 
     // Setup bridge.subscribe to capture handlers
     mockBridge.subscribe.mockImplementation(
@@ -227,6 +229,8 @@ describe('채팅 스트리밍 통합 테스트', () => {
 
   it('sendMessage: inputMode가 bridge.send payload에 포함된다', async () => {
     mockSession.currentSessionId = 'existing-session';
+    // 사용자가 plan을 고른 상태 — 페이로드에는 이 모드가 실려야 한다
+    mockSession.requestedInputMode = 'plan';
 
     render(
       <TestWrapper>

--- a/webview/src/contexts/ChatStreamContext.tsx
+++ b/webview/src/contexts/ChatStreamContext.tsx
@@ -24,7 +24,13 @@ interface SendMessagePayload {
   attachments?: Array<Record<string, unknown>>;
   context: Context[];
   workingDir: string;
-  inputMode: InputMode;
+  // The mode to ask a spawning CLI for, via `--permission-mode`. Omitted when
+  // nothing has established a mode for this session yet: the backend then passes
+  // no flag at all, so the CLI reads its own `permissions.defaultMode`. Handing it
+  // the composer's placeholder instead would override that setting, since
+  // `--permission-mode default` names the ask-before-edits mode rather than
+  // meaning "follow the configured default".
+  inputMode?: InputMode;
   // The user-selected model, sent so the backend can spawn the CLI with
   // `--model`. This makes a model change take effect even when the previous
   // process has exited (set_model can't reach a dead process). Omitted when no
@@ -328,7 +334,12 @@ export function ChatStreamProvider(props: ChatStreamProviderProps) {
         attachments: attachments?.map(a => ({ ...a.toPayload() })),
         context: context || [],
         workingDir: session.workingDirectory ?? '',
-        inputMode,
+        // The mode to ask the CLI for — omitted while nothing has established one,
+        // so the CLI reads its own settings instead of being handed the composer's
+        // placeholder. `--permission-mode default` means "ask before edits", not
+        // "follow settings", so passing it would override the user's configured
+        // default with the strictest mode.
+        inputMode: session.requestedInputMode ?? undefined,
         model: sessionModel ?? undefined,
       };
 

--- a/webview/src/contexts/SessionContext.tsx
+++ b/webview/src/contexts/SessionContext.tsx
@@ -11,7 +11,7 @@ import { getAdapter, onBridgeReady } from '../adapters';
 import { getLogForwarder } from '../api/logging';
 import { toTitle } from '../mappers/sessionTransformer';
 import { Route, routeToPath, sessionToPath, parseSessionIdFromPath, withWorkingDir } from '../router/routes';
-import { InputMode, getAvailableModes } from '../types/chatInput';
+import { InputMode, getAvailableModes, resolveConfiguredInputMode, FALLBACK_INPUT_MODE } from '../types/chatInput';
 import {isJetBrains} from "@/config/environment.ts";
 import { MessageType } from '@/shared';
 
@@ -29,16 +29,19 @@ interface SessionContextValue {
 
   // Input mode
   inputMode: InputMode;
+  /**
+   * The mode to ask a spawning CLI for, or null to let the CLI read its own
+   * settings. Differs from `inputMode` only while nothing has established a mode
+   * yet: the composer must still show something (the app fallback), but asking the
+   * CLI for that fallback would override the user's configured default.
+   */
+  requestedInputMode: InputMode | null;
   setInputMode: (mode: InputMode) => void;
   cycleInputMode: () => void;
   /** 현재 가용한 모드 목록 (모드 선택 패널이 표시할 항목) */
   availableModes: InputMode[];
-  /** 설정값에서 로드된 초기 모드를 동기화 (사용자가 직접 변경하지 않은 경우에만 적용) */
-  syncInitialInputMode: (initialMode: InputMode) => void;
-  /** CLI가 통보한 실제 적용 모드(system/init.permissionMode)를 반영. 사용자 변경 플래그는 건드리지 않는다. */
+  /** CLI가 통보한 실제 적용 모드(system/init.permissionMode)를 이 세션의 모드로 반영한다. */
   syncEffectiveMode: (mode: InputMode) => void;
-  /** 세션 전환 시 초기 모드 재동기화를 트리거하기 위한 카운터 */
-  modeResetTrigger: number;
 
   // Auto mode availability (CLI가 결정 — ChatStream에서 푸시)
   autoModeAvailable: boolean;
@@ -90,16 +93,12 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const [isLoading, setIsLoading] = useState(false);
   const newlyCreatedSessionIds = useRef(new Set<string>());
 
-  // Input mode 상태
-  const [inputMode, setInputModeState] = useState<InputMode>('ask_before_edit');
-  // 이 세션의 모드가 이미 정해졌는가. 켜지면 설정 기본값(permissions.defaultMode)은
-  // 더 이상 끼어들지 않는다. "사용자가 직접 골랐는가"가 아니라 "정해졌는가"인 이유:
-  // 세션은 사용자가 모드 버튼을 누르지 않아도 특정 모드로 진행 중일 수 있고
-  // (새 탭이 plan으로 열린 경우 등), 그 상태에서 인풋 영역이 교체됐다는 이유로
-  // 기본값이 되살아나면 진행 중인 세션의 모드가 조용히 뒤집힌다.
-  const isModeSettled = useRef(false);
-  // 세션 전환 시 초기 모드 재동기화를 트리거하기 위한 카운터
-  const [modeResetTrigger, setModeResetTrigger] = useState(0);
+  // 이 세션이 스스로 만들어낸 모드만 담는다 — 사용자가 직접 고른 모드, 또는 CLI가
+  // 통보한 실제 적용 모드. 아직 둘 다 없으면 null이고, 그동안은 설정 기본값이 보인다.
+  // 설정 기본값을 이 상태에 복사해 넣지 않는 이유: 복사하는 순간 설정 컨텍스트와의
+  // 연결이 끊겨, 뒤늦게 도착한 설정을 언제 다시 반영할지 판정하는 플래그가 필요해진다.
+  // 그 판정이 설정 로딩 전에 켜져 설정 기본값이 영영 반영되지 않았다(#264).
+  const [sessionInputMode, setSessionInputMode] = useState<InputMode | null>(null);
   // addNewSession 시 URL 변경으로 인한 모드 리셋을 건너뛰기 위한 플래그
   const skipNextModeReset = useRef(false);
 
@@ -107,9 +106,25 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const [autoModeAvailable, setAutoModeAvailable] = useState(false);
   const [autoFallbackNotice, setAutoFallbackNotice] = useState(false);
 
+  // 설정 기본값(permissions.defaultMode)은 상태가 아니라 파생값이다. 설정 컨텍스트가
+  // 갱신되면 — 그것이 첫 로드든 사용자의 설정 변경이든, 언제 도착하든 — 그대로 따라온다.
+  // 설정이 기본 모드를 정하지 않았거나 아직 도착하지 않았으면 null이다.
+  const configuredInputMode = resolveConfiguredInputMode(claudeSettings.permissions?.defaultMode);
+
+  // 화면에 보이는 모드. 세션이 만들어낸 값이 있으면 그것이, 없으면 설정 기본값이,
+  // 그것도 없으면 앱 최후 기본값이 보인다.
+  const inputMode = sessionInputMode ?? configuredInputMode ?? FALLBACK_INPUT_MODE;
+
+  // CLI를 띄울 때 `--permission-mode`로 요구할 모드. 화면에 보이는 모드와 달리 null이
+  // 될 수 있다 — 세션이 만들어낸 모드도 없고 설정에서 읽은 기본값도 없는 상태다.
+  // 그때 화면은 앱 최후 기본값(ask_before_edit)을 보여주지만, 그 값을 CLI에 요구하면
+  // 안 된다: `--permission-mode default`는 "설정을 따르라"가 아니라 "승인을 요구하라"는
+  // 뜻이어서 설정의 defaultMode를 덮어쓴다(실측 확인). 플래그를 아예 생략해야 CLI가
+  // 자기 설정 파일을 직접 읽어 GUI와 같은 값으로 돈다.
+  const requestedInputMode = sessionInputMode ?? configuredInputMode;
+
   const setInputMode = useCallback((newMode: InputMode) => {
-    isModeSettled.current = true;
-    setInputModeState(newMode);
+    setSessionInputMode(newMode);
   }, []);
 
   // 현재 가용한 모드 목록(순환·선택 패널이 공유한다).
@@ -119,33 +134,16 @@ export function SessionProvider({ children }: SessionProviderProps) {
   );
 
   const cycleInputMode = useCallback(() => {
-    isModeSettled.current = true;
-    setInputModeState((current) => {
-      const currentIndex = availableModes.indexOf(current);
-      const nextIndex = (currentIndex + 1) % availableModes.length;
-      return availableModes[nextIndex];
-    });
-  }, [availableModes]);
+    const currentIndex = availableModes.indexOf(inputMode);
+    const nextIndex = (currentIndex + 1) % availableModes.length;
+    setSessionInputMode(availableModes[nextIndex]);
+  }, [availableModes, inputMode]);
 
-  // 설정 기본값(permissions.defaultMode)을 세션 시작 시 한 번만 적용한다.
-  // 적용하는 순간 모드는 정해진 것으로 본다 — 이 함수는 ChatInput이 마운트될 때마다
-  // 호출되는데, AskUserQuestion·플랜 승인 패널이 뜨면 ChatInput이 언마운트됐다가
-  // 다시 붙는다. "아직 사용자가 모드를 고르지 않았다"는 이유로 그때마다 기본값을
-  // 다시 적용하면, plan으로 진행 중이던 세션이 답변 한 번에 기본값(예: bypass)으로
-  // 뒤집힌다 — 화면은 느슨한 모드를 보여주는데 CLI는 여전히 plan인, 표시와 실제가
-  // 어긋나는 상태가 된다.
-  const syncInitialInputMode = useCallback((initialMode: InputMode) => {
-    if (isModeSettled.current) return;
-    isModeSettled.current = true;
-    setInputModeState(initialMode);
-  }, []);
-
-  // CLI가 통보한 실제 적용 모드를 반영한다(진실원). 화면에 보이는 모드를 CLI가 실제
-  // 적용한 것과 일치시키고, 그 모드로 정해진 것으로 본다 — CLI가 실제로 그 모드로
-  // 돌고 있는 이상 설정 기본값이 나중에 이를 덮어써선 안 된다.
+  // CLI가 통보한 실제 적용 모드를 반영한다(진실원). 사용자가 플랜 모드를 요청하지
+  // 않았는데 CLI가 스스로 플랜 모드로 실행했거나, 스스로 플랜 모드를 벗어난 경우가
+  // 여기로 들어온다. 세션을 다시 열 때 백엔드가 복원해주는 마지막 모드도 같은 성격이다.
   const syncEffectiveMode = useCallback((mode: InputMode) => {
-    isModeSettled.current = true;
-    setInputModeState(mode);
+    setSessionInputMode(mode);
   }, []);
 
   const notifyAutoFallback = useCallback(() => setAutoFallbackNotice(true), []);
@@ -159,10 +157,9 @@ export function SessionProvider({ children }: SessionProviderProps) {
       skipNextModeReset.current = false;
       return;
     }
-    // 다른 세션으로 넘어갔으니 이전 세션에서 정해진 모드는 더 이상 유효하지 않다.
+    // 다른 세션으로 넘어갔으니 이전 세션이 만들어낸 모드는 더 이상 유효하지 않다.
     // 새 세션은 다시 설정 기본값에서 출발한다.
-    isModeSettled.current = false;
-    setModeResetTrigger(c => c + 1);
+    setSessionInputMode(null);
   }, [currentSessionId]);
 
   // JetBrains에서 kotlinBridgeReady 이벤트 후 IDE adapter 재초기화
@@ -364,12 +361,11 @@ export function SessionProvider({ children }: SessionProviderProps) {
     isLoading,
     workingDirectory,
     inputMode,
+    requestedInputMode,
     setInputMode,
     cycleInputMode,
     availableModes,
-    syncInitialInputMode,
     syncEffectiveMode,
-    modeResetTrigger,
     autoModeAvailable,
     setAutoModeAvailable,
     autoFallbackNotice,

--- a/webview/src/contexts/__tests__/SessionContext.test.tsx
+++ b/webview/src/contexts/__tests__/SessionContext.test.tsx
@@ -60,11 +60,13 @@ vi.mock('../WorkingDirContext', () => ({
   }),
 }));
 
+// The settings object the backend has delivered so far. Before the WebSocket
+// connects there is no `permissions` block at all — tests flip this to simulate
+// settings arriving late, which is exactly the race that broke #264.
+let mockClaudeSettings: { permissions: Record<string, unknown> } = { permissions: {} };
 vi.mock('../ClaudeSettingsContext', () => ({
   useClaudeSettings: () => ({
-    settings: {
-      permissions: {},
-    },
+    settings: mockClaudeSettings,
     scopeSettings: {},
     isLoading: false,
     scope: 'global',
@@ -126,6 +128,7 @@ describe('SessionContext', () => {
     vi.clearAllMocks();
     mockPathname = '/';
     mockIsConnected = true;
+    mockClaudeSettings = { permissions: {} };
     mockWorkingDirectory = '/test/workspace';
     mockSessionsIndex.mockResolvedValue({ sessions: [] });
     mockSessionsLoad.mockResolvedValue(undefined);
@@ -390,7 +393,7 @@ describe('SessionContext', () => {
 
       let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
 
-      render(
+      const { rerender } = render(
         <SessionProvider>
           <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
         </SessionProvider>
@@ -406,27 +409,78 @@ describe('SessionContext', () => {
       });
       expect(capturedCtx!.inputMode).toBe('plan');
 
-      // 다른 세션으로 전환
+      // 다른 세션으로 전환. currentSessionId는 URL에서 파생되므로, navigate가 바꾼
+      // 경로를 실제로 관측하려면 리렌더가 필요하다.
       act(() => {
         capturedCtx?.switchSession('session-1');
       });
+      rerender(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
 
-      // 세션 전환 후에는 모드가 "정해지지 않은" 상태로 리셋되어 syncInitialInputMode가
-      // 다시 적용 가능해야 함 (실제 적용은 ChatInput의 useEffect에서 이루어지므로
-      // 여기서는 재동기화 트리거가 올랐는지로 간접 확인)
+      // 세션이 바뀌면 이전 세션이 만들어낸 모드는 버려지고 설정 기본값으로 돌아간다.
       await waitFor(() => {
-        // modeResetTrigger가 증가했는지 확인 (간접 검증)
-        expect(capturedCtx?.modeResetTrigger).toBeGreaterThan(0);
+        expect(capturedCtx!.inputMode).toBe('ask_before_edit');
       });
     });
 
-    // ChatInput은 AskUserQuestion 패널·플랜 승인 패널이 뜨는 동안 언마운트됐다가 다시
-    // 붙고, 마운트될 때마다 syncInitialInputMode를 호출한다. 진행 중인 세션의 모드가
-    // 그 재호출로 설정 기본값에 덮이면, 화면은 느슨한 모드를 보여주는데 CLI는 원래
-    // 모드로 도는 표시/실제 불일치가 된다.
-    it('세션 모드가 정해진 뒤에는 초기값 재동기화가 이를 덮지 않는다', async () => {
-      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+    // #264: 설정은 WebSocket이 연결된 뒤에야 도착하므로, 화면이 먼저 그려지는 동안에는
+    // permissions 블록이 통째로 비어 있다. 그때 보이는 값은 "설정에 아무것도 없다"가
+    // 아니라 "아직 모른다"이므로, 설정이 도착한 순간 — 그것이 아무리 늦더라도 —
+    // 설정의 기본값이 화면에 반영되어야 한다.
+    it('설정이 뒤늦게 도착해도 그 기본값이 반영된다', async () => {
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
 
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // 연결 전 — 설정을 아직 못 받았으므로 앱의 최후 기본값이 보인다
+      expect(capturedCtx!.inputMode).toBe('ask_before_edit');
+
+      // 설정 도착: 사용자가 저장해둔 기본 모드는 bypassPermissions였다
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
+      rerender(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      expect(capturedCtx!.inputMode).toBe('bypass');
+    });
+
+    // #264: 화면은 무언가를 보여줘야 하므로 설정을 모를 때도 앱 최후 기본값을 띄운다.
+    // 하지만 그 값을 CLI에 요구하면 안 된다 — `--permission-mode default`는 "설정을
+    // 따르라"가 아니라 "승인을 요구하라"여서, 사용자가 설정해둔 기본 모드를 덮어쓴다.
+    // 요구할 모드가 없다는 것(null)과 화면에 보일 모드는 서로 다른 값이다.
+    it('설정을 모르는 동안에는 CLI에 요구할 모드가 없다', async () => {
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // 설정 미도착 — 화면에는 앱 최후 기본값이 보이지만 CLI에 요구할 것은 없다
+      expect(capturedCtx!.inputMode).toBe('ask_before_edit');
+      expect(capturedCtx!.requestedInputMode).toBeNull();
+
+      // 설정 도착 — 이제 요구할 모드가 생긴다
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
+      rerender(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+      expect(capturedCtx!.requestedInputMode).toBe('bypass');
+    });
+
+    it('사용자가 모드를 고르면 설정을 모르는 상태에서도 그 모드를 요구한다', async () => {
       let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
 
       render(
@@ -434,63 +488,106 @@ describe('SessionContext', () => {
           <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
         </SessionProvider>
       );
+      expect(capturedCtx!.requestedInputMode).toBeNull();
 
-      // 세션이 plan으로 진행 중 — 사용자가 모드 버튼을 누르지 않아도 이 상태일 수 있다
       act(() => {
-        capturedCtx?.syncInitialInputMode('plan');
-      });
-      expect(capturedCtx!.inputMode).toBe('plan');
-
-      // AskUserQuestion 답변 → ChatInput 재마운트 → 기본값으로 재동기화 시도
-      act(() => {
-        capturedCtx?.syncInitialInputMode('bypass');
+        capturedCtx?.setInputMode('plan');
       });
 
-      expect(capturedCtx!.inputMode).toBe('plan');
+      expect(capturedCtx!.requestedInputMode).toBe('plan');
     });
 
-    // CLI가 통보한 실제 적용 모드도 "정해진" 모드다. 그 뒤 인풋이 재마운트되어
-    // 기본값 재동기화가 호출돼도 CLI의 진실이 유지되어야 한다.
-    it('CLI가 통보한 모드도 초기값 재동기화에 덮이지 않는다', async () => {
-      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
-
+    // 설정 화면에서 기본 모드를 바꾸면, 아직 사용자가 손대지 않은 세션의 인풋도
+    // 그 변경을 따라와야 한다 — 설정 기본값은 복사본이 아니라 구독하는 값이다.
+    it('설정 기본값이 변경되면 손대지 않은 세션의 모드가 따라온다', async () => {
       let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
 
-      render(
+      mockClaudeSettings = { permissions: { defaultMode: 'plan' } };
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+      expect(capturedCtx!.inputMode).toBe('plan');
+
+      mockClaudeSettings = { permissions: { defaultMode: 'acceptEdits' } };
+      rerender(
         <SessionProvider>
           <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
         </SessionProvider>
       );
 
+      expect(capturedCtx!.inputMode).toBe('auto_edit');
+    });
+
+    // #172: ChatInput은 AskUserQuestion 패널·플랜 승인 패널이 뜨는 동안 언마운트됐다가
+    // 다시 붙는다. 진행 중인 세션의 모드가 그 사이 설정 기본값에 덮이면, 화면은 느슨한
+    // 모드를 보여주는데 CLI는 원래 모드로 도는 표시/실제 불일치가 된다.
+    it('CLI가 통보한 모드는 설정 기본값이 나중에 바뀌어도 덮이지 않는다', async () => {
+      mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      // 세션이 plan으로 진행 중 — 사용자가 모드 버튼을 누르지 않아도 CLI가 스스로
+      // plan으로 실행하면 이 상태가 된다.
       act(() => {
         capturedCtx?.syncEffectiveMode('plan');
       });
       expect(capturedCtx!.inputMode).toBe('plan');
 
-      act(() => {
-        capturedCtx?.syncInitialInputMode('bypass');
-      });
-
-      expect(capturedCtx!.inputMode).toBe('plan');
-    });
-
-    // Reload ordering: ChatInput mounts and applies the settings default the
-    // instant the page renders, but SESSION_LOADED (carrying the session's actual
-    // last mode) only arrives after a backend round trip — strictly later. The
-    // restored mode must still win even though it settles the mode SECOND.
-    it('세션 로드로 복원된 모드는 이미 정해진 기본값보다 늦게 도착해도 이긴다', async () => {
-      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
-
-      render(
+      // 그 뒤 설정이 도착하거나 변경돼도 진행 중인 세션의 모드는 유지된다
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
+      rerender(
         <SessionProvider>
           <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
         </SessionProvider>
       );
 
-      // ChatInput mounts first and applies the configured default (settles the mode).
+      expect(capturedCtx!.inputMode).toBe('plan');
+    });
+
+    it('사용자가 고른 모드는 설정 기본값이 나중에 바뀌어도 덮이지 않는다', async () => {
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      const { rerender } = render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
       act(() => {
-        capturedCtx?.syncInitialInputMode('bypass');
+        capturedCtx?.setInputMode('plan');
       });
+      expect(capturedCtx!.inputMode).toBe('plan');
+
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
+      rerender(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
+
+      expect(capturedCtx!.inputMode).toBe('plan');
+    });
+
+    // Reload ordering: the page renders (and shows the configured default) before
+    // SESSION_LOADED arrives with the session's actual last mode — strictly later.
+    // The restored mode must still win.
+    it('세션 로드로 복원된 모드는 설정 기본값보다 늦게 도착해도 이긴다', async () => {
+      let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
+
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
+      render(
+        <SessionProvider>
+          <TestConsumer onMount={(ctx) => { capturedCtx = ctx; }} />
+        </SessionProvider>
+      );
       expect(capturedCtx!.inputMode).toBe('bypass');
 
       // SESSION_LOADED arrives afterward with the session's actual last mode.
@@ -501,9 +598,10 @@ describe('SessionContext', () => {
       expect(capturedCtx!.inputMode).toBe('plan');
     });
 
-    it('세션 전환 후에는 초기값 재동기화가 다시 적용된다', async () => {
+    it('세션 전환 후에는 설정 기본값이 다시 적용된다', async () => {
       mockPathname = '/sessions/session-1';
       mockSessionsIndex.mockResolvedValue({ sessions: mockSessionDtos });
+      mockClaudeSettings = { permissions: { defaultMode: 'bypassPermissions' } };
 
       let capturedCtx: ReturnType<typeof useSessionContext> | null = null;
 
@@ -527,12 +625,10 @@ describe('SessionContext', () => {
         </SessionProvider>
       );
 
-      // 이전 세션에서 정해진 모드는 더 이상 유효하지 않으므로 기본값이 다시 적용된다
-      act(() => {
-        capturedCtx?.syncInitialInputMode('bypass');
+      // 이전 세션이 만들어낸 모드는 더 이상 유효하지 않으므로 설정 기본값이 다시 보인다
+      await waitFor(() => {
+        expect(capturedCtx!.inputMode).toBe('bypass');
       });
-
-      expect(capturedCtx!.inputMode).toBe('bypass');
     });
   });
 

--- a/webview/src/examples/StreamingExample.tsx
+++ b/webview/src/examples/StreamingExample.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useChatStreamContext } from '../contexts/ChatStreamContext';
 import { useChatInputState } from '../contexts/ChatInputStateContext';
 import { MessageRole, LoadedMessageType } from '../dto/common';
+import { InputModeValues } from '../types/chatInput';
 
 /**
  * Example component demonstrating streaming message integration
@@ -55,7 +56,7 @@ export const StreamingExample: React.FC = () => {
       </div>
 
       {/* Input */}
-      <form onSubmit={(e) => handleSubmit(e, 'ask_before_edit')} style={{ padding: '1rem', borderTop: '1px solid var(--ide-border)', display: 'flex', gap: '0.5rem' }}>
+      <form onSubmit={(e) => handleSubmit(e, InputModeValues.ASK_BEFORE_EDIT)} style={{ padding: '1rem', borderTop: '1px solid var(--ide-border)', display: 'flex', gap: '0.5rem' }}>
         <input
           type="text"
           value={input}

--- a/webview/src/pages/ChatPage/ChatInput/__tests__/ModelTag.custom-catalog.test.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/__tests__/ModelTag.custom-catalog.test.tsx
@@ -10,13 +10,14 @@ import type { ModelInfo } from '@/types/slashCommand';
 const CUSTOM_CATALOG: ModelInfo[] = [
   {
     value: 'default',
+    resolvedModel: 'glm-5.2-mayi[1m]',
     displayName: 'Default (recommended)',
     description: 'Use the default model (currently glm-5.2-mayi[1m])',
   },
-  { value: 'glm-5.2-mayi', displayName: 'glm-5.2-mayi', description: 'Custom Opus model' },
-  { value: 'glm-5.1-mayi', displayName: 'glm-5.1-mayi', description: 'Custom Fable model' },
-  { value: 'glm-4.7-mayi', displayName: 'glm-4.7-mayi', description: 'Custom Sonnet model' },
-  { value: 'glm-4.5-air-mayi', displayName: 'glm-4.5-air-mayi', description: 'Custom Haiku model' },
+  { value: 'glm-5.2-mayi', resolvedModel: 'glm-5.2-mayi', displayName: 'glm-5.2-mayi', description: 'Custom Opus model' },
+  { value: 'glm-5.1-mayi', resolvedModel: 'glm-5.1-mayi', displayName: 'glm-5.1-mayi', description: 'Custom Fable model' },
+  { value: 'glm-4.7-mayi', resolvedModel: 'glm-4.7-mayi', displayName: 'glm-4.7-mayi', description: 'Custom Sonnet model' },
+  { value: 'glm-4.5-air-mayi', resolvedModel: 'glm-4.5-air-mayi', displayName: 'glm-4.5-air-mayi', description: 'Custom Haiku model' },
 ];
 
 /** What the composer's model tag ends up showing for a given current model. */
@@ -34,7 +35,7 @@ describe('ModelTag label on a custom model catalog (issue #217)', () => {
   it('keeps showing it once the session starts and system/init echoes back', () => {
     // The regression: each of these is a shape system/init may report for the
     // very model the user picked. None of them may fall back to the default row.
-    for (const echoed of ['haiku', 'glm-4.5-air-mayi', 'glm-4.5-air-mayi[1m]', 'GLM-4.5-Air-MAYI']) {
+    for (const echoed of ['glm-4.5-air-mayi', 'glm-4.5-air-mayi[1m]', 'GLM-4.5-Air-MAYI']) {
       expect(tagLabel(echoed)).toBe('glm-4.5-air-mayi');
     }
   });
@@ -51,10 +52,22 @@ describe('ModelTag label on a custom model catalog (issue #217)', () => {
     expect(tagLabel('default')).toBe('Default (recommended)');
   });
 
-  it('resolves every non-default slot to its own model', () => {
-    expect(tagLabel('opus')).toBe('glm-5.2-mayi');
-    expect(tagLabel('sonnet')).toBe('glm-4.7-mayi');
-    expect(tagLabel('fable')).toBe('glm-5.1-mayi');
+  it('resolves every slot to its own model, never to a neighbour', () => {
+    // Each row here is a distinct proxy model, and the CLI reports whichever one
+    // is running by its id — so every slot must land back on itself.
+    expect(tagLabel('glm-5.2-mayi')).toBe('glm-5.2-mayi');
+    expect(tagLabel('glm-4.7-mayi')).toBe('glm-4.7-mayi');
+    expect(tagLabel('glm-5.1-mayi')).toBe('glm-5.1-mayi');
+  });
+
+  it('does not hand a coarse alias to a row that merely advertises that family', () => {
+    // "Custom Opus model" is marketing copy in the blurb, not a claim that the
+    // row answers to "opus". We used to read the family out of that sentence and
+    // pick a row by it; a proxy can point two differently-blurbed slots at one
+    // model, which makes that pick arbitrary. Nothing named "opus" here, so the
+    // honest answer is no row (the caller then keeps showing the user's pick).
+    expect(resolveModelInfo(CUSTOM_CATALOG, 'opus', { allowDefaultFallback: false })).toBeNull();
+    expect(resolveModelInfo(CUSTOM_CATALOG, 'haiku', { allowDefaultFallback: false })).toBeNull();
   });
 
   it('keeps labels short enough for a single-line bottom row', () => {
@@ -70,12 +83,13 @@ describe('ModelTag label on the Anthropic catalog (no regression)', () => {
   const ANTHROPIC_CATALOG: ModelInfo[] = [
     {
       value: 'default',
+      resolvedModel: 'claude-opus-4-8[1m]',
       displayName: 'Default (recommended)',
       description: 'Opus 4.8 with 1M context · Best for everyday tasks',
     },
-    { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · hard tasks' },
-    { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6 · everyday' },
-    { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
+    { value: 'opus[1m]', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · hard tasks' },
+    { value: 'sonnet', resolvedModel: 'claude-sonnet-4-6', displayName: 'Sonnet', description: 'Sonnet 4.6 · everyday' },
+    { value: 'haiku', resolvedModel: 'claude-haiku-4-5-20251001', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
   ];
 
   it('still extracts name + version from the description', () => {

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, KeyboardEvent, useState, type Clipboard
 import { CommandPalettePanel } from '@/commandPalette/ui/CommandPalettePanel';
 import { useCommandPalette } from '@/commandPalette/hooks/useCommandPalette';
 import { PanelSectionId, PanelItemType, CommandItem } from '@/types/commandPalette';
-import { INPUT_MODES, resolveInitialInputMode } from '../../../types/chatInput';
+import { INPUT_MODES } from '../../../types/chatInput';
 import { InputModeTag } from './InputModeTag';
 import { ModeSelectPanel } from './ModeSelectPanel';
 import { ScheduleSendPopover } from './ScheduleSendPopover';
@@ -54,7 +54,7 @@ interface NativeDropEntry {
 export function ChatInput() {
   const { t } = useTranslation('chat');
   const { textareaRef } = useChatInputFocus();
-  const { currentSessionId, sessionState, workingDirectory, inputMode: mode, cycleInputMode: cycleMode, setInputMode, availableModes, syncInitialInputMode, modeResetTrigger, autoFallbackNotice, dismissAutoFallback } = useSessionContext();
+  const { currentSessionId, sessionState, workingDirectory, inputMode: mode, cycleInputMode: cycleMode, setInputMode, availableModes, autoFallbackNotice, dismissAutoFallback } = useSessionContext();
   const chatStream = useChatStreamContext();
   const { handleSubmit: onSubmit, isStreaming, stop: onStop } = chatStream;
   const { input: value, setInput: onChange } = useChatInputState();
@@ -86,7 +86,7 @@ export function ChatInput() {
     setIsDragOver,
   } = useAttachments();
 
-  const { settings: claudeSettings, updateSetting: updateClaudeSetting, isLoading: claudeSettingsLoading } = useClaudeSettings();
+  const { settings: claudeSettings, updateSetting: updateClaudeSetting } = useClaudeSettings();
   // useCtrlEnterToSend + focusInputOnEditorContext migrated to the app settings.
   const { settings: appSettings } = useSettings();
   const { cycle: cycleEffort } = useEffort();
@@ -235,19 +235,6 @@ export function ChatInput() {
   }, [claudeSettings.alwaysThinkingEnabled, updateClaudeSetting]);
 
   const disabled = sessionState === SessionState.Error || !workingDirectory;
-
-  // Claude settings의 permissions.defaultMode에서 초기 모드 결정. claudeSettings는
-  // GET_CLAUDE_SETTINGS로 비동기 로드되므로, 로딩 중(claudeSettingsLoading)의
-  // defaultModeFlag는 "설정값이 없다"가 아니라 "아직 모른다"다. 이 값으로
-  // syncInitialInputMode를 호출해 모드를 확정(settle)해버리면, 실제 설정이 도착해도
-  // 이미 정해졌다는 이유로 반영되지 않는다 — 예: bypass가 기본값인데 로딩 중
-  // ask_before_edit로 먼저 확정되어 그 값이 굳어버림. 로딩이 끝난 뒤에만 호출한다.
-  const defaultModeFlag = claudeSettings.permissions?.defaultMode;
-  const initialInputMode = resolveInitialInputMode(defaultModeFlag);
-  useEffect(() => {
-    if (claudeSettingsLoading) return;
-    syncInitialInputMode(initialInputMode);
-  }, [initialInputMode, syncInitialInputMode, modeResetTrigger, claudeSettingsLoading]);
 
   const modeConfig = INPUT_MODES[mode];
 

--- a/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
+++ b/webview/src/pages/ChatPage/ModelSwitchOverlay/index.tsx
@@ -145,11 +145,18 @@ export function ModelSwitchOverlay({ onClose, autoSelectQuery }: ModelSwitchOver
       <div className="pb-1.5 px-1">
         {models.length === 0 ? (
           <div className="px-2 py-1 text-[0.9230rem] text-text-tertiary">{t('modelSwitch.loadingModels')}</div>
-        ) : models.map((m) => {
-          const selected = m.value === currentInfo?.value;
+        ) : models.map((m, i) => {
+          // Compare the row itself, not its `value`: a proxy catalog can map two
+          // slots onto one model id — the same `value` listed as both "Custom
+          // Sonnet model" and "Custom Haiku model" — and comparing values ticks
+          // both rows.
+          const selected = m === currentInfo;
           return (
             <button
-              key={m.value}
+              // `value` is the string we hand the CLI, not an identity within
+              // this list — a proxy catalog can list one id in two slots, and a
+              // duplicated key makes React reuse the wrong row.
+              key={i}
               onClick={() => void handleSelect(m.value)}
               className={`w-full relative flex items-center justify-between px-2 py-1 rounded-md text-start transition-colors ${
                 selected ? 'bg-surface-hover' : 'hover:bg-surface-hover'

--- a/webview/src/pages/ChatPage/message-renderers/NotificationMessageRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/NotificationMessageRenderer.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { LoadedMessageDto, LoadedMessageType, getTextContent } from '../../../types';
 import { useChatStreamContext } from '@/contexts/ChatStreamContext';
 import { useCliConfig } from '@/contexts/CliConfigContext';
-import { modelChangeTarget } from '@/types/models';
+import { isModelChangeFor } from '@/types/models';
 import { parseUserContent } from './utils/parseUserContent';
 import type { ModelInfo } from '@/types/slashCommand';
 
@@ -32,6 +32,10 @@ export const NotificationMessageRenderer: React.FC<NotificationMessageRendererPr
   // Match by model identity (the notice's `modelChangeValue`), not by display
   // text: the notice summary is localized while the echo is English, so string
   // equality would never converge and both lines would linger.
+  //
+  // Ask whether the echo names THIS row rather than resolving the echo to a row
+  // and comparing: several rows can resolve to one model id, so resolving picks
+  // one arbitrarily and the row the user actually chose may lose the comparison.
   const modelValue = message.modelChangeValue;
   if (modelValue) {
     const models: ModelInfo[] = controlResponse?.response?.response?.models ?? [];
@@ -39,7 +43,7 @@ export const NotificationMessageRenderer: React.FC<NotificationMessageRendererPr
       if (m.type !== LoadedMessageType.User) return false;
       const parsed = parseUserContent(getTextContent(m));
       if (!parsed.hasLocalCommandStdout && parsed.commandName !== 'model') return false;
-      return modelChangeTarget(parsed.text, models)?.value === modelValue;
+      return isModelChangeFor(parsed.text, modelValue, models);
     });
     if (echoArrived) return null;
   }

--- a/webview/src/pages/ChatPage/message-renderers/components/ContextUsageCard/__tests__/contextCard.test.ts
+++ b/webview/src/pages/ChatPage/message-renderers/components/ContextUsageCard/__tests__/contextCard.test.ts
@@ -104,6 +104,7 @@ describe('model display helpers', () => {
     const models: ModelInfo[] = [
       {
         value: 'opus[1m]',
+        resolvedModel: 'claude-opus-4-8[1m]',
         displayName: 'Opus',
         description: 'Opus 4.8 with 1M context · Best for everyday tasks',
       },

--- a/webview/src/pages/SettingsPage/Cli/__tests__/modelSelect.test.tsx
+++ b/webview/src/pages/SettingsPage/Cli/__tests__/modelSelect.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { toModelAlias } from '@/types/models';
+import type { ModelInfo } from '@/types/slashCommand';
+
+/**
+ * The Default Model row of CLI settings showed an EMPTY dropdown for anyone who
+ * had picked a model: the saved value was handed to the picker folded down to a
+ * coarse family alias ("opus[1m]" -> "opus"), no option carries that folded
+ * value, and an unmatched Select renders nothing at all.
+ *
+ * These lock the round-trip: whatever the settings file holds must select the
+ * row the user chose, and picking a row must save a value that selects it again.
+ */
+
+const updateClaudeSettingMock = vi.fn();
+let mockClaudeSettings: Record<string, unknown> = {};
+let mockModels: ModelInfo[] = [];
+
+vi.mock('@/contexts/SettingsContext', () => ({
+  useSettings: () => ({ settings: {}, updateSetting: vi.fn(), ideAttached: false, ideProduct: '' }),
+}));
+vi.mock('@/contexts/ClaudeSettingsContext', () => ({
+  useClaudeSettings: () => ({ settings: mockClaudeSettings, updateSetting: updateClaudeSettingMock }),
+}));
+vi.mock('@/contexts/CliConfigContext', () => ({
+  useCliConfig: () => ({ controlResponse: { response: { response: { models: mockModels } } } }),
+}));
+vi.mock('@/hooks/useVersionInfo', () => ({ useVersionInfo: () => ({ cliVersion: '2.1.170' }) }));
+vi.mock('@/contexts/WorkingDirContext', () => ({ useWorkingDir: () => ({ workingDirectory: '/tmp' }) }));
+vi.mock('@/contexts/FableProbeContext', () => ({
+  useFableProbe: () => ({ probedAvailable: null, probeFableAvailability: vi.fn() }),
+  shouldProbeFable: () => false,
+}));
+// Resolve synchronously so the detection round-trips settle within render and
+// don't land as un-acted state updates after the assertions.
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ send: () => ({ then: () => ({ catch: () => undefined }) }) }),
+}));
+
+import { CliSettings } from '../index';
+
+/** The catalog a real account serves, Fable row included. */
+const CATALOG: ModelInfo[] = [
+  {
+    value: 'default',
+    resolvedModel: 'claude-opus-5[1m]',
+    displayName: 'Default (recommended)',
+    description: 'Opus 5 with 1M context · Best for everyday tasks',
+  },
+  { value: 'fable', resolvedModel: 'claude-fable-5', displayName: 'Fable', description: 'Fable 5 · creative' },
+  {
+    value: 'opus[1m]',
+    resolvedModel: 'claude-opus-5[1m]',
+    displayName: 'Opus (1M context)',
+    description: 'Opus 5 with 1M context · hard tasks',
+  },
+  { value: 'sonnet', resolvedModel: 'claude-sonnet-5', displayName: 'Sonnet', description: 'Sonnet 5 · everyday' },
+  { value: 'haiku', resolvedModel: 'claude-haiku-4-5-20251001', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
+];
+
+/** The label the Default Model dropdown currently displays. */
+function modelTriggerLabel(): string {
+  return screen.getByRole('button', { name: 'Default Model' }).textContent ?? '';
+}
+
+beforeEach(() => {
+  updateClaudeSettingMock.mockReset();
+  mockClaudeSettings = {};
+  mockModels = CATALOG;
+});
+
+describe('CLI settings — Default Model dropdown', () => {
+  it('displays the saved model, not an empty trigger', () => {
+    // The regression: this exact value rendered a blank dropdown.
+    mockClaudeSettings = { model: 'opus[1m]' };
+    render(<CliSettings />);
+    expect(modelTriggerLabel()).toContain('Opus (1M context)');
+  });
+
+  it('displays every catalog row a user could have saved', () => {
+    for (const row of CATALOG.filter((m) => m.value !== 'default')) {
+      mockClaudeSettings = { model: row.value };
+      const { unmount } = render(<CliSettings />);
+      expect(modelTriggerLabel()).toContain(row.displayName);
+      unmount();
+    }
+  });
+
+  it('shows the default row when no model is saved', () => {
+    mockClaudeSettings = {};
+    render(<CliSettings />);
+    expect(modelTriggerLabel()).toContain('Default (recommended)');
+  });
+
+  it('shows a default label before the CLI has served a catalog', () => {
+    mockModels = [];
+    mockClaudeSettings = {};
+    render(<CliSettings />);
+    expect(modelTriggerLabel().trim()).not.toBe('');
+  });
+
+  it('rules out the folded-alias value that caused the blank dropdown', () => {
+    // The old code passed `toModelAlias(saved)` as the Select value. Assert here
+    // that no option carries that folded value, so the shape of the bug is
+    // pinned even though the buggy line is gone: were it reintroduced, the
+    // Select would again match nothing and render blank.
+    const optionValues = ['', ...CATALOG.filter((m) => m.value !== 'default').map((m) => m.value)];
+    expect(toModelAlias('opus[1m]')).toBe('opus');
+    expect(optionValues).not.toContain(toModelAlias('opus[1m]'));
+  });
+});

--- a/webview/src/pages/SettingsPage/Cli/index.tsx
+++ b/webview/src/pages/SettingsPage/Cli/index.tsx
@@ -11,7 +11,7 @@ import { useCliConfig } from '@/contexts/CliConfigContext';
 import { useVersionInfo } from '@/hooks/useVersionInfo';
 import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import { useFableProbe, shouldProbeFable } from '@/contexts/FableProbeContext';
-import { DEFAULT_MODEL_ALIAS, toModelAlias, withFableFallback } from '@/types/models';
+import { DEFAULT_MODEL_ALIAS, withFableFallback } from '@/types/models';
 import { MessageType } from '@/shared';
 import { useTranslation } from '@/i18n';
 import { OpenFilesWithRow } from './OpenFilesWithRow';
@@ -179,7 +179,7 @@ export function CliSettings() {
           }
         >
           <Select
-            value={claudeSettings.model ? toModelAlias(claudeSettings.model) : ''}
+            value={claudeSettings.model || ''}
             options={modelOptions}
             ariaLabel={t('cli.model.label')}
             onChange={(value) => void updateClaudeSetting('model', value || null)}

--- a/webview/src/pages/SettingsPage/Permissions/index.tsx
+++ b/webview/src/pages/SettingsPage/Permissions/index.tsx
@@ -3,7 +3,7 @@ import { Select, type SelectOption } from '@/components/Select';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { SettingBadge, SettingBadgeVariant } from '@/components';
-import { type InputMode, INPUT_MODES, getAvailableModes, CLI_FLAG_TO_INPUT_MODE, INPUT_MODE_TO_CLI_FLAG } from '@/types/chatInput';
+import { type InputMode, INPUT_MODES, getAvailableModes, resolveInitialInputMode, INPUT_MODE_TO_CLI_FLAG } from '@/types/chatInput';
 import type { PermissionsConfig } from '@/types/claude-settings';
 import { useTranslation } from '@/i18n';
 
@@ -23,7 +23,7 @@ export function PermissionsSettings() {
   const isDefaultModeNotSet = rawDefaultMode === undefined && scope === 'project';
   const defaultModeValue = isDefaultModeNotSet
     ? NOT_SET_VALUE
-    : (rawDefaultMode ? (CLI_FLAG_TO_INPUT_MODE[rawDefaultMode] ?? 'ask_before_edit') : 'ask_before_edit');
+    : resolveInitialInputMode(rawDefaultMode);
 
   const mergedBypassDisabled = mergedPermissions.disableBypassPermissionsMode === 'disable';
 

--- a/webview/src/types/__tests__/models.test.ts
+++ b/webview/src/types/__tests__/models.test.ts
@@ -6,6 +6,7 @@ import {
   resolveModelLabel,
   findModelForSelection,
   modelChangeTarget,
+  isModelChangeFor,
   isAutoModeAvailable,
   withFableFallback,
   resolveCurrentModel,
@@ -14,12 +15,18 @@ import {
 } from '../models';
 import type { ModelInfo } from '../slashCommand';
 
-function model(value: string, displayName = value): ModelInfo {
-  return { value, displayName, description: `${displayName} desc` };
+/**
+ * A catalog row as the CLI actually serves it: every row it resolved carries a
+ * `resolvedModel` alongside the `value` we hand back to select it. Tests that
+ * need a row WITHOUT one (our Fable fallback, an unresolved row) build the
+ * object literally instead of using this helper.
+ */
+function model(value: string, displayName = value, resolvedModel = `claude-${value}`): ModelInfo {
+  return { value, resolvedModel, displayName, description: `${displayName} desc` };
 }
 
 function modelWithAuto(value: string, supportsAutoMode: boolean): ModelInfo {
-  return { value, displayName: value, description: `${value} desc`, supportsAutoMode };
+  return { ...model(value), supportsAutoMode };
 }
 
 describe('findModelForSelection', () => {
@@ -170,13 +177,14 @@ describe('custom model catalogs (issue #217)', () => {
   const CUSTOM_MODELS: ModelInfo[] = [
     {
       value: 'default',
+      resolvedModel: 'glm-5.2-mayi[1m]',
       displayName: 'Default (recommended)',
       description: 'Use the default model (currently glm-5.2-mayi[1m])',
     },
-    { value: 'glm-5.2-mayi', displayName: 'glm-5.2-mayi', description: 'Custom Opus model' },
-    { value: 'glm-5.1-mayi', displayName: 'glm-5.1-mayi', description: 'Custom Fable model' },
-    { value: 'glm-4.7-mayi', displayName: 'glm-4.7-mayi', description: 'Custom Sonnet model' },
-    { value: 'glm-4.5-air-mayi', displayName: 'glm-4.5-air-mayi', description: 'Custom Haiku model' },
+    { value: 'glm-5.2-mayi', resolvedModel: 'glm-5.2-mayi', displayName: 'glm-5.2-mayi', description: 'Custom Opus model' },
+    { value: 'glm-5.1-mayi', resolvedModel: 'glm-5.1-mayi', displayName: 'glm-5.1-mayi', description: 'Custom Fable model' },
+    { value: 'glm-4.7-mayi', resolvedModel: 'glm-4.7-mayi', displayName: 'glm-4.7-mayi', description: 'Custom Sonnet model' },
+    { value: 'glm-4.5-air-mayi', resolvedModel: 'glm-4.5-air-mayi', displayName: 'glm-4.5-air-mayi', description: 'Custom Haiku model' },
   ];
 
   it('derives the family from the description when the value carries no family token', () => {
@@ -199,10 +207,18 @@ describe('custom model catalogs (issue #217)', () => {
 
   it('keeps a user-picked custom model displayed after the session starts', () => {
     // Regression for #217: the user picks the Haiku slot and sends a message;
-    // system/init echoes the coarse alias, which must resolve back to the very
-    // model the user picked — not to the "default" row.
-    expect(resolveModelInfo(CUSTOM_MODELS, 'haiku')?.value).toBe('glm-4.5-air-mayi');
-    expect(resolveModelInfo(CUSTOM_MODELS, 'sonnet')?.value).toBe('glm-4.7-mayi');
+    // system/init echoes the id that slot resolved to, which must land back on
+    // the very row the user picked — not on the "default" row.
+    expect(resolveModelInfo(CUSTOM_MODELS, 'glm-4.5-air-mayi')?.value).toBe('glm-4.5-air-mayi');
+    expect(resolveModelInfo(CUSTOM_MODELS, 'glm-4.7-mayi')?.value).toBe('glm-4.7-mayi');
+  });
+
+  it('does not put a coarse alias on an arbitrary row of that family', () => {
+    // A proxy catalog can map ONE id onto two slots ("Custom Sonnet model" and
+    // "Custom Haiku model" both serving it), so picking a row by the family
+    // named in its blurb picks whichever comes first — a guess, not a match.
+    // Better to identify nothing than to tick a row we cannot justify.
+    expect(resolveModelInfo(CUSTOM_MODELS, 'haiku', { allowDefaultFallback: false })).toBeNull();
   });
 
   it('resolves the raw custom id the CLI may echo back, suffix and case included', () => {
@@ -293,18 +309,19 @@ describe('resolveModelInfo', () => {
 
 describe('modelChangeTarget', () => {
   const models: ModelInfo[] = [
-    { value: 'default', displayName: 'Default (recommended)', description: 'Opus 4.8 with 1M context · recommended' },
-    { value: 'opus[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · best for hard tasks' },
-    { value: 'sonnet', displayName: 'Sonnet', description: 'Sonnet 4.6 · everyday' },
-    { value: 'haiku', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
+    { value: 'default', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Default (recommended)', description: 'Opus 4.8 with 1M context · recommended' },
+    { value: 'opus[1m]', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · best for hard tasks' },
+    { value: 'sonnet', resolvedModel: 'claude-sonnet-4-6', displayName: 'Sonnet', description: 'Sonnet 4.6 · everyday' },
+    { value: 'haiku', resolvedModel: 'claude-haiku-4-5-20251001', displayName: 'Haiku', description: 'Haiku 4.5 · fast' },
   ];
 
-  it('resolves "Set model to <full id>" to the model value + friendly label', () => {
-    // CLI echoes the bare id for the opus[1m] selection
-    expect(modelChangeTarget('Set model to claude-opus-4-8[1m]', models)).toEqual({
-      value: 'opus[1m]',
-      label: 'Opus 4.8',
-    });
+  it('resolves "Set model to <full id>" to a friendly label', () => {
+    // The CLI echoes the bare id. Two rows here serve that id — "Default
+    // (recommended)" and "Opus" — exactly as the real catalog does, so only the
+    // label is well-defined; both rows carry the same one. Which row got picked
+    // is the caller's business, and the caller that cares asks
+    // `isModelChangeFor` instead (see below).
+    expect(modelChangeTarget('Set model to claude-opus-4-8[1m]', models)?.label).toBe('Opus 4.8');
   });
 
   it('resolves "Set model to <alias> (<id>)" by the alias before the paren', () => {
@@ -320,8 +337,8 @@ describe('modelChangeTarget', () => {
 
   it('still parses when wrapped in a local-command-stdout tag', () => {
     expect(
-      modelChangeTarget('<local-command-stdout>Set model to claude-opus-4-8[1m]</local-command-stdout>', models),
-    ).toEqual({ value: 'opus[1m]', label: 'Opus 4.8' });
+      modelChangeTarget('<local-command-stdout>Set model to claude-opus-4-8[1m]</local-command-stdout>', models)?.label,
+    ).toBe('Opus 4.8');
   });
 
   it('returns null for text that is not a model-change line', () => {
@@ -331,6 +348,38 @@ describe('modelChangeTarget', () => {
 
   it('falls back to the raw token (value and label) when the model is unknown', () => {
     expect(modelChangeTarget('Set model to mystery', [])).toEqual({ value: 'mystery', label: 'mystery' });
+  });
+});
+
+describe('isModelChangeFor', () => {
+  // Mirrors the real catalog: "default" and "opus[1m]" serve one model id.
+  const models: ModelInfo[] = [
+    { value: 'default', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Default (recommended)', description: 'Opus 4.8 with 1M context · recommended' },
+    { value: 'opus[1m]', resolvedModel: 'claude-opus-4-8[1m]', displayName: 'Opus', description: 'Opus 4.8 with 1M context · best for hard tasks' },
+    { value: 'sonnet', resolvedModel: 'claude-sonnet-4-6', displayName: 'Sonnet', description: 'Sonnet 4.6 · everyday' },
+  ];
+
+  it('matches every row the echoed id resolves to, not just the first one', () => {
+    // Whichever of the two the user picked, the echo announces their change —
+    // so the local notice for that row must recognize it and step aside.
+    expect(isModelChangeFor('Set model to claude-opus-4-8[1m]', 'opus[1m]', models)).toBe(true);
+    expect(isModelChangeFor('Set model to claude-opus-4-8[1m]', 'default', models)).toBe(true);
+  });
+
+  it('does not match a row serving a different model', () => {
+    expect(isModelChangeFor('Set model to claude-opus-4-8[1m]', 'sonnet', models)).toBe(false);
+  });
+
+  it('matches when the echo names the row value itself', () => {
+    expect(isModelChangeFor('Set model to sonnet (claude-sonnet-4-6)', 'sonnet', models)).toBe(true);
+  });
+
+  it('matches an unknown model against the raw token, so a proxy model still dedupes', () => {
+    expect(isModelChangeFor('Set model to my-proxy-model', 'my-proxy-model', [])).toBe(true);
+  });
+
+  it('is false for text that is not a model-change line', () => {
+    expect(isModelChangeFor('hello world', 'sonnet', models)).toBe(false);
   });
 });
 

--- a/webview/src/types/chatInput.ts
+++ b/webview/src/types/chatInput.ts
@@ -148,15 +148,32 @@ export const CLI_FLAG_TO_INPUT_MODE: Record<string, InputMode> = {
 } as const;
 
 /**
- * The InputMode a session should start in, given the CLI flag configured as
- * `permissions.defaultMode` (undefined when settings have not resolved a value —
- * distinct from "no default configured", which the CLI itself never reports; the
- * absence here is purely "we don't know yet"). Falls back to ask_before_edit for
- * both an absent setting and an unrecognized flag, so a stale/renamed flag never
- * silently grants a looser mode than intended.
+ * The mode the app shows before it knows anything else — no session mode yet and
+ * no `permissions.defaultMode` read from settings. The strictest of the modes, so
+ * an unknown state never displays looser permissions than the user actually has.
+ */
+export const FALLBACK_INPUT_MODE: InputMode = InputModeValues.ASK_BEFORE_EDIT;
+
+/**
+ * The InputMode the user's `permissions.defaultMode` names, or null when settings
+ * name none — either because they have not arrived yet or because the user never
+ * configured one. Both cases mean the same thing to a spawning CLI: do not pass
+ * `--permission-mode`, let the CLI read its own settings.
+ *
+ * An unrecognized flag also yields null rather than a guess, so a stale or renamed
+ * flag never silently grants a looser mode than intended.
+ */
+export function resolveConfiguredInputMode(defaultModeFlag: string | undefined): InputMode | null {
+  if (!defaultModeFlag) return null;
+  return CLI_FLAG_TO_INPUT_MODE[defaultModeFlag] ?? null;
+}
+
+/**
+ * The InputMode to display for a session that has not established one of its own:
+ * the configured default when settings name one, else the app's fallback.
  */
 export function resolveInitialInputMode(defaultModeFlag: string | undefined): InputMode {
-  return defaultModeFlag ? (CLI_FLAG_TO_INPUT_MODE[defaultModeFlag] ?? InputModeValues.ASK_BEFORE_EDIT) : InputModeValues.ASK_BEFORE_EDIT;
+  return resolveConfiguredInputMode(defaultModeFlag) ?? FALLBACK_INPUT_MODE;
 }
 
 // ============================================

--- a/webview/src/types/models.ts
+++ b/webview/src/types/models.ts
@@ -51,14 +51,13 @@ export function modelInfoAlias(info: ModelInfo): string {
 }
 
 /**
- * Normalize a model id for comparison: lowercase and strip a context-window
- * suffix (`[1m]`). The CLI echoes the running model back through `system/init`
- * in a slightly different shape than the catalog lists it, and for custom
- * models there is no family token to fall back on — so this comparison is what
- * keeps the user's exact pick on screen.
+ * Reduce a model id to letters and digits, lowercased. One model is named in
+ * different shapes across sources (`opus[1m]` vs `claude-opus-5[1m]`,
+ * `GLM-4.5-Air-MAYI` vs `glm-4.5-air-mayi`), so a comparison of last resort keys
+ * on this rather than on the raw strings.
  */
-function normalizeModelId(value: string): string {
-  return value.toLowerCase().replace(/\[[^\]]*\]$/, '');
+function alphanumericKey(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]/g, '');
 }
 
 /**
@@ -229,10 +228,12 @@ export function resolveModelLabel(info: ModelInfo): string {
  * rather than rendering nothing.
  *
  * Resolution order:
- *  1. exact `value` match — preserves fine-grained user picks
- *  2. alias-equivalence — same model family via `toModelAlias`
- *  3. the `default` item — a sane visible fallback
- *  4. `null` — caller renders a raw label of last resort
+ *  1. exact `resolvedModel` — the concrete id the CLI reports as running
+ *  2. exact `displayName` — a custom catalog puts its real id here
+ *  3. exact `value` — preserves fine-grained user picks ("opusplan")
+ *  4. alphanumeric containment — same id written in a different shape
+ *  5. the `default` item — a sane visible fallback
+ *  6. `null` — caller renders a raw label of last resort
  */
 /**
  * Resolve a model the user *explicitly named* (e.g. "/model fable"), matching
@@ -266,20 +267,34 @@ export function resolveModelInfo(
   if (models.length === 0) return null;
   const target = current ?? DEFAULT_MODEL_ALIAS;
 
-  const exact = models.find((m) => m.value === target);
-  if (exact) return exact;
+  // The CLI selects a row by its `value` but reports the running model as the
+  // concrete id that row resolved to, and the catalog carries that id on every
+  // row it resolved. So `resolvedModel` is the precise thing to match on, and it
+  // needs no guessing about id shapes — custom proxy catalogs included, whose ids
+  // carry no family token to fall back on (issue #217).
+  const resolved = models.find((m) => m.resolvedModel !== undefined && m.resolvedModel === target);
+  if (resolved) return resolved;
 
-  // A CLI-echoed value may carry a suffix or differ in case from the catalog
-  // entry (`glm-4.5-air-mayi[1m]`, `GLM-4.5-Air-MAYI`), so try a normalized
-  // match before widening to the family — it keeps the user's precise pick.
-  const normalized = normalizeModelId(target);
-  const idMatch = models.find((m) => normalizeModelId(m.value) === normalized);
-  if (idMatch) return idMatch;
+  const byName = models.find((m) => m.displayName === target);
+  if (byName) return byName;
 
-  const targetAlias = toModelAlias(target);
-  if (targetAlias !== DEFAULT_MODEL_ALIAS) {
-    const aliasMatch = models.find((m) => modelInfoAlias(m) === targetAlias);
-    if (aliasMatch) return aliasMatch;
+  // An exact `value` before any loose comparison: "opusplan" contains "opus", so
+  // a containment pass alone would hand back the coarser row and lose the
+  // fine-grained pick the user actually made.
+  const exactValue = models.find((m) => m.value === target);
+  if (exactValue) return exactValue;
+
+  // Last resort: one model is named in different shapes across sources
+  // (`opus[1m]` vs `claude-opus-5[1m]`, `GLM-4.5-Air-MAYI` vs `glm-4.5-air-mayi`).
+  // Comparing on letters and digits alone drops punctuation, case and suffixes,
+  // and either side may be the longer form — so accept containment both ways.
+  const targetKey = alphanumericKey(target);
+  if (targetKey) {
+    const contained = models.find((m) => {
+      const valueKey = alphanumericKey(m.value);
+      return valueKey !== '' && (targetKey.includes(valueKey) || valueKey.includes(targetKey));
+    });
+    if (contained) return contained;
   }
 
   // Callers that need to know whether the model was genuinely identified (see
@@ -329,9 +344,39 @@ export function modelChangeTarget(
   text: string,
   models: ModelInfo[],
 ): { value: string; label: string } | null {
-  const match = text.match(/Set model to (.+?)(?:\s*[(<]|$)/);
-  if (!match) return null;
-  const raw = match[1].trim();
+  const raw = modelChangeToken(text);
+  if (raw === null) return null;
   const info = resolveModelInfo(models, raw);
   return info ? { value: info.value, label: resolveModelLabel(info) } : { value: raw, label: raw };
+}
+
+/** The model token inside a CLI `/model` echo line, or null if it isn't one. */
+function modelChangeToken(text: string): string | null {
+  const match = text.match(/Set model to (.+?)(?:\s*[(<]|$)/);
+  return match ? match[1].trim() : null;
+}
+
+/**
+ * Whether a CLI `/model` echo line announces the row selected as `value`.
+ *
+ * Distinct from `modelChangeTarget`, which answers "which row is this?" and so
+ * must pick ONE. The echo names the id the row resolved to, and several rows can
+ * resolve to the same id — "Default (recommended)" and "Opus (1M context)" both
+ * serve `claude-opus-5[1m]`, as do two slots of a proxy catalog pointed at one
+ * model. Asking "is this row the one?" answers exactly what the caller knows it
+ * needs, instead of making the resolver guess between rows it cannot separate.
+ */
+export function isModelChangeFor(
+  text: string,
+  value: string,
+  models: ModelInfo[],
+): boolean {
+  const raw = modelChangeToken(text);
+  if (raw === null) return false;
+  if (raw === value) return true; // the echo named the row's own value
+  const row = models.find((m) => m.value === value);
+  if (row?.resolvedModel !== undefined && row.resolvedModel === raw) return true;
+  // Neither side named the row directly — fall back to the shared resolver, so
+  // an id written in another shape still converges (see `resolveModelInfo`).
+  return resolveModelInfo(models, raw, { allowDefaultFallback: false })?.value === value;
 }

--- a/webview/src/types/slashCommand.ts
+++ b/webview/src/types/slashCommand.ts
@@ -31,6 +31,14 @@ export interface AgentInfo {
 
 export interface ModelInfo {
   value: string;
+  /**
+   * The concrete model this row resolves to, as the CLI reports it
+   * (`claude-haiku-4-5-20251001`). `value` is what we hand back to the CLI to
+   * select the row; this is what the CLI echoes as the running model on
+   * `system/init`, so placing a reported model on its row keys on this field.
+   * Absent on rows the CLI did not resolve (our Fable fallback row).
+   */
+  resolvedModel?: string;
   displayName: string;
   description: string;
   supportsEffort?: boolean;


### PR DESCRIPTION
Fixes #264. Also covers the model half of #265 (closed as a duplicate of #264).

Two settings-driven defaults were being applied by copying a value that should have stayed derived, and both drifted away from what the user configured.

## 1. The configured default permission mode never applied (#264)

New sessions always started in "Ask before edits", whatever `permissions.defaultMode` said. A regression from #172, as the reporter identified.

**Why.** The session's mode state was seeded with a hardcoded mode plus a flag meaning "this session already has a mode". Settings arrive asynchronously, so that flag was already set by the time the configured default showed up, and the default was discarded.

**Fix.** That state now holds ONLY a mode the session itself established — the user picking one, or the CLI reporting the one it applied. While it is empty, the configured default is read straight from settings, so a late arrival simply shows up. No flag decides when settings may still be honoured, because nothing is copied.

**A second cause, on the way to the CLI.** The composer handed its displayed mode to every spawning CLI. That looks harmless but is not: `--permission-mode default` names the ask-before-edits mode rather than meaning "follow the configured default", so passing the placeholder actively overrode the setting. The payload now omits the mode until something establishes one, and the CLI reads its own settings.

This is also what the report's step 6 describes (switching to Bypass mid-session had no effect): the requested mode was pinned to the placeholder, so a manual change never differed from what the process was already running and never triggered the restart that applies it.

**Measured, not reasoned.** Two things here were settled by running the CLI rather than by reading code:

- *What `--permission-mode default` means to the CLI.* With `permissions.defaultMode: bypassPermissions` in the global settings, `claude -p --permission-mode default` was asked to write a file in an isolated directory. It refused: the response carried `permission_denials` for `Write`, and no file appeared. So the flag value `default` names the ask-before-edits mode and overrides the setting — omitting the flag is what defers to it. The fix rests on this distinction.
- *Step 6, end to end in the IDE.* Switching to Bypass mid-session produced, in the backend log, mode-change detection, a CLI restart, and a resume carrying `--permission-mode bypassPermissions`; the tool then ran with no approval prompt.

## 2. Models were identified by guesswork (#265)

Placing a running model on its catalog row rested on comparing name shapes, and on a last-resort guess: read a family token ("opus", "haiku") out of the row's description and take any row of that family.

**Why that guess is unsound.** A proxy catalog can point two differently described slots at ONE model — the screenshot in #265 shows a single id listed as both "Custom Sonnet model" and "Custom Haiku model" — so "any row of that family" is really "whichever row comes first", and a user's pick lands on a neighbour.

**Why it was unnecessary.** Every catalog row the CLI resolved already carries the concrete model id it resolves to, and that is exactly what the CLI echoes as the running model. The field was simply missing from our type and so never used. It is now carried through and matched first; the family guess is gone.

Two consequences fell out of rows sharing one resolved id — the real Anthropic catalog resolves both "Default (recommended)" and "Opus (1M context)" to the same model:

- Deduping the CLI's model-change echo against our own instant notice resolved the echo to a row and compared it with the row the user clicked. With two rows sharing an id, those differ, the lines stopped converging, and the same change showed twice. The comparison now asks whether the echo names the clicked row.
- The picker's tick and React's row identity both keyed on the row value, so one id in two slots ticked both rows and let React reuse the wrong one.

## 3. The Default Model dropdown rendered blank

Anyone with a model configured saw an empty dropdown in Settings → CLI. The saved value was folded to a coarse family alias before being handed to the dropdown (`opus[1m]` → `opus`), no option carries that folded value, and an unmatched dropdown renders nothing at all. It now uses the saved value as-is.

This screen had no test at all, which is why the regression went unnoticed; it has one now.

## Verification

| Check | Result |
|---|---|
| `wv-test` | 1979 passed (216 files) |
| `wv-lint` | clean |
| `be-test` | 1126 passed, 8 skipped (100 files) |
| `be-lint` | clean |


