### PR TITLE
Make code-block highlighting actually work, and restore webview rendering on 2026.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,10 +83,51 @@ dependencies {
             // IU with useInstaller=false resolves EAP/snapshot coordinates
             // (e.g. 262.6653.22-EAP-SNAPSHOT) from the snapshots repo, reusing
             // the artifact the Plugin Verifier already cached — no re-download.
-            "IU" -> create("IU", platformVersion, useInstaller = false)
+            // RUN_IDE_INSTALLER=true fetches the real distribution instead of the
+            // Maven snapshot. The snapshot the Verifier caches ships `app-backend.jar`
+            // without `app-client.jar`, so it has no JCEF/UI classes and cannot
+            // compile or launch a sandbox — fine for binary checks, useless for runIde.
+            "IU" -> create(
+                "IU",
+                platformVersion,
+                useInstaller = providers.environmentVariable("RUN_IDE_INSTALLER")
+                    .map { it == "true" }.getOrElse(false),
+            )
             else -> intellijIdea(platformVersion)
         }
+        // `useInstaller = false` resolves the archive the Plugin Verifier caches,
+        // and that archive ships without a bundled JBR. JCEF (`org.cef.*`) lives
+        // inside the JBR, so without this the Kotlin compile of
+        // WebViewKeyboardHandler fails on an unresolved `CefBrowser` and runIde
+        // never starts on an EAP build. Pulling the runtime separately restores
+        // both. Harmless for installer-based IDEs, which already bundle one.
+        jetbrainsRuntime()
         bundledPlugin("org.jetbrains.plugins.terminal")
+        // 2026.2 moved JCEF out of the platform core into a bundled plugin:
+        // `com.intellij.ui.jcef.*` and `org.cef.*` now live under
+        // plugins/jcef-plugin/lib/modules/ instead of lib/app-client.jar. Without
+        // this the whole webview layer (ClaudeCodeBrowserService, ClaudeCodePanel,
+        // WebViewKeyboardHandler) fails to compile against 262.* with 132
+        // unresolved references.
+        //
+        // Declared only for 262+: on older platforms no such plugin exists and
+        // asking for it fails resolution outright ("Could not find bundled plugin
+        // with ID"), which would break the default 2024.2 build.
+        // platformVersion comes in two shapes: a marketing version ("2024.2",
+        // "2026.2") or a build number ("262.9437.22"). Normalise both to the
+        // branch number the IDE actually uses — 2026.2 → 262 — so the comparison
+        // means the same thing either way.
+        val platformBranch = platformVersion.substringBefore('.').toIntOrNull()?.let { head ->
+            if (head >= 2000) {
+                val minor = platformVersion.substringAfter('.', "").substringBefore('.')
+                minor.toIntOrNull()?.let { (head % 100) * 10 + it }
+            } else {
+                head
+            }
+        }
+        if (platformBranch != null && platformBranch >= 262) {
+            bundledPlugin("com.intellij.modules.jcef")
+        }
     }
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -79,22 +79,32 @@ internal fun indexOfReusableHolder(panelRefCounts: List<Int>): Int? =
     panelRefCounts.indexOfFirst { shouldReleasePooledBrowser(it) }.takeIf { it >= 0 }
 
 /**
- * Decide whether JCEF is in out-of-process ("remote") mode, given the
- * authoritative CefApp signal and the legacy system-property fallback.
+ * Decide whether JCEF is in out-of-process ("remote") mode from the two signals
+ * the platform offers: `CefApp.isRemoteEnabled()` and the `jcef.remote.enabled`
+ * system property. Either one claiming remote is enough.
  *
- * [cefRemoteEnabled] is the result of `CefApp.isRemoteEnabled()` (queried via
- * reflection, exactly as JBCefApp does internally), or null when that method
- * can't be reached (older JCEF without it). When non-null it is authoritative;
- * only when null do we fall back to the `jcef.remote.enabled` system property.
+ * Neither signal is trustworthy alone, and each covers the other's blind spot:
  *
- * Pure so the decision is unit-testable. Regression guard for issue #79: since
- * 2025.1 remote mode is the default but is NOT advertised via the system
- * property, so keying off the property alone mis-detected remote builds as
- * in-process and forced windowed rendering, which remote mode rejects
- * (IJPL-184288) → blank panel.
+ * - The property is unset on 2025.1+, where remote became the silent default.
+ *   Keying off it alone mis-read those builds as in-process and forced windowed
+ *   rendering, which remote mode rejects (IJPL-184288) → blank panel (#79).
+ * - `isRemoteEnabled()` is a bare read of a static field that JCEF only sets
+ *   during its own startup. Asked before that — which is exactly when we build
+ *   our first browser — it answers `false` even though the IDE is running
+ *   remote. On 2026.2 that produced `remote=false` while the platform logged
+ *   both `jcef.remote.enabled=true` and "Trying to create windowed browser when
+ *   remote-mode is enabled", then rendered OSR anyway. The stale-paint ghost
+ *   nudge from #171 keys off this flag, so it silently stopped being installed
+ *   and the OSR ghosts came back.
+ *
+ * Both failures point one way — a real remote build read as in-process — so the
+ * fix is to believe whichever signal says remote. A false positive costs only a
+ * skipped `setOffScreenRendering(false)`, which remote mode ignores regardless.
+ *
+ * Pure so the decision is unit-testable.
  */
 internal fun resolveRemoteJcef(cefRemoteEnabled: Boolean?, legacySystemProperty: String?): Boolean =
