### PR TITLE
fix(settings): honour "Open Settings as" in the IDE, not a stale cache

### DIFF
--- a/webview/src/contexts/SettingsContext.tsx
+++ b/webview/src/contexts/SettingsContext.tsx
@@ -6,6 +6,7 @@ import { useWorkingDir } from '@/contexts/WorkingDirContext';
 import { isJetBrains, isMobile, getIdeTheme, subscribeIdeTheme } from '@/config/environment';
 import { applyZoom, MOBILE_BASE_ZOOM, ZOOM_DEFAULT } from '@/utils/zoom';
 import { MessageType } from '@/shared';
+import { setCurrentSettings } from '@/utils/openSettingsAt';
 
 interface SettingsContextValue {
   settings: SettingsState;
@@ -92,6 +93,15 @@ export function SettingsProvider({ children }: SettingsProviderProps) {
   const ideProduct = mergedQuery.data?.ideProduct ?? '';
   const scopeSettings = scopeQuery.data?.settings ?? {};
   const isLoading = mergedQuery.isLoading && !mergedQuery.data;
+
+  // Mirror the live settings value into openSettingsAt's module scope so hook-free
+  // callers (toast actions, command-palette items) read the same source of truth
+  // as the UI — covering initial load and backend SETTINGS_CHANGED pushes, not just
+  // local edits. See openSettingsAt.ts's top comment for why this replaced reading
+  // the localStorage cache directly (issue #280: stale per-tab cache in JetBrains).
+  useEffect(() => {
+    setCurrentSettings(settings);
+  }, [settings]);
 
   // Apply font size to root element so rem-based sizes scale globally
   useEffect(() => {

--- a/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/SessionHeader.test.tsx
@@ -9,6 +9,8 @@ import { SessionHeader } from '../SessionHeader/index';
 import { SessionMetaDto } from '../../../dto';
 import type { SessionState } from '../../../types';
 import { Route } from '@/router';
+import { setCurrentSettings } from '@/utils/openSettingsAt';
+import { DEFAULT_SETTINGS, type SettingsState } from '@/types/settings';
 
 // 테스트 시점 기준 상대 날짜 생성 헬퍼.
 // 기준 시각을 "오늘 정오"로 고정한다. 자정 직후(예: 00:00~02:00)에 실행하면
@@ -161,10 +163,12 @@ beforeEach(() => {
     updateSettingWithScope: vi.fn(),
   };
 
-  // openSettingsAt reads the open-mode preference from this cache; clear it so
-  // one test's stored preference cannot leak into the next.
+  // openSettingsAt reads the open-mode preference from this module-scope mirror
+  // (kept in sync by SettingsContext in real usage; mocked away here, so we seed
+  // it directly) — reset it so one test's stored preference cannot leak into
+  // the next.
   mockOpenSettingsAdapter.mockReset();
-  localStorage.clear();
+  setCurrentSettings({ ...DEFAULT_SETTINGS } as SettingsState);
 });
 
 describe('SessionHeader', () => {
@@ -404,10 +408,7 @@ describe('SessionHeader', () => {
 
   it('설정 항목: openSettingsAs=new-tab이면 General 목적지로 새 탭을 연다', async () => {
     const user = userEvent.setup();
-    localStorage.setItem(
-      'claude-code-settings',
-      JSON.stringify({ openSettingsAs: 'new-tab' }),
-    );
+    setCurrentSettings({ ...DEFAULT_SETTINGS, openSettingsAs: 'new-tab' } as SettingsState);
     render(<SessionHeader />, { wrapper: queryWrapper });
 
     await openOverflowMenu(user);

--- a/webview/src/utils/__tests__/openSettingsAt.test.ts
+++ b/webview/src/utils/__tests__/openSettingsAt.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Route } from '@/router';
-import { OpenSettingsMode, SettingKey } from '@/types/settings';
+import { DEFAULT_SETTINGS, OpenSettingsMode, SettingKey, type SettingsState } from '@/types/settings';
 
 const openSettingsAdapterMock = vi.fn();
 vi.mock('@/adapters', () => ({
@@ -9,6 +9,7 @@ vi.mock('@/adapters', () => ({
 
 import {
   openSettingsAt,
+  setCurrentSettings,
   OPEN_SETTINGS_OVERLAY_EVENT,
   type OpenSettingsOverlayDetail,
 } from '../openSettingsAt';
@@ -28,24 +29,25 @@ function listenForOverlay(): { detail: () => OpenSettingsOverlayDetail | null; s
   };
 }
 
-function storeOpenMode(mode: OpenSettingsMode): void {
-  localStorage.setItem(
-    SETTINGS_STORAGE_KEY,
-    JSON.stringify({ [SettingKey.OPEN_SETTINGS_AS]: mode }),
-  );
+/** Simulate SettingsContext mirroring a loaded settings value in, the way it
+ * does on every render once `settings` changes (see SettingsContext.tsx). */
+function loadSettings(mode: OpenSettingsMode): void {
+  setCurrentSettings({ ...DEFAULT_SETTINGS, [SettingKey.OPEN_SETTINGS_AS]: mode } as SettingsState);
 }
 
 describe('openSettingsAt', () => {
   beforeEach(() => {
     openSettingsAdapterMock.mockReset().mockResolvedValue(undefined);
     localStorage.clear();
+    // Reset the module mirror to its pre-boot state before each test.
+    setCurrentSettings(undefined as unknown as SettingsState);
   });
   afterEach(() => {
     localStorage.clear();
   });
 
   it('opens an overlay over the current screen when that is the user preference', async () => {
-    storeOpenMode(OpenSettingsMode.OVERLAY);
+    loadSettings(OpenSettingsMode.OVERLAY);
     const overlay = listenForOverlay();
 
     await openSettingsAt(Route.SETTINGS_SPONSOR);
@@ -57,7 +59,7 @@ describe('openSettingsAt', () => {
   });
 
   it('opens a dedicated tab at the SAME target when that is the user preference', async () => {
-    storeOpenMode(OpenSettingsMode.NEW_TAB);
+    loadSettings(OpenSettingsMode.NEW_TAB);
     const overlay = listenForOverlay();
 
     await openSettingsAt(Route.SETTINGS_SPONSOR);
@@ -69,7 +71,7 @@ describe('openSettingsAt', () => {
     overlay.stop();
   });
 
-  it('defaults to the overlay when no preference has been stored yet', async () => {
+  it('defaults to the overlay when no settings have loaded yet', async () => {
     const overlay = listenForOverlay();
 
     await openSettingsAt(Route.SETTINGS_SPONSOR);
@@ -79,18 +81,8 @@ describe('openSettingsAt', () => {
     overlay.stop();
   });
 
-  it('falls back to the overlay when the stored settings are unreadable', async () => {
-    localStorage.setItem(SETTINGS_STORAGE_KEY, '{ not json');
-    const overlay = listenForOverlay();
-
-    await openSettingsAt(Route.SETTINGS_SPONSOR);
-
-    expect(overlay.detail()).toEqual({ route: Route.SETTINGS_SPONSOR });
-    overlay.stop();
-  });
-
   it('works for any settings route, not just the sponsor page', async () => {
-    storeOpenMode(OpenSettingsMode.NEW_TAB);
+    loadSettings(OpenSettingsMode.NEW_TAB);
 
     await openSettingsAt(Route.SETTINGS_PERMISSIONS);
 
@@ -98,13 +90,33 @@ describe('openSettingsAt', () => {
   });
 
   it('falls back to the overlay when opening a tab fails (e.g. pop-up blocked)', async () => {
-    storeOpenMode(OpenSettingsMode.NEW_TAB);
+    loadSettings(OpenSettingsMode.NEW_TAB);
     openSettingsAdapterMock.mockRejectedValue(new Error('Pop-up might be blocked'));
     const overlay = listenForOverlay();
 
     // A blocked pop-up must not swallow the click — the user still gets there.
     await expect(openSettingsAt(Route.SETTINGS_SPONSOR)).resolves.toBeUndefined();
     expect(overlay.detail()).toEqual({ route: Route.SETTINGS_SPONSOR });
+    overlay.stop();
+  });
+
+  it('regression (#280): uses the loaded settings, not a stale localStorage cache from another tab', async () => {
+    // Simulate the JetBrains bug: this editor tab's localStorage still has an
+    // old cached preference (new-tab) from before the user changed it, but the
+    // settings actually loaded from the backend in THIS tab say overlay — the
+    // real, current source of truth. openSettingsAt must follow the loaded
+    // settings, not the stale per-tab cache.
+    localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [SettingKey.OPEN_SETTINGS_AS]: OpenSettingsMode.NEW_TAB }),
+    );
+    loadSettings(OpenSettingsMode.OVERLAY);
+    const overlay = listenForOverlay();
+
+    await openSettingsAt(Route.SETTINGS_SPONSOR);
+
+    expect(overlay.detail()).toEqual({ route: Route.SETTINGS_SPONSOR });
+    expect(openSettingsAdapterMock).not.toHaveBeenCalled();
     overlay.stop();
   });
 });

--- a/webview/src/utils/openSettingsAt.ts
+++ b/webview/src/utils/openSettingsAt.ts
@@ -13,9 +13,20 @@ import { DEFAULT_SETTINGS, OpenSettingsMode, SettingKey, type SettingsState } fr
  *
  * Deliberately hook-free: the most common callers (a toast action, a command
  * palette item, a keyboard shortcut) run OUTSIDE React rendering, where hooks
- * are unavailable. So the open mode is read from the settings cache in
- * localStorage, and the overlay is requested via a window event that
+ * are unavailable. So the open mode is read from {@link setCurrentSettings}, a
+ * module-scope mirror of SettingsContext's live `settings` value (kept in sync
+ * by the provider on every render — load, backend push, or local edit), and
+ * the overlay is requested via a window event that
  * {@link useSettingsOverlayNavigation} turns into a real route transition.
+ *
+ * This deliberately does NOT read SettingsContext's localStorage cache: that
+ * cache is written only on local edits (see SettingsContext's
+ * writeLocalStorageSettings call sites), so it goes stale whenever settings
+ * change through any other path (initial backend load, SETTINGS_CHANGED
+ * push). In JetBrains each editor tab is its own JCEF browser with its own
+ * localStorage, so a tab that never itself changed a setting would keep
+ * reading a stale cached mode forever (issue #280). The module variable below
+ * has no such gap because it mirrors the same `settings` the UI renders from.
  */
 
 /** Window event asking the app shell to open settings as an overlay. */
@@ -27,29 +38,30 @@ export interface OpenSettingsOverlayDetail {
 }
 
 /**
- * Mirrors SettingsContext's localStorage cache key. Reading the cache (rather
- * than the bridge) keeps this synchronous and usable outside React; the value is
- * written on every settings load/change, so it is the same value the UI shows.
+ * Module-scope mirror of SettingsContext's `settings` value, kept in sync by
+ * the provider (see SettingsContext.tsx) so this file can read the real
+ * settings source outside React without becoming a hook. `undefined` before
+ * the provider mounts or before the first settings load resolves.
  */
-const SETTINGS_STORAGE_KEY = 'claude-code-settings';
+let currentSettings: SettingsState | undefined;
 
 /**
- * Resolve the user's open-mode preference without React. Any failure (no cache
- * yet, corrupted JSON, storage disabled) falls back to the default rather than
- * throwing — a preference lookup must never block the navigation itself.
+ * Called by SettingsContext whenever its `settings` value changes (initial
+ * load, backend SETTINGS_CHANGED push, or a local edit). Do not call this
+ * from anywhere else — it exists solely to keep this module's mirror in sync
+ * with the one source of truth SettingsContext already computes.
+ */
+export function setCurrentSettings(settings: SettingsState): void {
+  currentSettings = settings;
+}
+
+/**
+ * Resolve the user's open-mode preference without React. Falls back to the
+ * default when the mirror hasn't been populated yet (boot, before the first
+ * settings load resolves) — a preference lookup must never block navigation.
  */
 function resolveOpenMode(): OpenSettingsMode {
-  try {
-    const stored = localStorage.getItem(SETTINGS_STORAGE_KEY);
-    if (stored) {
-      const parsed = JSON.parse(stored) as Partial<SettingsState>;
-      const mode = parsed[SettingKey.OPEN_SETTINGS_AS];
-      if (mode === OpenSettingsMode.OVERLAY || mode === OpenSettingsMode.NEW_TAB) return mode;
-    }
-  } catch {
-    /* unreadable cache → fall through to the default */
-  }
-  return DEFAULT_SETTINGS[SettingKey.OPEN_SETTINGS_AS];
+  return currentSettings?.[SettingKey.OPEN_SETTINGS_AS] ?? DEFAULT_SETTINGS[SettingKey.OPEN_SETTINGS_AS];
 }
 
 function requestOverlay(route: Route): void {


### PR DESCRIPTION
Setting "Open Settings as" to Overlay had no effect in JetBrains: the gear
button kept opening a new editor tab. The same setting worked in the browser.

## Cause

`openSettingsAt()` resolved the preference by reading SettingsContext's
localStorage cache rather than the settings themselves.

That cache is written only when the user edits a setting locally — the initial
backend load and `SETTINGS_CHANGED` pushes update the react-query cache and
leave localStorage untouched. So the value it reads is a copy that can sit
arbitrarily far behind the settings the UI is rendering from.

The browser hides this because every tab shares one localStorage per origin:
whichever tab edits the setting writes the copy the other tabs read. In
JetBrains each editor tab is its own JCEF browser with its own localStorage, so
a chat tab that never itself changed the setting keeps reading whatever was
cached there — indefinitely, since no other path writes it.

## Fix

Read the live settings instead. SettingsContext already computes the one value
the UI renders from; it now mirrors that into a module variable openSettingsAt
reads. That covers load, backend push and local edit alike, because it is the
same value rather than a copy kept in step by hand.

The function stays hook-free, which is why it cannot just call `useSettings`:
most callers (a toast action, a command-palette item, a keyboard shortcut) run
outside React.

The localStorage cache stays as it is. It has a separate, legitimate job: the
inline `<script>` in index.html reads it before the bundle loads to avoid an
RTL/LTR flash, and no module variable can serve that. What is removed is only
its use as a settings source here.

## Testing

The regression test plants a stale `new-tab` cache alongside loaded settings
that say `overlay` and asserts the overlay wins — the exact divergence above.

- webview: 226 files / 2067 tests passing
- backend: 103 files / 1147 passing
- `full-build` (including Kotlin) successful
- Verified in a running IDE: switching between Overlay and New tab both work,
  and settings open as an overlay in a tab that never changed the setting
  itself

Closes #280
