### PR TITLE
Restore the dark code-block boundary, and test math alongside the highlighter

### DIFF
--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -371,7 +371,15 @@
   /* Markdown */
   --md-inline-code-bg: rgba(127, 251, 255, 0.17);
   --md-inline-code-fg: rgba(127, 251, 255, 0.8);
-  --md-code-block-bg: rgba(0, 0, 0, 0.15);
+  /* Lightens the surface rather than darkening it. Layering black over a dark
+     background barely moves it: rgba(0,0,0,.15) over #1a1a1a resolved to
+     #161616, a 1.04:1 contrast — the block read as a slightly darker patch of
+     the page, not as a block. It went unnoticed while the code inside was
+     forced to one cyan colour, which marked the region on its own; once real
+     syntax highlighting landed (#282) the text turned the same grey as body
+     copy and the boundary disappeared with it. At 0.05 white the block sits at
+     1.135:1, matching what light mode already had. */
+  --md-code-block-bg: rgba(255, 255, 255, 0.05);
   --md-code-copy-btn-bg: rgba(255, 255, 255, 0.18);
   --md-code-copy-btn-bg-hover: rgba(255, 255, 255, 0.32);
   --md-code-copy-btn-fg: #ffffff;

--- a/webview/src/utils/__tests__/mathPlugin.test.tsx
+++ b/webview/src/utils/__tests__/mathPlugin.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { Streamdown } from 'streamdown';
 import { math } from '../mathPlugin';
+import { code } from '../codePlugin';
 
 /**
  * `$…$` used to be treated as inline math (issue #232). Text that merely
@@ -10,17 +11,41 @@ import { math } from '../mathPlugin';
  * duplicated on screen — while every CJK character inside logged a KaTeX
  * `unicodeTextInMathMode` warning.
  */
