### PR TITLE
Add Compose compiler plugin to Gradle version catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+﻿[versions]
+# Kotlin version used by plugin catalog
+kotlin = "2.3.21"
+
+[plugins]
+org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }


### PR DESCRIPTION
Why
Add the Kotlin Compose compiler plugin to the Gradle version catalog so projects using the catalog can opt into JetBrains Compose support consistently and reuse the Kotlin version entry.

What
- Create gradle/libs.versions.toml with a `kotlin = "2.3.21"` entry under [versions].
- Add a plugin catalog entry for the Compose compiler:
  `compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }`.

Approach
A single-file change was made to introduce the catalog entry. The file was committed on branch `waitpro0-create-plan`.

Notes and validation
- Local Gradle validation was attempted on the host but failed because JAVA_HOME is not set in this environment. To validate locally or in CI, run:
  `./gradlew --no-daemon help` or trigger a Gradle sync in your IDE.
- If the repo uses a different version-catalog location, update accordingly.

Reviewers
- Minimal and safe change; review for correct Kotlin version and whether the project prefers a different catalog location or plugin id.