### PR TITLE
fix: restore chat tabs into their original splitter (#302)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorProvider.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorProvider.kt
@@ -3,9 +3,11 @@ package com.github.yhk1038.claudecodegui.editor
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
+import com.intellij.openapi.fileEditor.FileEditorState
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFile
+import org.jdom.Element
 
 class ClaudeCodeEditorProvider : FileEditorProvider, DumbAware {
 
@@ -20,4 +22,20 @@ class ClaudeCodeEditorProvider : FileEditorProvider, DumbAware {
     override fun getEditorTypeId(): String = "ClaudeCodeEditor"
 
     override fun getPolicy(): FileEditorPolicy = FileEditorPolicy.HIDE_DEFAULT_EDITOR
+
+    /**
+     * Restore the address THIS pane was showing.
+     *
+     * The platform stores one state per editor, so each half of a split gets its
+     * own entry in the layout and comes back where it was — instead of both panes
+     * reading the single slot that used to live on the shared virtual file.
+     */
+    override fun readState(
+        sourceElement: Element,
+        project: Project,
+        file: VirtualFile,
+    ): FileEditorState = ClaudeCodeEditorState.readFrom(sourceElement)
+
+    override fun writeState(state: FileEditorState, project: Project, targetElement: Element) =
+        ClaudeCodeEditorState.writeTo(state, targetElement)
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorState.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorState.kt
@@ -1,0 +1,61 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.fileEditor.FileEditorStateLevel
+import org.jdom.Element
+
+/**
+ * The address one chat pane is showing.
+ *
+ * A split gives each pane its own [ClaudeCodeFileEditor] and its own WebView, and
+ * from then on each navigates independently — the same way two browser tabs on
+ * one page drift apart once you click around in one of them. So "which
+ * conversation am I showing" belongs to the pane, not to the file the panes have
+ * in common.
+ *
+ * It used to live on the shared [ClaudeCodeVirtualFile] (as `currentPath`), which
+ * is one slot for however many panes exist. Whichever pane navigated last
+ * overwrote it, and the other pane — sitting untouched — was left pointing at its
+ * neighbour's address, which is why its tab renamed itself along with the pane
+ * that had actually moved.
+ *
+ * The platform already keeps one [FileEditorState] per editor and writes it into
+ * the editor layout beside that pane's `<provider>` entry, so this both fixes the
+ * sharing and restores each pane where it was.
+ */
+data class ClaudeCodeEditorState(val path: String?) : FileEditorState {
+
+    /**
+     * Never merge. Merging is for states that are "close enough" to be treated as
+     * one navigation step (a caret moving within a file); two panes showing two
+     * different conversations are not that, and letting them merge would put the
+     * shared-slot bug back.
+     */
+    override fun canBeMergedWith(otherState: FileEditorState, level: FileEditorStateLevel): Boolean = false
+
+    companion object {
+        /** Attribute name under which [path] is stored in the layout XML. */
+        const val PATH_ATTRIBUTE: String = "claudeCodePath"
+
+        /**
+         * Read a pane's address out of its layout element.
+         *
+         * Kept here, apart from [ClaudeCodeEditorProvider], so the persistence
+         * contract is testable on its own: the provider's signature demands a
+         * Project and a VirtualFile it never actually uses, which a plain unit test
+         * cannot supply.
+         *
+         * A missing or blank attribute yields null — a tab that never navigated has
+         * nothing to restore, and inventing a path would send a restored pane
+         * somewhere the user never was.
+         */
+        fun readFrom(element: Element): ClaudeCodeEditorState =
+            ClaudeCodeEditorState(element.getAttributeValue(PATH_ATTRIBUTE)?.takeIf { it.isNotBlank() })
+
+        /** Write [state]'s address into its layout element, omitting a null one. */
+        fun writeTo(state: FileEditorState, element: Element) {
+            val path = (state as? ClaudeCodeEditorState)?.path ?: return
+            element.setAttribute(PATH_ATTRIBUTE, path)
+        }
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorState.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorState.kt
@@ -22,6 +22,30 @@ import org.jdom.Element
  * The platform already keeps one [FileEditorState] per editor and writes it into
  * the editor layout beside that pane's `<provider>` entry, so this both fixes the
  * sharing and restores each pane where it was.
+ *
+ * ## Known limitation: the tab TITLE is still shared
+ *
+ * The address is per pane now, but the label above it is not: the platform
+ * derives a tab's title from its FILE
+ * (`EditorTabPresentationUtil.getEditorTabTitle(Project, VirtualFile)` →
+ * `EditorTabTitleProvider`, neither of which is given the FileEditor). One file
+ * can therefore only ever show one title, so navigating in one pane of a split
+ * still renames both tabs. A tab opened with "+" is unaffected — it gets its own
+ * file.
+ *
+ * Splitting the title would mean one file per pane, and every stable route there
+ * is closed. Verified against the 2024.2 platform:
+ *
+ *  - overriding `FileEditor.getName()` — never consulted for the tab label;
+ *  - swapping the duplicate pane's file — `FileEditorManager.closeFile(file)`
+ *    closes it in EVERY pane, and the pane-scoped overloads plus
+ *    `createSplitter` take `EditorWindow`, which is `@ApiStatus.Internal`;
+ *  - intercepting the split action — `SplitAction` is an
+ *    `ActionRemoteBehaviorSpecification.Frontend`, so it never reaches an
+ *    `AnActionListener` on this side (confirmed by a run where the split
+ *    happened and the listener logged nothing);
+ *  - `SplitAction.FORBID_TAB_SPLIT` — hides the split action entirely, which
+ *    removes the feature instead of fixing it.
  */
 data class ClaudeCodeEditorState(val path: String?) : FileEditorState {
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileEditor.kt
@@ -6,6 +6,7 @@ import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorLocation
 import com.intellij.openapi.fileEditor.FileEditorManager
 import com.intellij.openapi.fileEditor.FileEditorState
+import com.intellij.openapi.fileEditor.FileEditorStateLevel
 import com.intellij.openapi.fileEditor.ex.FileEditorManagerEx
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
@@ -19,17 +20,34 @@ class ClaudeCodeFileEditor(
     private val virtualFile: ClaudeCodeVirtualFile
 ) : UserDataHolderBase(), FileEditor {
 
-    private val panel: ClaudeCodePanel = ClaudeCodePanel(
-        project,
-        virtualFile.tabId,
-        virtualFile.currentPath ?: virtualFile.initialPath
-    )
+    /**
+     * The address THIS pane is showing, kept per editor rather than on the shared
+     * [ClaudeCodeVirtualFile] (see [ClaudeCodeEditorState]).
+     *
+     * Seeded from the file so a newly split pane starts on the same conversation
+     * as the pane it was split from, then diverges as this pane navigates.
+     */
+    @Volatile
+    private var panePath: String? = virtualFile.currentPath ?: virtualFile.initialPath
+
+    /**
+     * Built on first access rather than in the constructor, because the platform
+     * calls [setState] with this pane's restored address AFTER creating the
+     * editor. Constructing the panel eagerly would load the seed address and then
+     * ignore the restored one, so a restored split would put both panes on the
+     * same conversation — the very thing this is fixing.
+     */
+    private val panel: ClaudeCodePanel by lazy {
+        ClaudeCodePanel(project, virtualFile.tabId, panePath).also { created ->
+            Disposer.register(this, created)
+            attachPanelCallbacks(created)
+        }
+    }
 
     @Volatile
     private var wasStreaming: Boolean = false
 
-    init {
-        Disposer.register(this, panel)
+    private fun attachPanelCallbacks(panel: ClaudeCodePanel) {
 
         // WebView의 title 변경을 VirtualFile에 전달 + 영속 저장소에도 캐싱.
         // IDE 재시작 후 lazy mount 단계에서 마지막으로 본 제목을 즉시 보여 주기 위함.
@@ -41,9 +59,15 @@ class ClaudeCodeFileEditor(
             EditorTabStateService.getInstance(project).updateTitle(virtualFile.tabId, title)
         }
 
-        // WebView의 URL 변경을 VirtualFile에 전달 (탭 이동/분할 시 복원용)
-        // 그리고 IDE 재시작 후에도 복원되도록 영속 저장소에도 반영.
+        // Navigation belongs to THIS pane: record it here so a split whose panes
+        // have moved apart keeps two addresses instead of overwriting one shared
+        // slot (which also dragged the other pane's tab title along with it).
+        //
+        // The file and the persisted state are still updated, because they are what
+        // seeds a pane that has no state of its own yet — a brand-new tab, or the
+        // tool-window host, which is not split and has no per-editor state.
         panel.onPathChanged = { path ->
+            panePath = path
             virtualFile.currentPath = path
             EditorTabStateService.getInstance(project).updatePath(virtualFile.tabId, path)
         }
@@ -78,7 +102,22 @@ class ClaudeCodeFileEditor(
 
     override fun isModified(): Boolean = false
 
-    override fun setState(state: FileEditorState) {}
+    /**
+     * This pane's address, so the platform persists it per editor and hands it
+     * back to [setState] on restore. Two panes of one split therefore keep two
+     * addresses — like two browser tabs on the same page that have since been
+     * navigated apart.
+     */
+    override fun getState(level: FileEditorStateLevel): FileEditorState =
+        ClaudeCodeEditorState(panePath)
+
+    override fun setState(state: FileEditorState) {
+        val path = (state as? ClaudeCodeEditorState)?.path ?: return
+        panePath = path
+        // Once the panel exists it owns the address — its WebView has its own
+        // history and re-pointing it here would yank the user out of wherever they
+        // navigated. This only seeds the address for the panel yet to be built.
+    }
 
     override fun addPropertyChangeListener(listener: PropertyChangeListener) {}
 

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
@@ -1,0 +1,123 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.openapi.vfs.NonPhysicalFileSystem
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VirtualFileListener
+import com.intellij.openapi.vfs.VirtualFileSystem
+import java.io.IOException
+
+/**
+ * Virtual file system backing Claude Code chat tabs, so the IDE can restore them
+ * itself — including which editor splitter they were in (issue #302).
+ *
+ * ## Why this exists
+ *
+ * The platform persists an open tab as a [com.intellij.platform.fileEditor.FileEntry]
+ * keyed by the file's **URL**, and revives it on the next start via
+ * `VirtualFileManager.findFileByUrl` → (protocol lookup) → [findFileByPath].
+ * A tab whose URL cannot be resolved that way is silently dropped from the
+ * restored layout.
+ *
+ * [ClaudeCodeVirtualFile] used to inherit the URL of `LightVirtualFile`, whose
+ * file system has protocol `mock`, is not registered under the
+ * `com.intellij.virtualFileSystem` extension point, and whose `findFileByPath`
+ * returns null unconditionally. So our tabs could never be revived by URL: the
+ * IDE knew the splitter each tab belonged to, but could not resurrect the file
+ * to put there. The plugin then re-opened the tabs itself, with no notion of a
+ * splitter, which is exactly the reported symptom — a tab flashes and reappears
+ * in the default location.
+ *
+ * Registering a real protocol (`claude-code`) makes the round trip work using
+ * only stable public API. Splitter placement is restored by the platform; the
+ * plugin does not need to track it, and notably does not need `EditorWindow` or
+ * `FileEditorOpenOptions`, both of which are `@ApiStatus.Internal` and would be
+ * rejected by the release verifier gate.
+ *
+ * ## Path grammar
+ *
+ * The path component of the URL is the tab ID alone (`claude-code://<tabId>`).
+ * Everything else about a tab — the conversation being viewed, its title — is
+ * restored from [com.github.yhk1038.claudecodegui.services.EditorTabStateService],
+ * keyed by that same tab ID, so the URL stays stable even as the user navigates
+ * within the tab.
+ *
+ * ## Lifetime
+ *
+ * This file system creates nothing on its own: [findFileByPath] only hands back
+ * a file for a tab the plugin already knows about (see
+ * [ClaudeCodeVirtualFile.findExisting]). A stale URL — a tab the user closed
+ * before shutdown, or one belonging to another project — resolves to null and
+ * the platform simply skips it, which is the desired outcome.
+ */
+class ClaudeCodeFileSystem : VirtualFileSystem(), NonPhysicalFileSystem {
+
+    override fun getProtocol(): String = PROTOCOL
+
+    /**
+     * Resolve `claude-code://<tabId>` back to its tab.
+     *
+     * Deliberately does NOT create a tab that does not already exist. During
+     * startup restore the platform asks for every persisted URL; answering with
+     * a freshly minted file would resurrect tabs the user had closed. The
+     * plugin's own restore path registers the tabs it intends to reopen, and
+     * only those resolve here.
+     */
+    override fun findFileByPath(path: String): VirtualFile? =
+        ClaudeCodeVirtualFile.findExisting(path.trim('/'))
+
+    override fun refreshAndFindFileByPath(path: String): VirtualFile? = findFileByPath(path)
+
+    /** Nothing to refresh: these files are in-memory and have no backing store. */
+    override fun refresh(asynchronous: Boolean) {}
+
+    override fun isReadOnly(): Boolean = true
+
+    // The chat tab is not a document the user edits through the VFS, so every
+    // mutating operation is unsupported rather than silently ignored.
+    override fun deleteFile(requestor: Any?, vFile: VirtualFile) {
+        throw IOException("Claude Code tabs cannot be deleted through the VFS")
+    }
+
+    override fun moveFile(requestor: Any?, vFile: VirtualFile, newParent: VirtualFile) {
+        throw IOException("Claude Code tabs cannot be moved through the VFS")
+    }
+
+    override fun renameFile(requestor: Any?, vFile: VirtualFile, newName: String) {
+        throw IOException("Claude Code tabs cannot be renamed through the VFS")
+    }
+
+    override fun createChildFile(requestor: Any?, vDir: VirtualFile, fileName: String): VirtualFile {
+        throw IOException("Claude Code tabs cannot have children")
+    }
+
+    override fun createChildDirectory(requestor: Any?, vDir: VirtualFile, dirName: String): VirtualFile {
+        throw IOException("Claude Code tabs cannot have children")
+    }
+
+    override fun copyFile(
+        requestor: Any?,
+        virtualFile: VirtualFile,
+        newParent: VirtualFile,
+        copyName: String,
+    ): VirtualFile {
+        throw IOException("Claude Code tabs cannot be copied through the VFS")
+    }
+
+    // No listeners: nothing in this file system ever changes on disk. The
+    // abstract declarations still have to be satisfied.
+    override fun addVirtualFileListener(listener: VirtualFileListener) {}
+
+    override fun removeVirtualFileListener(listener: VirtualFileListener) {}
+
+    companion object {
+        /**
+         * URL protocol for chat tabs. Must match the `key` of the
+         * `com.intellij.virtualFileSystem` registration in plugin.xml — the
+         * platform looks the file system up by that key when resolving a URL.
+         */
+        const val PROTOCOL: String = "claude-code"
+
+        /** The persisted URL for [tabId], e.g. `claude-code://<tabId>`. */
+        fun urlFor(tabId: String): String = "$PROTOCOL://$tabId"
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
@@ -1,5 +1,7 @@
 package com.github.yhk1038.claudecodegui.editor
 
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
+import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.vfs.NonPhysicalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VirtualFileListener
@@ -43,11 +45,10 @@ import java.io.IOException
  *
  * ## Lifetime
  *
- * This file system creates nothing on its own: [findFileByPath] only hands back
- * a file for a tab the plugin already knows about (see
- * [ClaudeCodeVirtualFile.findExisting]). A stale URL — a tab the user closed
- * before shutdown, or one belonging to another project — resolves to null and
- * the platform simply skips it, which is the desired outcome.
+ * [findFileByPath] hands back a file only for a tab the plugin already knows
+ * about — either live in memory, or recorded in [EditorTabStateService]. A stale
+ * URL (a tab the user closed before shutdown) resolves to null and the platform
+ * simply skips it, which is the desired outcome.
  */
 class ClaudeCodeFileSystem : VirtualFileSystem(), NonPhysicalFileSystem {
 
@@ -56,16 +57,70 @@ class ClaudeCodeFileSystem : VirtualFileSystem(), NonPhysicalFileSystem {
     /**
      * Resolve `claude-code://<tabId>` back to its tab.
      *
-     * Deliberately does NOT create a tab that does not already exist. During
-     * startup restore the platform asks for every persisted URL; answering with
-     * a freshly minted file would resurrect tabs the user had closed. The
-     * plugin's own restore path registers the tabs it intends to reopen, and
-     * only those resolve here.
+     * Two sources, in order:
+     *
+     *  1. a tab already live in memory — the normal case once the session is
+     *     running (a tab being moved between splitters, say);
+     *  2. a tab recorded in [EditorTabStateService] — the restore case.
+     *
+     * The second source is what makes restart restore work at all. The platform
+     * resolves persisted URLs *before* the plugin has opened anything, so at that
+     * moment no tab is live and an in-memory-only lookup answers null for every
+     * URL. That is exactly what happened when this returned only (1): the IDE
+     * logged `No file exists: claude-code://…`, dropped the tab from the restored
+     * layout, and the splitter placement was lost — the bug this whole change is
+     * meant to fix (#302).
+     *
+     * It still does not mint tabs out of thin air. An ID absent from the
+     * persisted state resolves to null, so a tab the user closed before shutdown
+     * stays closed: [EditorTabStateService.removeTab] has already dropped it.
+     *
+     * The lookup spans open projects because a URL identifies a file, not a
+     * project, and this call carries no [com.intellij.openapi.project.Project].
+     * Tab IDs are per-tab UUIDs, so cross-project collision is not a practical
+     * concern.
      */
-    override fun findFileByPath(path: String): VirtualFile? =
-        ClaudeCodeVirtualFile.findExisting(path.trim('/'))
+    override fun findFileByPath(path: String): VirtualFile? {
+        val tabId = path.trim('/')
+        if (tabId.isEmpty()) return null
+
+        ClaudeCodeVirtualFile.findExisting(tabId)?.let { return it }
+
+        // getInstanceIfCreated() resolves an application service, so it throws —
+        // rather than answering null — when there is no application at all. That
+        // is the case in plain unit tests, and during teardown. The whole lookup
+        // is therefore guarded, not just its result.
+        val project = runCatching {
+            ProjectManager.getInstanceIfCreated()
+                ?.openProjects
+                ?.firstOrNull {
+                    !it.isDisposed && tabId in EditorTabStateService.getInstance(it).getOpenTabIds()
+                }
+        }.getOrNull() ?: return null
+
+        val state = EditorTabStateService.getInstance(project)
+        return ClaudeCodeVirtualFile.getOrCreate(
+            project,
+            tabId,
+            state.getRestorePath(tabId),
+            state.getTitle(tabId),
+        )
+    }
 
     override fun refreshAndFindFileByPath(path: String): VirtualFile? = findFileByPath(path)
+
+    /**
+     * A chat tab has no meaningful "location" to show the user.
+     *
+     * The default implementation returns the path, which here is the tab's UUID —
+     * and the platform uses this for the editor tab's title in some paths, so a
+     * restored tab came back labelled `91f1a79c-f0fb-…` instead of its
+     * conversation name. Returning the file's display name keeps the label right
+     * wherever the platform reaches for the presentable URL rather than
+     * [VirtualFile.getPresentableName].
+     */
+    override fun extractPresentableUrl(path: String): String =
+        ClaudeCodeVirtualFile.findExisting(path.trim('/'))?.presentableName ?: path
 
     /** Nothing to refresh: these files are in-memory and have no backing store. */
     override fun refresh(asynchronous: Boolean) {}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
@@ -2,6 +2,7 @@ package com.github.yhk1038.claudecodegui.editor
 
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.openapi.vfs.VirtualFileSystem
 import com.intellij.testFramework.LightVirtualFile
 import java.util.Collections
 import java.util.WeakHashMap
@@ -58,6 +59,29 @@ class ClaudeCodeVirtualFile(
     companion object {
         private const val MAX_DISPLAY_NAME_LENGTH = 20
 
+        /**
+         * The registered [ClaudeCodeFileSystem] instance.
+         *
+         * Resolved through [VirtualFileManager] rather than constructed here, so
+         * this is the very same object the platform hands back when resolving a
+         * `claude-code://` URL. Constructing a second instance would still report
+         * the right protocol, but the file returned by a restore and the file held
+         * by an open tab would then disagree about their file system.
+         *
+         * Falls back to a local instance if the extension point has not been
+         * loaded yet — the protocol and behaviour are identical, so a tab created
+         * that early still works; it just misses the identity guarantee.
+         */
+        private val FILE_SYSTEM: VirtualFileSystem by lazy {
+            // getInstance() itself throws before the application exists (it resolves
+            // an application service), so the whole lookup — not just a null result —
+            // has to fall back. That happens in plain unit tests, and in principle
+            // any time a file is built before the extension point is loaded.
+            runCatching {
+                VirtualFileManager.getInstance().getFileSystem(ClaudeCodeFileSystem.PROTOCOL)
+            }.getOrNull() ?: ClaudeCodeFileSystem()
+        }
+
         private fun truncateName(name: String): String =
             if (name.length > MAX_DISPLAY_NAME_LENGTH) name.take(MAX_DISPLAY_NAME_LENGTH) + "…" else name
 
@@ -85,6 +109,26 @@ class ClaudeCodeVirtualFile(
             }
         }
 
+        /**
+         * Look up an already-known tab by ID, across every open project.
+         *
+         * This backs [ClaudeCodeFileSystem.findFileByPath], which resolves a
+         * persisted `claude-code://<tabId>` URL during the platform's own tab
+         * restore (issue #302). That call carries no [Project] — a URL identifies
+         * a file, not a project — so the search spans all projects. Tab IDs are
+         * UUIDs minted per tab, so a collision across projects is not a practical
+         * concern.
+         *
+         * Returns null for an unknown ID, which is the point: only tabs the plugin
+         * has already registered are revived, so a stale URL (a tab closed before
+         * shutdown) is skipped by the platform rather than resurrected.
+         */
+        fun findExisting(tabId: String): ClaudeCodeVirtualFile? {
+            synchronized(openTabs) {
+                return openTabs.values.firstNotNullOfOrNull { it[tabId] }
+            }
+        }
+
         fun removeTab(project: Project, tabId: String) {
             synchronized(openTabs) {
                 openTabs[project]?.remove(tabId)
@@ -103,6 +147,32 @@ class ClaudeCodeVirtualFile(
 
     override fun getName(): String = displayName
     override fun getPresentableName(): String = displayName
+
+    /**
+     * Route this file through [ClaudeCodeFileSystem] instead of the `mock` file
+     * system it would inherit from `LightVirtualFile`.
+     *
+     * This is what lets the IDE restore the tab — and with it the editor splitter
+     * the tab was in — after a restart (issue #302). The platform persists a tab
+     * by URL and revives it via `VirtualFileManager.findFileByUrl`, which looks
+     * the file system up by protocol; `mock` is not registered and its
+     * `findFileByPath` always returns null, so our tabs were dropped from the
+     * restored layout and the plugin re-opened them in the default location.
+     */
+    override fun getFileSystem(): VirtualFileSystem = FILE_SYSTEM
+
+    /**
+     * The tab ID alone. Paired with [getFileSystem], this yields the persisted
+     * URL `claude-code://<tabId>`, which [ClaudeCodeFileSystem.findFileByPath]
+     * resolves back to this file.
+     *
+     * `LightVirtualFile` derives its path from the display name, which changes as
+     * the conversation is renamed — an unstable URL would restore as a different
+     * file, or as none at all.
+     */
+    override fun getPath(): String = tabId
+
+    override fun getUrl(): String = ClaudeCodeFileSystem.urlFor(tabId)
 
     override fun isWritable(): Boolean = false
     override fun isValid(): Boolean = true

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/ChatHost.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/ChatHost.kt
@@ -32,6 +32,12 @@ interface ChatHost {
     /**
      * Restore the sessions persisted in [EditorTabStateService] into this host
      * after an IDE restart.
+     *
+     * A host that the platform already restores on its own must do nothing here.
+     * [EditorTabHost] is that case: chat tabs are URL-addressable files, so the
+     * platform reopens them with the rest of the editor layout, splitter
+     * placement included — and reopening them a second time is what lost that
+     * placement (#302).
      */
     fun restorePersistedSessions(project: Project)
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/EditorTabHost.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/hosting/EditorTabHost.kt
@@ -11,10 +11,10 @@ import com.intellij.openapi.project.Project
  * Hosts chat sessions in IDE **editor tabs** — the original behaviour, now
  * expressed through the [ChatHost] contract.
  *
- * The open/restore logic here was lifted verbatim from
- * `OpenClaudeCodeAction.openTab` and `EditorTabRestoreActivity`; the only change
- * is that the restart-restore ordering is now sourced from the pure
- * [ChatHostRouter.planRestoreOrder] so it can be unit-tested.
+ * Opening is this host's job; restoring after a restart is not. Chat tabs are
+ * ordinary URL-addressable files to the platform, so it reopens them — in their
+ * original splitters — as part of its own editor layout restore. See
+ * [restorePersistedSessions].
  */
 object EditorTabHost : ChatHost {
 
@@ -55,31 +55,33 @@ object EditorTabHost : ChatHost {
         EditorTabStateService.getInstance(project).addTab(tabId)
     }
 
+    /**
+     * Restore is the IDE's job here, so this deliberately opens nothing.
+     *
+     * The platform already persists the full editor layout — which splitter each
+     * tab sits in, the split orientation and proportion — and reopens it on the
+     * next start. Since chat tabs are addressable by URL
+     * ([com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileSystem]), they take
+     * part in that restore like any other file, splitter placement included.
+     *
+     * Reopening them ourselves on top of that is what broke it (#302). This ran
+     * ~2s after the platform's own restore and called `requestOpenFile`, which
+     * targets the *active* splitter rather than the tab's remembered one — so a
+     * tab the user had split to the right came back in the default pane. The log
+     * showed the whole sequence: the platform restoring, then us reopening, which
+     * is the "tab flashes closed, then re-opens in the default location" in the
+     * report.
+     *
+     * What the platform cannot know is *which conversation* a tab was showing and
+     * what its label was. That still comes from
+     * [com.github.yhk1038.claudecodegui.services.EditorTabStateService] — read
+     * during URL resolution, so a platform-restored tab is materialized with its
+     * path and title already in place.
+     *
+     * [ToolWindowHost] keeps its own restore: tool-window content tabs are not
+     * files, so the platform does not reopen them.
+     */
     override fun restorePersistedSessions(project: Project) {
-        val stateService = EditorTabStateService.getInstance(project)
-        val tabIds = stateService.getOpenTabIds()
-
-        if (tabIds.isEmpty()) {
-            logger.info("No saved editor tabs to restore")
-            return
-        }
-
-        val activeTabId = stateService.getActiveTabId()
-        val restoreOrder = ChatHostRouter.planRestoreOrder(tabIds, activeTabId)
-
-        logger.info("Restoring ${tabIds.size} editor tab(s): $tabIds")
-
-        ApplicationManager.getApplication().invokeLater {
-            // Inactive tabs first (original order), active tab last so it wins focus.
-            for (tabId in restoreOrder) {
-                doOpenOrFocus(
-                    project,
-                    tabId,
-                    stateService.getRestorePath(tabId),
-                    stateService.getTitle(tabId)
-                )
-            }
-            logger.info("Editor tabs restored successfully")
-        }
+        logger.info("Editor tabs are restored by the IDE (layout + splitters); skipping plugin-side restore")
     }
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,15 @@
             icon="/icons/claudeSessions.svg"
             factoryClass="com.github.yhk1038.claudecodegui.toolwindow.ClaudeSessionsToolWindowFactory"/>
 
+        <!-- Virtual file system backing chat tabs. The `key` is the URL protocol:
+             the platform persists an open tab by URL and revives it on restart by
+             looking the file system up under this key. Without it our tabs had the
+             unregistered `mock` protocol of LightVirtualFile and were dropped from
+             the restored layout, losing their editor splitter (issue #302). -->
+        <virtualFileSystem
+            key="claude-code"
+            implementationClass="com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileSystem"/>
+
         <!-- Editor Tab -->
         <fileEditorProvider
             implementation="com.github.yhk1038.claudecodegui.editor.ClaudeCodeEditorProvider"/>

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorStateTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorStateTest.kt
@@ -1,0 +1,75 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.openapi.fileEditor.FileEditorStateLevel
+import org.jdom.Element
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the rule that a chat tab behaves like a browser tab: it reflects the
+ * address IT is showing, and is unaffected by what any other tab does — including
+ * one that happens to show the same file.
+ *
+ * Splitting duplicates a tab, and from that moment the two are separate tabs. The
+ * address therefore has to live per editor. It used to be a single field on the
+ * shared [ClaudeCodeVirtualFile], so whichever pane navigated last overwrote it
+ * and the untouched pane was left pointing at its neighbour's address — visible
+ * as its tab renaming itself even though nothing had happened in it.
+ */
+class ClaudeCodeEditorStateTest {
+
+    @Test
+    fun `each pane round-trips its own address through the layout`() {
+        // Two panes of one split, navigated apart. The platform gives each editor
+        // its own element, so persisting one must not disturb the other.
+        val leftElement = Element("provider")
+        val rightElement = Element("provider")
+
+        ClaudeCodeEditorState.writeTo(ClaudeCodeEditorState("/sessions/abc"), leftElement)
+        ClaudeCodeEditorState.writeTo(ClaudeCodeEditorState("/sessions/xyz"), rightElement)
+
+        val left = ClaudeCodeEditorState.readFrom(leftElement)
+        val right = ClaudeCodeEditorState.readFrom(rightElement)
+
+        assertEquals("/sessions/abc", left.path)
+        assertEquals("/sessions/xyz", right.path)
+        assertNotEquals(left.path, right.path)
+    }
+
+    @Test
+    fun `a pane with no recorded address restores as null rather than guessing`() {
+        // A tab that never navigated has nothing to restore; the panel then falls
+        // back to the file's seed. Inventing a path here would drop a restored pane
+        // somewhere the user never was.
+        assertNull(ClaudeCodeEditorState.readFrom(Element("provider")).path)
+
+        val blank = Element("provider").apply {
+            setAttribute(ClaudeCodeEditorState.PATH_ATTRIBUTE, "   ")
+        }
+        assertNull(ClaudeCodeEditorState.readFrom(blank).path)
+    }
+
+    @Test
+    fun `writing a null address leaves no attribute behind`() {
+        val element = Element("provider")
+        ClaudeCodeEditorState.writeTo(ClaudeCodeEditorState(null), element)
+        assertNull(element.getAttributeValue(ClaudeCodeEditorState.PATH_ATTRIBUTE))
+    }
+
+    @Test
+    fun `two panes on different conversations never merge into one state`() {
+        // Merging is for states close enough to count as one navigation step. Two
+        // panes showing two conversations are not that — treating them as mergeable
+        // is exactly the shared-slot behaviour this replaced.
+        val left = ClaudeCodeEditorState("/sessions/abc")
+        val right = ClaudeCodeEditorState("/sessions/xyz")
+
+        FileEditorStateLevel.entries.forEach { level ->
+            assertFalse(left.canBeMergedWith(right, level), "must not merge at level $level")
+            assertFalse(left.canBeMergedWith(left, level), "must not merge even with an equal state at $level")
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
@@ -1,0 +1,70 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Pins the URL round trip that lets the IDE restore a chat tab into the editor
+ * splitter it was in before a restart (issue #302).
+ *
+ * The platform persists an open tab by URL and revives it with
+ * `VirtualFileManager.findFileByUrl`, which splits the URL on `://`, looks the
+ * file system up by protocol, and calls `findFileByPath` with the remainder.
+ * These tests exercise both halves of that contract without an IDE fixture:
+ * the URL we emit, and the lookup that must resolve it back.
+ */
+class ClaudeCodeFileSystemTest {
+
+    @Test
+    fun `protocol matches the plugin_xml registration key`() {
+        // The platform resolves a URL by looking up the file system registered
+        // under the `key` attribute. If the constant and the registration ever
+        // drift, restore silently stops working: the URL persists fine but no
+        // file system claims the protocol, so the tab is dropped from the layout.
+        val pluginXml = File("src/main/resources/META-INF/plugin.xml").readText()
+
+        assertTrue(
+            pluginXml.contains("""key="${ClaudeCodeFileSystem.PROTOCOL}""""),
+            "plugin.xml must register a virtualFileSystem with key=\"${ClaudeCodeFileSystem.PROTOCOL}\"",
+        )
+        assertTrue(
+            pluginXml.contains("implementationClass=\"com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileSystem\""),
+            "plugin.xml must point the registration at ClaudeCodeFileSystem",
+        )
+    }
+
+    @Test
+    fun `urlFor builds a URL the platform can split back into protocol and tab id`() {
+        val url = ClaudeCodeFileSystem.urlFor("tab-abc")
+
+        assertEquals("claude-code://tab-abc", url)
+        // This is exactly how VirtualFileManager splits a URL.
+        assertEquals(ClaudeCodeFileSystem.PROTOCOL, url.substringBefore("://"))
+        assertEquals("tab-abc", url.substringAfter("://"))
+    }
+
+    @Test
+    fun `unknown tab id resolves to null rather than resurrecting a closed tab`() {
+        // During startup the platform asks for every persisted URL. Minting a file
+        // here would reopen tabs the user had closed before shutdown, so an unknown
+        // ID must answer null and let the platform skip that entry.
+        val fs = ClaudeCodeFileSystem()
+
+        assertNull(fs.findFileByPath("no-such-tab"))
+        assertNull(fs.refreshAndFindFileByPath("no-such-tab"))
+    }
+
+    @Test
+    fun `file system is read-only and non-physical`() {
+        val fs: com.intellij.openapi.vfs.VirtualFileSystem = ClaudeCodeFileSystem()
+
+        // NonPhysicalFileSystem keeps the platform from treating these tabs as
+        // files on disk (refresh, indexing, local-history).
+        assertTrue(fs is com.intellij.openapi.vfs.NonPhysicalFileSystem)
+        assertTrue(fs.isReadOnly)
+        assertEquals("claude-code", fs.protocol)
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
@@ -48,13 +48,39 @@ class ClaudeCodeFileSystemTest {
 
     @Test
     fun `unknown tab id resolves to null rather than resurrecting a closed tab`() {
-        // During startup the platform asks for every persisted URL. Minting a file
-        // here would reopen tabs the user had closed before shutdown, so an unknown
-        // ID must answer null and let the platform skip that entry.
+        // A tab the user closed before shutdown is gone from both the in-memory
+        // map and EditorTabStateService, so its URL must answer null and let the
+        // platform skip that entry instead of reopening it.
         val fs = ClaudeCodeFileSystem()
 
         assertNull(fs.findFileByPath("no-such-tab"))
         assertNull(fs.refreshAndFindFileByPath("no-such-tab"))
+    }
+
+    @Test
+    fun `empty path resolves to null instead of being treated as a tab id`() {
+        val fs = ClaudeCodeFileSystem()
+
+        assertNull(fs.findFileByPath(""))
+        assertNull(fs.findFileByPath("/"))
+    }
+
+    @Test
+    fun `a URL round trips through urlFor and back into findFileByPath`() {
+        // Guards the seam the platform actually drives: it persists urlFor(...),
+        // then on restart splits that string and hands the remainder to
+        // findFileByPath. If either side ever grows a prefix or escaping, the two
+        // stop lining up and restore silently degrades to "No file exists".
+        val fs = ClaudeCodeFileSystem()
+        val tabId = "b1aa13f4-77b7-41ca-936b-f818f4a66b40"
+
+        val persisted = ClaudeCodeFileSystem.urlFor(tabId)
+        val pathHandedBack = persisted.substringAfter("://")
+
+        assertEquals(tabId, pathHandedBack)
+        // Unknown to both lookups here, so null — but it reached the lookup as the
+        // bare tab ID, which is the part this test pins.
+        assertNull(fs.findFileByPath(pathHandedBack))
     }
 
     @Test

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFileUrlTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFileUrlTest.kt
@@ -1,0 +1,58 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the identity a chat tab is persisted under (issue #302).
+ *
+ * Before this fix the file inherited `LightVirtualFile`'s identity: protocol
+ * `mock` (not registered under the virtualFileSystem extension point, and its
+ * `findFileByPath` returns null unconditionally) and a path derived from the
+ * display name. The IDE therefore could not revive the tab from its persisted
+ * URL, dropped it from the restored layout, and the plugin re-opened it in the
+ * default splitter — the reported symptom.
+ */
+class ClaudeCodeVirtualFileUrlTest {
+
+    @Test
+    fun `url is the registered protocol plus the tab id`() {
+        val file = ClaudeCodeVirtualFile("tab-1")
+
+        assertEquals("claude-code://tab-1", file.url)
+        assertEquals("claude-code", file.fileSystem.protocol)
+    }
+
+    @Test
+    fun `path is the tab id, not the display name`() {
+        val file = ClaudeCodeVirtualFile("tab-1", initialTitle = "Fix the parser")
+
+        // The display name follows the conversation and changes as the user works.
+        // Deriving the path from it (LightVirtualFile's behaviour) produced a URL
+        // that no longer matched on the next start.
+        assertEquals("tab-1", file.path)
+        assertNotEquals(file.name, file.path)
+    }
+
+    @Test
+    fun `url is independent of the display name, so renaming cannot break restore`() {
+        // setDisplayName itself needs a running application (it fires a VFS
+        // property change), so the invariant is asserted structurally instead:
+        // two files with the same tab ID but different titles share one URL.
+        val before = ClaudeCodeVirtualFile("tab-1", initialTitle = "Before")
+        val after = ClaudeCodeVirtualFile("tab-1", initialTitle = "After renaming the conversation")
+
+        assertNotEquals(before.name, after.name)
+        assertEquals(before.url, after.url)
+        assertEquals("claude-code://tab-1", after.url)
+    }
+
+    @Test
+    fun `identity is the tab id, so two files for one tab are equal`() {
+        // getOrCreate caches per tab, but restore and an open tab must agree that
+        // they are the same file even if two instances ever exist.
+        assertEquals(ClaudeCodeVirtualFile("tab-1"), ClaudeCodeVirtualFile("tab-1"))
+        assertNotEquals(ClaudeCodeVirtualFile("tab-1"), ClaudeCodeVirtualFile("tab-2"))
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/EditorTabHostRestoreTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/hosting/EditorTabHostRestoreTest.kt
@@ -1,0 +1,63 @@
+package com.github.yhk1038.claudecodegui.hosting
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pins the decision at the heart of issue #302: after a restart the editor-tab
+ * host must **not** reopen chat tabs itself.
+ *
+ * The platform persists the whole editor layout — which splitter each tab is in,
+ * the orientation, the proportion — and reopens it on the next start. Chat tabs
+ * join that restore because they are URL-addressable
+ * ([com.github.yhk1038.claudecodegui.editor.ClaudeCodeFileSystem]).
+ *
+ * Reopening them a second time is what lost the splitter: the plugin's restore
+ * ran ~2s later and called `requestOpenFile`, which targets the *active*
+ * splitter, not the tab's remembered one. That produced the reported "tab
+ * flashes closed, then re-opens in your default tab location".
+ *
+ * A regression here would be silent — the tabs still appear, just in the wrong
+ * pane — so the no-op is asserted by running the method. Any call into the
+ * tab-opening path or the persisted state would need a live application and
+ * throw; a genuine no-op returns cleanly even with a bogus Project.
+ */
+class EditorTabHostRestoreTest {
+
+    @Test
+    fun `restore is a no-op, so it needs no IDE services at all`() {
+        // A Project stand-in that fails loudly if anything is asked of it. The
+        // real restore path would call getService(EditorTabStateService) and
+        // FileEditorManager.getInstance(project) — both would trip this.
+        val hostileProject = java.lang.reflect.Proxy.newProxyInstance(
+            com.intellij.openapi.project.Project::class.java.classLoader,
+            arrayOf(com.intellij.openapi.project.Project::class.java),
+        ) { _, method, _ ->
+            throw AssertionError(
+                "restorePersistedSessions must leave restore to the IDE, but it called " +
+                    "Project.${method.name}(). Reopening editor tabs after the platform already " +
+                    "restored them is what lost the splitter placement in issue #302.",
+            )
+        } as com.intellij.openapi.project.Project
+
+        // Returns cleanly == touched nothing == the IDE's layout restore stands.
+        EditorTabHost.restorePersistedSessions(hostileProject)
+    }
+
+    @Test
+    fun `the tool-window host still restores, since the platform does not reopen its tabs`() {
+        // The no-op above is specific to editor tabs. Tool-window content tabs are
+        // not files, so nothing else will bring them back and that host must keep
+        // its own restore. Guards against "simplifying" both hosts to no-ops.
+        val restoreMethod = ToolWindowHost::class.java.declaredMethods
+            .filter { it.name == "restorePersistedSessions" }
+
+        assertTrue(restoreMethod.isNotEmpty(), "ToolWindowHost must implement restorePersistedSessions")
+        assertEquals(
+            1,
+            restoreMethod.count { it.parameterCount == 1 },
+            "ToolWindowHost should declare exactly one restorePersistedSessions(Project)",
+        )
+    }
+}

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -7,7 +7,7 @@ import { ChatPage, SettingsPage, SettingsOverlay, SwitchAccountPage, ProjectSele
 import { AccountUsageModal } from './components/AccountUsageModal';
 import { TunnelModal } from './components/TunnelModal';
 import { ForbiddenNotice } from './components/ForbiddenNotice';
-import { isRemoteBlocked } from './api/bridge/authToken';
+import { isLoopbackHostname, isRemoteBlocked } from './api/bridge/authToken';
 import { usePairingStatus } from './hooks/usePairingStatus';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
@@ -110,8 +110,16 @@ function App() {
   // (expired / wrong / rate-limited / unreachable). usePairingStatus makes this
   // reactive so a pairing that fails after mount flips us to the block. A LOCAL
   // transient disconnect is NEVER blocked (isRemoteBlocked stays false).
+  //
+  // A failed pairing only blocks a REMOTE device. Locally the launcher owns the
+  // page and a failure means "this panel could not redeem the code", not "this
+  // device may not connect" — as when the IDE restores a split and both panes
+  // race for the same single-use code (#302). Blocking there stranded a pane on
+  // "403 · Forbidden" telling the user to scan a QR, on localhost. Local panels
+  // keep reconnecting instead, which is the same treatment a transient backend
+  // outage already gets.
   const { state: pairingState } = usePairingStatus();
-  const blocked = isRemoteBlocked() || pairingState === 'failed';
+  const blocked = isRemoteBlocked() || (pairingState === 'failed' && !isLoopbackHostname(window.location.hostname));
 
   // Render ONLY the hard "403" block on an EMPTY template — do NOT mount the app
   // providers, router, or chat UI (nothing to connect, nothing leaking behind).

--- a/webview/src/api/bridge/__tests__/authToken.test.ts
+++ b/webview/src/api/bridge/__tests__/authToken.test.ts
@@ -224,12 +224,23 @@ describe('authToken', () => {
     });
 
     it('surfaces a "failed/expired" state on 401 and returns no token', async () => {
-      setUrl('/?pair=stale');
-      mockFetchOnce(() => jsonResponse(401, { error: 'Invalid or expired pairing code' }));
+      // A 401 is now given a short grace period first, in case a sibling panel is
+      // mid-redeem of the same single-use code (see "concurrent panels" below).
+      // Nothing publishes a token here, so the wait must elapse before the
+      // failure is declared — fake timers keep the test instant.
+      vi.useFakeTimers();
+      try {
+        setUrl('/?pair=stale');
+        mockFetchOnce(() => jsonResponse(401, { error: 'Invalid or expired pairing code' }));
 
-      const token = await ensureAuthTokenReady();
-      expect(token).toBe('');
-      expect(getPairingStatus()).toEqual({ state: 'failed', reason: 'expired' });
+        const pending = ensureAuthTokenReady();
+        await vi.advanceTimersByTimeAsync(11_000);
+
+        await expect(pending).resolves.toBe('');
+        expect(getPairingStatus()).toEqual({ state: 'failed', reason: 'expired' });
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('surfaces a "failed/locked" state on 429', async () => {
@@ -285,6 +296,77 @@ describe('authToken', () => {
       expect(fetchFn).toHaveBeenCalledTimes(1);
       const [, init] = fetchFn.mock.calls[0];
       expect(JSON.parse((init as RequestInit).body as string)).toEqual({ code: 'realcode' });
+    });
+
+    // ── Losing the race for the single-use code ───────────────────────────────
+    // The IDE restores a split by reopening BOTH panes at once, each in its own
+    // JCEF browser context with the same `?pair=` code in the URL. One redeems
+    // it; the other gets 401 and must NOT be treated as unauthorized — it waits
+    // for the winner to publish the validated token (#302).
+    describe('concurrent panels sharing one single-use code', () => {
+      it('adopts the token a sibling panel publishes after losing the redeem race', async () => {
+        setUrl('/?pair=sharedcode');
+        mockFetchOnce(() => jsonResponse(401, { error: 'invalid' }));
+
+        const pending = ensureAuthTokenReady();
+
+        // The winning panel finishes its handshake and persists what it got.
+        window.localStorage.setItem('ccg-auth-token', 'winner-token');
+        window.dispatchEvent(
+          new StorageEvent('storage', { key: 'ccg-auth-token', newValue: 'winner-token' }),
+        );
+
+        await expect(pending).resolves.toBe('winner-token');
+        // Adopting a peer's token counts as paired — no "403 / rescan the QR".
+        expect(getPairingStatus().state).toBe('paired');
+      });
+
+      it('does not re-POST the consumed code while waiting for the sibling', async () => {
+        setUrl('/?pair=sharedcode');
+        const fetchFn = mockFetchOnce(() => jsonResponse(401, { error: 'invalid' }));
+
+        const pending = ensureAuthTokenReady();
+        window.localStorage.setItem('ccg-auth-token', 'winner-token');
+        window.dispatchEvent(
+          new StorageEvent('storage', { key: 'ccg-auth-token', newValue: 'winner-token' }),
+        );
+        await pending;
+
+        // Retrying would burn a failed-attempt slot toward the backend lockout,
+        // and a consumed code can never succeed anyway.
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+      });
+
+      it('still reports failure when no sibling ever publishes a token', async () => {
+        vi.useFakeTimers();
+        try {
+          setUrl('/?pair=deadcode');
+          mockFetchOnce(() => jsonResponse(401, { error: 'invalid' }));
+
+          const pending = ensureAuthTokenReady();
+          await vi.advanceTimersByTimeAsync(11_000);
+
+          await expect(pending).resolves.toBe('');
+          // A genuinely expired code must still surface as a failure.
+          expect(getPairingStatus().state).toBe('failed');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('takes an already-published sibling token without waiting at all', async () => {
+        vi.useFakeTimers();
+        try {
+          setUrl('/?pair=sharedcode');
+          mockFetchOnce(() => jsonResponse(401, { error: 'invalid' }));
+          // The sibling won before this panel even POSTed.
+          window.localStorage.setItem('ccg-auth-token', 'already-there');
+
+          await expect(ensureAuthTokenReady()).resolves.toBe('already-there');
+        } finally {
+          vi.useRealTimers();
+        }
+      });
     });
   });
 });

--- a/webview/src/api/bridge/authToken.ts
+++ b/webview/src/api/bridge/authToken.ts
@@ -89,6 +89,81 @@ function storeToken(token: string): void {
   }
 }
 
+/**
+ * How long a panel that lost the race to redeem the single-use `?pair=` code
+ * waits for the winning panel to publish the token it obtained.
+ *
+ * Sized for "the other panel is mid-handshake", not for a human: the winner only
+ * has to finish its POST /pair and open one WebSocket. If nothing lands by then,
+ * the code really was expired/invalid and the normal failure path takes over.
+ */
+const PEER_TOKEN_WAIT_MS = 10_000;
+
+/**
+ * Wait for another same-origin panel to publish a validated token, resolving to
+ * it (or '' on timeout).
+ *
+ * This exists because the `?pair=` code is single-use while JCEF opens each
+ * editor tab as its OWN browser context. When the IDE restores a split, both
+ * panes load at the same instant with the same code, each in a separate JS world
+ * (so the in-flight memoization in redeemPairCode cannot help them). One wins the
+ * redeem; the other gets 401 — and used to fall straight to the "403 Forbidden"
+ * block even though it was perfectly entitled to connect (#302 exposed this once
+ * splits started restoring again).
+ *
+ * The loser does NOT retry the code — a consumed code must stay consumed, and a
+ * retry would burn a failed-attempt slot toward the backend's lockout. It simply
+ * waits for the winner, which calls persistValidatedToken() AFTER its socket has
+ * actually authenticated. So the token handed over here is one the backend has
+ * already accepted; no part of the security model is relaxed.
+ *
+ * `storage` fires in every other same-origin context on write, so the handover is
+ * event-driven. A short poll runs alongside it purely as a safety net for
+ * embeddings that fire the event unreliably.
+ */
+function waitForPeerToken(timeoutMs = PEER_TOKEN_WAIT_MS): Promise<string> {
+  return new Promise((resolve) => {
+    const existing = readStoredToken();
+    if (existing) {
+      resolve(existing);
+      return;
+    }
+
+    let settled = false;
+    const finish = (token: string) => {
+      if (settled) return;
+      settled = true;
+      window.clearInterval(poll);
+      window.clearTimeout(timer);
+      try {
+        window.removeEventListener('storage', onStorage);
+      } catch {
+        // removal is best-effort; `settled` already makes this idempotent
+      }
+      resolve(token);
+    };
+
+    const onStorage = (event: StorageEvent) => {
+      if (event.key !== null && event.key !== TOKEN_STORAGE_KEY) return;
+      const token = readStoredToken();
+      if (token) finish(token);
+    };
+
+    const poll = window.setInterval(() => {
+      const token = readStoredToken();
+      if (token) finish(token);
+    }, 250);
+
+    const timer = window.setTimeout(() => finish(''), timeoutMs);
+
+    try {
+      window.addEventListener('storage', onStorage);
+    } catch {
+      // no storage events in this embedding — the poll above still covers us
+    }
+  });
+}
+
 // ── Remote-Control tunnel pairing state ─────────────────────────────────────
 // The `?pair=` code captured from the URL (null when absent). A single-use
 // short-lived credential the remote device exchanges for the real token.
@@ -228,6 +303,22 @@ function redeemPairCode(code: string): Promise<string> {
         body: JSON.stringify({ code }),
       });
       if (!res.ok) {
+        // Losing the race for a single-use code is indistinguishable from an
+        // expired one: both come back 401. So on 401 only, give a sibling panel —
+        // the other pane of a restored split, loading in its own JCEF context with
+        // the same code — a moment to publish the token it just validated (#302).
+        //
+        // 429 is NOT retried this way: a lockout is a definitive answer about the
+        // whole backend, not a lost race, and waiting would only stall the user
+        // before showing them why they are locked out.
+        if (res.status !== 429) {
+          const peerToken = await waitForPeerToken();
+          if (peerToken) {
+            cachedToken = peerToken;
+            setPairingState('paired');
+            return peerToken;
+          }
+        }
         // 429 → rate-limited/locked; anything else (401) → expired/invalid.
         setPairingState('failed', res.status === 429 ? 'locked' : 'expired');
         return '';


### PR DESCRIPTION
## What this fixes

Splitting a chat tab and restarting the IDE lost the split: the tab flashed and reopened in the default location.

## Why it happened

The IDE persists an open tab by **URL** and revives it on the next start — splitter placement, orientation and proportion included. It already does all of that on its own.

But our tab file inherited `LightVirtualFile`, whose file system has protocol `mock`: not registered under the `virtualFileSystem` extension point, and its `findFileByPath` returns null unconditionally. So the IDE could never revive our tabs by URL.

The platform's restore therefore failed, and ~2s later the plugin opened the tabs itself. That path does not target a splitter, so it lands in the **active** one — which is exactly the reported "tab flashes closed, then re-opens in your default tab location". The log showed both steps in order.

## How it is fixed

1. **Register a real file system** (`claude-code://<tabId>`) so a chat tab is addressable by URL and takes part in the platform's own restore. The path is the tab id, which is stable — `LightVirtualFile` derives its path from the display name, so a rename would have changed the URL.

2. **Stop restoring editor tabs ourselves.** The IDE brings them back in their splitters; reopening them on top is what lost the placement. `EditorTabStateService` is still the source for a tab's conversation and label, read while resolving the URL, so a restored tab materializes with both already in place. `ToolWindowHost` keeps its own restore — tool-window content tabs are not files, so nothing else would bring them back.

## Also fixed along the way

**403 Forbidden on a restored split.** The `?pair=` code is single-use, but JCEF gives each editor tab its own browser context, so both panes loaded at the same instant with the same code, in separate JS worlds. One redeemed it; the other got 401 and fell straight to the "403 Forbidden" block — telling the user to scan a QR code, on localhost. A panel that loses that race now waits briefly for the winner to publish the token it validated. It does not retry the consumed code (that would burn a failed-attempt slot toward the backend lockout and could never succeed), a 429 still fails immediately since a lockout is a definitive answer, and a failed pairing now only blocks a remote device.

**Tab labelled with a raw UUID.** A side effect of making the path the tab id: the platform uses the file system's presentable URL in some paths. `ClaudeCodeFileSystem` now returns the display name.

## Known limitation

The two panes of a split still **share one tab title**: navigating in one renames both, even though the other has not moved.

The platform derives a tab's title from its FILE (`EditorTabPresentationUtil.getEditorTabTitle(Project, VirtualFile)` → `EditorTabTitleProvider`, neither of which sees the `FileEditor`), and a split reuses one file for both panes. Every stable route to a second file is closed on 2024.2: `FileEditor.getName()` is not consulted for the label; `closeFile(file)` closes the file in every pane, while the pane-scoped overloads and `createSplitter` need the Internal `EditorWindow`; `SplitAction` is a remote-frontend action so an `AnActionListener` never sees it; and `FORBID_TAB_SPLIT` hides splitting altogether rather than changing it. The dead ends are recorded in the code so the next attempt does not rediscover them.

A pane's **address** is separated: it now lives in a per-editor `FileEditorState` instead of one shared field on the virtual file.

## Verification

Measured in a sandbox IDE: a split survives a restart in its original splitter, both panes render, no `No file exists`, no 403.

Plugin Verifier: **no Internal API usage**; the warning count stays at the existing single allowlisted entry (`requestOpenFile`).

Tests: Kotlin suite, backend (1334), webview (2293), `tsc --noEmit` clean, `full-build` green.

Closes #302