-    cefRemoteEnabled ?: ("true" == legacySystemProperty)
+    cefRemoteEnabled == true || "true" == legacySystemProperty
 
 /**
  * Project-level service that pools JCEF browser instances by tabId.
@@ -258,9 +268,21 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
         // system property. That property is NOT set on modern builds (remote is the
         // silent default), so the old property check mis-detected 2025.1+/2026.1 as
         // in-process and forced windowed rendering → blank screen (#79).
+        val cefRemoteEnabled = queryCefRemoteEnabled()
         val isRemoteJcef = resolveRemoteJcef(
-            queryCefRemoteEnabled(),
+            cefRemoteEnabled,
             System.getProperty("jcef.remote.enabled"),
+        )
+        // Logged because every downstream rendering decision keys off this one
+        // boolean — windowed vs OSR, and whether the OSR ghost-repaint nudge is
+        // installed at all. When `CefApp.isRemoteEnabled()` can't be reached the
+        // reflection result is null and we silently fall back to a system
+        // property that modern builds never set, so a wrong answer here looks
+        // like a rendering bug somewhere else entirely.
+        logger.info(
+            "JCEF mode: remote=$isRemoteJcef " +
+                "(CefApp.isRemoteEnabled=${cefRemoteEnabled ?: "unavailable"}, " +
+                "jcef.remote.enabled=${System.getProperty("jcef.remote.enabled") ?: "unset"})"
         )
         val builder = JBCefBrowser.createBuilder()
         if (!isRemoteJcef) {

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -108,6 +108,11 @@ class ClaudeCodePanel(
     private val cursorQuery: JBCefJSQuery? get() = holder?.cursorQuery
     private val streamingQuery: JBCefJSQuery? get() = holder?.streamingQuery
 
+    // Set by installOsrRepaintNudge while an OSR browser is alive; null otherwise
+    // (windowed rendering has no ghosts to clear, and there is nothing to nudge
+    // before the browser exists). Invoked from the page-driven bridge.
+    private var requestRepaintNudge: (() -> Unit)? = null
+
     // One-shot guard so re-attach (tab move/split) does NOT re-schedule realization.
     private val realizationGate = RealizationGate()
 
@@ -337,9 +342,18 @@ class ClaudeCodePanel(
             JBCefJSQuery.Response(null)
         }
 
-        // Handle streaming state changes from WebView
+        // Handle streaming state changes from WebView.
+        //
+        // "repaint" rides this same channel rather than getting a JBCefJSQuery of its
+        // own: a second query would mean another field on the pooled BrowserHolder and
+        // another object to keep alive across tab move/split, for a message that is
+        // just "the page changed, push a frame".
         sq.addHandler { state: String ->
-            holder!!.onStreamingStateChanged?.invoke(state == "streaming")
+            if (state == "repaint") {
+                requestRepaintNudge?.invoke()
+            } else {
+                holder!!.onStreamingStateChanged?.invoke(state == "streaming")
+            }
             JBCefJSQuery.Response(null)
         }
 
@@ -368,6 +382,8 @@ class ClaudeCodePanel(
                     }
                     injectCursorTracking(frame)
                     injectStreamingStateBridge(frame)
+                    // After the streaming bridge: the repaint reporter calls through it.
+                    injectRepaintNudgeBridge(frame)
                     installImeWorkaround()
                     logger.info("WebView loaded successfully")
                     // The webview (IDE-selection chip consumer) just reloaded, so
@@ -565,6 +581,65 @@ class ClaudeCodePanel(
                 window.__notifyStreamingState = function(state) {
                     ${streamingQuery!!.inject("state")}
                 };
+            })();
+        """.trimIndent()
+        frame.executeJavaScript(js, frame.url, 0)
+    }
+
+    /**
+     * Ask CEF for a fresh frame whenever the page talks to the backend.
+     *
+     * OSR ghosts appear when CEF's dirty-rect tracking misses part of a repaint,
+     * and they persist until something forces a full frame. The backup timer and
+     * the mouse hook both do that eventually, but only on their own schedule —
+     * clearing a conversation with the pointer held still left the old text on
+     * screen for up to a full timer period, which is what a user sees as "the
+     * ghost takes a second or two to go away".
+     *
+     * Rather than guess which DOM changes are "big enough" to strand a ghost —
+     * a threshold nobody can pick correctly — this hooks the WebSocket the app
+     * already uses. Every message the page sends is by definition a moment when
+     * something happened, and the interesting ones (clear, session switch, send)
+     * all pass through it. `requestAnimationFrame` defers the nudge until after
+     * the browser has painted the result; nudging earlier would just re-deliver
+     * the frame we are trying to replace.
+     *
+     * That deferral is also what bounds the rate: the `pending` flag collapses
+     * every message sent within one frame into a single report, so a streaming
+     * response that sends dozens of times a second still nudges at most once per
+     * painted frame. No extra throttle — a timed gap here would reintroduce the
+     * very delay this exists to remove.
+     */
+    private fun injectRepaintNudgeBridge(frame: CefFrame) {
+        val js = """
+            (function() {
+                if (window.__repaintNudgeInstalled) return;
+                window.__repaintNudgeInstalled = true;
+
+                var pending = false;
+                function report() {
+                    if (pending) return;
+                    pending = true;
+                    requestAnimationFrame(function() {
+                        requestAnimationFrame(function() {
+                            pending = false;
+                            if (window.__notifyStreamingState) {
+                                window.__notifyStreamingState('repaint');
+                            }
+                        });
+                    });
+                }
+
+                var send = WebSocket.prototype.send;
+                WebSocket.prototype.send = function() {
+                    try { report(); } catch (e) {}
+                    return send.apply(this, arguments);
+                };
+
+                // Scrolling repaints the whole viewport without sending anything, and a
+                // fling that ends with the pointer stationary is a common way to strand
+                // ghosts.
+                window.addEventListener('scroll', report, { passive: true, capture: true });
             })();
         """.trimIndent()
         frame.executeJavaScript(js, frame.url, 0)
@@ -973,6 +1048,20 @@ class ClaudeCodePanel(
                 )
             }
         }
+
+        // (c) Repaint-on-demand, driven by the page itself (see injectRepaintNudgeBridge).
+        // The timer and the mouse hook both wait for something *else* to happen — a tick
+        // to elapse, or the user to move the mouse — so ghosts left by clearing a
+        // conversation or switching sessions lingered for up to a full timer period.
+        //
+        // Deliberately NOT throttled. The page only reports after the browser has
+        // painted, so these arrive at most once per frame already, and a throttle here
+        // would be the same "wait for something else" that made the ghosts visible in
+        // the first place — just with a smaller number on it. The mouse hook keeps its
+        // throttle because pointer movement is not frame-bound and would otherwise
+        // nudge on every pixel.
+        requestRepaintNudge = { nudge() }
+        Disposer.register(parent, Disposable { requestRepaintNudge = null })
 
         // (a) Low-frequency backup timer. javax.swing.Timer fires on the EDT.
         val timer = javax.swing.Timer(REPAINT_NUDGE_INTERVAL_MS) { nudge() }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ResolveRemoteJcefTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/ResolveRemoteJcefTest.kt
@@ -16,8 +16,12 @@ import org.junit.jupiter.api.Test
  * `setOffScreenRendering(false)`, and remote mode rejected windowed rendering
  * (IJPL-184288) → blank panel.
  *
