### PR TITLE
Sync the root READMEs with the retitled JCEF troubleshooting entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Same backend, same UI, opened in your default browser on `http://localhost:19836
 Problems that come up often, which we have not been able to fix on our side yet but for which a known workaround exists, are collected in **[docs/troubleshooting](docs/troubleshooting/en/README.md)** — each with the symptoms, the cause, how to fix it, and links to the related issues.
 
 - [Wayland clipboard](docs/troubleshooting/en/wayland-clipboard.md) — pasting into the chat input fails on Linux · Wayland · KDE Plasma
-- [Android Studio JCEF runtime](docs/troubleshooting/en/android-studio-jcef.md) — Android Studio shows a guidance panel instead of the chat UI, or a blank window
+- [Android Studio JCEF](docs/troubleshooting/en/android-studio-jcef.md) — Android Studio shows a guidance panel or an exception instead of the chat UI, or a blank window
 
 If your problem is not listed there, please [open an issue](https://github.com/Swttch/swttch/issues/new/choose).
 

--- a/docs/README.de.md
+++ b/docs/README.de.md
@@ -136,7 +136,7 @@ Die Claude Code GUI, die in Cursor und VS Code beliebt ist, ist jetzt auch in Je
 Häufig auftretende Probleme, die wir noch nicht selbst beheben konnten, für die es aber eine bekannte Lösung gibt, sind unter **[docs/troubleshooting](troubleshooting/de/README.md)** gesammelt — jeweils mit Symptomen, Ursache, Lösung und Links zu den zugehörigen Issues.
 
 - [Wayland-Zwischenablage](troubleshooting/de/wayland-clipboard.md) — wenn das Einfügen in das Chat-Eingabefeld unter Linux · Wayland · KDE Plasma fehlschlägt
-- [Android-Studio-JCEF-Runtime](troubleshooting/de/android-studio-jcef.md) — wenn Android Studio ein Hinweispanel statt der Chat-Oberfläche oder ein leeres Fenster zeigt
+- [JCEF in Android Studio](troubleshooting/de/android-studio-jcef.md) — wenn Android Studio ein Hinweispanel oder eine Ausnahme statt der Chat-Oberfläche oder ein leeres Fenster zeigt
 
 Steht Ihr Problem nicht in der Liste, [eröffnen Sie bitte ein Issue](https://github.com/Swttch/swttch/issues/new/choose).
 

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -136,7 +136,7 @@ La misma interfaz gráfica de Claude Code que amas en Cursor y VS Code, ahora di
 Los problemas frecuentes que todavía no hemos podido corregir por nuestra parte, pero para los que existe una solución conocida, están recogidos en **[docs/troubleshooting](troubleshooting/es/README.md)**, cada uno con los síntomas, la causa, cómo solucionarlo y enlaces a los issues relacionados.
 
 - [Portapapeles en Wayland](troubleshooting/es/wayland-clipboard.md) — cuando pegar en el campo de chat falla en Linux · Wayland · KDE Plasma
-- [Runtime JCEF de Android Studio](troubleshooting/es/android-studio-jcef.md) — cuando Android Studio muestra un panel informativo en lugar del chat, o una ventana en blanco
+- [JCEF en Android Studio](troubleshooting/es/android-studio-jcef.md) — cuando Android Studio muestra un panel informativo o una excepción en lugar del chat, o una ventana en blanco
 
 Si tu problema no está en la lista, por favor [abre un issue](https://github.com/Swttch/swttch/issues/new/choose).
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -136,7 +136,7 @@ La même interface Claude Code GUI que vous aimez dans Cursor et VS Code, mainte
 Les problèmes fréquents que nous n'avons pas encore pu corriger de notre côté, mais pour lesquels une solution connue existe, sont rassemblés dans **[docs/troubleshooting](troubleshooting/fr/README.md)**, chacun avec les symptômes, la cause, la solution et des liens vers les issues associées.
 
 - [Presse-papiers Wayland](troubleshooting/fr/wayland-clipboard.md) — lorsque le collage dans le champ de chat échoue sous Linux · Wayland · KDE Plasma
-- [Runtime JCEF d'Android Studio](troubleshooting/fr/android-studio-jcef.md) — lorsque Android Studio affiche un panneau d'information au lieu du chat, ou une fenêtre vide
+- [JCEF dans Android Studio](troubleshooting/fr/android-studio-jcef.md) — lorsque Android Studio affiche un panneau d'information ou une exception au lieu du chat, ou une fenêtre vide
 
 Si votre problème ne figure pas dans la liste, merci d'[ouvrir une issue](https://github.com/Swttch/swttch/issues/new/choose).
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -135,7 +135,7 @@ Cursor と VS Code で親しまれている Claude Code GUI が、JetBrains IDE 
 よく発生する問題のうち、まだこちらで直せていないものの既知の解決方法があるものを、**[docs/troubleshooting](troubleshooting/ja/README.md)** に症状・原因・解決方法と関連 Issue へのリンクとともにまとめてあります。
 
 - [Wayland のクリップボード](troubleshooting/ja/wayland-clipboard.md) — Linux · Wayland · KDE Plasma でチャット入力欄に貼り付けができないとき
-- [Android Studio の JCEF ランタイム](troubleshooting/ja/android-studio-jcef.md) — Android Studio でチャット画面の代わりに案内パネルが出る、またはウィンドウが空のとき
+- [Android Studio の JCEF](troubleshooting/ja/android-studio-jcef.md) — Android Studio でチャット画面の代わりに案内パネルや例外が出る、またはウィンドウが空のとき
 
 一覧にない問題は [Issue を開いて](https://github.com/Swttch/swttch/issues/new/choose)お知らせください。
 

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -135,7 +135,7 @@ Cursor와 VS Code에서 사랑받는 Claude Code GUI를 이제 JetBrains IDE에�
 자주 발생하는 문제들 중, 아직 저희가 직접 고치지 못했지만 알려진 해결 방법이 있는 것들을 **[docs/troubleshooting](troubleshooting/ko/README.md)** 에 증상·원인·해결 방법과 관련 이슈 링크와 함께 정리해두었습니다.
 
 - [Wayland 클립보드](troubleshooting/ko/wayland-clipboard.md) — Linux · Wayland · KDE Plasma 에서 채팅 입력창에 붙여넣기가 안 될 때
-- [Android Studio JCEF 런타임](troubleshooting/ko/android-studio-jcef.md) — Android Studio 에서 채팅 화면 대신 안내 패널이 뜨거나 창이 비어 있을 때
+- [Android Studio JCEF](troubleshooting/ko/android-studio-jcef.md) — Android Studio 에서 채팅 화면 대신 안내 패널이나 예외가 뜨거나, 창이 비어 있을 때
 
 목록에 없는 문제라면 [이슈를 열어](https://github.com/Swttch/swttch/issues/new/choose) 알려주세요.
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -135,7 +135,7 @@
 常见问题中，我们尚未能自行修复、但已有已知解决方法的那些，整理在 **[docs/troubleshooting](troubleshooting/zh/README.md)** 中，每篇都包含症状、原因、解决方法以及相关 Issue 的链接。
 
 - [Wayland 剪贴板](troubleshooting/zh/wayland-clipboard.md) — 在 Linux · Wayland · KDE Plasma 上无法向聊天输入框粘贴时
-- [Android Studio JCEF 运行时](troubleshooting/zh/android-studio-jcef.md) — Android Studio 显示引导面板而不是聊天界面，或者窗口空白时
+- [Android Studio JCEF](troubleshooting/zh/android-studio-jcef.md) — Android Studio 显示引导面板或抛出异常而不是聊天界面，或者窗口空白时
 
 如果列表中没有您遇到的问题，请[提交 Issue](https://github.com/Swttch/swttch/issues/new/choose) 告诉我们。
 


### PR DESCRIPTION
#327 rewrote the Android Studio JCEF troubleshooting page — 2026.2 moved JCEF into a separate plugin, so the page is no longer about the runtime — and updated the per-language indexes to match.

The copies of that same line in the seven root READMEs were left behind, so the two disagreed on both the title and the symptom. A reader arriving from a root README was told to expect a guidance panel, when what 2026.2 actually throws is an exception.

Seven files, one line each. No code changes.