### PR TITLE
Explain the JCEF runtime mismatch instead of leaving a blank panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Same backend, same UI, opened in your default browser on `http://localhost:19836
 
 Android Studio ships with a JetBrains Runtime (JBR) that does **not** include JCEF (Chromium Embedded Framework). This plugin's WebView UI relies on JCEF, so it will display a guidance panel instead of the chat UI when launched on the default Android Studio runtime.
 
+### Requires Android Studio 2026.1.3 or later
+
+On **2026.1.2 and earlier there is no working combination**, so update the IDE before swapping the runtime. Those versions boot on Java 21 and bundle their own `JCefAppConfig`; a JCEF-enabled JBR 21 shadows it from the boot layer with a copy missing a method the platform calls, so the browser throws while being created and the panel stays blank. JBR 25 has that method, but those builds cannot boot on Java 25 at all. Android Studio 2026.1.3 moved its bundled runtime to Java 25, which resolves it — see [#295](https://github.com/Swttch/swttch/issues/295) for the full test matrix.
+
 ### Switch to a JCEF-enabled runtime
 
 1. Open Find Action: `Cmd+Shift+A` (macOS) or `Ctrl+Shift+A` (Windows/Linux).

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -243,7 +243,23 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
             list[reuseIdx]
         } else {
             logger.info("Creating new JCEF browser for tab: $tabId (view #${list.size + 1})")
-            createHolder().also { list.add(it) }
+            // A runtime whose JCEF disagrees with the platform's own copy throws while
+            // the browser is being built, not from isJcefAvailable() — the classes are
+            // all present, only a method is missing. Android Studio ≤2026.1.2 bundles a
+            // JCefAppConfig with isRemoteEnabled() and boots on Java 21; adding a
+            // JCEF-enabled JBR 21 shadows that jar from the boot layer with a copy that
+            // lacks the method, and JBCefApp's constructor calls it (issue #295).
+            // Letting the Error escape leaves the panel with nothing attached at all,
+            // which is the blank window users report — so answer null and let the caller
+            // show the mismatch panel.
+            runCatching { createHolder() }
+                .onFailure { e ->
+                    if (e !is NoSuchMethodError && e !is NoClassDefFoundError) throw e
+                    logger.warn("JCEF runtime is incompatible with this IDE — cannot create browser for tab: $tabId", e)
+                }
+                .getOrNull()
+                ?.also { list.add(it) }
+                ?: return null
         }
         holder.panelRefCount += 1
         // Bump the token so any release scheduled before this acquire aborts.

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -207,10 +207,17 @@ class ClaudeCodePanel(
     }
 
     private fun realizeBrowser() {
-        // Acquire (or reuse) the pooled browser holder. May return null if JCEF
-        // became unavailable between init and now — defensive check.
+        // Acquire (or reuse) the pooled browser holder. Null means the browser could
+        // not be built: either JCEF went away between init and now, or the runtime's
+        // JCEF disagrees with the platform's and construction threw (issue #295).
+        // Swapping the placeholder for an explanation matters more than the
+        // distinction — leaving the label up is what users saw as a blank window.
         val acquired = browserService.getOrCreate(tabId) ?: run {
-            logger.warn("JCEF became unavailable before realizeBrowser for tab: $tabId")
+            logger.warn("Could not create a JCEF browser for tab: $tabId — showing runtime mismatch panel")
+            remove(loadingLabel)
+            add(JcefRuntimeMismatchPanel(), BorderLayout.CENTER)
+            revalidate()
+            repaint()
             return
         }
         holder = acquired

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefRuntimeMismatchPanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefRuntimeMismatchPanel.kt
@@ -1,0 +1,83 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.ui.HyperlinkLabel
+import java.awt.BorderLayout
+import java.awt.Component
+import javax.swing.BorderFactory
+import javax.swing.Box
+import javax.swing.BoxLayout
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+
+/**
+ * Fallback panel shown when JCEF is present but unusable — the runtime ships a
+ * JCEF whose API disagrees with the one the IDE compiled against, so building a
+ * browser throws instead of returning one.
+ *
+ * Distinct from [JcefUnavailablePanel], which covers the *absent* JCEF case and
+ * can be fixed by installing a JCEF runtime. Here a JCEF runtime is already
+ * installed; installing another of the same generation would fail identically,
+ * so this panel points at the IDE version instead (issue #295).
+ *
+ * Concretely: Android Studio ≤2026.1.2 boots on Java 21 and bundles its own
+ * `JCefAppConfig` with `isRemoteEnabled()`. Selecting a JCEF-enabled JBR 21
+ * shadows that jar from the boot layer with a copy lacking the method, and
+ * `JBCefApp`'s constructor calls it → `NoSuchMethodError`. JBR 25 has the method
+ * but those builds cannot boot on Java 25 (the Security Manager was removed in
+ * Java 24). Android Studio 2026.1.3 moved its bundled runtime to Java 25, which
+ * resolves it — hence "update the IDE" rather than "swap the runtime".
+ */
+class JcefRuntimeMismatchPanel : JPanel(BorderLayout()) {
+
+    private val logger = Logger.getInstance(JcefRuntimeMismatchPanel::class.java)
+
+    init {
+        border = BorderFactory.createEmptyBorder(40, 40, 40, 40)
+
+        val content = JPanel().apply {
+            layout = BoxLayout(this, BoxLayout.Y_AXIS)
+            alignmentX = Component.CENTER_ALIGNMENT
+        }
+
+        val message = JLabel(
+            "<html><div style='text-align:center; width: 480px;'>" +
+            "<h2 style='margin-top:0;'>This IDE and its runtime disagree</h2>" +
+            "<p>The chat UI could not start because the selected JetBrains Runtime " +
+            "ships a version of JCEF that this IDE was not built against. The browser " +
+            "fails while it is being created, which is why this panel is here instead " +
+            "of the chat.</p>" +
+            "<p style='text-align:left;'><b>On Android Studio, update the IDE:</b></p>" +
+            "<ol style='text-align:left;'>" +
+            "<li>Update Android Studio to <b>2026.1.3 or later</b></li>" +
+            "<li>Open Find Action: <b>Cmd+Shift+A</b> (macOS) or <b>Ctrl+Shift+A</b> (Windows/Linux)</li>" +
+            "<li>Run <b>&quot;Choose Boot Java Runtime for the IDE&hellip;&quot;</b></li>" +
+            "<li>Pick a runtime whose name contains <b>JCEF</b>, then restart</li>" +
+            "</ol>" +
+            "<p>Selecting a different runtime on 2026.1.2 or earlier will not help — " +
+            "those versions have no working combination.</p>" +
+            "</div></html>"
+        ).apply {
+            horizontalAlignment = SwingConstants.CENTER
+            alignmentX = Component.CENTER_ALIGNMENT
+        }
+
+        val details = HyperlinkLabel("Read the full explanation").apply {
+            alignmentX = Component.CENTER_ALIGNMENT
+            setHyperlinkTarget(DETAILS_URL)
+        }
+
+        content.add(message)
+        content.add(Box.createVerticalStrut(16))
+        content.add(details)
+
+        add(content, BorderLayout.CENTER)
+
+        logger.info("JcefRuntimeMismatchPanel created — JCEF is present but incompatible with this IDE")
+    }
+
+    companion object {
+        private const val DETAILS_URL = "https://github.com/Swttch/swttch/issues/295"
+    }
+}


### PR DESCRIPTION
## What

When the chat panel cannot build a JCEF browser, it now shows a panel explaining why instead of rendering nothing at all.

## Why

A user on Android Studio 2026.1.1 Patch 2 followed the guidance panel we ship, installed a JCEF-enabled runtime, and got a completely blank chat window — no text, no error, nothing to act on. They came back twice, and both times the advice we gave was wrong.

The cause is a class conflict, not a bad download. Android Studio 261 bundles its own `JCefAppConfig` in `intellij.libraries.jcef.jar`, and the platform calls `isRemoteEnabled()` on it. A JCEF-enabled JBR 21 puts a `jcef` module in the boot layer, which shadows that jar with a copy that has no such method, so `JBCefApp`'s constructor throws `NoSuchMethodError`. Nothing caught it, the Error escaped `realizeBrowser()`, and the panel ended up with no component attached — the blank window.

`isJcefAvailable()` cannot catch this: every class is present, only a method is missing, so the capability probe passes and the failure happens later, while the browser is being built.

## How

- `ClaudeCodeBrowserService.getOrCreate()` wraps `createHolder()` and answers `null` on `NoSuchMethodError` / `NoClassDefFoundError`. Anything else still propagates.
- `ClaudeCodePanel.realizeBrowser()` swaps its placeholder for the new panel when it gets `null`, instead of returning and leaving the label up.
- `JcefRuntimeMismatchPanel` (new) explains the mismatch and links to #295.

Guarding a single call site would not have worked: 2026.1.1 throws from `setOffScreenRendering` and 2026.1.2 from `build()`, because remote-mode detection differs between them. The whole of `createHolder()` has to be covered.

The panel says "update the IDE", not "swap the runtime", because on 2026.1.2 and earlier no runtime works.

## Verification

Each Android Studio build was installed and its boot runtime swapped by hand, with the plugin loaded and a chat tab open.

| Android Studio | Runtime | Before | After |
|---|---|---|---|
| 2026.1.1 Patch 2 | JCEF JBR 21 | blank window + IDE error popup | explanation panel |
| 2026.1.2 | JCEF JBR 21 | blank window + IDE error popup | explanation panel |
| 2026.1.1 / 2026.1.2 | JCEF JBR 25 | IDE does not boot (Security Manager removed in Java 24) | unchanged |
| 2026.1.3 | JCEF JBR 25 | chat renders, backend starts, bridge exchanges messages | unchanged |

2026.1.3 is the fix on Google's side — it moved the bundled runtime from Java 21 to Java 25. README now states that as the requirement rather than implying any runtime swap will do.

`wv-lint`, `be-lint`, `wv-test` (2081 tests) and `full-build` all pass.

Background and the full matrix: #295


### Not verified on Windows

Every run above was on macOS (Apple Silicon). The panel itself touches no OS-specific surface — no paths, no process spawning, no environment variables, no shell — only `Logger`, `HyperlinkLabel` and Swing components with an HTML string, so there is nothing here that behaves differently per platform.

The failure this panel replaces is also specific to Android Studio: other JetBrains IDEs bundle a JCEF-enabled runtime, so they never reach the code path that throws. Reproducing it on Windows would mean installing Android Studio 2026.1.2 or earlier there and swapping in a JCEF-enabled JBR 21 by hand.

Worth a look if someone has that machine handy; flagging it rather than implying coverage we do not have.