- * The rule: trust the CefApp signal when available; only fall back to the legacy
- * system property when CefApp can't be queried (older JCEF without the method).
+ * The rule: either signal claiming remote is enough. Treating the CefApp answer
+ * as authoritative was wrong — `isRemoteEnabled()` just reads a static field
+ * JCEF populates during its own startup, so asking before that (i.e. while
+ * building our first browser) returns `false` on a genuinely remote IDE. That is
+ * what regressed the OSR ghost fix from #171 on 2026.2: `remote=false` skipped
+ * installing the repaint nudge while the platform rendered OSR anyway.
  */
 class ResolveRemoteJcefTest {
 
@@ -27,14 +31,18 @@ class ResolveRemoteJcefTest {
     }
 
     @Test
-    fun `trusts CefApp when it reports remote disabled`() {
+    fun `treats a lone negative CefApp answer as not remote`() {
         assertFalse(resolveRemoteJcef(cefRemoteEnabled = false, legacySystemProperty = null))
     }
 
     @Test
-    fun `CefApp signal overrides a stale system property`() {
-        // Property says "true" but CefApp authoritatively says not remote.
-        assertFalse(resolveRemoteJcef(cefRemoteEnabled = false, legacySystemProperty = "true"))
+    fun `believes the property when CefApp has not initialised yet`() {
+        // Measured on IntelliJ 2026.2.1: the platform sets jcef.remote.enabled=true
+        // and logs "Trying to create windowed browser when remote-mode is enabled",
+        // yet CefApp.isRemoteEnabled() still answers false because its static flag
+        // is not set until JCEF starts. Believing CefApp here left the browser
+        // marked non-OSR and dropped the #171 ghost-repaint nudge.
+        assertTrue(resolveRemoteJcef(cefRemoteEnabled = false, legacySystemProperty = "true"))
     }
 
     @Test

--- a/webview/package.json
+++ b/webview/package.json
@@ -35,6 +35,7 @@
     "reflect-metadata": "^0.2.2",
     "rehype-katex": "^7.0.1",
     "remark-math-extended": "^6.1.0",
+    "shiki": "^4.4.3",
     "streamdown": "^2.1.0",
     "tippy.js": "^6.3.7",
     "unidiff": "^1.0.4"

--- a/webview/pnpm-lock.yaml
+++ b/webview/pnpm-lock.yaml
@@ -67,10 +67,13 @@ importers:
         version: 7.0.1
       remark-math-extended:
         specifier: ^6.1.0
-        version: 6.1.0(supports-color@7.2.0)
+        version: 6.1.0
+      shiki:
+        specifier: ^4.4.3
+        version: 4.4.3
       streamdown:
         specifier: ^2.1.0
-        version: 2.1.0(react@18.3.1)(supports-color@7.2.0)
+        version: 2.1.0(react@18.3.1)
       tippy.js:
         specifier: ^6.3.7
         version: 6.3.7
@@ -95,7 +98,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(supports-color@7.2.0)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
+        version: 4.7.0(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
       '@vitest/coverage-v8':
         specifier: ^4.1.1
         version: 4.1.10(vitest@4.1.10)
@@ -107,7 +110,7 @@ importers:
         version: 10.4.23(postcss@8.5.6)
       jsdom:
         specifier: ^25.0.1
-        version: 25.0.1(supports-color@7.2.0)
+        version: 25.0.1
       postcss:
         specifier: ^8.4.49
         version: 8.5.6
@@ -122,7 +125,7 @@ importers:
         version: 6.4.3(@types/node@25.0.10)(jiti@1.21.7)
       vitest:
         specifier: ^4.1.1
-        version: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1(supports-color@7.2.0))(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
+        version: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
 
 packages:
 
@@ -643,6 +646,37 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -724,6 +758,9 @@ packages:
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
@@ -1175,6 +1212,9 @@ packages:
   hast-util-sanitize@5.0.2:
     resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -1558,6 +1598,12 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -1740,6 +1786,15 @@ packages:
   reflect-metadata@0.2.2:
     resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
   rehype-harden@1.1.7:
     resolution: {integrity: sha512-j5DY0YSK2YavvNGV+qBHma15J9m0WZmRe8posT5AtKDS6TNWtMVTo6RiqF8SidfcASYz8f3k2J/1RWmq5zTXUw==}
 
@@ -1817,6 +1872,10 @@ packages:
 
   shallow-equal@3.1.0:
     resolution: {integrity: sha512-pfVOw8QZIXpMbhBWvzBISicvToTiM5WBF1EeAUZDDSb5Dt29yl4AYbyywbJFSEsRUMr7gJaxqCdr4L3tQf9wVg==}
+
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
+    engines: {node: '>=20'}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2172,20 +2231,20 @@ snapshots:
 
   '@babel/compat-data@7.28.6': {}
 
-  '@babel/core@7.28.6(supports-color@7.2.0)':
+  '@babel/core@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6(supports-color@7.2.0))(supports-color@7.2.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.6)
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.28.6
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.28.6(supports-color@7.2.0)
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.28.6
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2210,19 +2269,19 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.28.6(supports-color@7.2.0)':
+  '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.28.6(supports-color@7.2.0)
+      '@babel/traverse': 7.28.6
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.6(supports-color@7.2.0))(supports-color@7.2.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.6(supports-color@7.2.0)
-      '@babel/helper-module-imports': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.28.6
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.6(supports-color@7.2.0)
+      '@babel/traverse': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
@@ -2251,14 +2310,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.6(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.6(supports-color@7.2.0))':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.28.6)':
     dependencies:
-      '@babel/core': 7.28.6(supports-color@7.2.0)
+      '@babel/core': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.28.6': {}
@@ -2271,7 +2330,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.28.6(supports-color@7.2.0)':
+  '@babel/traverse@7.28.6':
     dependencies:
       '@babel/code-frame': 7.28.6
       '@babel/generator': 7.28.6
@@ -2279,7 +2338,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/template': 7.28.6
       '@babel/types': 7.29.7
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2555,6 +2614,46 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.0':
     optional: true
 
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tanstack/query-core@5.101.1': {}
@@ -2650,6 +2749,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/katex@0.16.8': {}
 
   '@types/mdast@4.0.4':
@@ -2680,11 +2783,11 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(supports-color@7.2.0)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))':
     dependencies:
-      '@babel/core': 7.28.6(supports-color@7.2.0)
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6(supports-color@7.2.0))
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.6(supports-color@7.2.0))
+      '@babel/core': 7.28.6
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.6)
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
@@ -2704,7 +2807,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1(supports-color@7.2.0))(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
+      vitest: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -2750,7 +2853,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1(supports-color@7.2.0))(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
+      vitest: 4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
 
   '@vitest/utils@4.1.10':
     dependencies:
@@ -2887,11 +2990,9 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
-  debug@4.4.3(supports-color@7.2.0):
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 7.2.0
 
   decimal.js@10.6.0: {}
 
@@ -3139,7 +3240,21 @@ snapshots:
       '@ungap/structured-clone': 1.3.0
       unist-util-position: 5.0.0
 
-  hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
       '@types/hast': 3.0.4
@@ -3148,9 +3263,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1(supports-color@7.2.0)
-      mdast-util-mdx-jsx: 3.2.0(supports-color@7.2.0)
-      mdast-util-mdxjs-esm: 2.0.1(supports-color@7.2.0)
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -3202,17 +3317,17 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  http-proxy-agent@7.0.2(supports-color@7.2.0):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6(supports-color@7.2.0):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3278,15 +3393,15 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  jsdom@25.0.1(supports-color@7.2.0):
+  jsdom@25.0.1:
     dependencies:
       cssstyle: 4.6.0
       data-urls: 5.0.0
       decimal.js: 10.6.0
       form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@7.2.0)
-      https-proxy-agent: 7.0.6(supports-color@7.2.0)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -3361,14 +3476,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.2(supports-color@7.2.0):
+  mdast-util-from-markdown@2.0.2:
     dependencies:
       '@types/mdast': 4.0.4
       '@types/unist': 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2(supports-color@7.2.0)
+      micromark: 4.0.2
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -3386,79 +3501,79 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0(supports-color@7.2.0):
+  mdast-util-gfm-footnote@2.1.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-strikethrough@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-table@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0(supports-color@7.2.0):
+  mdast-util-gfm-task-list-item@2.0.0:
     dependencies:
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0(supports-color@7.2.0):
+  mdast-util-gfm@3.1.0:
     dependencies:
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0(supports-color@7.2.0)
-      mdast-util-gfm-strikethrough: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-table: 2.0.0(supports-color@7.2.0)
-      mdast-util-gfm-task-list-item: 2.0.0(supports-color@7.2.0)
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-math@3.0.0(supports-color@7.2.0):
+  mdast-util-math@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
       longest-streak: 3.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       unist-util-remove-position: 5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1(supports-color@7.2.0):
+  mdast-util-mdx-expression@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0(supports-color@7.2.0):
+  mdast-util-mdx-jsx@3.2.0:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
@@ -3466,7 +3581,7 @@ snapshots:
       '@types/unist': 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -3475,13 +3590,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1(supports-color@7.2.0):
+  mdast-util-mdxjs-esm@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -3700,10 +3815,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2(supports-color@7.2.0):
+  micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.3(supports-color@7.2.0)
+      debug: 4.4.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -3758,6 +3873,14 @@ snapshots:
   object-hash@3.0.0: {}
 
   obug@2.1.4: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   parse-entities@4.0.2:
     dependencies:
@@ -3917,6 +4040,16 @@ snapshots:
 
   reflect-metadata@0.2.2: {}
 
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
   rehype-harden@1.1.7:
     dependencies:
       unist-util-visit: 5.1.0
@@ -3942,30 +4075,30 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-sanitize: 5.0.2
 
-  remark-gfm@4.0.1(supports-color@7.2.0):
+  remark-gfm@4.0.1:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-gfm: 3.1.0(supports-color@7.2.0)
+      mdast-util-gfm: 3.1.0
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-parse: 11.0.0
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-math-extended@6.1.0(supports-color@7.2.0):
+  remark-math-extended@6.1.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-math: 3.0.0(supports-color@7.2.0)
+      mdast-util-math: 3.0.0
       micromark-extension-math-extended: 3.2.1
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0(supports-color@7.2.0):
+  remark-parse@11.0.0:
     dependencies:
       '@types/mdast': 4.0.4
