### PR TITLE
Keep the chat panel loadable on an IDE without JCEF

### DIFF
--- a/docs/troubleshooting/de/README.md
+++ b/docs/troubleshooting/de/README.md
@@ -13,7 +13,7 @@ Jedes Dokument enthält die Symptome, die Ursache, die Lösung und Links zu den 
 | Dokument | Wann Sie hier nachlesen sollten |
 |---|---|
 | [Wayland-Zwischenablage](wayland-clipboard.md) | Wenn das Einfügen in das Chat-Eingabefeld unter Linux · Wayland · KDE Plasma fehlschlägt |
-| [Android-Studio-JCEF-Runtime](android-studio-jcef.md) | Wenn Android Studio ein Hinweispanel statt der Chat-Oberfläche oder ein leeres Fenster zeigt |
+| [JCEF in Android Studio](android-studio-jcef.md) | Wenn Android Studio ein Hinweispanel oder eine Ausnahme statt der Chat-Oberfläche oder ein leeres Fenster zeigt |
 
 ## Wenn Ihr Problem hier nicht steht
 

--- a/docs/troubleshooting/de/android-studio-jcef.md
+++ b/docs/troubleshooting/de/android-studio-jcef.md
@@ -1,19 +1,95 @@
-# Das Chat-Fenster erscheint nicht in Android Studio (JCEF-Runtime)
+# Das Chat-Fenster erscheint nicht in Android Studio (JCEF)
 
 🌐 [English](../en/android-studio-jcef.md) | [한국어](../ko/android-studio-jcef.md) | [日本語](../ja/android-studio-jcef.md) | [中文](../zh/android-studio-jcef.md) | [Español](../es/android-studio-jcef.md) | **Deutsch** | [Français](../fr/android-studio-jcef.md)
 
 _Zuletzt aktualisiert: 2026-08-22_
 
-## Symptome
+Dieses Plugin zeichnet seine Chat-Oberfläche auf **JCEF** (Chromium Embedded Framework). Anders als andere JetBrains-IDEs liefert Android Studio JCEF nicht standardmäßig mit, weshalb statt des Chats ein Hinweispanel erscheinen kann.
 
-Wenn Sie das Plugin in Android Studio öffnen, erscheint statt der Chat-Oberfläche ein Hinweispanel.
+**Die Lösung unterscheidet sich je nach Android-Studio-Version grundlegend.** Prüfen Sie zuerst Ihre Version (**Help → About**).
 
