### PR TITLE
State the rename as our own decision, not a favour to users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The same Claude Code GUI you love in Cursor and VS Code, now available in JetBra
 > This repository moved from `yhk1038/claude-code-gui-jetbrains` to `Swttch/swttch`.
 > Your existing links and `git clone` URLs keep working.
 >
-> It's the same product. We renamed it because so many of you asked us to support a
-> wider range of providers beyond Claude Code, and we're taking that seriously.
+> It's the same product. We renamed it so we can support a wider range of providers
+> beyond Claude Code.
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -7,8 +7,8 @@ Die Claude Code GUI, die in Cursor und VS Code beliebt ist, ist jetzt auch in Je
 > Dieses Repository ist von `yhk1038/claude-code-gui-jetbrains` nach `Swttch/swttch` umgezogen.
 > Bestehende Links und `git clone`-URLs funktionieren weiterhin.
 >
-> Es ist dasselbe Produkt. Wir haben es umbenannt, weil viele von euch sich Unterstützung für
-> mehr Anbieter über Claude Code hinaus gewünscht haben — und das nehmen wir ernst.
+> Es ist dasselbe Produkt. Wir haben es umbenannt, um mehr Anbieter über Claude Code
+> hinaus unterstützen zu können.
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -7,8 +7,8 @@ La misma interfaz gráfica de Claude Code que amas en Cursor y VS Code, ahora di
 > Este repositorio se trasladó de `yhk1038/claude-code-gui-jetbrains` a `Swttch/swttch`.
 > Tus enlaces existentes y las URLs de `git clone` siguen funcionando.
 >
-> Es el mismo producto. Lo renombramos porque muchos de ustedes nos pidieron dar soporte a
-> una gama más amplia de proveedores más allá de Claude Code, y nos lo tomamos en serio.
+> Es el mismo producto. Lo renombramos para poder dar soporte a una gama más amplia
+> de proveedores más allá de Claude Code.
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -7,8 +7,8 @@ La même interface Claude Code GUI que vous aimez dans Cursor et VS Code, mainte
 > Ce dépôt a été déplacé de `yhk1038/claude-code-gui-jetbrains` vers `Swttch/swttch`.
 > Vos liens existants et les URLs `git clone` continuent de fonctionner.
 >
-> C'est le même produit. Nous l'avons renommé parce que beaucoup d'entre vous nous ont demandé
-> de prendre en charge davantage de fournisseurs au-delà de Claude Code, et nous le prenons au sérieux.
+> C'est le même produit. Nous l'avons renommé afin de pouvoir prendre en charge
+> davantage de fournisseurs au-delà de Claude Code.
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -7,8 +7,7 @@ Cursor と VS Code で親しまれている Claude Code GUI が、JetBrains IDE 
 > このリポジトリは `yhk1038/claude-code-gui-jetbrains` から `Swttch/swttch` へ移行しました。
 > 既存のリンクや `git clone` の URL はそのまま動作します。
 >
-> 製品は同じです。Claude Code にとどまらず、より多くのプロバイダーへの対応を求める声が多く、
-> その要望を真剣に受け止めて名称を変更しました。
+> 製品は同じです。Claude Code にとどまらず、より多くのプロバイダーに対応していくために名称を変更しました。
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -7,8 +7,7 @@ Cursor와 VS Code에서 사랑받는 Claude Code GUI를 이제 JetBrains IDE에�
 > 이 저장소는 `yhk1038/claude-code-gui-jetbrains`에서 `Swttch/swttch`로 옮겨졌습니다.
 > 기존 링크와 `git clone` 주소는 계속 동작합니다.
 >
-> 같은 제품입니다. Claude Code를 넘어 더 많은 프로바이더를 지원해 달라는 요청이 많았고,
-> 그 요청을 진지하게 받아들여 이름을 바꿨습니다.
+> 같은 제품입니다. Claude Code를 넘어 더 많은 프로바이더를 지원하기 위해 이름을 바꿨습니다.
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -7,8 +7,7 @@
 > 本仓库已从 `yhk1038/claude-code-gui-jetbrains` 迁移至 `Swttch/swttch`。
 > 原有链接和 `git clone` 地址仍然有效。
 >