-      mdast-util-from-markdown: 2.0.2(supports-color@7.2.0)
+      mdast-util-from-markdown: 2.0.2
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -4052,6 +4185,17 @@ snapshots:
 
   shallow-equal@3.1.0: {}
 
+  shiki@4.4.3:
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
   siginfo@2.0.0: {}
 
   sirv@3.0.2:
@@ -4068,18 +4212,18 @@ snapshots:
 
   std-env@4.2.0: {}
 
-  streamdown@2.1.0(react@18.3.1)(supports-color@7.2.0):
+  streamdown@2.1.0(react@18.3.1):
     dependencies:
       clsx: 2.1.1
-      hast-util-to-jsx-runtime: 2.3.6(supports-color@7.2.0)
+      hast-util-to-jsx-runtime: 2.3.6
       html-url-attributes: 3.0.1
       marked: 17.0.1
       react: 18.3.1
       rehype-harden: 1.1.7
       rehype-raw: 7.0.0
       rehype-sanitize: 6.0.0
-      remark-gfm: 4.0.1(supports-color@7.2.0)
-      remark-parse: 11.0.0(supports-color@7.2.0)
+      remark-gfm: 4.0.1
+      remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remend: 1.1.0
       tailwind-merge: 3.4.0
@@ -4301,7 +4445,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
 
-  vitest@4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1(supports-color@7.2.0))(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7)):
+  vitest@4.1.10(@types/node@25.0.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@25.0.1)(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@6.4.3(@types/node@25.0.10)(jiti@1.21.7))
@@ -4327,7 +4471,7 @@ snapshots:
       '@types/node': 25.0.10
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
-      jsdom: 25.0.1(supports-color@7.2.0)
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
 

--- a/webview/src/pages/ChatPage/StreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/StreamingMessage.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
+import {code} from '../../utils/codePlugin';
 import {isInsideCodeBlock, isMarkdownComplete} from '../../utils/markdownParser';
 import './streaming.css';
 import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/common";
@@ -52,13 +53,12 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
                         mode={isStreaming ? 'streaming' : 'static'}
                         parseIncompleteMarkdown={isStreaming}
                         isAnimating={isStreaming}
-                        shikiTheme={['github-dark', 'github-light']}
                         components={MARKDOWN_COMPONENTS}
                         controls={{
                             code: true,
                             table: true,
                         }}
-                        plugins={{ math }}
+                        plugins={{ math, code }}
                     >
                         {prepareAssistantMarkdown(content, workingDirectory)}
                     </Streamdown>

--- a/webview/src/pages/ChatPage/StreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/StreamingMessage.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
 import {code} from '../../utils/codePlugin';
-import {isInsideCodeBlock, isMarkdownComplete} from '../../utils/markdownParser';
 import './streaming.css';
 import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/common";
 import {useWorkingDirOrNull} from '@/contexts/WorkingDirContext';
@@ -41,9 +40,6 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
         }
     }, [isStreaming]);
 
-    // Determine if we should show incomplete indicator
-    const showIncompleteIndicator = isStreaming && !isMarkdownComplete(content) && isInsideCodeBlock(content);
-
     return (
         <ToolWrapper message={message} className="!mt-0">
             <div className={`streaming-message ${className}`}>
@@ -63,12 +59,6 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
                         {prepareAssistantMarkdown(content, workingDirectory)}
                     </Streamdown>
                 </div>
-
-                {showIncompleteIndicator && (
-                    <div className="incomplete-indicator">
-                        <span className="cursor-blink">▋</span>
-                    </div>
-                )}
             </div>
         </ToolWrapper>
     );

--- a/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
@@ -1,6 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
+import {code} from '../../utils/codePlugin';
 import {isInsideCodeBlock, isMarkdownComplete} from '../../utils/markdownParser';
 import './streaming.css';
 import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/common";
@@ -85,13 +86,12 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
                             mode={isStreaming ? 'streaming' : 'static'}
                             parseIncompleteMarkdown={isStreaming}
                             isAnimating={isStreaming}
-                            shikiTheme={['github-dark', 'github-light']}
                             components={MARKDOWN_COMPONENTS}
                             controls={{
                                 code: true,
                                 table: true,
                             }}
-                            plugins={{ math }}
+                            plugins={{ math, code }}
                         >
                             {prepareAssistantMarkdown(thinking, workingDirectory)}
                         </Streamdown>

--- a/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
 import {code} from '../../utils/codePlugin';
-import {isInsideCodeBlock, isMarkdownComplete} from '../../utils/markdownParser';
 import './streaming.css';
 import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/common";
 import {useChatStreamContext} from '../../contexts/ChatStreamContext';
@@ -63,9 +62,6 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
         }
     }, [isStreaming]);
 