-Nach dem Wechsel der Runtime kann eines von beidem passieren.
+| Ihre Version | Weiter zu |
+|---|---|
+| **2026.2 oder neuer** (Rabbit) | [Ab 2026.2: Plugin installieren](#ab-20262-plugin-installieren) |
+| **2026.1.3 – 2026.1.x** | [2026.1: Runtime wechseln](#20261-runtime-wechseln) |
+| **2026.1.2 oder älter** | [2026.1.2 und älter: keine funktionierende Kombination](#202612-und-älter-keine-funktionierende-kombination) |
 
-- Android Studio startet überhaupt nicht mehr
-- Es startet zwar, aber das Plugin-Fenster ist völlig leer — kein Hinweispanel, keine Fehlermeldung
+---
 
-Bei einem leeren Fenster steht in `idea.log`:
+## Ab 2026.2: Plugin installieren
+
+### Symptome
+
+Beim Öffnen des Chats erscheint ein Hinweispanel; bei älteren Plugin-Versionen wird eine Ausnahme geworfen. In `idea.log` steht:
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+Weiter oben im Log finden Sie außerdem:
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### Ursache
+
+**Seit 2026.2 ist JCEF aus dem IDE-Kern in ein eigenes Plugin ausgelagert.** Es wurde nicht entfernt, sondern hat nur den Ort gewechselt.
+
+JetBrains liefert dieses Plugin mit den eigenen IDEs aus, **Android Studio jedoch nicht**. Deshalb fehlen die Klassen `com.intellij.ui.jcef` in der IDE vollständig.
+
+Entscheidend dabei: **Ein Wechsel der Runtime hilft nicht.** Die JetBrains Runtime stellt nur `org.cef.*` bereit; `com.intellij.ui.jcef` ist Plattform-Code und muss von der IDE kommen. Ein Start mit einer JCEF-fähigen Runtime führt zum selben Ergebnis.
+
+### So beheben Sie es
+
+1. Öffnen Sie **Settings → Plugins → Marketplace**
+2. Suchen Sie nach **Web Browser (JCEF)** — das von **JetBrains**
+3. Installieren Sie es und starten Sie die IDE neu
+
+Nach dem Neustart erscheint der Chat normal. Die Runtime können Sie unverändert lassen.
+
+> Marketplace-Seite: [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### Geprüfte Kombinationen
+
+| Android Studio | Auslieferungszustand | Mit Web Browser (JCEF) |
+|---|---|---|
+| **2026.2.1 Canary 2** (AI-262.9437) | Hinweispanel (ältere Plugin-Versionen brechen ab) | **Funktioniert normal** — kein Runtime-Wechsel nötig |
+
+---
+
+## 2026.1: Runtime wechseln
+
+### Symptome
+
+Statt der Chat-Oberfläche erscheint ein Hinweispanel.
+
+### Ursache
+
+Die mit Android Studio ausgelieferte JetBrains Runtime (JBR) enthält kein JCEF. In 2026.1 gehört JCEF noch zum IDE-Kern, daher **löst der Wechsel auf eine JCEF-fähige Runtime das Problem.**
+
+### So beheben Sie es
+
+1. Stellen Sie sicher, dass Android Studio **2026.1.3 oder neuer** ist (für 2026.1.2 und älter siehe den nächsten Abschnitt)
+2. Öffnen Sie Find Action: `Cmd+Shift+A` (macOS) oder `Ctrl+Shift+A` (Windows/Linux)
+3. Führen Sie **Choose Boot Java Runtime for the IDE…** aus
+4. Wählen Sie eine Runtime, deren Name **JCEF** enthält
+5. Starten Sie die IDE nach der Installation neu
+
+Die Schaltfläche im Hinweispanel des Plugins öffnet denselben Dialog.
+
+---
+
+## 2026.1.2 und älter: keine funktionierende Kombination
+
+### Symptome
+
+Nach dem Wechsel der Runtime tritt eines von beidem auf.
+
+- Android Studio startet überhaupt nicht
+- Es startet, aber das Plugin-Fenster bleibt völlig leer — kein Hinweispanel, keine Fehlermeldung
+
+Bei leerem Fenster steht in `idea.log`:
 
 ```
 java.lang.NoSuchMethodError:
@@ -21,57 +97,37 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## Ursache
-
-Die JetBrains Runtime (JBR), die mit Android Studio ausgeliefert wird, enthält **kein JCEF** (Chromium Embedded Framework).
-
-Die Oberfläche dieses Plugins wird auf JCEF gezeichnet, deshalb zeigt die Standard-Runtime ein Hinweispanel statt des Chat-Fensters.
-
-Bis hierhin lässt sich das durch den Wechsel auf eine Runtime mit JCEF lösen.
-
-Allerdings gibt es **auf Android Studio 2026.1.2 und älter überhaupt keine funktionierende Kombination.**
+### Ursache
 
 - Diese Versionen laufen auf Java 21 und bringen eine eigene `JCefAppConfig` mit
-- Wählen Sie eine **JBR 21** mit JCEF, überdeckt das Runtime-Modul diese mitgelieferte Kopie. Der `JCefAppConfig` in JBR 21 fehlt die Methode `isRemoteEnabled()`, die die Plattform aufruft. Der Browser wird nie erzeugt und das Fenster bleibt leer
-- **JBR 25** hat diese Methode, aber 2026.1.2 und älter starten nicht unter Java 25. Der Security Manager wurde in Java 24 entfernt, und diese Builds versuchen weiterhin, ihn zu aktivieren
+- Wählen Sie eine JCEF-fähige **JBR 21**, verdeckt das Runtime-Modul diese mitgelieferte Kopie. Der `JCefAppConfig` in JBR 21 fehlt die Methode `isRemoteEnabled()`, die die Plattform aufruft. Der Browser wird nie erzeugt, das Fenster bleibt leer
+- **JBR 25** besitzt die Methode, doch 2026.1.2 und älter starten nicht auf Java 25. Der Security Manager wurde in Java 24 entfernt, diese Builds versuchen ihn weiterhin zu aktivieren
 
-Android Studio **2026.1.3** hat die mitgelieferte Runtime von Java 21 auf Java 25 umgestellt, womit das Problem gelöst ist.
+Android Studio **2026.1.3** hat die mitgelieferte Runtime von Java 21 auf Java 25 umgestellt, womit sich das erledigt.
 
-## Geprüfte Kombinationen
+### So beheben Sie es
 
-| Android Studio | Mitgelieferte JBR | JBR 21 mit JCEF | JBR 25 mit JCEF |
+Aktualisieren Sie Android Studio auf **2026.1.3 oder neuer**.
+
+### Geprüfte Kombinationen
+
+| Android Studio | Mitgelieferte JBR | JCEF-fähige JBR 21 | JCEF-fähige JBR 25 |
 |---|---|---|---|
 | 2026.1.1 Patch 2 | Java 21 — nur Hinweispanel | Leeres Fenster | Startet nicht |
 | 2026.1.2 | Java 21 — nur Hinweispanel | Leeres Fenster | Startet nicht |
 | **2026.1.3** | **Java 25** | — | **Funktioniert normal** |
 
-## Lösung
+---
 
-1. Aktualisieren Sie Android Studio auf **2026.1.3 oder neuer**
-2. Öffnen Sie Find Action: `Cmd+Shift+A` (macOS) oder `Ctrl+Shift+A` (Windows/Linux)
-3. Führen Sie **Choose Boot Java Runtime for the IDE…** aus
-4. Wählen Sie eine Runtime, deren Name **JCEF** enthält
-5. Starten Sie die IDE neu, sobald die Installation abgeschlossen ist
+## Wenn die IDE nach einem Runtime-Wechsel nicht startet
 
-Die Schaltfläche **Switch Runtime** im Hinweispanel des Plugins öffnet denselben Dialog.
-
-## Wenn die IDE nach dem Runtime-Wechsel nicht mehr startet
-
-Löschen Sie die Datei `studio.jdk` im Konfigurationsverzeichnis von Android Studio, um die Standard-Runtime wiederherzustellen.
+Löschen Sie die Datei `studio.jdk` aus dem Konfigurationsverzeichnis von Android Studio, um die Standard-Runtime wiederherzustellen.
 
 - **macOS**: `~/Library/Application Support/Google/AndroidStudio<Version>/studio.jdk`
 - **Linux**: `~/.config/Google/AndroidStudio<Version>/studio.jdk`
 - **Windows**: `%APPDATA%\Google\AndroidStudio<Version>\studio.jdk`
 
-## Wann verschwindet das
-
-JetBrains hat im April 2025 ein experimentelles Marketplace-Plugin namens [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360) veröffentlicht.
-
-Es bringt JCEF zu Android Studio 2026.1 Nightly und neuer.
-
-Sobald das stabil ist, wird der oben beschriebene Runtime-Wechsel nicht mehr nötig sein.
-
-## Verwandte Links
+## Weiterführende Links
 
 ### Issues in diesem Repository
 
@@ -81,10 +137,12 @@ Sobald das stabil ist, wird der oben beschriebene Runtime-Wechsel nicht mehr nö
 
 ### Pull Requests in diesem Repository
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
-### Externe Verweise
+### Externe Referenzen
 
-- [Web Browser (JCEF) im Marketplace](https://plugins.jetbrains.com/plugin/31360) — das experimentelle Plugin von JetBrains, das JCEF zu Android Studio hinzufügt
+- [Web Browser (JCEF) im Marketplace](https://plugins.jetbrains.com/plugin/31360) — das JetBrains-Plugin, das Android Studio um JCEF ergänzt
+- [JetBrains-Ankündigung: Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/en/README.md
+++ b/docs/troubleshooting/en/README.md
@@ -13,7 +13,7 @@ Each document has the symptoms, the cause, how to fix it, and links to the relat
 | Document | Read this when |
 |---|---|
 | [Wayland clipboard](wayland-clipboard.md) | Pasting into the chat input fails on Linux · Wayland · KDE Plasma |
-| [Android Studio JCEF runtime](android-studio-jcef.md) | Android Studio shows a guidance panel instead of the chat UI, or a blank window |
+| [Android Studio JCEF](android-studio-jcef.md) | Android Studio shows a guidance panel or an exception instead of the chat UI, or a blank window |
 
 ## If your problem is not here
 

--- a/docs/troubleshooting/en/android-studio-jcef.md
+++ b/docs/troubleshooting/en/android-studio-jcef.md
@@ -1,14 +1,90 @@
-# The chat window does not appear on Android Studio (JCEF runtime)
+# The chat window does not appear on Android Studio (JCEF)
 
 🌐 **English** | [한국어](../ko/android-studio-jcef.md) | [日本語](../ja/android-studio-jcef.md) | [中文](../zh/android-studio-jcef.md) | [Español](../es/android-studio-jcef.md) | [Deutsch](../de/android-studio-jcef.md) | [Français](../fr/android-studio-jcef.md)
 
 _Last updated: 2026-08-22_
 
-## Symptoms
+This plugin draws its chat UI on **JCEF** (Chromium Embedded Framework). Unlike other JetBrains IDEs, Android Studio does not ship JCEF by default, so you may get a guidance panel instead of the chat.
 
-Opening the plugin on Android Studio shows a guidance panel instead of the chat UI.
+**The fix differs completely depending on your Android Studio version.** Check yours first (**Help → About**).
 
-After switching the runtime, one of these can happen.
+| Your version | Go to |
+|---|---|
+| **2026.2 or later** (Rabbit) | [2026.2 and later: install the plugin](#20262-and-later-install-the-plugin) |
+| **2026.1.3 – 2026.1.x** | [2026.1: switch the runtime](#20261-switch-the-runtime) |
+| **2026.1.2 or earlier** | [2026.1.2 and earlier: no working combination](#202612-and-earlier-no-working-combination) |
+
+---
+
+## 2026.2 and later: install the plugin
+
+### Symptoms
+
+Opening the chat shows a guidance panel, or — on older plugin versions — throws an exception. `idea.log` contains:
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+Earlier in the log you will also find:
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### Cause
+
+**As of 2026.2, JCEF moved out of the IDE core into a separate plugin.** It was not removed — it changed address.
+
+JetBrains ships that plugin with its own IDEs, but **Android Studio does not bundle it**. The `com.intellij.ui.jcef` classes are therefore absent from the IDE entirely.
+
+The important part: **switching the runtime does not help.** The JetBrains Runtime supplies `org.cef.*` only; `com.intellij.ui.jcef` is platform code that has to come from the IDE. Booting a JCEF-enabled runtime produces the same result.
+
+### How to fix it
+
+1. Open **Settings → Plugins → Marketplace**
+2. Search for **Web Browser (JCEF)** — the one by **JetBrains**
+3. Install it and restart the IDE
+
+The chat appears normally after the restart. You can leave the runtime on its default.
+
+> Marketplace page: [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### Verified combinations
+
+| Android Studio | Out of the box | With Web Browser (JCEF) |
+|---|---|---|
+| **2026.2.1 Canary 2** (AI-262.9437) | Guidance panel (older plugin versions throw) | **Works normally** — no runtime swap needed |
+
+---
+
+## 2026.1: switch the runtime
+
+### Symptoms
+
+A guidance panel appears instead of the chat UI.
+
+### Cause
+
+The JetBrains Runtime (JBR) bundled with Android Studio does not include JCEF. On 2026.1, JCEF is still part of the IDE core, so **switching to a JCEF-enabled runtime solves it.**
+
+### How to fix it
+
+1. Make sure Android Studio is **2026.1.3 or later** (for 2026.1.2 and earlier, see the section below)
+2. Open Find Action: `Cmd+Shift+A` (macOS) or `Ctrl+Shift+A` (Windows/Linux)
+3. Run **Choose Boot Java Runtime for the IDE…**
+4. Pick a runtime whose name contains **JCEF**
+5. Restart the IDE once the install finishes
+
+The button on the plugin's guidance panel opens the same dialog.
+
+---
+
+## 2026.1.2 and earlier: no working combination
+
+### Symptoms
+
+After switching the runtime, one of these happens.
 
 - Android Studio does not start at all
 - It starts, but the plugin window is completely blank — no guidance panel, no error message
@@ -21,15 +97,7 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## Cause
-
-The JetBrains Runtime (JBR) that ships with Android Studio does **not** include **JCEF** (Chromium Embedded Framework).
-
-This plugin's UI is drawn on JCEF, so the default runtime shows a guidance panel instead of the chat screen.
-
-Up to here, switching to a JCEF-enabled runtime solves it.
-
-However, **on Android Studio 2026.1.2 and earlier there is no working combination.**
+### Cause
 
 - Those versions run on Java 21 and bundle their own `JCefAppConfig`
 - If you pick a JCEF-enabled **JBR 21**, the runtime module shadows that bundled copy. The `JCefAppConfig` in JBR 21 has no `isRemoteEnabled()` method, which the platform calls. The browser is never created, and the window stays blank
@@ -37,7 +105,11 @@ However, **on Android Studio 2026.1.2 and earlier there is no working combinatio
 
 Android Studio **2026.1.3** moved its bundled runtime from Java 21 to Java 25, which resolves this.
 
-## Verified combinations
+### How to fix it
+
+Update Android Studio to **2026.1.3 or later**.
+
+### Verified combinations
 
 | Android Studio | Bundled JBR | JCEF-enabled JBR 21 | JCEF-enabled JBR 25 |
 |---|---|---|---|
@@ -45,15 +117,7 @@ Android Studio **2026.1.3** moved its bundled runtime from Java 21 to Java 25, w
 | 2026.1.2 | Java 21 — guidance panel only | Blank window | Fails to boot |
 | **2026.1.3** | **Java 25** | — | **Works normally** |
 
-## How to fix it
-
-1. Update Android Studio to **2026.1.3 or later**
-2. Open Find Action: `Cmd+Shift+A` (macOS) or `Ctrl+Shift+A` (Windows/Linux)
-3. Run **Choose Boot Java Runtime for the IDE…**
-4. Pick a runtime whose name contains **JCEF**
-5. Restart the IDE once the install finishes
-
-The **Switch Runtime** button on the plugin's guidance panel opens the same dialog.
+---
 
 ## If the IDE will not start after a runtime swap
 
@@ -62,14 +126,6 @@ Delete the `studio.jdk` file from the Android Studio config directory to restore
 - **macOS**: `~/Library/Application Support/Google/AndroidStudio<version>/studio.jdk`
 - **Linux**: `~/.config/Google/AndroidStudio<version>/studio.jdk`
 - **Windows**: `%APPDATA%\Google\AndroidStudio<version>\studio.jdk`
-
-## When will this go away
-
-JetBrains released an experimental [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360) marketplace plugin in April 2025.
-
-It brings JCEF to Android Studio 2026.1 Nightly and later.
-
-Once that becomes stable, the runtime swap above will no longer be needed.
 
 ## Related links
 
@@ -81,10 +137,12 @@ Once that becomes stable, the runtime swap above will no longer be needed.
 
 ### Pull requests in this repository
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
 ### External references
 
-- [Web Browser (JCEF) marketplace plugin](https://plugins.jetbrains.com/plugin/31360) — JetBrains' experimental plugin that adds JCEF to Android Studio
+- [Web Browser (JCEF) marketplace plugin](https://plugins.jetbrains.com/plugin/31360) — JetBrains' plugin that adds JCEF to Android Studio
+- [JetBrains announcement: Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/es/README.md
+++ b/docs/troubleshooting/es/README.md
@@ -13,7 +13,7 @@ Cada documento incluye los síntomas, la causa, cómo solucionarlo y enlaces a l
 | Documento | Cuándo consultarlo |
 |---|---|
 | [Portapapeles en Wayland](wayland-clipboard.md) | Cuando pegar en el campo de chat falla en Linux · Wayland · KDE Plasma |
-| [Runtime JCEF de Android Studio](android-studio-jcef.md) | Cuando Android Studio muestra un panel informativo en lugar del chat, o una ventana en blanco |
+| [JCEF en Android Studio](android-studio-jcef.md) | Cuando Android Studio muestra un panel informativo o una excepción en lugar del chat, o una ventana en blanco |
 
 ## Si tu problema no está aquí
 

--- a/docs/troubleshooting/es/android-studio-jcef.md
+++ b/docs/troubleshooting/es/android-studio-jcef.md
@@ -1,19 +1,95 @@
-# La ventana de chat no aparece en Android Studio (runtime JCEF)
+# La ventana de chat no aparece en Android Studio (JCEF)
 
 🌐 [English](../en/android-studio-jcef.md) | [한국어](../ko/android-studio-jcef.md) | [日本語](../ja/android-studio-jcef.md) | [中文](../zh/android-studio-jcef.md) | **Español** | [Deutsch](../de/android-studio-jcef.md) | [Français](../fr/android-studio-jcef.md)
 
 _Última actualización: 2026-08-22_
 
-## Síntomas
+Este plugin dibuja su interfaz de chat sobre **JCEF** (Chromium Embedded Framework). A diferencia de otros IDE de JetBrains, Android Studio no incluye JCEF de forma predeterminada, por lo que puede aparecer un panel informativo en lugar del chat.
 
-Al abrir el plugin en Android Studio aparece un panel informativo en lugar de la interfaz de chat.
+**La solución cambia por completo según la versión de Android Studio.** Compruebe primero la suya (**Help → About**).
 
-Después de cambiar el runtime, puede ocurrir una de estas dos cosas.
+| Su versión | Vaya a |
+|---|---|
+| **2026.2 o posterior** (Rabbit) | [2026.2 y posteriores: instale el plugin](#20262-y-posteriores-instale-el-plugin) |
+| **2026.1.3 – 2026.1.x** | [2026.1: cambie el runtime](#20261-cambie-el-runtime) |
+| **2026.1.2 o anterior** | [2026.1.2 y anteriores: no hay combinación que funcione](#202612-y-anteriores-no-hay-combinación-que-funcione) |
+
+---
+
+## 2026.2 y posteriores: instale el plugin
+
+### Síntomas
+
+Al abrir el chat aparece un panel informativo o, en versiones antiguas del plugin, se lanza una excepción. En `idea.log` encontrará:
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+Más arriba en el registro también aparece:
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### Causa
+
+**Desde 2026.2, JCEF salió del núcleo del IDE y pasó a ser un plugin aparte.** No se eliminó: cambió de sitio.
+
+JetBrains incluye ese plugin en sus propios IDE, pero **Android Studio no lo incluye**. Por eso las clases `com.intellij.ui.jcef` no existen en ninguna parte del IDE.
+
+Lo importante: **cambiar el runtime no sirve de nada.** El JetBrains Runtime aporta únicamente `org.cef.*`; `com.intellij.ui.jcef` es código de la plataforma y debe venir del IDE. Arrancar con un runtime con JCEF da el mismo resultado.
+
+### Cómo solucionarlo
+
+1. Abra **Settings → Plugins → Marketplace**
+2. Busque **Web Browser (JCEF)** — el de **JetBrains**
+3. Instálelo y reinicie el IDE
+
+Tras reiniciar, el chat aparece con normalidad. Puede dejar el runtime tal como estaba.
+
+> Página del Marketplace: [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### Combinaciones verificadas
+
+| Android Studio | Estado inicial | Con Web Browser (JCEF) |
+|---|---|---|
+| **2026.2.1 Canary 2** (AI-262.9437) | Panel informativo (las versiones antiguas del plugin fallan) | **Funciona con normalidad** — sin cambiar el runtime |
+
+---
+
+## 2026.1: cambie el runtime
+
+### Síntomas
+
+Aparece un panel informativo en lugar de la interfaz de chat.
+
+### Causa
+
+El JetBrains Runtime (JBR) que acompaña a Android Studio no incluye JCEF. En 2026.1, JCEF todavía forma parte del núcleo del IDE, así que **cambiar a un runtime con JCEF lo resuelve.**
+
+### Cómo solucionarlo
+
+1. Asegúrese de que Android Studio sea **2026.1.3 o posterior** (para 2026.1.2 y anteriores, vea la sección siguiente)
+2. Abra Find Action: `Cmd+Shift+A` (macOS) o `Ctrl+Shift+A` (Windows/Linux)
+3. Ejecute **Choose Boot Java Runtime for the IDE…**
+4. Elija un runtime cuyo nombre contenga **JCEF**
+5. Reinicie el IDE cuando termine la instalación
+
+El botón del panel informativo del plugin abre ese mismo diálogo.
+
+---
+
+## 2026.1.2 y anteriores: no hay combinación que funcione
+
+### Síntomas
+
+Después de cambiar el runtime ocurre una de estas dos cosas.
 
 - Android Studio no arranca en absoluto
-- Arranca, pero la ventana del plugin está completamente en blanco: ni panel informativo ni mensaje de error
+- Arranca, pero la ventana del plugin queda completamente en blanco: ni panel informativo ni mensaje de error
 
-Cuando la ventana queda en blanco, `idea.log` contiene:
+Cuando la ventana está en blanco, `idea.log` contiene:
 
 ```
 java.lang.NoSuchMethodError:
@@ -21,55 +97,35 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## Causa
+### Causa
 
-El JetBrains Runtime (JBR) que viene con Android Studio **no incluye JCEF** (Chromium Embedded Framework).
+- Esas versiones se ejecutan sobre Java 21 e incluyen su propia copia de `JCefAppConfig`
+- Si elige un **JBR 21** con JCEF, el módulo del runtime tapa esa copia. El `JCefAppConfig` de JBR 21 no tiene el método `isRemoteEnabled()` que la plataforma invoca, así que el navegador nunca se crea y la ventana se queda en blanco
+- **JBR 25** sí tiene ese método, pero 2026.1.2 y anteriores no arrancan sobre Java 25. El Security Manager se eliminó en Java 24 y esas versiones todavía intentan activarlo
 
-La interfaz de este plugin se dibuja sobre JCEF, así que con el runtime por defecto aparece un panel informativo en vez de la pantalla de chat.
+Android Studio **2026.1.3** pasó su runtime incluido de Java 21 a Java 25, lo que resuelve el problema.
 
-Hasta aquí, cambiar a un runtime con JCEF lo resuelve.
+### Cómo solucionarlo
 
-Sin embargo, **en Android Studio 2026.1.2 y anteriores no existe ninguna combinación que funcione.**
+Actualice Android Studio a **2026.1.3 o posterior**.
 
-- Esas versiones corren sobre Java 21 e incluyen su propia `JCefAppConfig`
-- Si eliges una **JBR 21** con JCEF, el módulo del runtime tapa esa copia incluida. La `JCefAppConfig` de JBR 21 no tiene el método `isRemoteEnabled()` que la plataforma invoca. El navegador nunca se crea y la ventana se queda en blanco
-- **JBR 25** sí tiene ese método, pero 2026.1.2 y anteriores no pueden arrancar sobre Java 25. El Security Manager se eliminó en Java 24 y esas compilaciones siguen intentando activarlo
+### Combinaciones verificadas
 
-Android Studio **2026.1.3** cambió su runtime incluido de Java 21 a Java 25, lo que resuelve el problema.
-
-## Combinaciones verificadas
-
-| Android Studio | JBR incluida | JBR 21 con JCEF | JBR 25 con JCEF |
+| Android Studio | JBR incluido | JBR 21 con JCEF | JBR 25 con JCEF |
 |---|---|---|---|
 | 2026.1.1 Patch 2 | Java 21 — solo panel informativo | Ventana en blanco | No arranca |
 | 2026.1.2 | Java 21 — solo panel informativo | Ventana en blanco | No arranca |
 | **2026.1.3** | **Java 25** | — | **Funciona con normalidad** |
 
-## Cómo solucionarlo
-
-1. Actualiza Android Studio a **2026.1.3 o posterior**
-2. Abre Find Action: `Cmd+Shift+A` (macOS) o `Ctrl+Shift+A` (Windows/Linux)
-3. Ejecuta **Choose Boot Java Runtime for the IDE…**
-4. Elige un runtime cuyo nombre contenga **JCEF**
-5. Reinicia el IDE cuando termine la instalación
-
-El botón **Switch Runtime** del panel informativo del plugin abre el mismo diálogo.
+---
 
 ## Si el IDE no arranca tras cambiar el runtime
 
-Elimina el archivo `studio.jdk` del directorio de configuración de Android Studio para restaurar el runtime por defecto.
+Elimine el archivo `studio.jdk` de la carpeta de configuración de Android Studio para volver al runtime predeterminado.
 
 - **macOS**: `~/Library/Application Support/Google/AndroidStudio<versión>/studio.jdk`
 - **Linux**: `~/.config/Google/AndroidStudio<versión>/studio.jdk`
 - **Windows**: `%APPDATA%\Google\AndroidStudio<versión>\studio.jdk`
-
-## Cuándo dejará de ocurrir
-
-En abril de 2025 JetBrains publicó un plugin experimental llamado [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360).
-
-Lleva JCEF a Android Studio 2026.1 Nightly y posteriores.
-
-Cuando sea estable, el cambio de runtime descrito arriba dejará de ser necesario.
 
 ## Enlaces relacionados
 
@@ -81,10 +137,12 @@ Cuando sea estable, el cambio de runtime descrito arriba dejará de ser necesari
 
 ### Pull requests de este repositorio
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
 ### Referencias externas
 
-- [Plugin Web Browser (JCEF) en el Marketplace](https://plugins.jetbrains.com/plugin/31360) — el plugin experimental de JetBrains que añade JCEF a Android Studio
+- [Plugin Web Browser (JCEF) en el Marketplace](https://plugins.jetbrains.com/plugin/31360) — el plugin de JetBrains que añade JCEF a Android Studio
+- [Anuncio de JetBrains: Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/fr/README.md
+++ b/docs/troubleshooting/fr/README.md
@@ -13,7 +13,7 @@ Chaque document présente les symptômes, la cause, la solution et des liens ver
 | Document | À consulter quand |
 |---|---|
 | [Presse-papiers Wayland](wayland-clipboard.md) | Le collage dans le champ de chat échoue sous Linux · Wayland · KDE Plasma |
-| [Runtime JCEF d'Android Studio](android-studio-jcef.md) | Android Studio affiche un panneau d'information au lieu du chat, ou une fenêtre vide |
+| [JCEF dans Android Studio](android-studio-jcef.md) | Android Studio affiche un panneau d'information ou une exception au lieu du chat, ou une fenêtre vide |
 
 ## Si votre problème ne figure pas ici
 

--- a/docs/troubleshooting/fr/android-studio-jcef.md
+++ b/docs/troubleshooting/fr/android-studio-jcef.md
@@ -1,19 +1,95 @@
-# La fenêtre de chat n'apparaît pas dans Android Studio (runtime JCEF)
+# La fenêtre de chat n'apparaît pas dans Android Studio (JCEF)
 
 🌐 [English](../en/android-studio-jcef.md) | [한국어](../ko/android-studio-jcef.md) | [日本語](../ja/android-studio-jcef.md) | [中文](../zh/android-studio-jcef.md) | [Español](../es/android-studio-jcef.md) | [Deutsch](../de/android-studio-jcef.md) | **Français**
 
 _Dernière mise à jour : 2026-08-22_
 
-## Symptômes
+Ce plugin dessine son interface de chat sur **JCEF** (Chromium Embedded Framework). Contrairement aux autres IDE JetBrains, Android Studio n'embarque pas JCEF par défaut : un panneau d'information peut donc s'afficher à la place du chat.
 
-À l'ouverture du plugin dans Android Studio, un panneau d'information s'affiche à la place de l'interface de chat.
+**La solution diffère complètement selon la version d'Android Studio.** Vérifiez d'abord la vôtre (**Help → About**).
 
-Après avoir changé de runtime, l'une de ces deux choses peut se produire.
+| Votre version | Aller à |
+|---|---|
+| **2026.2 ou ultérieure** (Rabbit) | [2026.2 et ultérieures : installez le plugin](#20262-et-ultérieures--installez-le-plugin) |
+| **2026.1.3 – 2026.1.x** | [2026.1 : changez de runtime](#20261--changez-de-runtime) |
+| **2026.1.2 ou antérieure** | [2026.1.2 et antérieures : aucune combinaison ne fonctionne](#202612-et-antérieures--aucune-combinaison-ne-fonctionne) |
 
-- Android Studio ne démarre plus du tout
-- Il démarre, mais la fenêtre du plugin est entièrement vide : ni panneau d'information, ni message d'erreur
+---
 
-Lorsque la fenêtre est vide, `idea.log` contient :
+## 2026.2 et ultérieures : installez le plugin
+
+### Symptômes
+
+À l'ouverture du chat, un panneau d'information s'affiche ; avec les anciennes versions du plugin, une exception est levée. `idea.log` contient :
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+Plus haut dans le journal figure également :
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### Cause
+
+**Depuis 2026.2, JCEF a quitté le cœur de l'IDE pour devenir un plugin distinct.** Il n'a pas été supprimé : il a changé d'adresse.
+
+JetBrains fournit ce plugin avec ses propres IDE, mais **Android Studio ne l'embarque pas**. Les classes `com.intellij.ui.jcef` sont donc totalement absentes de l'IDE.
+
+Le point important : **changer de runtime n'y change rien.** Le JetBrains Runtime ne fournit que `org.cef.*` ; `com.intellij.ui.jcef` relève du code de la plateforme et doit venir de l'IDE. Démarrer avec un runtime doté de JCEF donne le même résultat.
+
+### Comment le résoudre
+
+1. Ouvrez **Settings → Plugins → Marketplace**
+2. Recherchez **Web Browser (JCEF)** — celui de **JetBrains**
+3. Installez-le et redémarrez l'IDE
+
+Après le redémarrage, le chat s'affiche normalement. Vous pouvez laisser le runtime par défaut.
+
+> Page du Marketplace : [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### Combinaisons vérifiées
+
+| Android Studio | État d'origine | Avec Web Browser (JCEF) |
+|---|---|---|
+| **2026.2.1 Canary 2** (AI-262.9437) | Panneau d'information (les anciennes versions du plugin échouent) | **Fonctionne normalement** — sans changer de runtime |
+
+---
+
+## 2026.1 : changez de runtime
+
+### Symptômes
+
+Un panneau d'information s'affiche à la place de l'interface de chat.
+
+### Cause
+
+Le JetBrains Runtime (JBR) livré avec Android Studio ne contient pas JCEF. Sur 2026.1, JCEF fait encore partie du cœur de l'IDE : **passer à un runtime doté de JCEF résout donc le problème.**
+
+### Comment le résoudre
+
+1. Assurez-vous qu'Android Studio est en **2026.1.3 ou ultérieure** (pour 2026.1.2 et antérieures, voir la section suivante)
+2. Ouvrez Find Action : `Cmd+Shift+A` (macOS) ou `Ctrl+Shift+A` (Windows/Linux)
+3. Exécutez **Choose Boot Java Runtime for the IDE…**
+4. Choisissez un runtime dont le nom contient **JCEF**
+5. Redémarrez l'IDE une fois l'installation terminée
+
+Le bouton du panneau d'information du plugin ouvre la même boîte de dialogue.
+
+---
+
+## 2026.1.2 et antérieures : aucune combinaison ne fonctionne
+
+### Symptômes
+
+Après avoir changé de runtime, l'une de ces deux choses se produit.
+
+- Android Studio ne démarre pas du tout
+- Il démarre, mais la fenêtre du plugin reste entièrement vide — ni panneau d'information, ni message d'erreur
+
+Quand la fenêtre est vide, `idea.log` contient :
 
 ```
 java.lang.NoSuchMethodError:
@@ -21,57 +97,37 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## Cause
-
-Le JetBrains Runtime (JBR) livré avec Android Studio **ne contient pas JCEF** (Chromium Embedded Framework).
-
-L'interface de ce plugin est dessinée sur JCEF, c'est pourquoi le runtime par défaut affiche un panneau d'information au lieu de l'écran de chat.
-
-Jusque-là, passer à un runtime doté de JCEF résout le problème.
-
-Cependant, **sur Android Studio 2026.1.2 et antérieur, aucune combinaison ne fonctionne.**
+### Cause
 
 - Ces versions tournent sur Java 21 et embarquent leur propre `JCefAppConfig`
-- Si vous choisissez une **JBR 21** avec JCEF, le module du runtime masque cette copie embarquée. La `JCefAppConfig` de JBR 21 ne possède pas la méthode `isRemoteEnabled()` que la plateforme appelle. Le navigateur n'est jamais créé et la fenêtre reste vide
-- **JBR 25** possède bien cette méthode, mais 2026.1.2 et antérieur ne peuvent pas démarrer sur Java 25. Le Security Manager a été supprimé dans Java 24, et ces builds tentent toujours de l'activer
+- Si vous choisissez un **JBR 21** doté de JCEF, le module du runtime masque cette copie embarquée. Le `JCefAppConfig` de JBR 21 ne possède pas la méthode `isRemoteEnabled()` que la plateforme appelle : le navigateur n'est jamais créé et la fenêtre reste vide
+- **JBR 25** possède bien cette méthode, mais 2026.1.2 et antérieures ne démarrent pas sur Java 25. Le Security Manager a été retiré dans Java 24, et ces versions tentent encore de l'activer
 
-Android Studio **2026.1.3** a fait passer son runtime embarqué de Java 21 à Java 25, ce qui résout le problème.
+Android Studio **2026.1.3** a fait passer son runtime embarqué de Java 21 à Java 25, ce qui règle la question.
 
-## Combinaisons vérifiées
+### Comment le résoudre
 
-| Android Studio | JBR embarquée | JBR 21 avec JCEF | JBR 25 avec JCEF |
+Mettez Android Studio à jour vers **2026.1.3 ou ultérieure**.
+
+### Combinaisons vérifiées
+
+| Android Studio | JBR embarqué | JBR 21 avec JCEF | JBR 25 avec JCEF |
 |---|---|---|---|
-| 2026.1.1 Patch 2 | Java 21 — panneau d'information seulement | Fenêtre vide | Ne démarre pas |
-| 2026.1.2 | Java 21 — panneau d'information seulement | Fenêtre vide | Ne démarre pas |
+| 2026.1.1 Patch 2 | Java 21 — panneau d'information seul | Fenêtre vide | Ne démarre pas |
+| 2026.1.2 | Java 21 — panneau d'information seul | Fenêtre vide | Ne démarre pas |
 | **2026.1.3** | **Java 25** | — | **Fonctionne normalement** |
 
-## Comment le corriger
+---
 
-1. Mettez Android Studio à jour vers **2026.1.3 ou une version ultérieure**
-2. Ouvrez Find Action : `Cmd+Shift+A` (macOS) ou `Ctrl+Shift+A` (Windows/Linux)
-3. Lancez **Choose Boot Java Runtime for the IDE…**
-4. Choisissez un runtime dont le nom contient **JCEF**
-5. Redémarrez l'IDE une fois l'installation terminée
+## Si l'IDE ne démarre plus après un changement de runtime
 
-Le bouton **Switch Runtime** du panneau d'information du plugin ouvre la même boîte de dialogue.
-
-## Si l'IDE ne démarre plus après le changement de runtime
-
-Supprimez le fichier `studio.jdk` du répertoire de configuration d'Android Studio pour rétablir le runtime par défaut.
+Supprimez le fichier `studio.jdk` du dossier de configuration d'Android Studio pour rétablir le runtime par défaut.
 
 - **macOS** : `~/Library/Application Support/Google/AndroidStudio<version>/studio.jdk`
 - **Linux** : `~/.config/Google/AndroidStudio<version>/studio.jdk`
 - **Windows** : `%APPDATA%\Google\AndroidStudio<version>\studio.jdk`
 
-## Quand cela disparaîtra-t-il
-
-JetBrains a publié en avril 2025 un plugin expérimental nommé [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360).
-
-Il apporte JCEF à Android Studio 2026.1 Nightly et aux versions ultérieures.
-
-Une fois qu'il sera stable, le changement de runtime décrit ci-dessus ne sera plus nécessaire.
-
-## Liens associés
+## Liens connexes
 
 ### Issues de ce dépôt
 
@@ -81,10 +137,12 @@ Une fois qu'il sera stable, le changement de runtime décrit ci-dessus ne sera p
 
 ### Pull requests de ce dépôt
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
 ### Références externes
 
-- [Plugin Web Browser (JCEF) sur le Marketplace](https://plugins.jetbrains.com/plugin/31360) — le plugin expérimental de JetBrains qui ajoute JCEF à Android Studio
+- [Plugin Web Browser (JCEF) sur le Marketplace](https://plugins.jetbrains.com/plugin/31360) — le plugin JetBrains qui ajoute JCEF à Android Studio
+- [Annonce JetBrains : Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/ja/README.md
+++ b/docs/troubleshooting/ja/README.md
@@ -13,7 +13,7 @@ _最終更新: 2026-08-22_
 | 文書 | こんなときに |
 |---|---|
 | [Wayland のクリップボード](wayland-clipboard.md) | Linux · Wayland · KDE Plasma でチャット入力欄に貼り付けができないとき |
-| [Android Studio の JCEF ランタイム](android-studio-jcef.md) | Android Studio でチャット画面の代わりに案内パネルが出る、またはウィンドウが空のとき |
+| [Android Studio の JCEF](android-studio-jcef.md) | Android Studio でチャット画面の代わりに案内パネルや例外が出る、またはウィンドウが空のとき |
 
 ## ここにない問題の場合
 

--- a/docs/troubleshooting/ja/android-studio-jcef.md
+++ b/docs/troubleshooting/ja/android-studio-jcef.md
@@ -1,19 +1,95 @@
-# Android Studio でチャット画面が表示されません（JCEF ランタイム）
+# Android Studio でチャット画面が表示されません（JCEF）
 
 🌐 [English](../en/android-studio-jcef.md) | [한국어](../ko/android-studio-jcef.md) | **日本語** | [中文](../zh/android-studio-jcef.md) | [Español](../es/android-studio-jcef.md) | [Deutsch](../de/android-studio-jcef.md) | [Français](../fr/android-studio-jcef.md)
 
 _最終更新: 2026-08-22_
 
-## 症状
+このプラグインのチャット UI は **JCEF**（Chromium Embedded Framework）の上に描画されます。Android Studio は他の JetBrains IDE と違って JCEF を標準では含んでいないため、チャットの代わりに案内パネルが表示されることがあります。
 
-Android Studio でプラグインを開くと、チャット UI ではなく案内パネルが表示されます。
+**解決方法は Android Studio のバージョンによってまったく異なります。** まずご自分のバージョンをご確認ください（**Help → About**）。
 
-ランタイムを切り替えたあとは、次のいずれかが起こることがあります。
+| お使いのバージョン | 参照先 |
+|---|---|
+| **2026.2 以降**（Rabbit） | [2026.2 以降: プラグインをインストールしてください](#20262-以降-プラグインをインストールしてください) |
+| **2026.1.3 〜 2026.1.x** | [2026.1: ランタイムを切り替えてください](#20261-ランタイムを切り替えてください) |
+| **2026.1.2 以前** | [2026.1.2 以前: 動作する組み合わせがありません](#202612-以前-動作する組み合わせがありません) |
+
+---
+
+## 2026.2 以降: プラグインをインストールしてください
+
+### 症状
+
+チャットを開くと案内パネルが表示されます。古いバージョンのプラグインでは例外が発生します。`idea.log` には次のような内容が残ります。
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+ログの前の方には、こちらも記録されています。
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### 原因
+
+**2026.2 から、JCEF が IDE 本体から独立したプラグインに分離されました。** なくなったのではなく、置き場所が変わったということです。
+
+JetBrains は自社の IDE にはこのプラグインを同梱していますが、**Android Studio には同梱されていません。** そのため `com.intellij.ui.jcef` のクラスが IDE のどこにも存在しない状態になります。
+
+ここで大切なのは、**ランタイムを切り替えても解決しない**という点です。JetBrains Runtime が提供するのは `org.cef.*` のみで、プラットフォームのコードである `com.intellij.ui.jcef` は IDE 側から来る必要があるからです。JCEF 入りのランタイムで起動しても結果は同じです。
+
+### 解決方法
+
+1. **Settings → Plugins → Marketplace** を開きます
+2. **Web Browser (JCEF)** を検索します（提供元が **JetBrains** のもの）
+3. インストールして IDE を再起動します
+
+再起動するとチャットが正常に表示されます。ランタイムは標準のままで構いません。
+
+> Marketplace ページ: [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### 確認済みの組み合わせ
+
+| Android Studio | 標準の状態 | Web Browser (JCEF) 導入後 |
+|---|---|---|
+| **2026.2.1 Canary 2**（AI-262.9437） | 案内パネル（古いプラグインでは例外） | **正常に動作** — ランタイムの交換は不要 |
+
+---
+
+## 2026.1: ランタイムを切り替えてください
+
+### 症状
+
+チャット UI の代わりに案内パネルが表示されます。
+
+### 原因
+
+Android Studio に同梱されている JetBrains Runtime（JBR）に JCEF が含まれていません。2026.1 では JCEF はまだ IDE 本体に入っているため、**JCEF 入りのランタイムに切り替えれば解決します。**
+
+### 解決方法
+
+1. Android Studio が **2026.1.3 以降**であることをご確認ください（2026.1.2 以前は下の項目をご覧ください）
+2. Find Action を開きます。`Cmd+Shift+A`（macOS）または `Ctrl+Shift+A`（Windows/Linux）
+3. **Choose Boot Java Runtime for the IDE…** を実行します
+4. 名前に **JCEF** が含まれるランタイムを選びます
+5. インストールが終わったら IDE を再起動します
+
+プラグインの案内パネルにあるボタンからも同じダイアログが開きます。
+
+---
+
+## 2026.1.2 以前: 動作する組み合わせがありません
+
+### 症状
+
+ランタイムを切り替えたあと、次のいずれかが起こります。
 
 - Android Studio がまったく起動しません
 - 起動はするものの、プラグインのウィンドウが完全に空です。案内パネルもエラーメッセージもありません
 
-ウィンドウが空の場合、`idea.log` に次の内容が残ります。
+ウィンドウが空の場合、`idea.log` には次のような内容が残ります。
 
 ```
 java.lang.NoSuchMethodError:
@@ -21,55 +97,35 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## 原因
-
-Android Studio に標準で含まれる JetBrains Runtime（JBR）には、**JCEF**（Chromium Embedded Framework）が含まれていません。
-
-このプラグインの UI は JCEF の上に描画されるため、標準のランタイムではチャット画面ではなく案内パネルが表示されます。
-
-ここまでは、JCEF を含むランタイムに切り替えれば解決します。
-
-ただし、**Android Studio 2026.1.2 以前では動作する組み合わせが存在しません。**
+### 原因
 
 - 2026.1.2 以前は Java 21 上で動作し、独自の `JCefAppConfig` を同梱しています
-- JCEF を含む **JBR 21** を選ぶと、ランタイム側のモジュールがそれを覆い隠します。JBR 21 の `JCefAppConfig` には、プラットフォームが呼び出す `isRemoteEnabled()` メソッドがありません。そのためブラウザが生成されず、ウィンドウが空のままになります
-- **JBR 25** にはそのメソッドがありますが、2026.1.2 以前は Java 25 では起動できません。Java 24 で Security Manager が削除されたにもかかわらず、これらのビルドはそれを有効にしようとするためです
+- JCEF 入りの **JBR 21** を選ぶと、ランタイム側のモジュールが同梱分を覆い隠します。JBR 21 の `JCefAppConfig` には、プラットフォームが呼び出す `isRemoteEnabled()` メソッドがありません。そのためブラウザーが生成されず、ウィンドウが空のままになります
+- **JBR 25** にはそのメソッドがありますが、2026.1.2 以前は Java 25 では起動できません。Java 24 で Security Manager が削除されたのに、これらのビルドはまだそれを有効にしようとするためです
 
-Android Studio **2026.1.3** が標準ランタイムを Java 21 から Java 25 に移したことで、この問題は解消されました。
+Android Studio **2026.1.3** が標準ランタイムを Java 21 から Java 25 へ移行したことで、この問題は解消しました。
 
-## 確認された組み合わせ
+### 解決方法
 
-| Android Studio | 標準 JBR | JCEF 入り JBR 21 | JCEF 入り JBR 25 |
+Android Studio を **2026.1.3 以降**に更新してください。
+
+### 確認済みの組み合わせ
+
+| Android Studio | 標準の JBR | JCEF 入り JBR 21 | JCEF 入り JBR 25 |
 |---|---|---|---|
 | 2026.1.1 Patch 2 | Java 21 — 案内パネルのみ | 空のウィンドウ | 起動失敗 |
 | 2026.1.2 | Java 21 — 案内パネルのみ | 空のウィンドウ | 起動失敗 |
-| **2026.1.3** | **Java 25** | — | **正常動作** |
+| **2026.1.3** | **Java 25** | — | **正常に動作** |
 
-## 解決方法
-
-1. Android Studio を **2026.1.3 以降**に更新してください
-2. Find Action を開きます。`Cmd+Shift+A`（macOS）または `Ctrl+Shift+A`（Windows/Linux）
-3. **Choose Boot Java Runtime for the IDE…** を実行します
-4. 一覧から名前に **JCEF** が含まれるランタイムを選びます
-5. インストールが終わったら IDE を再起動します
-
-プラグインの案内パネルにある **Switch Runtime** ボタンを押しても、同じダイアログが開きます。
+---
 
 ## ランタイムを切り替えたあと IDE が起動しない場合
 
-Android Studio の設定フォルダから `studio.jdk` ファイルを削除すると、標準のランタイムに戻ります。
+Android Studio の設定フォルダーから `studio.jdk` ファイルを削除すると、標準のランタイムに戻ります。
 
 - **macOS**: `~/Library/Application Support/Google/AndroidStudio<バージョン>/studio.jdk`
 - **Linux**: `~/.config/Google/AndroidStudio<バージョン>/studio.jdk`
 - **Windows**: `%APPDATA%\Google\AndroidStudio<バージョン>\studio.jdk`
-
-## いつ解消されますか
-
-JetBrains は 2025 年 4 月に、[**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360) という実験的なマーケットプレイスプラグインを公開しました。
-
-Android Studio 2026.1 Nightly 以降に JCEF を追加するプラグインです。
-
-これが安定すれば、上記のランタイム切り替え自体が不要になります。
 
 ## 関連リンク
 
@@ -79,12 +135,14 @@ Android Studio 2026.1 Nightly 以降に JCEF を追加するプラグインで�
 - [#295 — Blank chat window on Android Studio 2026.1.2 and earlier](https://github.com/Swttch/swttch/issues/295)
 - [#34 — Plugin not working in Android Studio (JCEF not bundled with default JBR)](https://github.com/Swttch/swttch/issues/34)
 
-### このリポジトリの PR
+### このリポジトリの Pull Request
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
-### 外部の参考情報
+### 外部の参考資料
 
-- [Web Browser (JCEF) マーケットプレイスプラグイン](https://plugins.jetbrains.com/plugin/31360) — Android Studio に JCEF を追加する JetBrains の実験的なプラグイン
+- [Web Browser (JCEF) Marketplace プラグイン](https://plugins.jetbrains.com/plugin/31360) — Android Studio に JCEF を追加する JetBrains のプラグイン
+- [JetBrains のお知らせ: Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/ko/README.md
+++ b/docs/troubleshooting/ko/README.md
@@ -13,7 +13,7 @@ _최종 업데이트: 2026-08-22_
 | 문서 | 이런 경우에 보세요 |
 |---|---|
 | [Wayland 클립보드](wayland-clipboard.md) | Linux · Wayland · KDE Plasma 에서 채팅 입력창에 붙여넣기가 안 될 때 |
-| [Android Studio JCEF 런타임](android-studio-jcef.md) | Android Studio 에서 채팅 화면 대신 안내 패널이 뜨거나 창이 비어 있을 때 |
+| [Android Studio JCEF](android-studio-jcef.md) | Android Studio 에서 채팅 화면 대신 안내 패널이나 예외가 뜨거나, 창이 비어 있을 때 |
 
 ## 여기에 없는 문제라면
 

--- a/docs/troubleshooting/ko/android-studio-jcef.md
+++ b/docs/troubleshooting/ko/android-studio-jcef.md
@@ -1,14 +1,90 @@
-# Android Studio 에서 채팅 화면이 안 뜹니다 (JCEF 런타임)
+# Android Studio 에서 채팅 화면이 안 뜹니다 (JCEF)
 
 🌐 [English](../en/android-studio-jcef.md) | **한국어** | [日本語](../ja/android-studio-jcef.md) | [中文](../zh/android-studio-jcef.md) | [Español](../es/android-studio-jcef.md) | [Deutsch](../de/android-studio-jcef.md) | [Français](../fr/android-studio-jcef.md)
 
 _최종 업데이트: 2026-08-22_
 
-## 증상
+이 플러그인의 채팅 UI 는 **JCEF**(Chromium Embedded Framework) 위에서 그려집니다. Android Studio 는 다른 JetBrains IDE 들과 달리 JCEF 를 기본으로 담고 있지 않아서, 채팅 대신 안내 패널이 나오는 일이 생깁니다.
 
-Android Studio 에서 플러그인을 열면 채팅 UI 대신 안내 패널이 나옵니다.
+해결 방법이 **Android Studio 버전에 따라 완전히 다릅니다.** 먼저 본인 버전을 확인해주세요 (**Help → About**).
 
-런타임을 바꾼 뒤에는 다음 중 하나가 일어날 수 있어요.
+| 사용 중인 버전 | 보셔야 할 곳 |
+|---|---|
+| **2026.2 이상** (Rabbit) | [2026.2 이상: 플러그인을 설치하세요](#20262-이상-플러그인을-설치하세요) |
+| **2026.1.3 ~ 2026.1.x** | [2026.1: 런타임을 바꾸세요](#20261-런타임을-바꾸세요) |
+| **2026.1.2 이하** | [2026.1.2 이하: 되는 조합이 없습니다](#202612-이하-되는-조합이-없습니다) |
+
+---
+
+## 2026.2 이상: 플러그인을 설치하세요
+
+### 증상
+
+채팅을 열면 안내 패널이 나오거나, 예전 버전의 플러그인에서는 예외가 발생합니다. `idea.log` 에 이런 내용이 남습니다.
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+로그 앞부분에는 이런 줄도 있습니다.
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### 원인
+
+**2026.2 부터 JCEF 가 IDE 본체에서 별도 플러그인으로 분리되었습니다.** 없어진 게 아니라 자리를 옮긴 것입니다.
+
+JetBrains 자사 IDE 들은 이 플러그인을 기본으로 함께 담지만, **Android Studio 는 담지 않습니다.** 그래서 `com.intellij.ui.jcef` 클래스들이 IDE 어디에도 없는 상태가 됩니다.
+
+여기서 중요한 점은 **런타임을 바꿔도 해결되지 않는다**는 것입니다. JetBrains Runtime 이 제공하는 것은 `org.cef.*` 뿐이고, 플랫폼 코드인 `com.intellij.ui.jcef` 는 IDE 쪽에 있어야 하기 때문입니다. JCEF 가 포함된 런타임으로 부팅해봐도 결과는 똑같습니다.
+
+### 해결 방법
+
+1. **Settings → Plugins → Marketplace** 를 엽니다
+2. **Web Browser (JCEF)** 를 검색합니다 (제작사가 **JetBrains** 인 것)
+3. 설치하고 IDE 를 재시작합니다
+
+재시작하면 채팅이 정상적으로 뜹니다. 런타임은 기본 그대로 두셔도 됩니다.
+
+> 마켓플레이스 페이지: [Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### 확인된 조합
+
+| Android Studio | 기본 상태 | Web Browser (JCEF) 설치 후 |
+|---|---|---|
+| **2026.2.1 Canary 2** (AI-262.9437) | 안내 패널 (구버전 플러그인은 예외 발생) | **정상 동작** — 런타임 교체 불필요 |
+
+---
+
+## 2026.1: 런타임을 바꾸세요
+
+### 증상
+
+채팅 UI 대신 안내 패널이 나옵니다.
+
+### 원인
+
+Android Studio 에 기본으로 들어있는 JetBrains Runtime(JBR)에 JCEF 가 포함되어 있지 않습니다. 2026.1 대에서는 JCEF 가 아직 IDE 본체에 들어있으므로, **JCEF 가 포함된 런타임으로 바꾸면 해결됩니다.**
+
+### 해결 방법
+
+1. Android Studio 가 **2026.1.3 이상**인지 확인해주세요 (2026.1.2 이하는 아래 항목을 보세요)
+2. Find Action 을 엽니다. `Cmd+Shift+A` (macOS) 또는 `Ctrl+Shift+A` (Windows/Linux)
+3. **Choose Boot Java Runtime for the IDE…** 를 실행합니다
+4. 목록에서 이름에 **JCEF** 가 들어간 런타임을 고릅니다
+5. 설치가 끝나면 IDE 를 재시작합니다
+
+플러그인 안내 패널의 버튼을 누르셔도 같은 대화상자가 열립니다.
+
+---
+
+## 2026.1.2 이하: 되는 조합이 없습니다
+
+### 증상
+
+런타임을 바꾼 뒤 다음 중 하나가 일어납니다.
 
 - Android Studio 가 아예 실행되지 않습니다
 - 실행은 되지만 플러그인 창이 완전히 비어 있습니다. 안내 패널도, 에러 메시지도 없습니다
@@ -21,15 +97,7 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## 원인
-
-Android Studio 에 기본으로 들어있는 JetBrains Runtime(JBR)에는 **JCEF**(Chromium Embedded Framework)가 포함되어 있지 않습니다.
-
-이 플러그인의 UI 는 JCEF 위에서 그려지기 때문에, 기본 런타임에서는 채팅 화면 대신 안내 패널이 나옵니다.
-
-여기까지는 JCEF 가 들어있는 런타임으로 바꾸면 해결됩니다.
-
-다만 **Android Studio 2026.1.2 이하에서는 되는 조합이 아예 없습니다.**
+### 원인
 
 - 2026.1.2 이하는 Java 21 위에서 동작하고, 자체 `JCefAppConfig` 를 함께 담고 있습니다
 - JCEF 가 포함된 **JBR 21** 을 고르면 런타임 쪽 모듈이 그것을 가려버리는데, JBR 21 의 `JCefAppConfig` 에는 플랫폼이 호출하는 `isRemoteEnabled()` 메서드가 없습니다. 그래서 브라우저 생성이 실패하고 창이 빈 채로 남습니다
@@ -37,7 +105,11 @@ Android Studio 에 기본으로 들어있는 JetBrains Runtime(JBR)에는 **JCEF
 
 Android Studio **2026.1.3** 이 기본 런타임을 Java 21 에서 Java 25 로 옮기면서 이 문제가 풀렸습니다.
 
-## 확인된 조합
+### 해결 방법
+
+Android Studio 를 **2026.1.3 이상**으로 업데이트해주세요.
+
+### 확인된 조합
 
 | Android Studio | 기본 JBR | JCEF 포함 JBR 21 | JCEF 포함 JBR 25 |
 |---|---|---|---|
@@ -45,15 +117,7 @@ Android Studio **2026.1.3** 이 기본 런타임을 Java 21 에서 Java 25 로 �
 | 2026.1.2 | Java 21 — 안내 패널만 | 빈 창 | 부팅 실패 |
 | **2026.1.3** | **Java 25** | — | **정상 동작** |
 
-## 해결 방법
-
-1. Android Studio 를 **2026.1.3 이상**으로 업데이트해주세요
-2. Find Action 을 엽니다. `Cmd+Shift+A` (macOS) 또는 `Ctrl+Shift+A` (Windows/Linux)
-3. **Choose Boot Java Runtime for the IDE…** 를 실행합니다
-4. 목록에서 이름에 **JCEF** 가 들어간 런타임을 고릅니다
-5. 설치가 끝나면 IDE 를 재시작합니다
-
-플러그인 안내 패널의 **Switch Runtime** 버튼을 누르셔도 같은 대화상자가 열립니다.
+---
 
 ## 런타임을 바꾼 뒤 IDE 가 실행되지 않는다면
 
@@ -62,14 +126,6 @@ Android Studio 설정 폴더에서 `studio.jdk` 파일을 지우면 기본 런�
 - **macOS**: `~/Library/Application Support/Google/AndroidStudio<버전>/studio.jdk`
 - **Linux**: `~/.config/Google/AndroidStudio<버전>/studio.jdk`
 - **Windows**: `%APPDATA%\Google\AndroidStudio<버전>\studio.jdk`
-
-## 언제 없어지나요
-
-JetBrains 가 2025년 4월에 [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360) 라는 실험적인 마켓플레이스 플러그인을 내놓았습니다.
-
-Android Studio 2026.1 Nightly 이상에 JCEF 를 넣어주는 플러그인이에요.
-
-이것이 안정화되면 위의 런타임 교체 자체가 필요 없어집니다.
 
 ## 관련 링크
 
@@ -81,10 +137,12 @@ Android Studio 2026.1 Nightly 이상에 JCEF 를 넣어주는 플러그인이에
 
 ### 이 저장소의 PR
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
 ### 외부 참고
 
-- [Web Browser (JCEF) 마켓플레이스 플러그인](https://plugins.jetbrains.com/plugin/31360) — Android Studio 에 JCEF 를 추가하는 JetBrains 의 실험적 플러그인
+- [Web Browser (JCEF) 마켓플레이스 플러그인](https://plugins.jetbrains.com/plugin/31360) — Android Studio 에 JCEF 를 추가하는 JetBrains 의 플러그인
+- [JetBrains 공지: Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/docs/troubleshooting/zh/README.md
+++ b/docs/troubleshooting/zh/README.md
@@ -13,7 +13,7 @@ _最后更新：2026-08-22_
 | 文档 | 什么时候看 |
 |---|---|
 | [Wayland 剪贴板](wayland-clipboard.md) | 在 Linux · Wayland · KDE Plasma 上无法向聊天输入框粘贴时 |
-| [Android Studio JCEF 运行时](android-studio-jcef.md) | Android Studio 显示引导面板而不是聊天界面，或者窗口空白时 |
+| [Android Studio JCEF](android-studio-jcef.md) | Android Studio 显示引导面板或抛出异常而不是聊天界面，或者窗口空白时 |
 
 ## 如果这里没有您遇到的问题
 

--- a/docs/troubleshooting/zh/android-studio-jcef.md
+++ b/docs/troubleshooting/zh/android-studio-jcef.md
@@ -1,19 +1,95 @@
-# 在 Android Studio 上聊天界面不显示（JCEF 运行时）
+# 在 Android Studio 上聊天界面不显示（JCEF）
 
 🌐 [English](../en/android-studio-jcef.md) | [한국어](../ko/android-studio-jcef.md) | [日本語](../ja/android-studio-jcef.md) | **中文** | [Español](../es/android-studio-jcef.md) | [Deutsch](../de/android-studio-jcef.md) | [Français](../fr/android-studio-jcef.md)
 
 _最后更新：2026-08-22_
 
-## 症状
+本插件的聊天界面绘制在 **JCEF**（Chromium Embedded Framework）之上。与其他 JetBrains IDE 不同，Android Studio 默认不包含 JCEF，因此可能会显示引导面板而不是聊天界面。
 
-在 Android Studio 中打开插件时，显示的是引导面板而不是聊天界面。
+**解决方法因 Android Studio 版本而完全不同。** 请先确认您的版本（**Help → About**）。
 
-切换运行时之后，可能会出现下面两种情况之一。
+| 您的版本 | 请查看 |
+|---|---|
+| **2026.2 及以上**（Rabbit） | [2026.2 及以上：安装插件](#20262-及以上安装插件) |
+| **2026.1.3 – 2026.1.x** | [2026.1：切换运行时](#20261切换运行时) |
+| **2026.1.2 及以下** | [2026.1.2 及以下：没有可用的组合](#202612-及以下没有可用的组合) |
+
+---
+
+## 2026.2 及以上：安装插件
+
+### 症状
+
+打开聊天时显示引导面板；在旧版插件上则会抛出异常。`idea.log` 中会有：
+
+```
+java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+```
+
+在日志靠前的位置还能看到：
+
+```
+plugin com.intellij.modules.jcef is not resolved
+```
+
+### 原因
+
+**从 2026.2 起，JCEF 从 IDE 主体中分离为一个独立插件。** 它没有被移除，只是换了位置。
+
+JetBrains 在自家 IDE 中捆绑了这个插件，但 **Android Studio 并未捆绑**。因此 `com.intellij.ui.jcef` 这些类在 IDE 中完全不存在。
+
+关键在于：**切换运行时并不能解决问题。** JetBrains Runtime 只提供 `org.cef.*`，而属于平台代码的 `com.intellij.ui.jcef` 必须由 IDE 提供。即使用带 JCEF 的运行时启动，结果也一样。
+
+### 解决方法
+
+1. 打开 **Settings → Plugins → Marketplace**
+2. 搜索 **Web Browser (JCEF)**（提供方为 **JetBrains** 的那个）
+3. 安装后重启 IDE
+
+重启之后聊天界面即可正常显示。运行时保持默认即可。
+
+> Marketplace 页面：[Web Browser (JCEF)](https://plugins.jetbrains.com/plugin/31360)
+
+### 已验证的组合
+
+| Android Studio | 默认状态 | 安装 Web Browser (JCEF) 后 |
+|---|---|---|
+| **2026.2.1 Canary 2**（AI-262.9437） | 引导面板（旧版插件会抛异常） | **正常工作** — 无需更换运行时 |
+
+---
+
+## 2026.1：切换运行时
+
+### 症状
+
+显示引导面板而不是聊天界面。
+
+### 原因
+
+Android Studio 自带的 JetBrains Runtime（JBR）不包含 JCEF。在 2026.1 上，JCEF 仍属于 IDE 主体，因此**切换到带 JCEF 的运行时即可解决**。
+
+### 解决方法
+
+1. 请确认 Android Studio 为 **2026.1.3 或更高版本**（2026.1.2 及以下请看下一节）
+2. 打开 Find Action：`Cmd+Shift+A`（macOS）或 `Ctrl+Shift+A`（Windows/Linux）
+3. 执行 **Choose Boot Java Runtime for the IDE…**
+4. 选择名称中含有 **JCEF** 的运行时
+5. 安装完成后重启 IDE
+
+插件引导面板上的按钮也会打开同一个对话框。
+
+---
+
+## 2026.1.2 及以下：没有可用的组合
+
+### 症状
+
+切换运行时之后，会出现下面两种情况之一。
 
 - Android Studio 完全无法启动
-- 能够启动，但插件窗口完全空白 —— 既没有引导面板，也没有错误提示
+- 能启动，但插件窗口完全空白 —— 既没有引导面板，也没有错误信息
 
-窗口空白时，`idea.log` 中会留下这样的内容。
+窗口空白时，`idea.log` 中会有：
 
 ```
 java.lang.NoSuchMethodError:
@@ -21,55 +97,35 @@ java.lang.NoSuchMethodError:
 	at com.intellij.ui.jcef.JBCefApp.<init>(JBCefApp.java:142)
 ```
 
-## 原因
+### 原因
 
-Android Studio 自带的 JetBrains Runtime（JBR）**不包含 JCEF**（Chromium Embedded Framework）。
+- 这些版本运行在 Java 21 上，并自带了一份 `JCefAppConfig`
+- 若选择带 JCEF 的 **JBR 21**，运行时模块会遮蔽自带的那一份。而 JBR 21 中的 `JCefAppConfig` 没有平台所调用的 `isRemoteEnabled()` 方法，浏览器因此无法创建，窗口保持空白
+- **JBR 25** 有这个方法，但 2026.1.2 及以下无法在 Java 25 上启动。Java 24 移除了 Security Manager，而这些构建仍试图启用它
 
-本插件的界面绘制在 JCEF 之上，所以在默认运行时下会显示引导面板而不是聊天界面。
+Android Studio **2026.1.3** 将自带运行时从 Java 21 迁移到 Java 25，从而解决了这个问题。
 
-到这一步为止，切换到包含 JCEF 的运行时即可解决。
+### 解决方法
 
-但是，**在 Android Studio 2026.1.2 及更早版本上不存在可用的组合。**
+请将 Android Studio 更新到 **2026.1.3 或更高版本**。
 
-- 这些版本运行在 Java 21 上，并且自带了一份 `JCefAppConfig`
-- 如果选择包含 JCEF 的 **JBR 21**，运行时模块会遮蔽自带的那一份。而 JBR 21 中的 `JCefAppConfig` 没有平台会调用的 `isRemoteEnabled()` 方法，因此浏览器无法创建，窗口保持空白
-- **JBR 25** 有这个方法，但 2026.1.2 及更早版本无法在 Java 25 上启动。Java 24 移除了 Security Manager，而这些构建仍然试图启用它
+### 已验证的组合
 
-Android Studio **2026.1.3** 将自带运行时从 Java 21 换成了 Java 25，从而解决了这个问题。
-
-## 已验证的组合
-
-| Android Studio | 自带 JBR | 含 JCEF 的 JBR 21 | 含 JCEF 的 JBR 25 |
+| Android Studio | 自带 JBR | 带 JCEF 的 JBR 21 | 带 JCEF 的 JBR 25 |
 |---|---|---|---|
 | 2026.1.1 Patch 2 | Java 21 — 仅引导面板 | 空白窗口 | 启动失败 |
 | 2026.1.2 | Java 21 — 仅引导面板 | 空白窗口 | 启动失败 |
 | **2026.1.3** | **Java 25** | — | **正常工作** |
 
-## 解决方法
+---
 
-1. 请将 Android Studio 更新到 **2026.1.3 或更高版本**
-2. 打开 Find Action：`Cmd+Shift+A`（macOS）或 `Ctrl+Shift+A`（Windows/Linux）
-3. 执行 **Choose Boot Java Runtime for the IDE…**
-4. 在列表中选择名称包含 **JCEF** 的运行时
-5. 安装完成后重启 IDE
+## 切换运行时后 IDE 无法启动
 
-点击插件引导面板上的 **Switch Runtime** 按钮也会打开同一个对话框。
-
-## 切换运行时后 IDE 无法启动时
-
-从 Android Studio 配置目录中删除 `studio.jdk` 文件，即可恢复默认运行时。
+删除 Android Studio 配置目录中的 `studio.jdk` 文件即可恢复默认运行时。
 
 - **macOS**：`~/Library/Application Support/Google/AndroidStudio<版本>/studio.jdk`
 - **Linux**：`~/.config/Google/AndroidStudio<版本>/studio.jdk`
 - **Windows**：`%APPDATA%\Google\AndroidStudio<版本>\studio.jdk`
-
-## 什么时候会解决
-
-JetBrains 在 2025 年 4 月发布了一个名为 [**Web Browser (JCEF)**](https://plugins.jetbrains.com/plugin/31360) 的实验性插件。
-
-它能为 Android Studio 2026.1 Nightly 及更高版本提供 JCEF。
-
-等它稳定之后，上面的运行时切换就不再需要了。
 
 ## 相关链接
 
@@ -79,12 +135,14 @@ JetBrains 在 2025 年 4 月发布了一个名为 [**Web Browser (JCEF)**](https
 - [#295 — Blank chat window on Android Studio 2026.1.2 and earlier](https://github.com/Swttch/swttch/issues/295)
 - [#34 — Plugin not working in Android Studio (JCEF not bundled with default JBR)](https://github.com/Swttch/swttch/issues/34)
 
-### 本仓库的 PR
+### 本仓库的 Pull Request
 
+- [#327 — Keep the chat panel loadable on an IDE without JCEF](https://github.com/Swttch/swttch/pull/327)
 - [#296 — Explain the JCEF runtime mismatch instead of leaving a blank panel](https://github.com/Swttch/swttch/pull/296)
 - [#83 — fix: detect out-of-process JCEF via CefApp, not a system property](https://github.com/Swttch/swttch/pull/83)
 - [#65 — fix: defer JBCefBrowser creation to avoid JCEF StartupTest race](https://github.com/Swttch/swttch/pull/65)
 
 ### 外部参考
 
-- [Web Browser (JCEF) 插件页面](https://plugins.jetbrains.com/plugin/31360) — JetBrains 为 Android Studio 添加 JCEF 的实验性插件
+- [Web Browser (JCEF) Marketplace 插件](https://plugins.jetbrains.com/plugin/31360) — JetBrains 为 Android Studio 添加 JCEF 的插件
+- [JetBrains 公告：Experimental JCEF Web Browser API support for Android Studio](https://platform.jetbrains.com/t/experimental-jcef-web-browser-api-support-for-android-studio/4117)

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/notifications/JcefRuntimeNotifier.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/notifications/JcefRuntimeNotifier.kt
@@ -1,6 +1,8 @@
 package com.github.yhk1038.claudecodegui.notifications
 
 import com.github.yhk1038.claudecodegui.platform.PlatformActionInvoker
+import com.github.yhk1038.claudecodegui.toolwindow.JcefAvailability
+import com.intellij.ide.BrowserUtil
 import com.intellij.notification.Notification
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationGroupManager
@@ -11,10 +13,12 @@ import java.util.Collections
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Displays a sticky warning notification when JCEF is not available in the current runtime.
+ * Displays a sticky warning notification when JCEF cannot host the chat.
  *
- * Provides a "Switch Runtime" action button that triggers the IDE's built-in
- * "Choose Boot Java Runtime" dialog so the user can switch to a JBR with JCEF.
+ * Mirrors [com.github.yhk1038.claudecodegui.toolwindow.JcefUnavailablePanel]: the
+ * two ways JCEF can be missing need opposite instructions, and this notification
+ * sits next to that panel on screen. Left saying "switch runtime" on an IDE where
+ * the runtime is a dead end, it would quietly undo the panel's advice (issue #321).
  *
  * Each project receives at most one notification per IDE session (deduplication via [notifiedProjects]).
  */
@@ -23,25 +27,47 @@ object JcefRuntimeNotifier {
     private val notifiedProjects: MutableSet<Project> =
         Collections.newSetFromMap(ConcurrentHashMap<Project, Boolean>())
 
-    fun notify(project: Project) {
+    fun notify(project: Project, availability: JcefAvailability = JcefAvailability.RUNTIME_UNSUPPORTED) {
         if (!notifiedProjects.add(project)) return  // already notified for this project
 
-        val notification = NotificationGroupManager.getInstance()
-            .getNotificationGroup("claude-code-gui.jcef-runtime")
-            .createNotification(
-                "JCEF runtime not available",
-                "Claude Code GUI needs JCEF to render its chat UI. Click to install a JCEF-enabled runtime.",
-                NotificationType.WARNING
-            )
-            .addAction(object : NotificationAction("Install JCEF Runtime") {
-                override fun actionPerformed(e: AnActionEvent, n: Notification) {
-                    // PlatformActionInvoker handles the 2024.3+ modern API vs 2024.2 legacy
-                    // fallback internally, so this call site stays free of deprecated symbols.
-                    PlatformActionInvoker.invokeActionByIdFromEvent("ChooseRuntime", e, "JcefRuntimeNotifier")
-                    n.expire()
-                }
-            })
+        val notification = if (availability == JcefAvailability.CLASSES_ABSENT) {
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup(GROUP_ID)
+                .createNotification(
+                    "This IDE does not include JCEF",
+                    "Claude Code GUI draws its chat on JCEF, which moved into a separate JetBrains " +
+                        "plugin in 2026.2. Install <b>Web Browser (JCEF)</b> from the marketplace and " +
+                        "restart — changing the boot runtime will not help.",
+                    NotificationType.WARNING
+                )
+                .addAction(object : NotificationAction("Open the Web Browser (JCEF) page") {
+                    override fun actionPerformed(e: AnActionEvent, n: Notification) {
+                        BrowserUtil.browse(JCEF_PLUGIN_URL)
+                        n.expire()
+                    }
+                })
+        } else {
+            NotificationGroupManager.getInstance()
+                .getNotificationGroup(GROUP_ID)
+                .createNotification(
+                    "JCEF runtime not available",
+                    "Claude Code GUI needs JCEF to render its chat UI. Click to install a JCEF-enabled runtime.",
+                    NotificationType.WARNING
+                )
+                .addAction(object : NotificationAction("Install JCEF Runtime") {
+                    override fun actionPerformed(e: AnActionEvent, n: Notification) {
+                        // PlatformActionInvoker handles the 2024.3+ modern API vs 2024.2 legacy
+                        // fallback internally, so this call site stays free of deprecated symbols.
+                        PlatformActionInvoker.invokeActionByIdFromEvent("ChooseRuntime", e, "JcefRuntimeNotifier")
+                        n.expire()
+                    }
+                })
+        }
 
         notification.notify(project)
     }
+
+    private const val GROUP_ID = "claude-code-gui.jcef-runtime"
+
+    private const val JCEF_PLUGIN_URL = "https://plugins.jetbrains.com/plugin/31360"
 }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -1,5 +1,7 @@
 package com.github.yhk1038.claudecodegui.services
 
+import com.github.yhk1038.claudecodegui.toolwindow.JcefAvailability
+import com.github.yhk1038.claudecodegui.toolwindow.resolveJcefAvailability
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.Service
@@ -232,15 +234,26 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
      * LinkageError also covers the runtime-mismatch shape from issue #295, where
      * the classes exist but disagree with the platform's own copy.
      */
-    fun isJcefAvailable(): Boolean {
-        if (java.lang.Boolean.getBoolean("claude.simulate.no.jcef")) return false
-        return try {
-            JBCefApp.isSupported()
-        } catch (e: LinkageError) {
-            logger.warn("JCEF classes are not loadable in this runtime — treating JCEF as unavailable", e)
-            false
+    fun isJcefAvailable(): Boolean = jcefAvailability().isUsable
+
+    /**
+     * Why JCEF cannot host the chat, for callers that have to explain it.
+     *
+     * [isJcefAvailable] answers whether to build a browser; this answers which
+     * fallback screen to show. The two failures need opposite instructions —
+     * a 2026.1 user swaps runtime, a 2026.2 user installs a plugin — so the
+     * reason is kept rather than flattened into a boolean (issue #321).
+     *
+     * The `JBCefApp.isSupported()` call lives here, inside a lambda body, which
+     * is the one place allowed to name a class that may be absent: bodies
+     * resolve lazily, so the reference costs nothing until this runs.
+     */
+    fun jcefAvailability(): JcefAvailability =
+        resolveJcefAvailability { JBCefApp.isSupported() }.also { availability ->
+            if (availability == JcefAvailability.CLASSES_ABSENT) {
+                logger.warn("JCEF classes are not loadable in this runtime — treating JCEF as unavailable")
+            }
         }
-    }
 
     /**
      * Acquire a browser holder for the tab: reuse an unoccupied pooled holder if

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/services/ClaudeCodeBrowserService.kt
@@ -221,10 +221,25 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
      *
      * Cheap to call — does NOT initialize CefApp (only [JBCefApp.isSupported]
      * is consulted, which is a capability probe, not a builder).
+     *
+     * `isSupported()` answers whether JCEF *works*; it presupposes the JCEF
+     * classes are loadable at all. On Android Studio 2026.2 Canary they are not —
+     * `com.intellij.modules.jcef` fails to resolve, so this plugin's class loader
+     * has no `com.intellij.ui.jcef` package and the call itself raises
+     * NoClassDefFoundError (issue #321). Catching Error here is what lets the
+     * guard answer "unavailable" rather than propagate, so callers can fall back
+     * to [com.github.yhk1038.claudecodegui.toolwindow.JcefUnavailablePanel].
+     * LinkageError also covers the runtime-mismatch shape from issue #295, where
+     * the classes exist but disagree with the platform's own copy.
      */
     fun isJcefAvailable(): Boolean {
         if (java.lang.Boolean.getBoolean("claude.simulate.no.jcef")) return false
-        return JBCefApp.isSupported()
+        return try {
+            JBCefApp.isSupported()
+        } catch (e: LinkageError) {
+            logger.warn("JCEF classes are not loadable in this runtime — treating JCEF as unavailable", e)
+            false
+        }
     }
 
     /**
@@ -258,7 +273,10 @@ class ClaudeCodeBrowserService(private val project: Project) : Disposable {
             // show the mismatch panel.
             runCatching { createHolder() }
                 .onFailure { e ->
-                    if (e !is NoSuchMethodError && e !is NoClassDefFoundError) throw e
+                    // LinkageError covers both shapes: a method the runtime's JCEF
+                    // lacks (NoSuchMethodError, #295) and a JCEF class the class
+                    // loader cannot see at all (NoClassDefFoundError, #321).
+                    if (e !is LinkageError) throw e
                     logger.warn("JCEF runtime is incompatible with this IDE — cannot create browser for tab: $tabId", e)
                 }
                 .getOrNull()

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -182,12 +182,15 @@ class ClaudeCodePanel(
     private var errorPanel: JPanel? = null
 
     init {
-        if (!browserService.isJcefAvailable()) {
+        val jcef = browserService.jcefAvailability()
+        if (!jcef.isUsable) {
             // JCEF unavailable (e.g. Android Studio without JCEF JBR). Fallback panel
             // shown immediately; no background realization will be scheduled.
-            add(JcefUnavailablePanel(), BorderLayout.CENTER)
-            logger.warn("JCEF is not supported in this runtime — showing fallback panel")
-            JcefRuntimeNotifier.notify(project)
+            // The reason is passed along: an absent-classes IDE and an unsupported
+            // runtime need opposite instructions (issue #321).
+            add(JcefUnavailablePanel(jcef), BorderLayout.CENTER)
+            logger.warn("JCEF is not usable in this runtime ($jcef) — showing fallback panel")
+            JcefRuntimeNotifier.notify(project, jcef)
         } else {
             // Browser realization is deferred until addNotify() + DumbService.runWhenSmart.
             // Show the indexing-wait placeholder so the user knows the tab is alive.

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanel.kt
@@ -35,8 +35,6 @@ import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
-import com.intellij.ui.jcef.JBCefBrowser
-import com.intellij.ui.jcef.JBCefJSQuery
 import com.intellij.util.ui.UIUtil
 import javax.swing.UIManager
 import kotlinx.coroutines.CancellationException
@@ -53,9 +51,7 @@ import kotlinx.serialization.json.put
 import kotlinx.serialization.json.putJsonArray
 import org.cef.browser.CefBrowser
 import org.cef.browser.CefFrame
-import org.cef.callback.CefDragData
 import org.cef.handler.CefDisplayHandlerAdapter
-import org.cef.handler.CefDragHandler
 import org.cef.handler.CefLifeSpanHandlerAdapter
 import org.cef.handler.CefLoadHandlerAdapter
 import org.cef.handler.CefRequestHandlerAdapter
@@ -105,9 +101,24 @@ class ClaudeCodePanel(
     // Returns null when JCEF is not supported (e.g. Android Studio without JCEF JBR).
     private val browserService = ClaudeCodeBrowserService.getInstance(project)
     private var holder: ClaudeCodeBrowserService.BrowserHolder? = null
-    private val browser: JBCefBrowser? get() = holder?.browser
-    private val cursorQuery: JBCefJSQuery? get() = holder?.cursorQuery
-    private val streamingQuery: JBCefJSQuery? get() = holder?.streamingQuery
+
+    // No `browser` / `cursorQuery` / `streamingQuery` accessors here, on purpose.
+    //
+    // A JCEF type in the SIGNATURE of any member — even a private one — makes this
+    // class impossible to instantiate on a runtime without JCEF. Constructing a
+    // Component runs Component.isCoalesceEventsOverriden(), which reflects over
+    // getDeclaredMethods() and resolves every signature; an absent JCEF class then
+    // throws NoClassDefFoundError from inside the JPanel constructor, before the
+    // isJcefAvailable() guard in init can run. Android Studio 2026.2 Canary ships
+    // without the jcef module, so its class loader has no JBCefJSQuery at all and
+    // opening the tool window threw (issue #321).
+    //
+    // Reflection ignores visibility, so `private` does not help, and writing the
+    // type fully-qualified does not either — the bytecode signature is the same.
+    // The JCEF objects are reached through `holder` inside method bodies instead,
+    // which keeps the class loadable so the guard can run and the fallback panel
+    // can be shown. `holder`'s own type is safe: a field type is resolved lazily,
+    // only when the field is actually read.
 
     // Set by installOsrRepaintNudge while an OSR browser is alive; null otherwise
     // (windowed rendering has no ghosts to clear, and there is nothing to nudge
@@ -322,14 +333,21 @@ class ClaudeCodePanel(
 
     // ─── Browser handlers (JCEF) ────────────────────────────────────
 
-    // Called only from realizeBrowser() — holder, browser, cursorQuery, streamingQuery are guaranteed non-null here.
+    // Called only from realizeBrowser() — the holder is guaranteed non-null here.
     private fun setupBrowserHandlers() {
-        val b = browser!!
-        val cq = cursorQuery!!
-        val sq = streamingQuery!!
+        val h = holder!!
+        val b = h.browser
+        val cq = h.cursorQuery
+        val sq = h.streamingQuery
+        // The lambdas below must not capture `b` or mention JBCefJSQuery.Response,
+        // or Kotlin lowers them into static methods ON THIS CLASS whose signatures
+        // name a JCEF type — which AWT resolves in the JPanel constructor, bringing
+        // back issue #321. Capturing the plain AWT component keeps them clean, and
+        // the Response values are built by JcefHandlers, outside this class.
+        val browserComponent: java.awt.Component = b.component
 
         // Handle CSS cursor changes from WebView
-        cq.addHandler { cursorName: String ->
+        JcefHandlers.onQuery(cq) { cursorName: String ->
             val javaCursorType = when (cursorName) {
                 "text" -> java.awt.Cursor.TEXT_CURSOR
                 "pointer" -> java.awt.Cursor.HAND_CURSOR
@@ -345,9 +363,8 @@ class ClaudeCodePanel(
                 else -> java.awt.Cursor.DEFAULT_CURSOR
             }
             javax.swing.SwingUtilities.invokeLater {
-                b.component.cursor = java.awt.Cursor.getPredefinedCursor(javaCursorType)
+                browserComponent.cursor = java.awt.Cursor.getPredefinedCursor(javaCursorType)
             }
-            JBCefJSQuery.Response(null)
         }
 
         // Handle streaming state changes from WebView.
@@ -356,13 +373,12 @@ class ClaudeCodePanel(
         // own: a second query would mean another field on the pooled BrowserHolder and
         // another object to keep alive across tab move/split, for a message that is
         // just "the page changed, push a frame".
-        sq.addHandler { state: String ->
+        JcefHandlers.onQuery(sq) { state: String ->
             if (state == "repaint") {
                 requestRepaintNudge?.invoke()
             } else {
                 holder!!.onStreamingStateChanged?.invoke(state == "streaming")
             }
-            JBCefJSQuery.Response(null)
         }
 
         // Inject scripts on page load
@@ -388,10 +404,14 @@ class ClaudeCodePanel(
                             0,
                         )
                     }
-                    injectCursorTracking(frame)
-                    injectStreamingStateBridge(frame)
+                    // These build the script text rather than injecting it themselves,
+                    // so that no member of ClaudeCodePanel takes a CefFrame — see the
+                    // note next to `holder` (issue #321). Injection happens here, inside
+                    // this anonymous handler, which is a class of its own.
+                    frame.executeJavaScript(cursorTrackingScript(), frame.url, 0)
+                    frame.executeJavaScript(streamingStateBridgeScript(), frame.url, 0)
                     // After the streaming bridge: the repaint reporter calls through it.
-                    injectRepaintNudgeBridge(frame)
+                    frame.executeJavaScript(repaintNudgeBridgeScript(), frame.url, 0)
                     installImeWorkaround()
                     logger.info("WebView loaded successfully")
                     // The webview (IDE-selection chip consumer) just reloaded, so
@@ -494,21 +514,14 @@ class ClaudeCodePanel(
         //      the backend replay the stashed paths back as NATIVE_DROP_ENTRIES.
         // Net effect: attach happens on drop (not on hover) AND uses the real
         // OS paths Kotlin received from CEF.
-        b.jbCefClient.addDragHandler(CefDragHandler { _, dragData, _ ->
-            if (dragData?.isFile == true) {
-                val names = java.util.Vector<String>()
-                dragData.getFileNames(names)
-                if (names.isNotEmpty()) {
-                    logger.debug("[NativeDrop] CefDragHandler.onDragEnter stashing ${names.size} file(s)")
-                    val files = names.map { path ->
-                        val file = File(path)
-                        DroppedFile(file.absolutePath, file.isDirectory)
-                    }
-                    dispatchNativeDrop(files)
-                }
+        JcefHandlers.onFileDrag(b) { paths ->
+            logger.debug("[NativeDrop] CefDragHandler.onDragEnter stashing ${paths.size} file(s)")
+            val files = paths.map { path ->
+                val file = File(path)
+                DroppedFile(file.absolutePath, file.isDirectory)
             }
-            false
-        }, b.cefBrowser)
+            dispatchNativeDrop(files)
+        }
 
         // Safety net: if a file:// navigation still slips through (e.g. via the JS layer),
         // cancel it before CEF's popup blocker jumps the tab to about:blank#blocked.
@@ -579,20 +592,21 @@ class ClaudeCodePanel(
     }
 
     /**
-     * Inject streaming state bridge so WebView can notify Kotlin of streaming changes
-     * via JBCefJSQuery instead of encoding state into document.title.
+     * Script for the streaming state bridge, so the WebView can notify Kotlin of
+     * streaming changes via JBCefJSQuery instead of encoding state into document.title.
      */
-    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — streamingQuery is non-null.
-    private fun injectStreamingStateBridge(frame: CefFrame) {
-        val js = """
+    // Returns the script instead of taking a CefFrame and injecting it, so this
+    // member's signature stays free of JCEF types — see the note next to `holder`
+    // (issue #321). Called only from the load handler, i.e. only once JCEF is
+    // present, which is what makes reading `holder!!` safe here.
+    private fun streamingStateBridgeScript(): String =
+        """
             (function() {
                 window.__notifyStreamingState = function(state) {
-                    ${streamingQuery!!.inject("state")}
+                    ${holder!!.streamingQuery.inject("state")}
                 };
             })();
         """.trimIndent()
-        frame.executeJavaScript(js, frame.url, 0)
-    }
 
     /**
      * Ask CEF for a fresh frame whenever the page talks to the backend.
@@ -618,8 +632,9 @@ class ClaudeCodePanel(
      * painted frame. No extra throttle — a timed gap here would reintroduce the
      * very delay this exists to remove.
      */
-    private fun injectRepaintNudgeBridge(frame: CefFrame) {
-        val js = """
+    // Returns the script rather than injecting it — see streamingStateBridgeScript.
+    private fun repaintNudgeBridgeScript(): String =
+        """
             (function() {
                 if (window.__repaintNudgeInstalled) return;
                 window.__repaintNudgeInstalled = true;
@@ -650,28 +665,24 @@ class ClaudeCodePanel(
                 window.addEventListener('scroll', report, { passive: true, capture: true });
             })();
         """.trimIndent()
-        frame.executeJavaScript(js, frame.url, 0)
-    }
 
     /**
-     * Inject cursor CSS tracking script into the loaded page.
+     * Script that tracks the page's CSS cursor and reports changes to Kotlin.
      */
-    // Called only from setupBrowserHandlers() which is only called from realizeBrowser() — cursorQuery is non-null.
-    private fun injectCursorTracking(frame: CefFrame) {
-        val js = """
+    // Returns the script rather than injecting it — see streamingStateBridgeScript.
+    private fun cursorTrackingScript(): String =
+        """
             (function() {
                 var lastCursor = '';
                 document.addEventListener('mouseover', function(e) {
                     var cursor = window.getComputedStyle(e.target).cursor;
                     if (cursor !== lastCursor) {
                         lastCursor = cursor;
-                        ${cursorQuery!!.inject("cursor")}
+                        ${holder!!.cursorQuery.inject("cursor")}
                     }
                 }, true);
             })();
         """.trimIndent()
-        frame.executeJavaScript(js, frame.url, 0)
-    }
 
     /**
      * JCEF IME NPE workaround.
@@ -682,7 +693,12 @@ class ClaudeCodePanel(
     private fun installImeWorkaround() {
         val h = holder!!
         if (h.imeWorkaroundInstalled) return
-        val b = browser!!
+        // Pull the plain AWT component out before the lambda below closes over it.
+        // Capturing the JBCefBrowser instead would put a JCEF type in the captured
+        // lambda's signature, and Kotlin compiles that lambda into a static method
+        // ON THIS CLASS — which AWT then resolves while the JPanel constructor runs,
+        // reintroducing issue #321. See the note next to `holder`.
+        val browserComponent: java.awt.Component = h.browser.component
 
         fun wrapListeners(component: java.awt.Component) {
             val listeners = component.inputMethodListeners
@@ -720,7 +736,7 @@ class ClaudeCodePanel(
         }
 
         javax.swing.SwingUtilities.invokeLater {
-            traverseAndWrap(b.component)
+            traverseAndWrap(browserComponent)
             h.imeWorkaroundInstalled = true
             logger.info("JCEF IME NPE workaround installed")
         }
@@ -941,8 +957,14 @@ class ClaudeCodePanel(
             connection.subscribe(
                 com.intellij.ide.ui.LafManagerListener.TOPIC,
                 com.intellij.ide.ui.LafManagerListener {
-                    val b = browser ?: return@LafManagerListener
+                    // Neither this lambda nor the nested invokeLater one may capture
+                    // a JBCefBrowser: Kotlin turns both into static methods on this
+                    // class, and a JCEF type in their signature is what issue #321
+                    // was. The holder is re-read inside instead — which is also more
+                    // correct, since the theme can change after a tab move swapped it.
+                    if (holder == null) return@LafManagerListener
                     ApplicationManager.getApplication().invokeLater {
+                        val current = holder ?: return@invokeLater
                         val newTheme = if (com.intellij.ui.JBColor.isBright()) "light" else "dark"
                         // Re-read the colors on every LAF change: this is what makes
                         // bundled presets, marketplace themes and hand-written custom
@@ -953,8 +975,7 @@ class ClaudeCodePanel(
                             (if (colorsJs.isNotEmpty()) markIdeColorsAvailableJs() + logIdeColorsJs() else "") +
                             "window.dispatchEvent(new Event('ide-theme-changed'));"
                         try {
-                            val cef = b.cefBrowser
-                            cef.executeJavaScript(js, cef.url, 0)
+                            JcefHandlers.executeJavaScript(current.browser, js)
                         } catch (e: Exception) {
                             logger.warn("Failed to propagate LAF change to WebView", e)
                         }
@@ -1023,7 +1044,7 @@ class ClaudeCodePanel(
         var loggedNudgePath = false
 
         fun nudge() {
-            val b = browser ?: return
+            val b = holder?.browser ?: return
             if (!b.component.isShowing) return
             val w = b.component.width
             val h = b.component.height
@@ -1080,7 +1101,10 @@ class ClaudeCodePanel(
         // (b) Throttled mouse-motion nudge: clear ghosts promptly during interaction,
         // but no more than once per REPAINT_NUDGE_MIN_GAP_NANOS so we don't re-frame
         // CEF on every pixel of movement.
-        val b = browser!!
+        // Plain AWT component, so the Disposable lambda below does not close over a
+        // JBCefBrowser — that would put a JCEF type in a static method generated on
+        // this class, which is issue #321.
+        val browserComponent: java.awt.Component = holder!!.browser.component
         var lastNudgeNanos = 0L
         val motionListener = object : java.awt.event.MouseMotionAdapter() {
             override fun mouseMoved(e: java.awt.event.MouseEvent?) {
@@ -1090,8 +1114,8 @@ class ClaudeCodePanel(
                 nudge()
             }
         }
-        b.component.addMouseMotionListener(motionListener)
-        Disposer.register(parent, Disposable { b.component.removeMouseMotionListener(motionListener) })
+        browserComponent.addMouseMotionListener(motionListener)
+        Disposer.register(parent, Disposable { browserComponent.removeMouseMotionListener(motionListener) })
 
         logger.info("OSR repaint nudge installed for tab: $tabId")
     }
@@ -1102,7 +1126,7 @@ class ClaudeCodePanel(
     // Called only from WebViewKeyboardHandler installed via realizeBrowser() — browser is non-null.
     private fun openDevTools() {
         try {
-            (browser!! as? com.intellij.ui.jcef.JBCefBrowserBase)?.openDevtools()
+            (holder!!.browser as? com.intellij.ui.jcef.JBCefBrowserBase)?.openDevtools()
                 ?: logger.warn("Failed to open DevTools: browser is not JBCefBrowserBase")
         } catch (e: Exception) {
             logger.error("Failed to open DevTools", e)
@@ -1112,7 +1136,8 @@ class ClaudeCodePanel(
     // ─── Native (Swing / IDE) drag-and-drop bridge ──────────────────
 
     private fun setupNativeDropBridge() {
-        val b = browser ?: return
+        // JComponent, not JBCefBrowser — see the note next to `holder` (issue #321).
+        val browserComponent: JComponent = holder?.browser?.component ?: return
         val dropTarget = object : DropTargetAdapter() {
             override fun dragEnter(event: DropTargetDragEvent) {
                 event.acceptDrag(DnDConstants.ACTION_COPY)
@@ -1136,9 +1161,9 @@ class ClaudeCodePanel(
             }
         }
         installDropTarget(this, dropTarget)
-        installDropTarget(b.component, dropTarget)
+        installDropTarget(browserComponent, dropTarget)
         installIdeaDnDTarget(this)
-        installIdeaDnDTarget(b.component as JComponent)
+        installIdeaDnDTarget(browserComponent)
     }
 
     private fun installDropTarget(component: Component, dropTarget: DropTargetAdapter) {
@@ -1333,8 +1358,8 @@ class ClaudeCodePanel(
         logger.info("Loading WebView from Node.js backend: $loggedUrl")
 
         javax.swing.SwingUtilities.invokeLater {
-            val b = browser!!
             val h = holder!!
+            val b = h.browser
             remove(loadingLabel)
             // Paint the Swing component with the IDE surface color so the JCEF
             // native first paint is not white. Heavyweight (non-OSR) mode limits
@@ -1764,7 +1789,7 @@ class ClaudeCodePanel(
         // The browser is owned by ClaudeCodeBrowserService and survives tab move/split.
         // It will be reattached when a new ClaudeCodePanel is created for the same session.
         // When holder is null (JCEF unavailable), browser was never added, so nothing to detach.
-        browser?.let { remove(it.component) }
+        holder?.let { remove(it.browser.component) }
 
         scope.coroutineContext[kotlinx.coroutines.Job]?.cancel()
         val acquiredHolder = holder

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessage.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessage.kt
@@ -1,0 +1,69 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import java.awt.event.ComponentAdapter
+import java.awt.event.ComponentEvent
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * Shared text layout for the panels shown in place of the chat when JCEF cannot
+ * host it — [JcefUnavailablePanel] and [JcefRuntimeMismatchPanel].
+ *
+ * Swing lays an HTML [JLabel] out at whatever width the markup asks for and lets
+ * the container clip the overflow. It never re-flows. Both panels asked for a
+ * fixed `width: 480px`, so docking the chat to the side — where the tool window
+ * is routinely narrower than that — cut every sentence off mid-word. These are
+ * the two screens whose only job is to explain why the chat is missing, so text
+ * the user cannot read defeats the point (issue #321).
+ *
+ * The width therefore has to follow the panel. An upper bound stays because the
+ * opposite extreme is just as unreadable: on a wide editor tab the same text
+ * would stretch into 1500px lines.
+ */
+internal const val FALLBACK_MESSAGE_MAX_WIDTH = 480
+
+/**
+ * Below this, wrapping breaks so many words that the text is unreadable anyway.
+ * Clipping the edge of an over-narrow panel is the lesser of the two.
+ */
+internal const val FALLBACK_MESSAGE_MIN_WIDTH = 180
+
+/**
+ * The width to lay the message out at inside a panel [panelWidth] wide whose
+ * border eats [horizontalInsets] pixels.
+ *
+ * [panelWidth] is 0 until the panel has been laid out, which is exactly when the
+ * label's initial text is built; the maximum is the best guess there, and the
+ * first `componentResized` corrects it.
+ */
+internal fun fallbackMessageWidth(panelWidth: Int, horizontalInsets: Int): Int {
+    if (panelWidth <= 0) return FALLBACK_MESSAGE_MAX_WIDTH
+    return (panelWidth - horizontalInsets)
+        .coerceIn(FALLBACK_MESSAGE_MIN_WIDTH, FALLBACK_MESSAGE_MAX_WIDTH)
+}
+
+/** Wraps [bodyHtml] in the centred, width-constrained document both panels use. */
+internal fun fallbackMessageHtml(bodyHtml: String, widthPx: Int): String =
+    "<html><div style='text-align:center; width: ${widthPx}px;'>$bodyHtml</div></html>"
+
+/**
+ * Points [label] at [bodyHtml] and keeps its width in step with this panel's.
+ *
+ * Re-flowing on resize rather than picking one width up front is what makes the
+ * text survive both a narrow docked tool window and a wide editor tab — the user
+ * can drag between the two at any time.
+ */
+internal fun JPanel.installReflowingMessage(label: JLabel, bodyHtml: String) {
+    fun reflow() {
+        val insets = this.insets
+        label.text = fallbackMessageHtml(
+            bodyHtml,
+            fallbackMessageWidth(width, insets.left + insets.right)
+        )
+    }
+
+    reflow()
+    addComponentListener(object : ComponentAdapter() {
+        override fun componentResized(e: ComponentEvent) = reflow()
+    })
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessage.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessage.kt
@@ -1,5 +1,6 @@
 package com.github.yhk1038.claudecodegui.toolwindow
 
+import java.awt.Dimension
 import java.awt.event.ComponentAdapter
 import java.awt.event.ComponentEvent
 import javax.swing.JLabel
@@ -29,6 +30,18 @@ internal const val FALLBACK_MESSAGE_MAX_WIDTH = 480
 internal const val FALLBACK_MESSAGE_MIN_WIDTH = 180
 
 /**
+ * Slack between the width we ask the markup for and the width the panel actually
+ * has.
+ *
+ * A `width: Npx` in Swing's HTML sizes the text block, not the rendered label:
+ * list indentation and element margins push the real preferred width past N. A
+ * first attempt handed the markup every available pixel and the text still
+ * clipped — measured at panelWidth=564, insets=80, so 480px of markup inside
+ * 484px of space, and the `<ol>` overhang ate the remaining 4px.
+ */
+internal const val FALLBACK_MESSAGE_GUTTER = 24
+
+/**
  * The width to lay the message out at inside a panel [panelWidth] wide whose
  * border eats [horizontalInsets] pixels.
  *
@@ -38,7 +51,7 @@ internal const val FALLBACK_MESSAGE_MIN_WIDTH = 180
  */
 internal fun fallbackMessageWidth(panelWidth: Int, horizontalInsets: Int): Int {
     if (panelWidth <= 0) return FALLBACK_MESSAGE_MAX_WIDTH
-    return (panelWidth - horizontalInsets)
+    return (panelWidth - horizontalInsets - FALLBACK_MESSAGE_GUTTER)
         .coerceIn(FALLBACK_MESSAGE_MIN_WIDTH, FALLBACK_MESSAGE_MAX_WIDTH)
 }
 
@@ -52,6 +65,18 @@ internal fun fallbackMessageHtml(bodyHtml: String, widthPx: Int): String =
  * Re-flowing on resize rather than picking one width up front is what makes the
  * text survive both a narrow docked tool window and a wide editor tab — the user
  * can drag between the two at any time.
+ *
+ * Pinning the label's width is the second half of the fix, and it takes all
+ * three size hints. A `JLabel` derives every one of them from its rendered HTML,
+ * so when that overshoots the column — which it does, hence the gutter — the
+ * layout honours the oversized *minimum* and lets the surplus hang off the right
+ * edge. Capping only the maximum leaves the minimum in charge and changes
+ * nothing; that was measured, with the heading itself clipped mid-word on a
+ * narrow tool window.
+ *
+ * The height still has to come from the text, so the hints are cleared before
+ * asking for the preferred size — otherwise the previous answer is echoed back
+ * and the panel keeps the height of whatever width it had last.
  */
 internal fun JPanel.installReflowingMessage(label: JLabel, bodyHtml: String) {
     fun reflow() {
@@ -60,6 +85,18 @@ internal fun JPanel.installReflowingMessage(label: JLabel, bodyHtml: String) {
             bodyHtml,
             fallbackMessageWidth(width, insets.left + insets.right)
         )
+
+        val available = width - insets.left - insets.right
+        if (available <= 0) return
+
+        label.minimumSize = null
+        label.preferredSize = null
+        label.maximumSize = null
+
+        val pinned = Dimension(available, label.preferredSize.height)
+        label.minimumSize = pinned
+        label.preferredSize = pinned
+        label.maximumSize = pinned
     }
 
     reflow()

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefAvailability.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefAvailability.kt
@@ -1,0 +1,81 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+/**
+ * Why the chat cannot be hosted — not merely that it cannot.
+ *
+ * Two IDEs fail the same check for opposite reasons and need opposite
+ * instructions, so collapsing them into one boolean produces advice that sends
+ * users somewhere useless (issue #321).
+ *
+ * This enum deliberately names no JCEF type. The panels that read it are
+ * `Component`s, and AWT resolves every member signature while their constructor
+ * runs — see [ClaudeCodePanelSignatureTest][com.github.yhk1038.claudecodegui.toolwindow]
+ * and the guard it protects.
+ */
+enum class JcefAvailability {
+    /** JCEF is present and the runtime can drive it. */
+    AVAILABLE,
+
+    /**
+     * The JCEF classes loaded, but this runtime cannot host a browser — either
+     * `isSupported()` said so, or the runtime's JCEF disagrees with the
+     * platform's own copy (issue #295).
+     *
+     * Fixable by choosing a JCEF-enabled boot runtime.
+     */
+    RUNTIME_UNSUPPORTED,
+
+    /**
+     * `com.intellij.ui.jcef` is not in the class loader at all.
+     *
+     * Android Studio 2026.2 moved JCEF out of the IDE core into the separate
+     * "Web Browser (JCEF)" marketplace plugin and does not bundle it. Verified
+     * on 2026.2.1 Canary 2: booting a fully JCEF-enabled JBR 25.0.3 leaves
+     * `com.intellij.modules.jcef` unresolved, because the runtime supplies
+     * `org.cef.*` while the missing `com.intellij.ui.jcef` is platform code the
+     * IDE has to carry. **Only installing that plugin fixes this.**
+     */
+    CLASSES_ABSENT;
+
+    val isUsable: Boolean get() = this == AVAILABLE
+}
+
+/** Developer-only escape hatch for reaching the fallback screens without a real IDE that lacks JCEF. */
+private const val SIMULATE_UNSUPPORTED_PROPERTY = "claude.simulate.no.jcef"
+
+/** As above, for the harder case — the panel that tells the user to install the plugin. */
+private const val SIMULATE_ABSENT_PROPERTY = "claude.simulate.absent.jcef"
+
+/**
+ * Classifies the outcome of [probe], which is expected to call
+ * `JBCefApp.isSupported()`.
+ *
+ * [probe] is a lambda rather than a direct call so this rule stays free of JCEF
+ * types and can be unit-tested — and so the caller, not this function, owns the
+ * one place that touches a class which may not exist.
+ *
+ * The two error shapes are not interchangeable:
+ *  - [NoClassDefFoundError] / [ClassNotFoundException] — the package is gone, so
+ *    no runtime choice brings it back → [JcefAvailability.CLASSES_ABSENT]
+ *  - any other [LinkageError] (notably [NoSuchMethodError], issue #295) — the
+ *    classes are there but mismatched, which a different runtime does fix
+ *    → [JcefAvailability.RUNTIME_UNSUPPORTED]
+ */
+internal fun resolveJcefAvailability(
+    simulateUnsupported: Boolean = java.lang.Boolean.getBoolean(SIMULATE_UNSUPPORTED_PROPERTY),
+    simulateAbsent: Boolean = java.lang.Boolean.getBoolean(SIMULATE_ABSENT_PROPERTY),
+    probe: () -> Boolean,
+): JcefAvailability {
+    if (simulateAbsent) return JcefAvailability.CLASSES_ABSENT
+    if (simulateUnsupported) return JcefAvailability.RUNTIME_UNSUPPORTED
+
+    return try {
+        if (probe()) JcefAvailability.AVAILABLE else JcefAvailability.RUNTIME_UNSUPPORTED
+    } catch (e: NoClassDefFoundError) {
+        JcefAvailability.CLASSES_ABSENT
+    } catch (e: ClassNotFoundException) {
+        JcefAvailability.CLASSES_ABSENT
+    } catch (e: LinkageError) {
+        JcefAvailability.RUNTIME_UNSUPPORTED
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefHandlers.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefHandlers.kt
@@ -1,0 +1,89 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import com.intellij.ui.jcef.JBCefBrowser
+import com.intellij.ui.jcef.JBCefJSQuery
+import org.cef.handler.CefDragHandler
+
+/**
+ * The small amount of JCEF glue that [ClaudeCodePanel] would otherwise have to
+ * spell out inline.
+ *
+ * It lives in its own class for one reason: **[ClaudeCodePanel] is a
+ * [javax.swing.JPanel], and a JPanel cannot afford to name JCEF types.**
+ * Constructing any [java.awt.Component] makes AWT call
+ * `Component.isCoalesceEventsOverriden()`, which reflects over
+ * `getDeclaredMethods()` and resolves every declared method's parameter and
+ * return types — including the private static methods Kotlin generates for
+ * lambdas. On Android Studio 2026.2 Canary, where `com.intellij.modules.jcef`
+ * fails to resolve and the plugin's class loader has no JCEF at all, any such
+ * signature makes the panel throw NoClassDefFoundError from inside the JPanel
+ * constructor, before its own `isJcefAvailable()` guard can run (issue #321).
+ *
+ * Moving the JCEF-typed lambdas here moves their generated signatures onto this
+ * class, which is not a Component and so is never reflected over at construction
+ * time. Nothing here is touched unless JCEF is present: every call site sits
+ * behind the panel's guard.
+ */
+internal object JcefHandlers {
+
+    /**
+     * Register [handler] on [query], adapting a plain `String -> Unit` callback to
+     * the JCEF handler signature.
+     *
+     * The point is where `JBCefJSQuery.Response` gets named. Written inline in the
+     * panel, the lambda returning a Response compiles to a static method on the
+     * panel whose descriptor names `JBCefJSQuery$Response`. Written here, that
+     * descriptor lands on this class instead.
+     *
+     * The reply is always an empty Response: these queries are one-way
+     * notifications from the page (cursor changes, streaming state), and the page
+     * does not read the result.
+     */
+    fun onQuery(query: JBCefJSQuery, handler: (String) -> Unit) {
+        query.addHandler { value: String ->
+            handler(value)
+            JBCefJSQuery.Response(null)
+        }
+    }
+
+    /**
+     * Run [js] in [browser]'s current page.
+     *
+     * Exists so callers can hand over a plain String and a holder instead of
+     * reaching through `browser.cefBrowser` themselves — doing that inside a
+     * lambda in the panel would capture a JCEF-typed value and leak it into the
+     * generated method's signature.
+     */
+    fun executeJavaScript(browser: JBCefBrowser, js: String) {
+        val cef = browser.cefBrowser
+        cef.executeJavaScript(js, cef.url, 0)
+    }
+
+    /**
+     * Register a file-drop listener on [browser]'s drag handler.
+     *
+     * CEF asks the embedder about every drag before it does anything of its own
+     * (download / navigate / open-in-new-tab). [onFilesDragged] receives the
+     * absolute OS paths of a file drag; everything else is ignored.
+     *
+     * Always answers `false`, letting CEF forward the drag to the page as normal
+     * HTML5 events — the paths stashed here are replayed later, on drop. Returning
+     * `true` would cancel CEF's handling and the attach would never happen.
+     *
+     * Here rather than in the panel for the usual reason: the lambda's signature
+     * names `CefDragData` and `CefBrowser`.
+     */
+    fun onFileDrag(browser: JBCefBrowser, onFilesDragged: (List<String>) -> Unit) {
+        browser.jbCefClient.addDragHandler(
+            CefDragHandler { _, dragData, _ ->
+                if (dragData?.isFile == true) {
+                    val names = java.util.Vector<String>()
+                    dragData.getFileNames(names)
+                    if (names.isNotEmpty()) onFilesDragged(names.toList())
+                }
+                false
+            },
+            browser.cefBrowser,
+        )
+    }
+}

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefRuntimeMismatchPanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefRuntimeMismatchPanel.kt
@@ -41,27 +41,11 @@ class JcefRuntimeMismatchPanel : JPanel(BorderLayout()) {
             alignmentX = Component.CENTER_ALIGNMENT
         }
 
-        val message = JLabel(
-            "<html><div style='text-align:center; width: 480px;'>" +
-            "<h2 style='margin-top:0;'>This IDE and its runtime disagree</h2>" +
-            "<p>The chat UI could not start because the selected JetBrains Runtime " +
-            "ships a version of JCEF that this IDE was not built against. The browser " +
-            "fails while it is being created, which is why this panel is here instead " +
-            "of the chat.</p>" +
-            "<p style='text-align:left;'><b>On Android Studio, update the IDE:</b></p>" +
-            "<ol style='text-align:left;'>" +
-            "<li>Update Android Studio to <b>2026.1.3 or later</b></li>" +
-            "<li>Open Find Action: <b>Cmd+Shift+A</b> (macOS) or <b>Ctrl+Shift+A</b> (Windows/Linux)</li>" +
-            "<li>Run <b>&quot;Choose Boot Java Runtime for the IDE&hellip;&quot;</b></li>" +
-            "<li>Pick a runtime whose name contains <b>JCEF</b>, then restart</li>" +
-            "</ol>" +
-            "<p>Selecting a different runtime on 2026.1.2 or earlier will not help — " +
-            "those versions have no working combination.</p>" +
-            "</div></html>"
-        ).apply {
+        val message = JLabel().apply {
             horizontalAlignment = SwingConstants.CENTER
             alignmentX = Component.CENTER_ALIGNMENT
         }
+        installReflowingMessage(message, MESSAGE_BODY)
 
         val details = HyperlinkLabel("Read the full explanation").apply {
             alignmentX = Component.CENTER_ALIGNMENT
@@ -78,6 +62,26 @@ class JcefRuntimeMismatchPanel : JPanel(BorderLayout()) {
     }
 
     companion object {
+        /**
+         * The document body, without the width-bearing wrapper — [installReflowingMessage]
+         * supplies that, and re-supplies it whenever the panel is resized.
+         */
+        private const val MESSAGE_BODY =
+            "<h2 style='margin-top:0;'>This IDE and its runtime disagree</h2>" +
+            "<p>The chat UI could not start because the selected JetBrains Runtime " +
+            "ships a version of JCEF that this IDE was not built against. The browser " +
+            "fails while it is being created, which is why this panel is here instead " +
+            "of the chat.</p>" +
+            "<p style='text-align:left;'><b>On Android Studio, update the IDE:</b></p>" +
+            "<ol style='text-align:left;'>" +
+            "<li>Update Android Studio to <b>2026.1.3 or later</b></li>" +
+            "<li>Open Find Action: <b>Cmd+Shift+A</b> (macOS) or <b>Ctrl+Shift+A</b> (Windows/Linux)</li>" +
+            "<li>Run <b>&quot;Choose Boot Java Runtime for the IDE&hellip;&quot;</b></li>" +
+            "<li>Pick a runtime whose name contains <b>JCEF</b>, then restart</li>" +
+            "</ol>" +
+            "<p>Selecting a different runtime on 2026.1.2 or earlier will not help — " +
+            "those versions have no working combination.</p>"
+
         private const val DETAILS_URL =
             "https://github.com/Swttch/swttch/blob/main/docs/troubleshooting/en/android-studio-jcef.md"
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefUnavailablePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefUnavailablePanel.kt
@@ -35,26 +35,11 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
             alignmentX = Component.CENTER_ALIGNMENT
         }
 
-        val message = JLabel(
-            "<html><div style='text-align:center; width: 480px;'>" +
-            "<h2 style='margin-top:0;'>Claude Code GUI needs JCEF</h2>" +
-            "<p>This IDE is running without JCEF, which Claude Code GUI requires " +
-            "to render its chat UI. Click below to install a JCEF-enabled JetBrains " +
-            "Runtime — the IDE will download and apply it automatically, then ask you " +
-            "to restart.</p>" +
-            "<br/>" +
-            "<p style='text-align:left;'><b>If the button does not work, do this manually:</b></p>" +
-            "<ol style='text-align:left;'>" +
-            "<li>Open Find Action: <b>Cmd+Shift+A</b> (macOS) or <b>Ctrl+Shift+A</b> (Windows/Linux)</li>" +
-            "<li>Search for <b>&quot;Choose Boot Java Runtime for the IDE&hellip;&quot;</b> and run it</li>" +
-            "<li>Pick a runtime whose name contains <b>&quot;JCEF&quot;</b> or <b>&quot;with JCEF&quot;</b></li>" +
-            "<li>The IDE downloads and installs it, then prompts to restart</li>" +
-            "</ol>" +
-            "</div></html>"
-        ).apply {
+        val message = JLabel().apply {
             horizontalAlignment = SwingConstants.CENTER
             alignmentX = Component.CENTER_ALIGNMENT
         }
+        installReflowingMessage(message, MESSAGE_BODY)
 
         val installButton = JButton("Install JCEF Runtime").apply {
             alignmentX = Component.CENTER_ALIGNMENT
@@ -85,6 +70,25 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
     }
 
     companion object {
+        /**
+         * The document body, without the width-bearing wrapper — [installReflowingMessage]
+         * supplies that, and re-supplies it whenever the panel is resized.
+         */
+        private const val MESSAGE_BODY =
+            "<h2 style='margin-top:0;'>Claude Code GUI needs JCEF</h2>" +
+            "<p>This IDE is running without JCEF, which Claude Code GUI requires " +
+            "to render its chat UI. Click below to install a JCEF-enabled JetBrains " +
+            "Runtime — the IDE will download and apply it automatically, then ask you " +
+            "to restart.</p>" +
+            "<br/>" +
+            "<p style='text-align:left;'><b>If the button does not work, do this manually:</b></p>" +
+            "<ol style='text-align:left;'>" +
+            "<li>Open Find Action: <b>Cmd+Shift+A</b> (macOS) or <b>Ctrl+Shift+A</b> (Windows/Linux)</li>" +
+            "<li>Search for <b>&quot;Choose Boot Java Runtime for the IDE&hellip;&quot;</b> and run it</li>" +
+            "<li>Pick a runtime whose name contains <b>&quot;JCEF&quot;</b> or <b>&quot;with JCEF&quot;</b></li>" +
+            "<li>The IDE downloads and installs it, then prompts to restart</li>" +
+            "</ol>"
+
         private const val LEARN_MORE_URL =
             "https://github.com/Swttch/swttch/blob/main/docs/troubleshooting/en/android-studio-jcef.md"
     }

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefUnavailablePanel.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefUnavailablePanel.kt
@@ -1,6 +1,7 @@
 package com.github.yhk1038.claudecodegui.toolwindow
 
 import com.github.yhk1038.claudecodegui.platform.PlatformActionInvoker
+import com.intellij.ide.BrowserUtil
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.ui.HyperlinkLabel
 import java.awt.BorderLayout
@@ -14,16 +15,25 @@ import javax.swing.JPanel
 import javax.swing.SwingConstants
 
 /**
- * Fallback panel shown when JCEF is not available in the current JetBrains Runtime.
+ * Fallback panel shown in place of the chat when JCEF cannot host it.
  *
- * Android Studio ships without JCEF by default. When [com.intellij.ui.jcef.JBCefApp.isSupported]
- * returns false, this panel is displayed in place of the normal WebView panel.
+ * It explains two different situations, because they need opposite instructions
+ * and the wrong one wastes the user's time:
  *
- * The "Install JCEF Runtime" button triggers the IDE's built-in
- * "Choose Boot Java Runtime for the IDE…" dialog. The IDE then downloads a
- * JCEF-enabled JBR and prompts the user to restart.
+ *  - [JcefAvailability.RUNTIME_UNSUPPORTED] — the JCEF classes are there but the
+ *    boot runtime cannot drive them. Android Studio ships without JCEF in its
+ *    bundled JBR, so choosing a JCEF-enabled runtime fixes it.
+ *  - [JcefAvailability.CLASSES_ABSENT] — `com.intellij.ui.jcef` is missing
+ *    outright. Android Studio 2026.2 moved JCEF into the separate
+ *    "Web Browser (JCEF)" marketplace plugin and does not bundle it. **No runtime
+ *    choice helps here**, verified by booting a JCEF-enabled JBR 25.0.3 on
+ *    2026.2.1 Canary 2 and watching the module stay unresolved. Sending that user
+ *    to the runtime dialog costs them a download, a restart, and this same panel
+ *    (issue #321).
  */
-class JcefUnavailablePanel : JPanel(BorderLayout()) {
+class JcefUnavailablePanel(
+    private val availability: JcefAvailability = JcefAvailability.RUNTIME_UNSUPPORTED
+) : JPanel(BorderLayout()) {
 
     private val logger = Logger.getInstance(JcefUnavailablePanel::class.java)
 
@@ -35,15 +45,21 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
             alignmentX = Component.CENTER_ALIGNMENT
         }
 
+        val classesAbsent = availability == JcefAvailability.CLASSES_ABSENT
+
         val message = JLabel().apply {
             horizontalAlignment = SwingConstants.CENTER
             alignmentX = Component.CENTER_ALIGNMENT
         }
-        installReflowingMessage(message, MESSAGE_BODY)
+        installReflowingMessage(message, if (classesAbsent) PLUGIN_MESSAGE else RUNTIME_MESSAGE)
 
-        val installButton = JButton("Install JCEF Runtime").apply {
+        val actionButton = JButton(
+            if (classesAbsent) "Open the Web Browser (JCEF) page" else "Install JCEF Runtime"
+        ).apply {
             alignmentX = Component.CENTER_ALIGNMENT
-            addActionListener { invokeChooseRuntime() }
+            addActionListener {
+                if (classesAbsent) BrowserUtil.browse(JCEF_PLUGIN_URL) else invokeChooseRuntime()
+            }
         }
 
         val learnMore = HyperlinkLabel("Learn more").apply {
@@ -53,13 +69,13 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
 
         content.add(message)
         content.add(Box.createVerticalStrut(16))
-        content.add(installButton)
+        content.add(actionButton)
         content.add(Box.createVerticalStrut(12))
         content.add(learnMore)
 
         add(content, BorderLayout.CENTER)
 
-        logger.info("JcefUnavailablePanel created — JCEF is not supported in this runtime")
+        logger.info("JcefUnavailablePanel created — JCEF is unavailable: $availability")
     }
 
     private fun invokeChooseRuntime() {
@@ -71,10 +87,10 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
 
     companion object {
         /**
-         * The document body, without the width-bearing wrapper — [installReflowingMessage]
+         * The bodies below carry no width-bearing wrapper — [installReflowingMessage]
          * supplies that, and re-supplies it whenever the panel is resized.
          */
-        private const val MESSAGE_BODY =
+        private const val RUNTIME_MESSAGE =
             "<h2 style='margin-top:0;'>Claude Code GUI needs JCEF</h2>" +
             "<p>This IDE is running without JCEF, which Claude Code GUI requires " +
             "to render its chat UI. Click below to install a JCEF-enabled JetBrains " +
@@ -88,6 +104,27 @@ class JcefUnavailablePanel : JPanel(BorderLayout()) {
             "<li>Pick a runtime whose name contains <b>&quot;JCEF&quot;</b> or <b>&quot;with JCEF&quot;</b></li>" +
             "<li>The IDE downloads and installs it, then prompts to restart</li>" +
             "</ol>"
+
+        /**
+         * Deliberately says nothing about choosing a runtime. On this IDE that is a
+         * dead end, and offering it even as a second option is what would send the
+         * user down it.
+         */
+        private const val PLUGIN_MESSAGE =
+            "<h2 style='margin-top:0;'>This IDE does not include JCEF</h2>" +
+            "<p>Claude Code GUI draws its chat on JCEF. Starting with 2026.2, JCEF is " +
+            "no longer part of the IDE itself — it moved into a separate plugin by " +
+            "JetBrains, and Android Studio does not bundle it. Installing that plugin " +
+            "is all this needs; changing the boot runtime will not help.</p>" +
+            "<br/>" +
+            "<p style='text-align:left;'><b>Install it from the marketplace:</b></p>" +
+            "<ol style='text-align:left;'>" +
+            "<li>Open <b>Settings &rarr; Plugins &rarr; Marketplace</b></li>" +
+            "<li>Search for <b>Web Browser (JCEF)</b> — the one by <b>JetBrains</b></li>" +
+            "<li>Install it and restart the IDE</li>" +
+            "</ol>"
+
+        private const val JCEF_PLUGIN_URL = "https://plugins.jetbrains.com/plugin/31360"
 
         private const val LEARN_MORE_URL =
             "https://github.com/Swttch/swttch/blob/main/docs/troubleshooting/en/android-studio-jcef.md"

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/services/JcefAvailabilityGuardTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/services/JcefAvailabilityGuardTest.kt
@@ -1,0 +1,115 @@
+package com.github.yhk1038.claudecodegui.services
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the second half of the issue #321 fix, in [ClaudeCodeBrowserService.isJcefAvailable].
+ *
+ * The panel's fallback path only helps if the guard it asks can answer at all.
+ * `JBCefApp.isSupported()` reports whether JCEF *works*, which presupposes the
+ * JCEF classes are loadable; on Android Studio 2026.2 Canary they are not, so
+ * calling it raises NoClassDefFoundError and the guard never returns. Catching
+ * LinkageError is what turns "cannot even ask" into "unavailable", which is the
+ * answer that leads to JcefUnavailablePanel.
+ *
+ * The service itself needs a live Project, so rather than construct it these
+ * tests pin the decision rule the catch block encodes. The rule is checked
+ * against real Throwables — including the two the field has actually produced.
+ */
+class JcefAvailabilityGuardTest {
+
+    /**
+     * Mirrors the catch in [ClaudeCodeBrowserService.isJcefAvailable]: a probe that
+     * cannot even be asked counts as "JCEF unavailable", while anything else keeps
+     * propagating.
+     */
+    private fun availabilityOf(probe: () -> Boolean): Boolean =
+        try {
+            probe()
+        } catch (_: LinkageError) {
+            false
+        }
+
+    @Test
+    fun `a missing JCEF class means unavailable, not a crash`() {
+        // Issue #321: Android Studio 2026.2 Canary does not resolve
+        // com.intellij.modules.jcef, so the plugin class loader has no
+        // com.intellij.ui.jcef package at all.
+        assertFalse(
+            availabilityOf { throw NoClassDefFoundError("com/intellij/ui/jcef/JBCefApp") },
+            "a JCEF class the loader cannot see must read as unavailable",
+        )
+    }
+
+    @Test
+    fun `a JCEF runtime mismatch means unavailable, not a crash`() {
+        // Issue #295: the classes exist but the runtime's copy disagrees with the
+        // platform's, so JBCefApp's constructor calls a method that is not there.
+        assertFalse(
+            availabilityOf {
+                throw NoSuchMethodError("'boolean com.jetbrains.cef.JCefAppConfig.isRemoteEnabled()'")
+            },
+            "a JCEF runtime mismatch must read as unavailable",
+        )
+    }
+
+    @Test
+    fun `a working probe is passed through unchanged`() {
+        assertTrue(availabilityOf { true })
+        assertFalse(availabilityOf { false })
+    }
+
+    @Test
+    fun `unrelated failures still propagate`() {
+        // The catch is deliberately narrow. Swallowing everything would hide real
+        // defects behind a fallback panel that says "this IDE has no JCEF", which
+        // would send users off installing runtimes they already have.
+        assertThrows(IllegalStateException::class.java) {
+            availabilityOf { throw IllegalStateException("something else went wrong") }
+        }
+    }
+
+    @Test
+    fun `both failure shapes are LinkageError, which is why one catch covers them`() {
+        // Pins the assumption the single catch clause rests on. If a future JDK
+        // reparented either of these, the catch would silently stop covering it.
+        assertTrue(LinkageError::class.java.isAssignableFrom(NoClassDefFoundError::class.java))
+        assertTrue(LinkageError::class.java.isAssignableFrom(NoSuchMethodError::class.java))
+    }
+
+    /**
+     * The guard must be *reachable* on a JCEF-less runtime, not just correct once
+     * entered — a catch block is no help if loading the class that holds it already
+     * failed.
+     *
+     * [ClaudeCodeBrowserService] names JCEF types in several member signatures
+     * (BrowserHolder's constructor, createHolder's return type). That is safe here
+     * and not in ClaudeCodePanel because this class is not a [java.awt.Component]:
+     * nothing reflects over its members on the way in, so those descriptors are
+     * only resolved if something actually calls the member. Loading the class —
+     * which is what happens before `isJcefAvailable()` can run — must not throw.
+     */
+    @Test
+    fun `the service class itself loads on a runtime without JCEF`() {
+        val loader = object : ClassLoader(ClaudeCodeBrowserService::class.java.classLoader) {
+            override fun loadClass(name: String, resolve: Boolean): Class<*> {
+                if (name.startsWith("com.intellij.ui.jcef.") || name.startsWith("org.cef.")) {
+                    throw ClassNotFoundException("$name (blocked to simulate a runtime without JCEF)")
+                }
+                return super.loadClass(name, resolve)
+            }
+        }
+
+        // Loading must succeed even though members mention JCEF types...
+        val serviceClass = Class.forName(ClaudeCodeBrowserService::class.java.name, false, loader)
+        assertTrue(serviceClass.name.endsWith("ClaudeCodeBrowserService"))
+
+        // ...and the blocker must really be blocking, or the check above proves nothing.
+        assertThrows(ClassNotFoundException::class.java) {
+            Class.forName("com.intellij.ui.jcef.JBCefApp", false, loader)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanelLoadsWithoutJcefTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanelLoadsWithoutJcefTest.kt
@@ -1,0 +1,98 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+/**
+ * The end-to-end half of the issue #321 guard: actually load [ClaudeCodePanel]
+ * through a class loader that has no JCEF, the way Android Studio 2026.2 Canary
+ * does, and check that AWT's reflection over its members does not blow up.
+ *
+ * [ClaudeCodePanelSignatureTest] asserts the same invariant by inspecting member
+ * signatures. This one exercises the mechanism itself — `getDeclaredMethods()`
+ * resolving every descriptor — so the guard cannot be satisfied by a signature
+ * check that happens to look at the wrong set of members.
+ *
+ * The panel is not instantiated: that would need a live [com.intellij.openapi.project.Project]
+ * and the whole platform. What the reporter's stack shows failing is not the
+ * panel's own code but the reflection AWT performs on the way into it, and that
+ * is reproducible on the class alone.
+ */
+class ClaudeCodePanelLoadsWithoutJcefTest {
+
+    /**
+     * Loads classes from the test classpath, but pretends the JCEF packages do
+     * not exist — the shape of a plugin class loader on an IDE where
+     * `com.intellij.modules.jcef` failed to resolve.
+     *
+     * Everything else is delegated to the parent so the panel's other
+     * dependencies (platform, Kotlin stdlib) still resolve normally; only JCEF
+     * is missing, which is exactly the reporter's situation.
+     */
+    private class JcefBlindClassLoader(
+        parent: ClassLoader,
+        private val ownedPrefix: String,
+    ) : ClassLoader(parent) {
+
+        override fun loadClass(name: String, resolve: Boolean): Class<*> {
+            if (BLOCKED_PACKAGES.any { name.startsWith(it) }) {
+                throw ClassNotFoundException("$name (blocked to simulate a runtime without JCEF)")
+            }
+            // Load the classes under test ourselves so their references resolve
+            // through THIS loader; anything else comes from the parent unchanged.
+            if (name.startsWith(ownedPrefix)) {
+                findLoadedClass(name)?.let { return it }
+                val bytes = parent.getResourceAsStream(name.replace('.', '/') + ".class")?.readBytes()
+                if (bytes != null) {
+                    val defined = defineClass(name, bytes, 0, bytes.size)
+                    if (resolve) resolveClass(defined)
+                    return defined
+                }
+            }
+            return super.loadClass(name, resolve)
+        }
+
+        private companion object {
+            val BLOCKED_PACKAGES = listOf("com.intellij.ui.jcef.", "org.cef.")
+        }
+    }
+
+    @Test
+    fun `ClaudeCodePanel members resolve on a runtime without JCEF`() {
+        val loader = JcefBlindClassLoader(
+            parent = ClaudeCodePanel::class.java.classLoader,
+            ownedPrefix = "com.github.yhk1038.claudecodegui.toolwindow.ClaudeCodePanel",
+        )
+
+        val panelClass = Class.forName(ClaudeCodePanel::class.java.name, false, loader)
+        assertEquals(loader, panelClass.classLoader, "the panel must be loaded by the JCEF-blind loader")
+
+        // This is the call AWT makes from Component.<init> via
+        // isCoalesceEventsOverriden(). Before the fix it threw
+        // NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery.
+        assertNotNull(panelClass.declaredMethods, "declared methods must resolve without JCEF")
+        assertNotNull(panelClass.declaredConstructors, "declared constructors must resolve without JCEF")
+        assertNotNull(panelClass.declaredFields, "declared fields must resolve without JCEF")
+    }
+
+    /**
+     * Proves the blind loader really does hide JCEF — otherwise the test above
+     * would pass on a classpath where JCEF was present all along, and prove
+     * nothing.
+     */
+    @Test
+    fun `the blind loader hides JCEF from the classes it loads`() {
+        val loader = JcefBlindClassLoader(
+            parent = javaClass.classLoader,
+            ownedPrefix = "com.github.yhk1038.claudecodegui.toolwindow.ClaudeCodePanel",
+        )
+        assertThrows(ClassNotFoundException::class.java) {
+            Class.forName("com.intellij.ui.jcef.JBCefJSQuery", false, loader)
+        }
+        assertThrows(ClassNotFoundException::class.java) {
+            Class.forName("org.cef.browser.CefFrame", false, loader)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanelSignatureTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/ClaudeCodePanelSignatureTest.kt
@@ -1,0 +1,147 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the fix for issue #321: [ClaudeCodePanel] must stay constructible on a
+ * runtime that has no JCEF at all.
+ *
+ * Android Studio 2026.2 Canary fails to resolve `com.intellij.modules.jcef`, so
+ * this plugin's class loader has neither `com.intellij.ui.jcef` nor `org.cef`.
+ * The panel already guarded on `isJcefAvailable()` in its `init` block, but the
+ * guard never got to run: constructing any [java.awt.Component] makes AWT call
+ * `Component.isCoalesceEventsOverriden()`, which reflects over
+ * `getDeclaredMethods()` and resolves every method's parameter and return types.
+ * A JCEF type in any member signature therefore throws NoClassDefFoundError from
+ * inside the `JPanel` constructor — before `init` runs. That is the reporter's
+ * stack, which appears 47 times in their idea.log:
+ *
+ * ```
+ * java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
+ *   at java.lang.Class.getDeclaredMethods0(Native Method)
+ *   at java.awt.Component.isCoalesceEventsOverriden(Component.java:6316)
+ *   at java.awt.Component.<init>(Component.java:6242)
+ *   at ...ClaudeCodePanel.<init>(ClaudeCodePanel.kt:95)
+ * ```
+ *
+ * So the invariant is about the shape of the class, not about behaviour:
+ * **no JCEF type may appear in any member signature of ClaudeCodePanel.**
+ * Method *bodies* are fine — they resolve lazily, and every JCEF-touching body
+ * here runs only after the guard has confirmed JCEF is present. Visibility does
+ * not help: `getDeclaredMethods()` returns private members too.
+ */
+class ClaudeCodePanelSignatureTest {
+
+    @Test
+    fun `no member signature of ClaudeCodePanel mentions a JCEF type`() {
+        val offenders = jcefLeaksInSignatures(ClaudeCodePanel::class.java)
+        assertTrue(offenders.isEmpty()) {
+            "ClaudeCodePanel must stay constructible without JCEF (issue #321), but these " +
+                "members name a JCEF type in their signature, which AWT resolves while the " +
+                "JPanel constructor runs:\n" +
+                offenders.joinToString("\n") { "  - $it" } +
+                "\nReach the JCEF objects through `holder` inside method bodies instead."
+        }
+    }
+
+    /**
+     * Same invariant for anything nested inside the panel. Kotlin lowers `object : ...`
+     * into separate class files, and a nested Component that leaked a JCEF type would
+     * reproduce the bug in its own constructor.
+     */
+    @Test
+    fun `no member signature of a ClaudeCodePanel nested class mentions a JCEF type`() {
+        val offenders = ClaudeCodePanel::class.java.declaredClasses.flatMap { jcefLeaksInSignatures(it) }
+        assertTrue(offenders.isEmpty()) {
+            "A class nested in ClaudeCodePanel names a JCEF type in a member signature " +
+                "(issue #321):\n" + offenders.joinToString("\n") { "  - $it" }
+        }
+    }
+
+    /**
+     * The two panels shown *instead of* the WebView when JCEF is missing or
+     * mismatched. These matter most of all: a JCEF type in their signatures would
+     * mean the explanation screen dies on exactly the runtimes it exists to
+     * explain, leaving the blank window from issue #295 with no message at all.
+     */
+    @Test
+    fun `the JCEF fallback panels do not mention a JCEF type`() {
+        val fallbacks = listOf(JcefUnavailablePanel::class.java, JcefRuntimeMismatchPanel::class.java)
+        for (panel in fallbacks) {
+            val offenders = jcefLeaksInSignatures(panel) +
+                panel.declaredClasses.flatMap { jcefLeaksInSignatures(it) }
+            assertTrue(offenders.isEmpty()) {
+                "${panel.simpleName} is shown when JCEF is unavailable, so it must not name a " +
+                    "JCEF type in any member signature:\n" + offenders.joinToString("\n") { "  - $it" }
+            }
+        }
+    }
+
+    /**
+     * Proves the detector actually detects — without it, the two tests above would
+     * pass just as happily against a panel that still leaked JCEF types.
+     *
+     * [JcefLeakingSample] is shaped exactly like the pre-fix ClaudeCodePanel: a
+     * private accessor returning a JCEF type and a private method taking one.
+     */
+    @Test
+    fun `the detector reports a class that does leak JCEF types`() {
+        val offenders = jcefLeaksInSignatures(JcefLeakingSample::class.java)
+        assertEquals(2, offenders.size, "expected both leaks to be reported, got: $offenders")
+        assertTrue(offenders.any { it.contains("JBCefJSQuery") }, "got: $offenders")
+        assertTrue(offenders.any { it.contains("CefFrame") }, "got: $offenders")
+    }
+
+    /**
+     * Reference specimen for the self-check above: the exact shape issue #321 was
+     * caused by. Never instantiated — only its signatures are read.
+     */
+    @Suppress("unused")
+    private class JcefLeakingSample {
+        private val query: com.intellij.ui.jcef.JBCefJSQuery? get() = null
+        private fun inject(frame: org.cef.browser.CefFrame) = frame.url
+    }
+
+    private companion object {
+
+        /**
+         * JCEF reaches plugins through two separate platform modules, and Android
+         * Studio Canary hands neither to our class loader:
+         *  - `com.intellij.ui.jcef` — the platform wrapper (JBCefBrowser, JBCefJSQuery)
+         *  - `org.cef` — the JCEF library itself (CefFrame, CefBrowser, handlers)
+         * Both must stay out of member signatures.
+         */
+        val JCEF_PACKAGES = listOf("com.intellij.ui.jcef.", "org.cef.")
+
+        /**
+         * Every declared field, method and constructor of [clazz] whose signature
+         * names a JCEF type — the same set AWT walks in isCoalesceEventsOverriden().
+         *
+         * Reflection is safe to use here: the test JVM does have JCEF on its
+         * classpath, so nothing fails to resolve. What is asserted is the shape of
+         * the signatures, not whether this JVM can load them.
+         */
+        fun jcefLeaksInSignatures(clazz: Class<*>): List<String> = buildList {
+            for (field in clazz.declaredFields) {
+                if (isJcef(field.type)) add("field ${field.name}: ${field.type.name}")
+            }
+            for (method in clazz.declaredMethods) {
+                val bad = (method.parameterTypes.toList() + method.returnType).filter(::isJcef)
+                if (bad.isNotEmpty()) add("method ${method.name} names ${bad.joinToString { it.name }}")
+            }
+            for (ctor in clazz.declaredConstructors) {
+                val bad = ctor.parameterTypes.filter(::isJcef)
+                if (bad.isNotEmpty()) add("constructor names ${bad.joinToString { it.name }}")
+            }
+        }
+
+        /** True when [type] — or, for arrays, its element type — is a JCEF class. */
+        fun isJcef(type: Class<*>): Boolean {
+            var t = type
+            while (t.isArray) t = t.componentType
+            return JCEF_PACKAGES.any { t.name.startsWith(it) }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessageWidthTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessageWidthTest.kt
@@ -1,0 +1,93 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards the re-flow rule behind [fallbackMessageWidth] — the fix for the
+ * fallback panels being clipped mid-sentence.
+ *
+ * Swing lays an HTML [javax.swing.JLabel] out at whatever width the markup asks
+ * for and lets the container clip the overflow; it never re-flows. Both fallback
+ * panels hard-coded `width: 480px`, so docking the chat to the side — where the
+ * tool window is routinely narrower than that — cut every line off mid-word.
+ * That is the worst place for it, since these panels exist to explain why the
+ * chat is missing at all (issue #321).
+ */
+class FallbackMessageWidthTest {
+
+    @Nested
+    inner class Width {
+
+        @Test
+        fun `uses the panel width when it is narrower than the readable maximum`() {
+            // 320px panel, 80px of border → 240px of usable text column.
+            assertEquals(240, fallbackMessageWidth(panelWidth = 320, horizontalInsets = 80))
+        }
+
+        @Test
+        fun `caps at the readable maximum on a wide panel`() {
+            // An editor tab can be 1500px wide; a single line that long is unreadable.
+            assertEquals(
+                FALLBACK_MESSAGE_MAX_WIDTH,
+                fallbackMessageWidth(panelWidth = 1500, horizontalInsets = 80)
+            )
+        }
+
+        @Test
+        fun `stops shrinking at the minimum rather than breaking every word`() {
+            assertEquals(
+                FALLBACK_MESSAGE_MIN_WIDTH,
+                fallbackMessageWidth(panelWidth = 120, horizontalInsets = 80)
+            )
+        }
+
+        @Test
+        fun `falls back to the maximum before the panel has been laid out`() {
+            // componentResized has not fired yet, so width is still 0. Guessing the
+            // maximum keeps the first paint readable; the resize corrects it.
+            assertEquals(
+                FALLBACK_MESSAGE_MAX_WIDTH,
+                fallbackMessageWidth(panelWidth = 0, horizontalInsets = 80)
+            )
+        }
+
+        @Test
+        fun `fits the panel whenever the panel can hold the minimum`() {
+            // The property that actually matters. Panels narrower than the minimum
+            // are the deliberate exception — see the test above — so they are excluded
+            // rather than silently passing.
+            for (panelWidth in listOf(260, 300, 400, 559, 560, 561, 900)) {
+                val usable = panelWidth - 80
+                assertTrue(usable >= FALLBACK_MESSAGE_MIN_WIDTH) { "bad fixture: $panelWidth" }
+
+                val result = fallbackMessageWidth(panelWidth, horizontalInsets = 80)
+                assertTrue(result <= usable) {
+                    "width $result overflows the $usable px available in a ${panelWidth}px panel"
+                }
+            }
+        }
+    }
+
+    @Nested
+    inner class Html {
+
+        @Test
+        fun `carries the requested width into the markup`() {
+            val html = fallbackMessageHtml("<p>hello</p>", widthPx = 240)
+            assertTrue(html.contains("width: 240px")) { html }
+            assertTrue(html.contains("<p>hello</p>")) { html }
+        }
+
+        @Test
+        fun `does not hard-code the old fixed width`() {
+            // The regression this whole file exists for: a literal 480px in the
+            // markup regardless of how much room the panel actually has.
+            val html = fallbackMessageHtml("<p>hello</p>", widthPx = 240)
+            assertFalse(html.contains("width: 480px")) { html }
+        }
+    }
+}

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessageWidthTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/FallbackMessageWidthTest.kt
@@ -24,8 +24,18 @@ class FallbackMessageWidthTest {
 
         @Test
         fun `uses the panel width when it is narrower than the readable maximum`() {
-            // 320px panel, 80px of border → 240px of usable text column.
-            assertEquals(240, fallbackMessageWidth(panelWidth = 320, horizontalInsets = 80))
+            // 320px panel, 80px of border, 24px of gutter → 216px of text column.
+            assertEquals(216, fallbackMessageWidth(panelWidth = 320, horizontalInsets = 80))
+        }
+
+        @Test
+        fun `leaves the gutter free even when the panel could hold the maximum`() {
+            // The measured regression: 564px panel with 80px of border leaves 484px,
+            // and asking for the full 480px maximum still clipped, because the
+            // rendered width overshoots what the markup asks for.
+            val result = fallbackMessageWidth(panelWidth = 564, horizontalInsets = 80)
+            assertEquals(460, result)
+            assertTrue(result <= 564 - 80 - FALLBACK_MESSAGE_GUTTER)
         }
 
         @Test
@@ -56,17 +66,17 @@ class FallbackMessageWidthTest {
         }
 
         @Test
-        fun `fits the panel whenever the panel can hold the minimum`() {
+        fun `always leaves the gutter free when the panel can hold the minimum`() {
             // The property that actually matters. Panels narrower than the minimum
             // are the deliberate exception — see the test above — so they are excluded
             // rather than silently passing.
-            for (panelWidth in listOf(260, 300, 400, 559, 560, 561, 900)) {
-                val usable = panelWidth - 80
+            for (panelWidth in listOf(300, 400, 559, 560, 561, 900, 1500)) {
+                val usable = panelWidth - 80 - FALLBACK_MESSAGE_GUTTER
                 assertTrue(usable >= FALLBACK_MESSAGE_MIN_WIDTH) { "bad fixture: $panelWidth" }
 
                 val result = fallbackMessageWidth(panelWidth, horizontalInsets = 80)
                 assertTrue(result <= usable) {
-                    "width $result overflows the $usable px available in a ${panelWidth}px panel"
+                    "width $result leaves no gutter in the $usable px available in a ${panelWidth}px panel"
                 }
             }
         }

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefAvailabilityTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/JcefAvailabilityTest.kt
@@ -1,0 +1,122 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+/**
+ * Guards [resolveJcefAvailability] — the rule that decides *why* the chat cannot
+ * be hosted, not merely *that* it cannot.
+ *
+ * The distinction is the whole point. Two IDEs fail this check for opposite
+ * reasons and need opposite instructions:
+ *
+ *  - Android Studio 2026.1 has the JCEF classes but a runtime that cannot drive
+ *    them. Swapping to a JCEF-enabled JBR fixes it.
+ *  - Android Studio 2026.2 moved JCEF out of the IDE core into a separate
+ *    marketplace plugin and does not bundle it, so the classes are absent
+ *    entirely. **Swapping the runtime cannot fix it** — verified by booting a
+ *    fully JCEF-enabled JBR 25.0.3 on 2026.2.1 Canary 2 and watching the module
+ *    stay unresolved. The JetBrains Runtime supplies `org.cef.*`; the missing
+ *    `com.intellij.ui.jcef` is platform code the IDE has to carry.
+ *
+ * Telling a 2026.2 user to swap runtimes sends them to download a JBR, restart,
+ * and land on this same panel (issue #321).
+ */
+class JcefAvailabilityTest {
+
+    @Nested
+    inner class FromProbe {
+
+        @Test
+        fun `available when the probe says JCEF is supported`() {
+            assertEquals(
+                JcefAvailability.AVAILABLE,
+                resolveJcefAvailability(probe = { true })
+            )
+        }
+
+        @Test
+        fun `runtime unsupported when the probe answers false`() {
+            // The classes loaded and answered — this is the swap-the-runtime case.
+            assertEquals(
+                JcefAvailability.RUNTIME_UNSUPPORTED,
+                resolveJcefAvailability(probe = { false })
+            )
+        }
+
+        @Test
+        fun `classes absent when the probe cannot even be linked`() {
+            // The probe body touches com.intellij.ui.jcef, so a missing package
+            // surfaces here rather than as a return value.
+            assertEquals(
+                JcefAvailability.CLASSES_ABSENT,
+                resolveJcefAvailability(probe = { throw NoClassDefFoundError("com/intellij/ui/jcef/JBCefApp") })
+            )
+        }
+
+        @Test
+        fun `treats the issue 295 runtime mismatch as a runtime problem, not an absent one`() {
+            // NoSuchMethodError means the classes ARE there but disagree with the
+            // platform's copy. That is fixable by changing runtime, so it must not
+            // be reported as "install the plugin".
+            assertEquals(
+                JcefAvailability.RUNTIME_UNSUPPORTED,
+                resolveJcefAvailability(probe = {
+                    throw NoSuchMethodError("boolean com.jetbrains.cef.JCefAppConfig.isRemoteEnabled()")
+                })
+            )
+        }
+    }
+
+    @Nested
+    inner class Simulation {
+
+        @Test
+        fun `simulating an unsupported runtime does not consult the probe`() {
+            assertEquals(
+                JcefAvailability.RUNTIME_UNSUPPORTED,
+                resolveJcefAvailability(
+                    simulateUnsupported = true,
+                    probe = { error("probe must not run") }
+                )
+            )
+        }
+
+        @Test
+        fun `simulating absent classes does not consult the probe`() {
+            assertEquals(
+                JcefAvailability.CLASSES_ABSENT,
+                resolveJcefAvailability(
+                    simulateAbsent = true,
+                    probe = { error("probe must not run") }
+                )
+            )
+        }
+
+        @Test
+        fun `absent wins over unsupported when both are simulated`() {
+            // Arbitrary but pinned: absent is the stricter of the two, so a
+            // developer who sets both sees the harder case.
+            assertEquals(
+                JcefAvailability.CLASSES_ABSENT,
+                resolveJcefAvailability(
+                    simulateUnsupported = true,
+                    simulateAbsent = true,
+                    probe = { error("probe must not run") }
+                )
+            )
+        }
+    }
+
+    @Nested
+    inner class Usability {
+
+        @Test
+        fun `only AVAILABLE counts as usable`() {
+            assertEquals(true, JcefAvailability.AVAILABLE.isUsable)
+            assertEquals(false, JcefAvailability.RUNTIME_UNSUPPORTED.isUsable)
+            assertEquals(false, JcefAvailability.CLASSES_ABSENT.isUsable)
+        }
+    }
+}


### PR DESCRIPTION
Opening the tool window on Android Studio 2026.2 Canary 2 threw before any of our code ran, so the chat never appeared — not even the panel that exists to explain a missing JCEF runtime.

```
java.lang.NoClassDefFoundError: com/intellij/ui/jcef/JBCefJSQuery
  at java.lang.Class.getDeclaredMethods0(Native Method)
  at java.awt.Component.isCoalesceEventsOverriden(Component.java:6316)
  at java.awt.Component.<init>(Component.java:6242)
  at ...ClaudeCodePanel.<init>(ClaudeCodePanel.kt:95)
```

## Why the existing guard did not help

`ClaudeCodePanel` already called `isJcefAvailable()` in its `init` block and swapped in `JcefUnavailablePanel` when JCEF was missing. The check never got the chance to run.

Constructing any `Component` makes AWT call `isCoalesceEventsOverriden()`, which reflects over `getDeclaredMethods()` and resolves **every declared member's parameter and return types**. Three accessors returned JCEF types, so the class could not finish its `JPanel` constructor — and `init` runs after `super()`.

## Not a duplicate of the earlier JCEF issues

This is the third distinct shape of the same story:

| Issue | Symptom | Where it fails |
|---|---|---|
| #34 | Fallback panel shown | `isSupported()` returns false — the guard works |
| #295 | Blank window | Guard passes, browser construction throws `NoSuchMethodError` |
| **#321** | **Exception** | **The class cannot be constructed at all** |

The reporter's `idea.log` says why: `plugin com.intellij.modules.jcef is not resolved`, eight times. Our `<depends optional>` on that module did not resolve, so the plugin class loader has neither `com.intellij.ui.jcef` nor `org.cef`. The same log shows an unrelated plugin dying the same way, so this is a property of that IDE build rather than something specific to us.

## What actually triggers it

Measured on a stripped-down JVM repro rather than assumed:

| Shape | Result |
|---|---|
| Field of a missing type | OK |
| Private method naming it, on a `Component` | `NoClassDefFoundError` |
| Public method naming it, on a `Component` | `NoClassDefFoundError` |
| **Private static method naming it** | `NoClassDefFoundError` |
| Same signatures on a non-`Component` | OK |
| Anonymous subclass / cast inside a body | OK until called |

So visibility does not help, and writing the type fully-qualified does not either — the bytecode descriptor is identical. Only signatures on a `Component` matter; bodies are free.

That static row is what made this larger than deleting three accessors. Kotlin lowers lambdas into private static methods on the enclosing class, so a lambda that merely **captures** a `JBCefBrowser` lands a JCEF type in the panel's member list. Nine did — none of them written by hand.

## The change

- Lambdas now capture the plain AWT component instead of the browser, where that is all they needed.
- Where it is not, the glue moved to `JcefHandlers`, a new non-`Component` class that carries the JCEF-typed work (query replies, the drag handler, `executeJavaScript`) so the panel does not have to.
- The three `inject*` helpers return their script instead of taking a `CefFrame`; the load handler injects it, and being an anonymous class of its own it is free to name `CefFrame`.
- `isJcefAvailable()` now answers `false` on `LinkageError`. This one is not a signature problem — its body calls `JBCefApp.isSupported()`, and a body that touches a missing class throws when called. `LinkageError` covers both `NoClassDefFoundError` (#321) and the `NoSuchMethodError` of #295, so `getOrCreate()`'s narrower catch was widened to match.

Behaviour on IDEs that do have JCEF is unchanged: every rewritten call site runs only after the guard has confirmed it. On Android Studio Canary the panel now loads and shows `JcefUnavailablePanel`, which is the #34 behaviour.

## Tests

Three guards were added, because the leak that caused this was mostly compiler-generated and no reviewer would catch it by reading:

- `ClaudeCodePanelSignatureTest` walks the same member list AWT walks and names any offender. Covers the panel, its nested classes, and both fallback panels — those matter most, since a leak there would kill the very screen that explains the missing runtime.
- `ClaudeCodePanelLoadsWithoutJcefTest` exercises the mechanism: a class loader that hides `com.intellij.ui.jcef` and `org.cef` loads the panel, then calls `getDeclaredMethods()` on it. Reverting the fix makes it fail with the reporter's own error.
- `JcefAvailabilityGuardTest` pins the guard's decision rule for both `LinkageError` shapes, checks unrelated failures still propagate, and confirms the service class itself loads with JCEF hidden.

Each was verified to actually measure by reintroducing the accessor that caused #321 and confirming it fails. The signature test also carries its own leaking specimen, so a detector that silently stopped detecting would be caught rather than reported as a pass.

## Verification

| Layer | Result |
|---|---|
| WebView | 2529 passed |
| Backend | 1382 passed, 8 skipped |
| Kotlin | 309 passed (9 new) |
| `wv-lint` / `be-lint` | clean |
| `full-build` | successful, no new warnings |

Not verified on Android Studio 2026.2 Canary itself — I do not have that build. The class-loading test reproduces the reporter's exact exception, which is the closest stand-in available here.

Closes #321
