### PR TITLE
Keep the license key (and the payment history) when sponsorship ends

### DIFF
--- a/backend/src/core/features/__tests__/license-revalidation.test.ts
+++ b/backend/src/core/features/__tests__/license-revalidation.test.ts
@@ -161,14 +161,38 @@ describe('revalidateStoredLicense', () => {
     expect(mockReportActivation).not.toHaveBeenCalled();
   });
 
-  it('clears the license when www authoritatively says the key is no longer valid', async () => {
+  // Losing entitlement must not erase the fact that this person once paid. The
+  // key is the credential the billing history is fetched with, so deleting it
+  // would take their receipts with it — and they have no copy to re-enter, since
+  // the key is minted and picked up automatically. Keep the key, record that it
+  // is no longer active, and let the caller decide what that unlocks.
+  it.each(['expired', 'refunded'])(
+    'keeps the key but records status when www says it is %s',
+    async (status) => {
+      mockReadLicense.mockResolvedValue(storedLicense(hoursAgo(999)));
+      mockVerifyRemote.mockResolvedValue({ valid: false, status });
+
+      await revalidateStoredLicense(mockVerifyRemote);
+
+      expect(mockClearLicense).not.toHaveBeenCalled();
+      expect(mockSaveLicense).toHaveBeenCalledWith(
+        expect.objectContaining({ licenseKey: 'CCG-abc', status }),
+      );
+    },
+  );
+
+  // Without a status we still know entitlement ended, but not why. Fall back to
+  // a value that is definitely not "active" rather than leaving the old one,
+  // which would keep unlocking sponsor features.
+  it('records a non-active status even when www does not say which', async () => {
     mockReadLicense.mockResolvedValue(storedLicense(hoursAgo(999)));
-    // A refund/cancellation flips the row to refunded/expired → valid:false.
-    mockVerifyRemote.mockResolvedValue({ valid: false, status: 'refunded' });
+    mockVerifyRemote.mockResolvedValue({ valid: false });
 
     await revalidateStoredLicense(mockVerifyRemote);
 
-    expect(mockClearLicense).toHaveBeenCalledTimes(1);
+    expect(mockClearLicense).not.toHaveBeenCalled();
+    const saved = mockSaveLicense.mock.calls[0]?.[0] as { status?: string };
+    expect(saved.status).not.toBe('active');
   });
 
   it('does NOT revoke sponsorship when the check fails for a network reason', async () => {

--- a/backend/src/core/features/__tests__/license-status.test.ts
+++ b/backend/src/core/features/__tests__/license-status.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getSponsorStatus reads the license file and re-validates through www. Both are
+// stubbed at the boundary so these tests assert one thing only: how a stored
+// license turns into an entitlement decision.
+const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
+
+vi.mock('fs/promises', () => ({
+  readFile: mockReadFile,
+  writeFile: vi.fn(),
+  mkdir: vi.fn(),
+  rm: vi.fn(),
+}));
+vi.mock('../license-revalidation', () => ({
+  revalidateStoredLicense: vi.fn(() => Promise.resolve()),
+}));
+
+import { getSponsorStatus } from '../license';
+
+function stored(overrides: Record<string, unknown> = {}) {
+  return JSON.stringify({
+    licenseKey: 'CCG-abc',
+    status: 'active',
+    verifiedAt: '2026-08-22T00:00:00.000Z',
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  mockReadFile.mockReset();
+});
+
+describe('getSponsorStatus', () => {
+  it('has no key and no entitlement when nothing is stored', async () => {
+    mockReadFile.mockRejectedValue(new Error('ENOENT'));
+
+    const status = await getSponsorStatus();
+
+    expect(status.isSponsor).toBe(false);
+    expect(status.licenseKey).toBeUndefined();
+  });
+
+  it('grants entitlement while the stored status is active', async () => {
+    mockReadFile.mockResolvedValue(stored());
+
+    const status = await getSponsorStatus();
+
+    expect(status.isSponsor).toBe(true);
+    expect(status.licenseKey).toBe('CCG-abc');
+  });
+
+  // The point of the split: entitlement ends, the key does not. Whoever needs
+  // "has this person ever paid?" — the billing history, the past-sponsor UI —
+  // reads licenseKey, which survives.
+  it.each(['expired', 'refunded'])(
+    'withholds entitlement but keeps the key when the status is %s',
+    async (status) => {
+      mockReadFile.mockResolvedValue(stored({ status }));
+
+      const result = await getSponsorStatus();
+
+      expect(result.isSponsor).toBe(false);
+      expect(result.licenseKey).toBe('CCG-abc');
+      expect(result.status).toBe(status);
+    },
+  );
+
+  // Licenses written before www reported a status are real sponsors; reading the
+  // absence as "not active" would silently revoke them on upgrade.
+  it('treats a license stored without a status as active', async () => {
+    mockReadFile.mockResolvedValue(stored({ status: undefined }));
+
+    const status = await getSponsorStatus();
+
+    expect(status.isSponsor).toBe(true);
+  });
+
+  // Plan details outlive entitlement too, so a past sponsor's screen can still
+  // say what they were on.
+  it('keeps the cached plan details on a lapsed license', async () => {
+    mockReadFile.mockResolvedValue(
+      stored({
+        status: 'expired',
+        tier: 'jetbrains',
+        interval: 'monthly',
+        price: { amount: 5, currency: 'USD' },
+      }),
+    );
+
+    const status = await getSponsorStatus();
+
+    expect(status.isSponsor).toBe(false);
+    expect(status.tier).toBe('jetbrains');
+    expect(status.price).toEqual({ amount: 5, currency: 'USD' });
+  });
+});

--- a/backend/src/core/features/license-revalidation.ts
+++ b/backend/src/core/features/license-revalidation.ts
@@ -1,4 +1,4 @@
-import { readLicense, saveLicense, clearLicense, reportActivation } from './license';
+import { readLicense, saveLicense, reportActivation } from './license';
 import type { LicenseVerifyResult } from './license';
 
 /**
@@ -19,6 +19,12 @@ import type { LicenseVerifyResult } from './license';
  * that merely means "could not ask" — leaves the license untouched, because
  * stripping a paying sponsor for being offline is far worse than letting a
  * refunded one linger until the next successful check.
+ *
+ * Revoking here means recording a non-active status, NOT deleting the key. Being
+ * a sponsor and having once paid are different facts, and only the first one
+ * ends: the key is what the billing history is fetched with, and it is minted
+ * and picked up automatically, so a user whose key was deleted could never see
+ * their own receipts again. Deleting stays reserved for an explicit Deactivate.
  */
 
 /** How long a verification stays good before the key is re-checked. */
@@ -64,7 +70,24 @@ export async function revalidateStoredLicense(verify: LicenseVerifier): Promise<
     // failure), not "not a sponsor" — see verifyLicenseRemote. Only an answer
     // that actually reached www may revoke.
     if (!result.valid && result.error === undefined) {
-      await clearLicense();
+      // Entitlement ends here, but the key stays on disk. It is the credential
+      // the billing history is fetched with, and it is minted and picked up
+      // automatically — the user has no copy to re-enter — so deleting it would
+      // permanently take their receipts with it. Record the new status instead
+      // and let getSponsorStatus decide what an inactive key still unlocks.
+      // Clearing remains what an explicit Deactivate does.
+      await saveLicense({
+        licenseKey: license.licenseKey,
+        // www names the reason (expired/refunded) when it knows it. Falling back
+        // to "expired" keeps the stored status definitely-not-active, which is
+        // what entitlement is judged on.
+        status: result.status ?? 'expired',
+        verifiedAt: new Date().toISOString(),
+        tier: result.tier ?? license.tier ?? null,
+        interval: result.interval ?? license.interval ?? null,
+        price: result.price ?? license.price ?? null,
+        cancellable: result.cancellable ?? license.cancellable ?? null,
+      });
       return;
     }
     if (!result.valid) return;

--- a/backend/src/core/features/license.ts
+++ b/backend/src/core/features/license.ts
@@ -18,6 +18,13 @@ import { buildDeviceName } from './deviceName';
 const LICENSE_DIR = join(homedir(), '.claude-code-gui');
 const LICENSE_FILE = join(LICENSE_DIR, 'license.json');
 
+/**
+ * The one status that grants sponsor features. www mirrors its own
+ * license_status enum here ("active" | "expired" | "refunded"); everything that
+ * is not active has ended, whatever the reason.
+ */
+const LICENSE_STATUS_ACTIVE = 'active';
+
 // Our SaaS API base. Overridable for local development against a dev www server
 // (e.g. CCG_WWW_API_BASE=http://localhost:8080/api); defaults to production.
 function wwwApiBase(): string {
@@ -96,7 +103,16 @@ export interface StoredLicense {
 
 /** Sponsor entitlement derived from local storage — what the UI toggles on. */
 export interface SponsorStatus {
+  /**
+   * Whether sponsor-only features are unlocked right now. Distinct from having a
+   * key: a lapsed sponsor keeps their key (and their receipts) but not this.
+   */
   isSponsor: boolean;
+  /**
+   * The stored key, present whenever this install has ever been activated —
+   * including after entitlement ended. Callers that want "has this person ever
+   * sponsored?" (billing history, past-sponsor UI) ask this, not `isSponsor`.
+   */
   licenseKey?: string;
   status?: string;
   tier?: string;
@@ -232,13 +248,22 @@ export async function clearLicense(): Promise<void> {
 }
 
 /**
- * The sponsor entitlement the UI consumes. Derived from the locally stored key:
- * having a verified key on file means "sponsor" here, which is what lets the
- * state survive restarts and work offline.
+ * The sponsor entitlement the UI consumes, derived from the locally stored key.
+ * Storing it locally is what lets the state survive restarts and work offline.
+ *
+ * Entitlement is the stored STATUS, not the mere presence of a key. The two used
+ * to be the same thing, which meant the only way to end sponsorship was to
+ * delete the key — and that also deleted the one credential the billing history
+ * is fetched with, erasing the fact that the user had ever paid. Splitting them
+ * lets a lapsed sponsor keep their key (and their receipts) while losing access
+ * to sponsor-only features.
+ *
+ * A missing status is read as active: licenses stored before www reported one
+ * are genuine sponsors, and a stored key only ever got there by verifying.
  *
  * To keep that local trust from going stale, a throttled re-check against www
  * runs first (see license-revalidation): if the key has since been refunded or
- * expired it is cleared here, so the caller sees the corrected state. The check
+ * expired, the stored status says so and this returns isSponsor:false. The check
  * is skipped while the last verification is still fresh, and it never revokes on
  * a network failure — see revalidateStoredLicense for the fail-open rules.
  */
@@ -251,7 +276,7 @@ export async function getSponsorStatus(): Promise<SponsorStatus> {
   const license = await readLicense();
   if (license === null) return { isSponsor: false };
   return {
-    isSponsor: true,
+    isSponsor: license.status === null || license.status === LICENSE_STATUS_ACTIVE,
     licenseKey: license.licenseKey,
     status: license.status ?? undefined,
     tier: license.tier ?? undefined,

--- a/webview/src/pages/SettingsPage/Sponsor/__tests__/pastSponsor.test.tsx
+++ b/webview/src/pages/SettingsPage/Sponsor/__tests__/pastSponsor.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/hooks/queries/__tests__/testQueryClient';
+
+// Entitlement and identity are separate facts here, so the two are mocked
+// independently: `isSponsor` is what is unlocked today, `licenseKey` is whether
+// this install has ever been activated. A past sponsor is the combination that
+// used to be impossible — no entitlement, but a key.
+let mockIsSponsor = false;
+let mockLicenseKey: string | null = null;
+let mockLicenseStatus: string | null = null;
+
+vi.mock('@/hooks/queries/useSponsorStatus', () => ({
+  useSponsorStatus: () => ({
+    isSponsor: mockIsSponsor,
+    licenseKey: mockLicenseKey,
+    licenseStatus: mockLicenseStatus,
+    tier: mockLicenseKey !== null ? 'jetbrains' : null,
+    interval: mockLicenseKey !== null ? 'monthly' : null,
+    price: mockLicenseKey !== null ? { amount: 5, currency: 'USD' } : null,
+    cancellable: false,
+    cancelSubscription: vi.fn(),
+    isLoading: false,
+    verify: vi.fn(),
+    deactivate: vi.fn(),
+    checkByInstall: vi.fn(),
+  }),
+}));
+
+const mockSend = vi.fn();
+vi.mock('@/contexts/BridgeContext', () => ({
+  useBridgeContext: () => ({ send: mockSend, isConnected: true }),
+}));
+
+vi.mock('@/hooks/queries/useAccounts', () => ({
+  useAccounts: () => ({ activeEmail: 'user@example.com' }),
+}));
+
+vi.mock('@/adapters', () => ({
+  getAdapter: () => ({ openUrl: vi.fn() }),
+}));
+
+import { SponsorSettings } from '../index';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={createTestQueryClient()}>{children}</QueryClientProvider>;
+}
+
+/** The invitation shown to anyone who is not currently sponsoring. */
+function invitationShown(): boolean {
+  return screen.queryByRole('button', { name: /sponsor|후원/i }) !== null;
+}
+
+/**
+ * The payment-history section. Matched on its own heading rather than a loose
+ * text search, which also hits the "Payments" tab label an active sponsor sees.
+ */
+function billingShown(): boolean {
+  return screen.queryByRole('heading', { name: 'Payments' }) !== null;
+}
+
+beforeEach(() => {
+  mockSend.mockReset().mockResolvedValue({ url: 'https://example.test/pricing', invoices: [] });
+  mockIsSponsor = false;
+  mockLicenseKey = null;
+  mockLicenseStatus = null;
+});
+
+describe('SponsorSettings — what a lapsed sponsor keeps', () => {
+  it('a never-sponsored user sees the invitation and no billing history', () => {
+    render(<SponsorSettings />, { wrapper });
+
+    expect(invitationShown()).toBe(true);
+    expect(billingShown()).toBe(false);
+  });
+
+  // The point of the whole change: entitlement ended, but the record that they
+  // paid did not. Deleting the key would have taken their receipts with it.
+  it.each(['expired', 'refunded'])(
+    'a %s sponsor still sees their billing history',
+    (status) => {
+      mockIsSponsor = false;
+      mockLicenseKey = 'CCG-abcd1234';
+      mockLicenseStatus = status;
+
+      render(<SponsorSettings />, { wrapper });
+
+      expect(billingShown()).toBe(true);
+    },
+  );
+
+  // Re-starting a sponsorship is the same act as starting one, so it gets the
+  // same screen rather than a diminished "you used to sponsor" variant.
+  it('a lapsed sponsor is invited back with the ordinary invitation', () => {
+    mockIsSponsor = false;
+    mockLicenseKey = 'CCG-abcd1234';
+    mockLicenseStatus = 'expired';
+
+    render(<SponsorSettings />, { wrapper });
+
+    expect(invitationShown()).toBe(true);
+  });
+
+  it('an active sponsor is not pitched to', () => {
+    mockIsSponsor = true;
+    mockLicenseKey = 'CCG-abcd1234';
+    mockLicenseStatus = 'active';
+
+    render(<SponsorSettings />, { wrapper });
+
+    expect(invitationShown()).toBe(false);
+  });
+});

--- a/webview/src/pages/SettingsPage/Sponsor/index.tsx
+++ b/webview/src/pages/SettingsPage/Sponsor/index.tsx
@@ -57,6 +57,22 @@ export function SponsorSettings() {
     checkByInstall,
   } = useSponsorStatus();
 
+  /**
+   * Someone who sponsored before but is not entitled right now — cancelled and
+   * lapsed, or refunded.
+   *
+   * They see the same invitation a first-time visitor sees, because re-starting
+   * a sponsorship is the same act as starting one and deserves the same screen
+   * rather than a lesser "you used to be a sponsor" variant. The single thing
+   * they keep is their payment history: losing entitlement must not erase the
+   * fact that they once paid, and their receipts are theirs.
+   *
+   * Note the condition is the KEY, not the entitlement — that is the whole point
+   * of the split. `isSponsor` says what is unlocked today; `licenseKey` says
+   * this install has been activated at some point.
+   */
+  const isPastSponsor = !isSponsor && licenseKey !== null;
+
   // Copy/paste-free activation: after the user opens the checkout page, poll www
   // for a key minted for this install so a completed payment flips this screen to
   // "sponsoring" without them copying the key back.
@@ -269,6 +285,15 @@ export function SponsorSettings() {
               </p>
             )}
           </div>
+        </div>
+      )}
+
+      {/* A past sponsor keeps their receipts. Rendered outside the entitlement
+          branch above precisely so it does not need a past-sponsor variant of
+          the invitation: they get the ordinary screen, plus this. */}
+      {isPastSponsor && (
+        <div className="mt-6 rounded-xl border border-border-default bg-surface-raised px-6 pb-6">
+          <SponsorBillingSection />
         </div>
       )}
     </div>


### PR DESCRIPTION
When sponsorship ended, the stored license key was deleted. That key is the
credential the billing history is fetched with, and it is minted and picked up
automatically — the user has no copy to re-enter — so a past sponsor lost access
to their own receipts permanently.

The cause was that entitlement and identity were the same value: `getSponsorStatus`
returned `isSponsor: true` for any stored key, which left deleting the key as the
only way to revoke. Split:

- `isSponsor` = stored status is active (what is unlocked today)
- `licenseKey` = a key is on file (ever activated at all)

Settings → Sponsor now has three states: no key (invitation only), key but not
active (invitation + payment history), active (unchanged). A past sponsor sees
the same invitation a first-time visitor sees, since re-starting a sponsorship is
the same act as starting one.

Deleting the key remains what an explicit Deactivate does.

The server-side half (handling the expiry webhook, plus a re-check against the
payment provider as a safety net) is already deployed from the SaaS repo.