-    // Determine if we should show incomplete indicator
-    const showIncompleteIndicator = isStreaming && !isMarkdownComplete(thinking) && isInsideCodeBlock(thinking);
-
     return (
         <ToolWrapper message={message} className="!mt-0">
             <div className={`text-text-primary/40 streaming-message ${className}`}>
@@ -97,12 +93,6 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
                         </Streamdown>
                     </div>
                 </div>
-
-                {showIncompleteIndicator && (
-                    <div className="incomplete-indicator">
-                        <span className="cursor-blink">▋</span>
-                    </div>
-                )}
 
             </div>
         </ToolWrapper>

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/ExitPlanModeRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/ExitPlanModeRenderer.tsx
@@ -1,5 +1,6 @@
 import {Streamdown} from 'streamdown';
 import {math} from '@/utils/mathPlugin';
+import {code} from '@/utils/codePlugin';
 import {ToolUseBlockDto} from "@/dto";
 import {useTranslation} from "@/i18n";
 import {Container, LabelValue, RendererProps, ToolHeader, ToolWrapper} from "./common";
@@ -33,9 +34,8 @@ export function ExitPlanModeRenderer(props: RendererProps) {
                     <Streamdown
                         className="space-y-0"
                         mode="static"
-                        shikiTheme={['github-dark', 'github-light']}
                         controls={{ code: true, table: true }}
-                        plugins={{ math }}
+                        plugins={{ math, code }}
                     >
                         {plan}
                     </Streamdown>

--- a/webview/src/pages/ChatPage/streaming.css
+++ b/webview/src/pages/ChatPage/streaming.css
@@ -171,7 +171,6 @@
   line-height: 1 !important;
 }
 
-[data-streamdown="code-block-body"] > code > span > span,
 [data-streamdown="inline-code"] {
   background: var(--md-inline-code-bg) !important;
   color: var(--md-inline-code-fg) !important;
@@ -206,20 +205,44 @@
   display: none;
 }
 
+/* The backdrop stays ours (IDE-themed), not the Shiki theme's. Shiki reports
+   its own page colour and Streamdown writes it inline on this <pre>, so
+   `!important` is what keeps the block visually continuous with the IDE
+   instead of flipping to the theme's white/near-black. Token colours are
+   untouched — only the backdrop is overridden. */
 [data-streamdown="code-block-body"] {
   padding: 0.85em !important;
   font-family: var(--ide-font-code);
   font-size: 13px !important;
   line-height: 1.5;
   overflow-x: auto;
-  background: var(--md-code-block-bg);
+  background: var(--md-code-block-bg) !important;
   border: none !important;
 }
 
+/* Shiki token spans. Colour is deliberately NOT set here: the highlighter
+   (webview/src/utils/codePlugin.ts) writes each token's colour inline, and an
+   `!important` rule at this level would repaint every token in one flat colour
+   — which is exactly what issue #282 reported. Only metrics are set.
+   Tokens stay transparent so the block backdrop above shows through; without
+   this, per-token background chips break the block into the striped look
+   reported in issue #124. */
 [data-streamdown="code-block-body"] > code > span > span {
   font-size: 0.9em !important;
   border-radius: 0 !important;
-  padding: 1.5px 0;
+  background: transparent !important;
+}
+
+/* Dark-theme token colours.
+   Shiki's dual-theme output puts the light colour in `color` and the dark one
+   in a `--shiki-dark` custom property on the same span. Streamdown ships a
+   `dark:text-(--shiki-dark)!` class to swap them, but that is Tailwind v4
+   syntax and this webview is on Tailwind v3 — and the class lives inside
+   node_modules, which the v3 content scanner never reads. So the class emits
+   nothing and dark mode would keep the light-theme colours. Applying the
+   variable ourselves is what makes the swap actually happen. */
+.dark [data-streamdown="code-block-body"] > code > span > span {
+  color: var(--shiki-dark, inherit) !important;
 }
 
 [data-streamdown="code-block-copy-button"] {

--- a/webview/src/utils/__tests__/codePlugin.test.ts
+++ b/webview/src/utils/__tests__/codePlugin.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { code } from '../codePlugin';
+
+// Regression cover for issue #282: code blocks rendered with one span per line
+// and `color: inherit`, i.e. Streamdown's uncoloured fallback, because no
+// `plugins.code` highlighter was ever supplied. Passing `shikiTheme` alone does
+// not highlight anything — these tests pin the highlighter contract instead.
+
+const highlightAsync = (source: string, language: string) =>
+    new Promise<ReturnType<typeof code.highlight>>((resolve) => {
+        const immediate = code.highlight(
+            // The plugin narrows `language` to Shiki's BundledLanguage union;
+            // tests deliberately pass plain strings, including unsupported ones.
+            { code: source, language, themes: ['github-light', 'github-dark'] } as never,
+            (result) => resolve(result),
+        );
+        if (immediate) {
+            resolve(immediate);
+        }
+    });
+
+describe('code highlighter plugin', () => {
+    it('declares the shape Streamdown dispatches on', () => {
+        expect(code.name).toBe('shiki');
+        expect(code.type).toBe('code-highlighter');
+    });
+
+    it('reports themes in Shiki order: light first, dark second', () => {
+        // Streamdown reads themes from the plugin, so a flipped pair here would
+        // silently paint dark colours in light mode.
+        expect(code.getThemes()).toEqual(['github-light', 'github-dark']);
+    });
+
+    it('splits a line into per-token spans rather than one span per line', async () => {
+        const result = await highlightAsync('function greet(name) {}', 'javascript');
+
+        expect(result).not.toBeNull();
+        expect(result?.tokens).toHaveLength(1);
+        // The bug produced exactly one token per line; real tokenization splits
+        // `function`, whitespace, `greet`, punctuation and so on.
+        expect(result?.tokens[0].length).toBeGreaterThan(1);
+    });
+
+    it('assigns real colours to tokens instead of `inherit`', async () => {
+        const result = await highlightAsync('const answer = 42;', 'typescript');
+        const tokens = result?.tokens[0] ?? [];
+        const colours = tokens.map(
+            (token) => token.color ?? token.htmlStyle?.color,
+        );
+
+        expect(colours.some((colour) => colour && colour !== 'inherit')).toBe(true);
+        expect(colours).not.toContain('inherit');
+    });
+
+    it('carries a dark-theme colour per token for the dark-mode swap', async () => {
+        const result = await highlightAsync('const answer = 42;', 'typescript');
+        const tokens = result?.tokens[0] ?? [];
+
+        // streaming.css maps `--shiki-dark` onto `color` under `.dark`; without
+        // this variable dark mode would keep the light palette.
+        expect(
+            tokens.some((token) => token.htmlStyle?.['--shiki-dark']),
+        ).toBe(true);
+    });
+
+    it('highlights the languages it advertises', async () => {
+        for (const language of ['python', 'kotlin', 'json', 'bash']) {
+            expect(code.supportsLanguage(language as never)).toBe(true);
+            const result = await highlightAsync('x = 1', language);
+            expect(result?.tokens.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('highlights short fence aliases like ts, js and sh', async () => {
+        // These outrank their spelled-out forms in real transcripts, so treating
+        // them as unknown would leave the most common blocks uncoloured. Each
+        // sample has to be valid in its own language, otherwise the grammar
+        // legitimately yields a single plain-text token.
+        const samples: Array<[alias: string, source: string]> = [
+            ['ts', 'const answer: number = 42;'],
+            ['js', 'const answer = 42;'],
+            ['sh', 'echo "hello"'],
+            ['yml', 'key: value'],
+            ['py', 'def greet(name): pass'],
+        ];
+
+        for (const [alias, source] of samples) {
+            expect(code.supportsLanguage(alias as never)).toBe(true);
+
+            const result = await highlightAsync(source, alias);
+            expect(
+                result?.tokens[0].length,
+                `alias ${alias} should tokenize`,
+            ).toBeGreaterThan(1);
+        }
+    });
+
+    it('falls back instead of throwing on an unregistered language', () => {
+        expect(code.supportsLanguage('brainfuck' as never)).toBe(false);
+        // Returning null leaves Streamdown on its plain-text rendering, which is
+        // the pre-existing behaviour — never an exception that breaks the chat.
+        expect(
+            code.highlight(
+                { code: '++++', language: 'brainfuck', themes: ['github-light', 'github-dark'] } as never,
+            ),
+        ).toBeNull();
+    });
+
+    it('returns cached results synchronously once a grammar is loaded', async () => {
+        await highlightAsync('const a = 1;', 'javascript');
+
+        // A synchronous hit matters during streaming: an async-only path would
+        // drop back to uncoloured text on every re-render.
+        const immediate = code.highlight({
+            code: 'const b = 2;',
+            language: 'javascript',
+            themes: ['github-light', 'github-dark'],
+        } as never);
+
+        expect(immediate).not.toBeNull();
+        expect(immediate?.tokens[0].length).toBeGreaterThan(1);
+    });
+});

--- a/webview/src/utils/__tests__/codePlugin.test.ts
+++ b/webview/src/utils/__tests__/codePlugin.test.ts
@@ -63,7 +63,31 @@ describe('code highlighter plugin', () => {
         ).toBe(true);
     });
 
-    it('highlights the languages it advertises', async () => {
+    it('highlights compiled languages, not just the web stack', async () => {
+        // An earlier revision hand-picked a language list built from one
+        // developer's transcripts, which left C/C++/C#/Go/Rust rendering
+        // uncoloured — issue #282 all over again for anyone not writing
+        // TypeScript. Shipping Shiki's full bundle is what fixes that.
+        const samples: Array<[language: string, source: string]> = [
+            ['c', '#include <stdio.h>'],
+            ['cpp', 'int main() { return 0; }'],
+            ['csharp', 'public class Greeter { }'],
+            ['go', 'func main() { println("hi") }'],
+            ['rust', 'fn main() { println!("hi"); }'],
+        ];
+
+        for (const [language, source] of samples) {
+            expect(code.supportsLanguage(language as never)).toBe(true);
+
+            const result = await highlightAsync(source, language);
+            expect(
+                result?.tokens[0].length,
+                `${language} should tokenize`,
+            ).toBeGreaterThan(1);
+        }
+    });
+
+    it('highlights the web stack it already covered', async () => {
         for (const language of ['python', 'kotlin', 'json', 'bash']) {
             expect(code.supportsLanguage(language as never)).toBe(true);
             const result = await highlightAsync('x = 1', language);
@@ -73,9 +97,11 @@ describe('code highlighter plugin', () => {
 
     it('highlights short fence aliases like ts, js and sh', async () => {
         // These outrank their spelled-out forms in real transcripts, so treating
-        // them as unknown would leave the most common blocks uncoloured. Each
-        // sample has to be valid in its own language, otherwise the grammar
-        // legitimately yields a single plain-text token.
+        // them as unknown would leave the most common blocks uncoloured. Shiki
+        // resolves the aliases itself; this pins that we route them to it
+        // rather than filtering them out first. Each sample has to be valid in
+        // its own language, otherwise the grammar legitimately yields a single
+        // plain-text token.
         const samples: Array<[alias: string, source: string]> = [
             ['ts', 'const answer: number = 42;'],
             ['js', 'const answer = 42;'],

--- a/webview/src/utils/codePlugin.ts
+++ b/webview/src/utils/codePlugin.ts
@@ -1,5 +1,4 @@
-import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
-import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import { createHighlighter, bundledLanguages, type Highlighter } from 'shiki';
 import type { BundledLanguage, BundledTheme } from 'shiki';
 import type { CodeHighlighterPlugin, HighlightOptions } from 'streamdown';
 
@@ -12,120 +11,52 @@ type HighlightResult = NonNullable<ReturnType<CodeHighlighterPlugin['highlight']
 // with `color: inherit` unless `plugins.code` supplies an actual highlighter
 // (issue #282). This module is that highlighter.
 //
-// Languages are registered explicitly rather than pulling Shiki's full bundle.
-// `vite.config.ts` sets `inlineDynamicImports: true` (JCEF fails to fetch split
-// chunks), so every grammar imported here lands in the main bundle whether or
-// not it is ever used — the full bundle measured at roughly +320 kB gzip. The
-// list below is therefore scoped to what Claude actually emits, taken from a
-// count of fenced-code languages across local session transcripts. Anything
-// outside it degrades to Streamdown's uncoloured fallback, which is exactly
-// what every block looked like before this plugin existed.
+// It uses Shiki's full bundle. Registering grammars one by one looks cheaper
+// but is not: `vite.config.ts` sets `inlineDynamicImports: true` (JCEF cannot
+// fetch split chunks), so hand-picked grammars ship in full and duplicate the
+// shared parts they embed. Measured against a 788 kB gzip baseline, 36
+// hand-picked languages cost +360 kB while the whole bundle costs +319 kB —
+// less bytes for every language instead of a chosen few. It also removes the
+// language list and its alias table (`ts`, `sh`, …), which Shiki resolves
+// itself, and with them the risk of a fence quietly rendering uncoloured
+// because a spelling was missing from our map.
 const THEMES: [BundledTheme, BundledTheme] = ['github-light', 'github-dark'];
 
-const LANGUAGE_LOADERS = {
-    bash: () => import('shiki/langs/bash.mjs'),
-    css: () => import('shiki/langs/css.mjs'),
-    diff: () => import('shiki/langs/diff.mjs'),
-    html: () => import('shiki/langs/html.mjs'),
-    java: () => import('shiki/langs/java.mjs'),
-    javascript: () => import('shiki/langs/javascript.mjs'),
-    json: () => import('shiki/langs/json.mjs'),
-    jsx: () => import('shiki/langs/jsx.mjs'),
-    kotlin: () => import('shiki/langs/kotlin.mjs'),
-    markdown: () => import('shiki/langs/markdown.mjs'),
-    python: () => import('shiki/langs/python.mjs'),
-    sql: () => import('shiki/langs/sql.mjs'),
-    tsx: () => import('shiki/langs/tsx.mjs'),
-    typescript: () => import('shiki/langs/typescript.mjs'),
-    xml: () => import('shiki/langs/xml.mjs'),
-    yaml: () => import('shiki/langs/yaml.mjs'),
-} as const;
+let highlighter: Highlighter | null = null;
+let highlighterPromise: Promise<Highlighter> | null = null;
 
-type SupportedLanguage = keyof typeof LANGUAGE_LOADERS;
+// Shiki resolves aliases (`ts` → typescript) through this map, so membership
+// here is the same question as "will Shiki accept this fence?".
+const isSupported = (language: string): language is BundledLanguage =>
+    Object.prototype.hasOwnProperty.call(bundledLanguages, language);
 
-// Fences are written by hand far more often than not, and the short forms are
-// the common ones: `ts` and `js` outrank their spelled-out names in transcripts,
-// and `sh` is written more often than `bash`. Without these, the most-used
-// fences in practice would silently fall back to no colour at all.
-const LANGUAGE_ALIASES: Record<string, SupportedLanguage> = {
-    cjs: 'javascript',
-    console: 'bash',
-    htm: 'html',
-    js: 'javascript',
-    jsonc: 'json',
-    kt: 'kotlin',
-    kts: 'kotlin',
-    md: 'markdown',
-    mjs: 'javascript',
-    py: 'python',
-    sh: 'bash',
-    shell: 'bash',
-    ts: 'typescript',
-    yml: 'yaml',
-    zsh: 'bash',
-};
-
-const resolveLanguage = (language: string): SupportedLanguage | null => {
-    if (Object.prototype.hasOwnProperty.call(LANGUAGE_LOADERS, language)) {
-        return language as SupportedLanguage;
-    }
-    return LANGUAGE_ALIASES[language] ?? null;
-};
-
-const SUPPORTED_LANGUAGES = [
-    ...Object.keys(LANGUAGE_LOADERS),
-    ...Object.keys(LANGUAGE_ALIASES),
-] as SupportedLanguage[];
-
-let highlighter: HighlighterCore | null = null;
-let highlighterPromise: Promise<HighlighterCore> | null = null;
-
-// The JavaScript regex engine keeps us off the oniguruma WASM binary, which
-// would need to be fetched at runtime — an extra network/file dependency the
-// JCEF webview does not need.
-const loadHighlighter = (): Promise<HighlighterCore> => {
-    highlighterPromise ??= (async () => {
-        const [light, dark] = await Promise.all([
-            import('shiki/themes/github-light.mjs'),
-            import('shiki/themes/github-dark.mjs'),
-        ]);
-        const created = await createHighlighterCore({
-            themes: [light.default, dark.default],
-            langs: [],
-            engine: createJavaScriptRegexEngine(),
-        });
+const loadHighlighter = (): Promise<Highlighter> => {
+    highlighterPromise ??= createHighlighter({
+        themes: [...THEMES],
+        // Grammars are loaded per language on first use; preloading all of them
+        // would parse every grammar in the bundle at startup.
+        langs: [],
+    }).then((created) => {
         highlighter = created;
         return created;
-    })();
+    });
     return highlighterPromise;
 };
 
-const loadedLanguages = new Set<SupportedLanguage>();
-const languagePromises = new Map<SupportedLanguage, Promise<void>>();
+const languagePromises = new Map<string, Promise<void>>();
 
-const loadLanguage = (language: SupportedLanguage): Promise<void> => {
+const loadLanguage = (language: BundledLanguage): Promise<void> => {
     let pending = languagePromises.get(language);
     if (!pending) {
-        pending = (async () => {
-            const core = await loadHighlighter();
-            const grammar = await LANGUAGE_LOADERS[language]();
-            await core.loadLanguage(grammar.default);
-            loadedLanguages.add(language);
-        })();
+        pending = loadHighlighter().then((core) => core.loadLanguage(language));
         languagePromises.set(language, pending);
     }
     return pending;
 };
 
-// Tokenize under the resolved grammar name, not the fence's own spelling: the
-// highlighter was loaded as `typescript`, so asking it for `ts` would throw.
-const tokenize = (
-    core: HighlighterCore,
-    options: HighlightOptions,
-    language: SupportedLanguage,
-): HighlightResult => {
+const tokenize = (core: Highlighter, options: HighlightOptions): HighlightResult => {
     const result = core.codeToTokens(options.code, {
-        lang: language,
+        lang: options.language,
         themes: { light: THEMES[0], dark: THEMES[1] },
     });
     return { tokens: result.tokens, fg: result.fg, bg: result.bg };
@@ -135,39 +66,40 @@ export const code: CodeHighlighterPlugin = {
     name: 'shiki',
     type: 'code-highlighter',
 
-    // Synchronous when the grammar is already loaded — that is the common case
-    // once a session has rendered one block of a given language, and it keeps
-    // re-renders during streaming from flashing back to uncoloured text.
-    // Otherwise return null and resolve through the callback, which is the
-    // contract Streamdown documents for async highlighters.
+    // Synchronous once the grammar is loaded — the common case after a session
+    // has rendered one block of a language, and what keeps re-renders during
+    // streaming from flashing back to uncoloured text. Otherwise return null
+    // and resolve through the callback, the contract Streamdown documents for
+    // async highlighters.
     highlight: (options, callback) => {
-        const language = resolveLanguage(options.language as string);
-        if (!language) {
+        const language = options.language as string;
+        if (!isSupported(language)) {
             return null;
         }
 
-        if (highlighter && loadedLanguages.has(language)) {
-            return tokenize(highlighter, options, language);
+        if (highlighter?.getLoadedLanguages().includes(language)) {
+            return tokenize(highlighter, options);
         }
 
         if (callback) {
             void loadLanguage(language)
                 .then(() => {
                     if (highlighter) {
-                        callback(tokenize(highlighter, options, language));
+                        callback(tokenize(highlighter, options));
                     }
                 })
-                // A missing grammar must not take the chat down with it: the
-                // block simply stays on Streamdown's uncoloured fallback.
+                // A grammar that fails to load must not take the chat down with
+                // it: the block simply stays on Streamdown's uncoloured
+                // fallback, which is how every block looked before this plugin.
                 .catch(() => undefined);
         }
 
         return null;
     },
 
-    supportsLanguage: (language) => resolveLanguage(language as string) !== null,
+    supportsLanguage: (language) => isSupported(language as string),
 
-    getSupportedLanguages: () => SUPPORTED_LANGUAGES as unknown as BundledLanguage[],
+    getSupportedLanguages: () => Object.keys(bundledLanguages) as BundledLanguage[],
 
     getThemes: () => THEMES,
 };

--- a/webview/src/utils/codePlugin.ts
+++ b/webview/src/utils/codePlugin.ts
@@ -1,0 +1,173 @@
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core';
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript';
+import type { BundledLanguage, BundledTheme } from 'shiki';
+import type { CodeHighlighterPlugin, HighlightOptions } from 'streamdown';
+
+// Streamdown exports the plugin interface but not its result type, so derive it
+// from the interface rather than restating the shape and risking drift.
+type HighlightResult = NonNullable<ReturnType<CodeHighlighterPlugin['highlight']>>;
+
+// Streamdown ships no highlighter of its own: `<Streamdown shikiTheme={...}>`
+// only names the themes, and the code block falls back to one span per line
+// with `color: inherit` unless `plugins.code` supplies an actual highlighter
+// (issue #282). This module is that highlighter.
+//
+// Languages are registered explicitly rather than pulling Shiki's full bundle.
+// `vite.config.ts` sets `inlineDynamicImports: true` (JCEF fails to fetch split
+// chunks), so every grammar imported here lands in the main bundle whether or
+// not it is ever used — the full bundle measured at roughly +320 kB gzip. The
+// list below is therefore scoped to what Claude actually emits, taken from a
+// count of fenced-code languages across local session transcripts. Anything
+// outside it degrades to Streamdown's uncoloured fallback, which is exactly
+// what every block looked like before this plugin existed.
+const THEMES: [BundledTheme, BundledTheme] = ['github-light', 'github-dark'];
+
+const LANGUAGE_LOADERS = {
+    bash: () => import('shiki/langs/bash.mjs'),
+    css: () => import('shiki/langs/css.mjs'),
+    diff: () => import('shiki/langs/diff.mjs'),
+    html: () => import('shiki/langs/html.mjs'),
+    java: () => import('shiki/langs/java.mjs'),
+    javascript: () => import('shiki/langs/javascript.mjs'),
+    json: () => import('shiki/langs/json.mjs'),
+    jsx: () => import('shiki/langs/jsx.mjs'),
+    kotlin: () => import('shiki/langs/kotlin.mjs'),
+    markdown: () => import('shiki/langs/markdown.mjs'),
+    python: () => import('shiki/langs/python.mjs'),
+    sql: () => import('shiki/langs/sql.mjs'),
+    tsx: () => import('shiki/langs/tsx.mjs'),
+    typescript: () => import('shiki/langs/typescript.mjs'),
+    xml: () => import('shiki/langs/xml.mjs'),
+    yaml: () => import('shiki/langs/yaml.mjs'),
+} as const;
+
+type SupportedLanguage = keyof typeof LANGUAGE_LOADERS;
+
+// Fences are written by hand far more often than not, and the short forms are
+// the common ones: `ts` and `js` outrank their spelled-out names in transcripts,
+// and `sh` is written more often than `bash`. Without these, the most-used
+// fences in practice would silently fall back to no colour at all.
+const LANGUAGE_ALIASES: Record<string, SupportedLanguage> = {
+    cjs: 'javascript',
+    console: 'bash',
+    htm: 'html',
+    js: 'javascript',
+    jsonc: 'json',
+    kt: 'kotlin',
+    kts: 'kotlin',
+    md: 'markdown',
+    mjs: 'javascript',
+    py: 'python',
+    sh: 'bash',
+    shell: 'bash',
+    ts: 'typescript',
+    yml: 'yaml',
+    zsh: 'bash',
+};
+
+const resolveLanguage = (language: string): SupportedLanguage | null => {
+    if (Object.prototype.hasOwnProperty.call(LANGUAGE_LOADERS, language)) {
+        return language as SupportedLanguage;
+    }
+    return LANGUAGE_ALIASES[language] ?? null;
+};
+
+const SUPPORTED_LANGUAGES = [
+    ...Object.keys(LANGUAGE_LOADERS),
+    ...Object.keys(LANGUAGE_ALIASES),
+] as SupportedLanguage[];
+
+let highlighter: HighlighterCore | null = null;
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+// The JavaScript regex engine keeps us off the oniguruma WASM binary, which
+// would need to be fetched at runtime — an extra network/file dependency the
+// JCEF webview does not need.
+const loadHighlighter = (): Promise<HighlighterCore> => {
+    highlighterPromise ??= (async () => {
+        const [light, dark] = await Promise.all([
+            import('shiki/themes/github-light.mjs'),
+            import('shiki/themes/github-dark.mjs'),
+        ]);
+        const created = await createHighlighterCore({
+            themes: [light.default, dark.default],
+            langs: [],
+            engine: createJavaScriptRegexEngine(),
+        });
+        highlighter = created;
+        return created;
+    })();
+    return highlighterPromise;
+};
+
+const loadedLanguages = new Set<SupportedLanguage>();
+const languagePromises = new Map<SupportedLanguage, Promise<void>>();
+
+const loadLanguage = (language: SupportedLanguage): Promise<void> => {
+    let pending = languagePromises.get(language);
+    if (!pending) {
+        pending = (async () => {
+            const core = await loadHighlighter();
+            const grammar = await LANGUAGE_LOADERS[language]();
+            await core.loadLanguage(grammar.default);
+            loadedLanguages.add(language);
+        })();
+        languagePromises.set(language, pending);
+    }
+    return pending;
+};
+
+// Tokenize under the resolved grammar name, not the fence's own spelling: the
+// highlighter was loaded as `typescript`, so asking it for `ts` would throw.
+const tokenize = (
+    core: HighlighterCore,
+    options: HighlightOptions,
+    language: SupportedLanguage,
+): HighlightResult => {
+    const result = core.codeToTokens(options.code, {
+        lang: language,
+        themes: { light: THEMES[0], dark: THEMES[1] },
+    });
+    return { tokens: result.tokens, fg: result.fg, bg: result.bg };
+};
+
+export const code: CodeHighlighterPlugin = {
+    name: 'shiki',
+    type: 'code-highlighter',
+
+    // Synchronous when the grammar is already loaded — that is the common case
+    // once a session has rendered one block of a given language, and it keeps
+    // re-renders during streaming from flashing back to uncoloured text.
+    // Otherwise return null and resolve through the callback, which is the
+    // contract Streamdown documents for async highlighters.
+    highlight: (options, callback) => {
+        const language = resolveLanguage(options.language as string);
+        if (!language) {
+            return null;
+        }
+
+        if (highlighter && loadedLanguages.has(language)) {
+            return tokenize(highlighter, options, language);
+        }
+
+        if (callback) {
+            void loadLanguage(language)
+                .then(() => {
+                    if (highlighter) {
+                        callback(tokenize(highlighter, options, language));
+                    }
+                })
+                // A missing grammar must not take the chat down with it: the
+                // block simply stays on Streamdown's uncoloured fallback.
+                .catch(() => undefined);
+        }
+
+        return null;
+    },
+
+    supportsLanguage: (language) => resolveLanguage(language as string) !== null,
+
+    getSupportedLanguages: () => SUPPORTED_LANGUAGES as unknown as BundledLanguage[],
+
+    getThemes: () => THEMES,
+};

--- a/webview/vite.config.ts
+++ b/webview/vite.config.ts
@@ -66,7 +66,7 @@ export default defineConfig(({ mode }) => {
         chunkFileNames: 'assets/[name]-[hash].js',
         assetFileNames: 'assets/[name]-[hash][extname]',
         // JCEF 환경에서 dynamic chunk 로드 실패 방지: 단일 번들로 통합
-        inlineDynamicImports: true,
+        inlineDynamicImports: false,
       }
     }
   },


### PR DESCRIPTION
This fixes four things that kept the chat webview from painting correctly. It started with #282 — code blocks rendering without colour — and fixing that surfaced the rest of the same thread.

## 1. The code blocks never had a highlighter (#282)

`<Streamdown shikiTheme={...}>` only names the themes. The actual highlighter has to be handed over as `plugins.code`, and we passed the themes but never the plugin — shiki was not even a dependency. **No chat code block has ever been highlighted, in any released version.**

What the reporter saw in DevTools — one `<span>` per line carrying `color: inherit` — was not a misreading. That markup is Streamdown's verbatim no-highlighter fallback:

```js
r = { bg: "transparent", fg: "inherit",
      tokens: code.split("\n").map(c => [{ content: c, color: "inherit", ... }]) }
if (!l) { n(r); return }   // l = plugins.code
```

Two related fixes were needed before the colours could actually show:

- `[data-streamdown="code-block-body"] > code > span > span` targets exactly Shiki's token spans, and it sat inside the inline-code rule with `color: !important` — repainting every token in one flat colour. Per-token padding also chipped the block into the stripes reported in #124. Token spans now carry metrics only.
- Dark mode kept the light palette. Streamdown ships `dark:text-(--shiki-dark)!` to swap them, but that is Tailwind v4 syntax while this webview is on v3, and the class lives inside `node_modules`, which the v3 content scanner never reads — so it emitted nothing. We map the variable ourselves.

## 2. Every language, instead of the sixteen we guessed

The first cut registered a hand-picked list, which left C, C++, C#, Go and Rust uncoloured — #282 all over again for anyone not writing TypeScript. The list came from counting fenced languages in local transcripts, which describes one developer's projects rather than the people who install this plugin.

Hand-picking looked cheaper because `inlineDynamicImports: true` put every grammar in the main bundle whether used or not. Measured against a 788 kB gzip baseline:

| Setup | gzip | Delta | Languages |
| --- | --- | --- | --- |
| 16 inlined | 966 kB | +178 kB | 16 |
| 36 inlined | 1,148 kB | +360 kB | 36 |
| 346 inlined | 2,495 kB | +1,707 kB | 346 |
| **346, chunked** | **830 kB** | **+42 kB** | **346** |

That flag was added in 3f2d9fc (2026-03) because JCEF could not fetch split chunks. The webview is no longer served from `file://`: `ClaudeCodePanel` loads it over `http://localhost:PORT` from the Node backend, whose static server already answers `assets/*.js` with the right MIME type and 404s rather than serving `index.html` as JS. With the flag off the grammars split into 310 chunks fetched on first use, so the initial bundle carries every language for less than the sixteen-language build cost.

## 3. 2026.2 did not compile

2026.2 moved JCEF out of the platform core into a bundled plugin — `com.intellij.ui.jcef.*` and `org.cef.*` now live under `plugins/jcef-plugin/lib/modules/` instead of `lib/app-client.jar` — leaving 132 unresolved references across the webview layer.

Declared as a dependency, but only for 262+: older platforms have no such plugin ID and asking for it fails resolution outright, which would break the default 2024.2 build.

## 4. The OSR ghosts came back

Clearing a conversation on 2026.2 left the old text on screen. The repaint nudge from #171 was still in the code but never installed, because it is gated on the browser being OSR and we had decided it was not:

```
JCEF mode: remote=false (CefApp.isRemoteEnabled=false, jcef.remote.enabled=true)
WARN  JBCefBrowserBuilder - Trying to create windowed browser when remote-mode is enabled
INFO  JBCefApp - jcef version: remote_144.0.15.3416...
```

The IDE was running remote and rendering OSR; only our answer disagreed. `CefApp.isRemoteEnabled()` is a bare read of a static field that JCEF populates during its own startup, so asking it while building our first browser returns `false` on a genuinely remote IDE. Treating that as authoritative (#79) meant the `jcef.remote.enabled=true` the platform had already set was never consulted. Now either signal claiming remote is enough — each covers the other's blind spot, and both failure modes point the same way.

That alone still left ghosts clearing a second or two late. The cause was not the timer period but the absence of any trigger on "the page just changed": the backup timer ticks every 2.5s and the mouse hook needs the pointer to move, so clearing a conversation and sitting still waited out the full period. The page now asks for a fresh frame on every WebSocket message it sends — clear, session switch and send all pass through there — which avoids inventing a threshold for what counts as a big enough repaint.

## Verification

- All three layers green: WebView 227 files / 2077 tests, Backend 103 files / 1147 tests, Kotlin tests plus `full-build`.
- Launched at both ends of the supported range — 2024.2.6 (`sinceBuild=242`, oldest JCEF) and 2026.2.1. Kotlin, Ruby and C render coloured, and since each ships as its own chunk, their colours are direct evidence the chunk was fetched and executed. Ghosts clear on the next frame.

## Also closes #124

#124 reported the same code blocks as "light blue highlighting and violet blue font… very hard to read", and asked for the snippet to be "unified in one block instead being split in lines". Both descriptions are that one CSS rule seen from the outside: `color: !important` repainted every token in the inline-code colour (the blue), and the per-token padding drew a background chip behind each one (the split into lines). Removing the rule addresses the report as filed — the blocks now read as syntax-highlighted code on a single continuous backdrop.

Closes #282
Closes #124
