### PR TITLE
fix(settings): offer Auto as a default input mode (#272)

### DIFF
--- a/webview/src/pages/SettingsPage/Permissions/__tests__/index.test.tsx
+++ b/webview/src/pages/SettingsPage/Permissions/__tests__/index.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { ModelInfo } from '@/types/slashCommand';
+
+const updateSettingMock = vi.fn();
+let mockSettings: Record<string, unknown> = {};
+let mockScopeSettings: Record<string, unknown> = {};
+let mockScope = 'user';
+let mockModels: ModelInfo[] = [];
+let mockSessionModel: string | null = null;
+
+vi.mock('@/contexts/ClaudeSettingsContext', () => ({
+  useClaudeSettings: () => ({
+    settings: mockSettings,
+    scopeSettings: mockScopeSettings,
+    updateSetting: updateSettingMock,
+    scope: mockScope,
+  }),
+}));
+
+vi.mock('@/contexts/CliConfigContext', () => ({
+  useCliConfig: () => ({
+    controlResponse: { response: { response: { models: mockModels } } },
+  }),
+}));
+
+vi.mock('@/contexts/ChatStreamContext', () => ({
+  useChatStreamContext: () => ({ sessionModel: mockSessionModel }),
+}));
+
+import { PermissionsSettings } from '../index';
+
+const AUTO_MODEL: ModelInfo = {
+  value: 'sonnet',
+  displayName: 'Sonnet',
+  description: 'Sonnet',
+  supportsAutoMode: true,
+};
+const NO_AUTO_MODEL: ModelInfo = {
+  value: 'haiku',
+  displayName: 'Haiku',
+  description: 'Haiku',
+  supportsAutoMode: false,
+};
+
+/**
+ * Open the "Default Input Mode" dropdown and read the labels it offers. The
+ * selected option renders a trailing check marker, so compare on the label only.
+ */
+function openDefaultModeOptions(): string[] {
+  fireEvent.click(screen.getByRole('button', { name: /Default Input Mode/i }));
+  return screen.getAllByRole('option').map((o) => (o.textContent ?? '').replace(/✓/g, '').trim());
+}
+
+beforeEach(() => {
+  updateSettingMock.mockReset();
+  mockSettings = {};
+  mockScopeSettings = {};
+  mockScope = 'user';
+  mockModels = [AUTO_MODEL, NO_AUTO_MODEL];
+  mockSessionModel = 'sonnet';
+});
+
+describe('PermissionsSettings — default mode offers auto (#272)', () => {
+  it('offers Auto mode when the current model supports it', () => {
+    render(<PermissionsSettings />);
+    expect(openDefaultModeOptions()).toContain('Auto mode');
+  });
+
+  it('hides Auto mode when the current model does not support it', () => {
+    mockSessionModel = 'haiku';
+    render(<PermissionsSettings />);
+    expect(openDefaultModeOptions()).not.toContain('Auto mode');
+  });
+
+  it('hides Auto mode when admin policy disables it, even on a supporting model', () => {
+    mockSettings = { permissions: { disableAutoMode: 'disable' } };
+    render(<PermissionsSettings />);
+    expect(openDefaultModeOptions()).not.toContain('Auto mode');
+  });
+
+  it('keeps Auto mode listed when it is the saved value but model info has not arrived', () => {
+    // Empty catalog => availability unknown. A saved auto must stay listed,
+    // otherwise the dropdown silently drops the user's stored value.
+    mockModels = [];
+    mockSessionModel = null;
+    mockScopeSettings = { permissions: { defaultMode: 'auto' } };
+    render(<PermissionsSettings />);
+    expect(openDefaultModeOptions()).toContain('Auto mode');
+  });
+
+  it('persists Auto mode as the CLI defaultMode flag when picked', () => {
+    render(<PermissionsSettings />);
+    openDefaultModeOptions();
+    fireEvent.click(screen.getByRole('option', { name: 'Auto mode' }));
+    expect(updateSettingMock).toHaveBeenCalledWith(
+      'permissions',
+      expect.objectContaining({ defaultMode: 'auto' }),
+    );
+  });
+});

--- a/webview/src/pages/SettingsPage/Permissions/index.tsx
+++ b/webview/src/pages/SettingsPage/Permissions/index.tsx
@@ -3,8 +3,11 @@ import { Select, type SelectOption } from '@/components/Select';
 import { ToggleSwitch } from '@/components/ToggleSwitch';
 import { useClaudeSettings } from '@/contexts/ClaudeSettingsContext';
 import { SettingBadge, SettingBadgeVariant } from '@/components';
-import { type InputMode, INPUT_MODES, getAvailableModes, resolveInitialInputMode, INPUT_MODE_TO_CLI_FLAG } from '@/types/chatInput';
+import { type InputMode, InputModeValues, INPUT_MODES, getAvailableModes, resolveInitialInputMode, INPUT_MODE_TO_CLI_FLAG } from '@/types/chatInput';
 import type { PermissionsConfig } from '@/types/claude-settings';
+import { useCliConfig } from '@/contexts/CliConfigContext';
+import { useChatStreamContext } from '@/contexts/ChatStreamContext';
+import { isAutoModeAvailable } from '@/types/models';
 import { useTranslation } from '@/i18n';
 
 const NOT_SET_VALUE = '__NOT_SET__';
@@ -12,9 +15,16 @@ const NOT_SET_VALUE = '__NOT_SET__';
 export function PermissionsSettings() {
   const { t } = useTranslation('settings');
   const { settings, scopeSettings, updateSetting, scope } = useClaudeSettings();
+  const { controlResponse } = useCliConfig();
+  const { sessionModel } = useChatStreamContext();
 
   const permissions = (scopeSettings.permissions ?? {}) as PermissionsConfig;
   const mergedPermissions = (settings.permissions ?? {}) as PermissionsConfig;
+
+  const models = controlResponse?.response?.response?.models ?? [];
+  // The running model wins when a session is live; before that, the model the
+  // user has configured is the best prediction of what a new session will use.
+  const mergedModel = settings.model as string | undefined;
 
   const bypassDisabled = permissions.disableBypassPermissionsMode === 'disable';
   const isBypassNotSet = permissions.disableBypassPermissionsMode === undefined && scope === 'project';
@@ -26,6 +36,24 @@ export function PermissionsSettings() {
     : resolveInitialInputMode(rawDefaultMode);
 
   const mergedBypassDisabled = mergedPermissions.disableBypassPermissionsMode === 'disable';
+
+  // Auto mode is offered here under the same rule the chat input's mode panel
+  // uses (computed in ChatStreamContext): the current model's `supportsAutoMode`
+  // plus the `disableAutoMode` admin policy. `permissions.defaultMode` accepts
+  // "auto" in the CLI's own settings schema, so hiding it outright kept GUI
+  // users from a value the CLI allows (#272).
+  const autoModeAvailable = isAutoModeAvailable(
+    models,
+    sessionModel ?? mergedModel,
+    mergedPermissions.disableAutoMode,
+  );
+
+  // Until the model catalog arrives, availability is unknown rather than false.
+  // A default already saved as "auto" must stay listed through that window, or
+  // the dropdown would render a value it has no option for and silently show
+  // the user something other than what is stored.
+  const autoAlreadySaved = rawDefaultMode === INPUT_MODE_TO_CLI_FLAG[InputModeValues.AUTO];
+  const showAuto = autoModeAvailable || (models.length === 0 && autoAlreadySaved);
 
   const savePermissionsKey = async (key: keyof PermissionsConfig, value: unknown) => {
     const current = (scopeSettings.permissions ?? {}) as Record<string, unknown>;
@@ -44,7 +72,7 @@ export function PermissionsSettings() {
     ...(scope === 'project'
       ? [{ value: NOT_SET_VALUE, label: t('permissions.notSet'), italic: true }]
       : []),
-    ...getAvailableModes(mergedBypassDisabled).map((modeId) => ({
+    ...getAvailableModes(mergedBypassDisabled, showAuto).map((modeId) => ({
       value: modeId,
       label: INPUT_MODES[modeId].label,
     })),


### PR DESCRIPTION
Closes #272

## Problem

The **Default Input Mode** picker in Settings → Permissions never listed **Auto mode**, so users had to switch every new session to Auto by hand.

The picker called `getAvailableModes(mergedBypassDisabled)` without the second `autoAvailable` argument, so it fell back to the parameter default (`false`) and Auto was filtered out unconditionally. The chat input's mode panel passes the flag (`SessionContext.tsx`) and offered Auto correctly — the two screens had drifted apart.

## Why Auto belongs here

The CLI's own settings schema (shipped in the official extension as `claude-code-settings.schema.json`) accepts `auto` for `permissions.defaultMode`:

```
["acceptEdits", "auto", "bypassPermissions", "default", "dontAsk", "plan", "manual"]
```

A CLI user can write `defaultMode: "auto"` into `settings.json` today, so per the project's CLI-equivalence principle the GUI must allow it too.

## Change

Gate Auto here under the **same rule the chat input uses**: the current model's `supportsAutoMode` (via `isAutoModeAvailable`) plus the `disableAutoMode` admin policy. The running model wins when a session is live; before that the configured model is the best prediction of what a new session will use.

Additionally, a saved `auto` stays listed while the model catalog is still in flight. Availability is *unknown* rather than `false` in that window, and dropping the option would render a value the picker has no entry for — silently showing the user something other than what is stored.

## Testing

- New `Permissions/__tests__/index.test.tsx` — 5 cases: offers Auto on a supporting model, hides it on a non-supporting model, hides it under admin policy, keeps a saved Auto listed before model info arrives, and persists the `auto` CLI flag when picked. Verified failing before the fix.
- Full webview suite: **217 files / 1984 tests passing**
- `wv-lint` (tsc --noEmit): clean

Rebased onto latest `main` (`8c83544`); resolved one import-line conflict with #275, keeping its `resolveInitialInputMode` refactor.