-function renderMarkdown(text: string) {
+function renderMarkdown(text: string, plugins: object = { math }) {
   const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
   const { container } = render(
-    <Streamdown mode="static" parseIncompleteMarkdown={false} plugins={{ math }}>
+    <Streamdown mode="static" parseIncompleteMarkdown={false} plugins={plugins}>
       {text}
     </Streamdown>,
   );
   return {
     text: container.textContent ?? '',
     katexCount: container.querySelectorAll('[class*="katex"]').length,
+    codeBlockCount: container.querySelectorAll('[data-streamdown="code-block-body"]').length,
     warnCount: warn.mock.calls.length,
+  };
+}
+
+/**
+ * Same as [renderMarkdown], but waits for the code highlighter to finish.
+ *
+ * With `plugins.code` present, Streamdown renders a spinner skeleton in place
+ * of the block while the grammar loads, and only then swaps in the real
+ * `code-block-body`. Asserting synchronously would read that placeholder — an
+ * empty `textContent` — and look like the fence vanished.
+ */
+async function renderMarkdownWithCode(text: string, plugins: object) {
+  const result = renderMarkdown(text, plugins);
+  await waitFor(() => {
+    expect(document.querySelectorAll('[data-streamdown="code-block-body"]').length)
+      .toBeGreaterThan(0);
+  });
+  const container = document.body;
+  return {
+    ...result,
+    text: container.textContent ?? '',
+    katexCount: container.querySelectorAll('[class*="katex"]').length,
+    codeBlockCount: container.querySelectorAll('[data-streamdown="code-block-body"]').length,
   };
 }
 
@@ -60,5 +85,67 @@ describe('math plugin — single dollar is not math (issue #232)', () => {
   it('still renders inline math written with \\( \\)', () => {
     const { katexCount } = renderMarkdown('质能方程 \\(E = mc^2\\) 很有名。');
     expect(katexCount).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * The cases above render with `plugins={{ math }}` alone, but the chat now
+ * passes `{ math, code }` — a syntax highlighter was added for issue #282, and
+ * both plugins share one `plugins` object and one markdown pipeline. Re-running
+ * the same expectations in that combination is what proves the highlighter did
+ * not disturb the `$`-handling those cases were written to protect.
+ */
+describe('math still behaves once the code highlighter is plugged in (#282)', () => {
+  const both = { math, code };
+
+  it('leaves shell variables and prices alone', () => {
+    const { text, warnCount } = renderMarkdown(
+      '看有没有 $VAR 会被当变量展开（值为空）。价格是 $100 元。',
+      both,
+    );
+
+    expect(text).toContain('$VAR');
+    expect(text).toContain('$100');
+    expect(text.split('会被当变量展开').length - 1).toBe(1);
+    expect(warnCount).toBe(0);
+  });
+
+  it('still renders both math syntaxes', () => {
+    expect(renderMarkdown('$$\nE = mc^2\n$$', both).katexCount).toBeGreaterThan(0);
+    expect(renderMarkdown('质能方程 \\(E = mc^2\\) 很有名。', both).katexCount).toBeGreaterThan(0);
+  });
+
+  it('renders math and a fenced code block in one document', async () => {
+    // The realistic shape of an answer that explains a formula and then shows
+    // code — the two plugins have to coexist within a single parse.
+    const source = [
+      '质能方程 \\(E = mc^2\\) 很有名。',
+      '',
+      '```python',
+      'energy = mass * c ** 2',
+      '```',
+      '',
+      '$$',
+      'E = mc^2',
+      '$$',
+    ].join('\n');
+
+    const { katexCount, codeBlockCount, text } = await renderMarkdownWithCode(source, both);
+
+    expect(katexCount).toBeGreaterThan(0);
+    expect(codeBlockCount).toBe(1);
+    // The fence must stay code, not get swallowed as math or duplicated.
+    expect(text).toContain('energy');
+    expect(text.split('energy').length - 1).toBe(1);
+  });
+
+  it('does not treat a dollar inside a code fence as math', async () => {
+    const source = ['```bash', 'echo "$HOME and $PATH"', '```'].join('\n');
+    const { text, katexCount, warnCount } = await renderMarkdownWithCode(source, both);
+
+    expect(text).toContain('$HOME');
+    expect(text).toContain('$PATH');
+    expect(katexCount).toBe(0);
+    expect(warnCount).toBe(0);
   });
 });


### PR DESCRIPTION
Two follow-ups to #287, both found by looking at what the new syntax highlighting exposed rather than what it broke.

## Dark code blocks had no visible boundary

In dark mode a code block was drawn by layering black over an already dark surface: `rgba(0,0,0,.15)` over `#1a1a1a` resolves to `#161616` — a **1.04:1** contrast against the page. The block was fractionally *darker* than its surroundings and read as a smudge rather than a container. Blocks holding plain text suffered most, having no syntax colour to hint at where they began.

This was always true; it simply never showed. Before #287 the code inside was repainted in a single cyan, and that colour — absent from body copy — marked the region on its own. Real syntax highlighting turned the text the same grey as the surrounding prose, and the boundary went with it. The bug was doing the job of a feature.

Fixed by lightening the surface instead of darkening it. At `0.05` white the block resolves to `#252525` and **1.135:1**, matching the **1.140:1** light mode already had, and following the same convention as `--md-blockquote-bg` two lines below in the same file.

Light mode is untouched. Black over white works on its own terms, and those blocks already read cleanly.

## Math had no test covering the plugin combination the app actually uses

The `$`-handling cases from #232 all rendered with `plugins={{ math }}`, but the chat has passed `{ math, code }` since the highlighter landed. Both plugins share one `plugins` object and one markdown pipeline, so nothing verified that adding a highlighter left the math behaviour alone.

The same expectations now run in the real combination, plus two cases the single-plugin suite could not express:

- math and a fenced code block in one document, each rendering as itself
- `$HOME` / `$PATH` inside a bash fence staying literal instead of being read as math

Blocks containing a fence have to await the render: with `plugins.code` present Streamdown shows a spinner skeleton while the grammar loads and swaps in the real `code-block-body` afterwards, so a synchronous assertion reads an empty placeholder and looks like the fence vanished.

## Verification

- All three layers green: WebView 227 files / 2081 tests, Backend lint, `full-build`.
- The added math case was confirmed to bite by flipping `singleDollarTextMath` back to `true` — it fails alongside the three original ones.
- Dark-mode contrast confirmed by hand against the running dev server before and after.