-> 这仍是同一款产品。许多用户希望我们支持 Claude Code 之外的更多提供方，
-> 我们认真对待这一需求，因此更换了名称。
+> 这仍是同一款产品。为了支持 Claude Code 之外的更多提供方，我们更换了名称。
 
 [![JetBrains Marketplace](https://img.shields.io/jetbrains/plugin/v/30313?label=Marketplace)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/30313?label=Downloads)](https://plugins.jetbrains.com/plugin/30313-claude-code-with-gui)

--- a/docs/marketplaces/jetbrains/de.md
+++ b/docs/marketplaces/jetbrains/de.md
@@ -3,8 +3,8 @@
 **Die Claude Code GUI, die du aus Cursor und VS Code kennst — jetzt in JetBrains IDEs.**
 
 > **Wir haben einen neuen Namen — aus Claude Code with GUI wird Swttch.**
-> Es ist dasselbe Produkt, vom selben Entwickler. Wir haben es umbenannt, weil viele von euch
-> sich Unterstützung für mehr Anbieter über Claude Code hinaus gewünscht haben — und das nehmen wir ernst.
+> Es ist dasselbe Produkt, vom selben Entwickler. Wir haben es umbenannt, um mehr Anbieter
+> über Claude Code hinaus unterstützen zu können.
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | **Deutsch** | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 

--- a/docs/marketplaces/jetbrains/en.md
+++ b/docs/marketplaces/jetbrains/en.md
@@ -3,8 +3,8 @@
 **The Claude Code GUI you know from Cursor and VS Code — now in JetBrains IDEs.**
 
 > **We've been renamed — Claude Code with GUI is now Swttch.**
-> It's the same product, by the same developer. We renamed it because so many of you asked us
-> to support a wider range of providers beyond Claude Code, and we're taking that seriously.
+> It's the same product, by the same developer. We renamed it so we can support a wider range
+> of providers beyond Claude Code.
 
 🌐 **English** | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 

--- a/docs/marketplaces/jetbrains/es.md
+++ b/docs/marketplaces/jetbrains/es.md
@@ -3,8 +3,8 @@
 **La interfaz gráfica de Claude Code que conoces de Cursor y VS Code — ahora en JetBrains IDEs.**
 
 > **Hemos cambiado de nombre: Claude Code with GUI ahora es Swttch.**
-> Es el mismo producto, del mismo desarrollador. Lo renombramos porque muchos de ustedes nos
-> pidieron dar soporte a una gama más amplia de proveedores más allá de Claude Code, y nos lo tomamos en serio.
+> Es el mismo producto, del mismo desarrollador. Lo renombramos para poder dar soporte a una
+> gama más amplia de proveedores más allá de Claude Code.
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | **Español** | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 

--- a/docs/marketplaces/jetbrains/fr.md
+++ b/docs/marketplaces/jetbrains/fr.md
@@ -3,8 +3,8 @@
 **L'interface graphique Claude Code que vous connaissez dans Cursor et VS Code — désormais disponible dans les IDE JetBrains.**
 
 > **Nous avons changé de nom — Claude Code with GUI devient Swttch.**
-> C'est le même produit, du même développeur. Nous l'avons renommé parce que beaucoup d'entre vous
-> nous ont demandé de prendre en charge davantage de fournisseurs au-delà de Claude Code, et nous le prenons au sérieux.
+> C'est le même produit, du même développeur. Nous l'avons renommé afin de pouvoir prendre
+> en charge davantage de fournisseurs au-delà de Claude Code.
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | **Français**
 

--- a/docs/marketplaces/jetbrains/ja.md
+++ b/docs/marketplaces/jetbrains/ja.md
@@ -3,8 +3,8 @@
 **Cursor や VS Code でおなじみの Claude Code GUI が、JetBrains IDE に登場。**
 
 > **名称が変わりました — Claude Code with GUI は Swttch になりました。**
-> 同じ開発者による同じ製品です。Claude Code にとどまらず、より多くのプロバイダーへの対応を
-> 求める声が多く、その要望を真剣に受け止めて名称を変更しました。
+> 同じ開発者による同じ製品です。Claude Code にとどまらず、より多くのプロバイダーに
+> 対応していくために名称を変更しました。
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | **日本語** | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 

--- a/docs/marketplaces/jetbrains/ko.md
+++ b/docs/marketplaces/jetbrains/ko.md
@@ -3,8 +3,8 @@
 **Cursor와 VS Code에서 쓰던 그 Claude Code GUI를, 이제 JetBrains IDE에서.**
 
 > **이름이 바뀌었습니다 — Claude Code with GUI는 이제 Swttch입니다.**
-> 같은 개발자가 만드는 같은 제품입니다. Claude Code를 넘어 더 많은 프로바이더를 지원해 달라는
-> 요청이 많았고, 그 요청을 진지하게 받아들여 이름을 바꿨습니다.
+> 같은 개발자가 만드는 같은 제품입니다. Claude Code를 넘어 더 많은 프로바이더를 지원하기 위해
+> 이름을 바꿨습니다.
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | **한국어** | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | [中文](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/zh.md) | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 

--- a/docs/marketplaces/jetbrains/zh.md
+++ b/docs/marketplaces/jetbrains/zh.md
@@ -3,8 +3,8 @@
 **在 Cursor 和 VS Code 中熟悉的 Claude Code GUI 界面——现已登陆 JetBrains IDE。**
 
 > **我们更名了 —— Claude Code with GUI 现已更名为 Swttch。**
-> 这仍是同一位开发者打造的同一款产品。许多用户希望我们支持 Claude Code 之外的更多提供方，
-> 我们认真对待这一需求，因此更换了名称。
+> 这仍是同一位开发者打造的同一款产品。为了支持 Claude Code 之外的更多提供方，
+> 我们更换了名称。
 
 🌐 [English](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/en.md) | [한국어](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ko.md) | [日本語](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/ja.md) | **中文** | [Español](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/es.md) | [Deutsch](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/de.md) | [Français](https://github.com/Swttch/swttch/blob/main/docs/marketplaces/jetbrains/fr.md)
 


### PR DESCRIPTION
Follow-up to #284.

The rename notice shipped in all 14 docs read:

> We renamed it because so many of you asked us to support a wider range of providers beyond Claude Code, and we're taking that seriously.

That casts users as petitioners and us as the party graciously granting their request. "So many of you asked us" reads as *"you kept asking, so"*, and "we're taking that seriously" reads as *"we considered your request and approved it"*. Put together, the rename sounds like a favour we did rather than a direction we chose.

It also drifted from the pricing page, where the thing taken seriously is **the expansion itself**, not the requests:

> this new name is the result of taking that expansion seriously

Now it just says why we renamed it:

> We renamed it so we can support a wider range of providers beyond Claude Code.

No petitioners, nobody granting anything. Applied across 7 README translations and 7 marketplace docs, each phrased naturally in its own language rather than transliterated from the English.

Providers are left unnamed on purpose — naming one (Codex, say) would turn a direction into a commitment, and the pricing page does not name it either.

Docs only; no code paths touched.