### PR TITLE
fix: bring chat tabs back after a restart (#312)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorProvider.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorProvider.kt
@@ -1,5 +1,6 @@
 package com.github.yhk1038.claudecodegui.editor
 
+import com.github.yhk1038.claudecodegui.services.EditorTabStateService
 import com.intellij.openapi.fileEditor.FileEditor
 import com.intellij.openapi.fileEditor.FileEditorPolicy
 import com.intellij.openapi.fileEditor.FileEditorProvider
@@ -15,8 +16,24 @@ class ClaudeCodeEditorProvider : FileEditorProvider, DumbAware {
         return file is ClaudeCodeVirtualFile
     }
 
+    /**
+     * Build the pane, and tie a restored tab to its project on the way.
+     *
+     * A tab revived by the platform's layout restore is created before any
+     * project is open (issue #312), so it arrives here bare: no owner, no
+     * conversation, the generic label. This is the first moment a [Project] is
+     * in hand, so it is where the tab is claimed and filled in from
+     * [EditorTabStateService]. Both calls are no-ops for a tab that was opened
+     * normally, which already has all three.
+     */
     override fun createEditor(project: Project, file: VirtualFile): FileEditor {
-        return ClaudeCodeFileEditor(project, file as ClaudeCodeVirtualFile)
+        val chatTab = file as ClaudeCodeVirtualFile
+        ClaudeCodeVirtualFile.claim(project, chatTab.tabId)
+
+        val state = EditorTabStateService.getInstance(project)
+        chatTab.seedRestoredState(state.getPath(chatTab.tabId), state.getTitle(chatTab.tabId))
+
+        return ClaudeCodeFileEditor(project, chatTab)
     }
 
     override fun getEditorTypeId(): String = "ClaudeCodeEditor"

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystem.kt
@@ -45,40 +45,56 @@ import java.io.IOException
  *
  * ## Lifetime
  *
- * [findFileByPath] hands back a file only for a tab the plugin already knows
- * about — either live in memory, or recorded in [EditorTabStateService]. A stale
- * URL (a tab the user closed before shutdown) resolves to null and the platform
- * simply skips it, which is the desired outcome.
+ * [findFileByPath] answers for any well-formed tab ID, because the platform is
+ * the one that decides which tabs exist: it only asks about URLs it persisted,
+ * and a tab the user closed is already gone from that layout. Making existence
+ * conditional on plugin state instead is what broke restore outright in issue
+ * #312 — see [findFileByPath].
  */
 class ClaudeCodeFileSystem : VirtualFileSystem(), NonPhysicalFileSystem {
 
     override fun getProtocol(): String = PROTOCOL
 
     /**
-     * Resolve `claude-code://<tabId>` back to its tab.
+     * Resolve `claude-code://<tabId>` back to its tab. Never answers null for a
+     * well-formed ID.
      *
-     * Two sources, in order:
+     * ## Why it always answers
      *
-     *  1. a tab already live in memory — the normal case once the session is
-     *     running (a tab being moved between splitters, say);
-     *  2. a tab recorded in [EditorTabStateService] — the restore case.
+     * This is the single point the platform's restore hangs on: a tab whose URL
+     * does not resolve is dropped from the layout, and the (now empty) editor
+     * window is removed from its splitter. So a null here is not "skip one tab",
+     * it is "that chat, and the pane it lived in, are gone".
      *
-     * The second source is what makes restart restore work at all. The platform
-     * resolves persisted URLs *before* the plugin has opened anything, so at that
-     * moment no tab is live and an in-memory-only lookup answers null for every
-     * URL. That is exactly what happened when this returned only (1): the IDE
-     * logged `No file exists: claude-code://…`, dropped the tab from the restored
-     * layout, and the splitter placement was lost — the bug this whole change is
-     * meant to fix (#302).
+     * This used to answer only for a tab recorded in [EditorTabStateService],
+     * found by scanning `ProjectManager.openProjects`. That never worked after a
+     * restart, because the platform revives the layout *while the project is
+     * still opening*: a logged run of issue #312 caught `openProjects` empty at
+     * the lookup, with the project turning up there 3.8 seconds later. The state
+     * was intact the whole time — there was simply nobody to ask yet, so every
+     * chat tab was dropped on every restart and the IDE logged
+     * `No file exists: claude-code://…`.
      *
-     * It still does not mint tabs out of thin air. An ID absent from the
-     * persisted state resolves to null, so a tab the user closed before shutdown
-     * stays closed: [EditorTabStateService.removeTab] has already dropped it.
+     * The guard was not buying anything either. It was there to keep a tab the
+     * user had closed from being resurrected, but the platform only ever asks
+     * about URLs it persisted, and a closed tab is already out of that layout.
+     * So existence is decided where it belongs — in the platform's own record of
+     * what was open — and this call just hands back the address it was given.
      *
-     * The lookup spans open projects because a URL identifies a file, not a
-     * project, and this call carries no [com.intellij.openapi.project.Project].
-     * Tab IDs are per-tab UUIDs, so cross-project collision is not a practical
-     * concern.
+     * ## Where a tab's conversation and title come from
+     *
+     * When a project that remembers the tab is available, the file is seeded
+     * from [EditorTabStateService] as before. When none is — the restart case —
+     * the file is created bare and
+     * [ClaudeCodeEditorProvider.createEditor] fills both in as soon as it has a
+     * project, via [ClaudeCodeVirtualFile.seedRestoredState]. The pane's own
+     * address also arrives independently, through
+     * [ClaudeCodeEditorProvider.readState] → [ClaudeCodeFileEditor.setState].
+     *
+     * The project scan spans every open project because a URL identifies a file,
+     * not a project, and this call carries no
+     * [com.intellij.openapi.project.Project]. Tab IDs are per-tab UUIDs, so
+     * cross-project collision is not a practical concern.
      */
     override fun findFileByPath(path: String): VirtualFile? {
         val tabId = path.trim('/')
@@ -96,7 +112,13 @@ class ClaudeCodeFileSystem : VirtualFileSystem(), NonPhysicalFileSystem {
                 ?.firstOrNull {
                     !it.isDisposed && tabId in EditorTabStateService.getInstance(it).getOpenTabIds()
                 }
-        }.getOrNull() ?: return null
+        }.getOrNull()
+
+        if (project == null) {
+            // The restart case: no project can vouch for this tab yet. Hand back
+            // the tab anyway — see the note above on why waiting for one loses it.
+            return ClaudeCodeVirtualFile.getOrCreateUnclaimed(tabId)
+        }
 
         val state = EditorTabStateService.getInstance(project)
         return ClaudeCodeVirtualFile.getOrCreate(

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFile.kt
@@ -31,7 +31,7 @@ class ClaudeCodeVirtualFile(
     // (새 탭이 첫 페인트부터 hash 대신 앱 이름을 표시)
     @Volatile
     private var displayName: String = initialTitle?.let { truncateName(it) }
-        ?: "Claude Code"
+        ?: DEFAULT_DISPLAY_NAME
 
     // WebView가 현재 표시 중인 경로 (탭 이동 시 복원용)
     @Volatile
@@ -58,6 +58,9 @@ class ClaudeCodeVirtualFile(
 
     companion object {
         private const val MAX_DISPLAY_NAME_LENGTH = 20
+
+        /** Label a tab wears until it knows the conversation it is showing. */
+        private const val DEFAULT_DISPLAY_NAME: String = "Claude Code"
 
         /**
          * The registered [ClaudeCodeFileSystem] instance.
@@ -89,6 +92,28 @@ class ClaudeCodeVirtualFile(
             WeakHashMap<Project, MutableMap<String, ClaudeCodeVirtualFile>>()
         )
 
+        /**
+         * Tabs that exist but have no project yet.
+         *
+         * The platform revives a persisted tab by URL *while the project is still
+         * opening*: in a logged run of issue #312 the lookup saw
+         * `ProjectManager.openProjects` empty, and the project appeared there 3.8
+         * seconds later. So at the one moment that decides whether a chat tab
+         * comes back, there is no [Project] to key it under — and a tab that
+         * insisted on one was dropped from the layout every single restart.
+         *
+         * A tab does not actually need a project to exist: its ID is an address,
+         * and the project only arrives when the platform asks
+         * [ClaudeCodeEditorProvider] to build the editor. Tabs wait here until
+         * then and are moved into their project's map by [claim].
+         *
+         * Not weakly held, unlike [openTabs] — there is no project to hang the
+         * lifetime on. The bound is the number of distinct chat tab IDs the
+         * platform asks about before claiming them (an editor layout plus a
+         * recent-files list), so it stays in the tens.
+         */
+        private val unclaimedTabs = ConcurrentHashMap<String, ClaudeCodeVirtualFile>()
+
         fun getOrCreate(
             project: Project,
             tabId: String,
@@ -97,9 +122,46 @@ class ClaudeCodeVirtualFile(
         ): ClaudeCodeVirtualFile {
             synchronized(openTabs) {
                 val projectTabs = openTabs.getOrPut(project) { ConcurrentHashMap() }
-                return projectTabs.getOrPut(tabId) {
-                    ClaudeCodeVirtualFile(tabId, initialPath, initialTitle)
+                projectTabs[tabId]?.let { return it }
+                // A tab the platform already revived keeps its identity — one file
+                // per tab, whoever asked first. See [unclaimedTabs].
+                unclaimedTabs.remove(tabId)?.let { revived ->
+                    projectTabs[tabId] = revived
+                    return revived
                 }
+                return ClaudeCodeVirtualFile(tabId, initialPath, initialTitle)
+                    .also { projectTabs[tabId] = it }
+            }
+        }
+
+        /**
+         * Materialize a tab with no project in hand.
+         *
+         * This is the restore path: the platform hands over a persisted
+         * `claude-code://<tabId>` URL and expects a file back, long before any
+         * project is open. Returns the existing file when there is one, so the
+         * per-tab identity holds no matter which lookup gets there first.
+         */
+        fun getOrCreateUnclaimed(tabId: String): ClaudeCodeVirtualFile {
+            synchronized(openTabs) {
+                findExisting(tabId)?.let { return it }
+                return unclaimedTabs.getOrPut(tabId) { ClaudeCodeVirtualFile(tabId) }
+            }
+        }
+
+        /**
+         * Hand a revived tab to the project that is about to host it.
+         *
+         * Called from [ClaudeCodeEditorProvider.createEditor] — the first moment
+         * a restored tab and its project are both in hand. From here on the tab
+         * follows the ordinary per-project lifecycle: [removeTab] on a real
+         * close, and garbage collection with the project. A no-op for a tab that
+         * already belongs to a project.
+         */
+        fun claim(project: Project, tabId: String) {
+            synchronized(openTabs) {
+                val revived = unclaimedTabs.remove(tabId) ?: return
+                openTabs.getOrPut(project) { ConcurrentHashMap() }[tabId] = revived
             }
         }
 
@@ -110,7 +172,8 @@ class ClaudeCodeVirtualFile(
         }
 
         /**
-         * Look up an already-known tab by ID, across every open project.
+         * Look up an already-known tab by ID, across every project and the
+         * not-yet-claimed ones.
          *
          * This backs [ClaudeCodeFileSystem.findFileByPath], which resolves a
          * persisted `claude-code://<tabId>` URL during the platform's own tab
@@ -118,21 +181,44 @@ class ClaudeCodeVirtualFile(
          * a file, not a project — so the search spans all projects. Tab IDs are
          * UUIDs minted per tab, so a collision across projects is not a practical
          * concern.
-         *
-         * Returns null for an unknown ID, which is the point: only tabs the plugin
-         * has already registered are revived, so a stale URL (a tab closed before
-         * shutdown) is skipped by the platform rather than resurrected.
          */
         fun findExisting(tabId: String): ClaudeCodeVirtualFile? {
             synchronized(openTabs) {
-                return openTabs.values.firstNotNullOfOrNull { it[tabId] }
+                return openTabs.values.firstNotNullOfOrNull { it[tabId] } ?: unclaimedTabs[tabId]
             }
         }
 
         fun removeTab(project: Project, tabId: String) {
             synchronized(openTabs) {
                 openTabs[project]?.remove(tabId)
+                // A tab closed before it was ever claimed (the panel never mounted)
+                // would otherwise linger and be handed back to a later lookup.
+                unclaimedTabs.remove(tabId)
             }
+        }
+    }
+
+    /**
+     * Fill in what a revived tab could not know at birth.
+     *
+     * A tab restored by the platform is built with no project (see
+     * [unclaimedTabs]), so it starts on the generic label and with no address —
+     * both of those live in
+     * [com.github.yhk1038.claudecodegui.services.EditorTabStateService], which
+     * needs a [Project]. [ClaudeCodeEditorProvider.createEditor] is the first
+     * moment both are in hand, and this is what it fills in there.
+     *
+     * Deliberately silent, unlike [setDisplayName]: nothing is showing the old
+     * label yet, and firing a property change while the platform is mid-way
+     * through building the editor would be a notification about a tab that does
+     * not exist on screen. Neither value overwrites one the tab already has.
+     */
+    fun seedRestoredState(path: String?, title: String?) {
+        if (currentPath == null) {
+            currentPath = path
+        }
+        if (title != null && displayName == DEFAULT_DISPLAY_NAME) {
+            displayName = truncateName(title)
         }
     }
 

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeFileSystemTest.kt
@@ -1,7 +1,9 @@
 package com.github.yhk1038.claudecodegui.editor
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -47,14 +49,41 @@ class ClaudeCodeFileSystemTest {
     }
 
     @Test
-    fun `unknown tab id resolves to null rather than resurrecting a closed tab`() {
-        // A tab the user closed before shutdown is gone from both the in-memory
-        // map and EditorTabStateService, so its URL must answer null and let the
-        // platform skip that entry instead of reopening it.
+    fun `a tab resolves with no project open, which is when the platform asks`() {
+        // Issue #312. The platform restores the editor layout while the project
+        // is still opening: a logged run showed ProjectManager.openProjects empty
+        // at the moment of the lookup and the project appearing there 3.8s LATER.
+        // So a lookup that needs an open project to answer never answers, the
+        // platform logs "No file exists: claude-code://..." and drops the tab —
+        // and with it the splitter it was in, which is what the reporter saw.
+        //
+        // Resolving a tab must therefore not depend on project state. This test
+        // runs with no application and no project at all, exactly the emptiness
+        // the real restore hits.
         val fs = ClaudeCodeFileSystem()
+        val tabId = "77816be2-84a0-4056-8955-763c361b3c97"
 
-        assertNull(fs.findFileByPath("no-such-tab"))
-        assertNull(fs.refreshAndFindFileByPath("no-such-tab"))
+        val file = fs.findFileByPath(tabId)
+
+        assertNotNull(file, "a persisted chat tab must resolve even before any project is open")
+        assertEquals(tabId, (file as ClaudeCodeVirtualFile).tabId)
+        assertEquals(ClaudeCodeFileSystem.urlFor(tabId), file.url)
+    }
+
+    @Test
+    fun `the same tab id always resolves to the same file`() {
+        // The platform compares files by identity in places (detaching a browser
+        // component from its old parent, for one), and two files for one tab
+        // would each carry their own display name and path. Whoever asks first
+        // mints it; everyone after gets that same instance.
+        val fs = ClaudeCodeFileSystem()
+        val tabId = "3d3f1a2c-0000-4000-8000-000000000001"
+
+        val first = fs.findFileByPath(tabId)
+        val second = fs.refreshAndFindFileByPath(tabId)
+
+        assertNotNull(first)
+        assertSame(first, second)
     }
 
     @Test
@@ -78,9 +107,11 @@ class ClaudeCodeFileSystemTest {
         val pathHandedBack = persisted.substringAfter("://")
 
         assertEquals(tabId, pathHandedBack)
-        // Unknown to both lookups here, so null — but it reached the lookup as the
-        // bare tab ID, which is the part this test pins.
-        assertNull(fs.findFileByPath(pathHandedBack))
+        // And the lookup answers with that same tab, which is the whole point of
+        // the round trip: the platform gets a file back to put in the layout.
+        val resolved = fs.findFileByPath(pathHandedBack)
+        assertNotNull(resolved)
+        assertEquals(tabId, (resolved as ClaudeCodeVirtualFile).tabId)
     }
 
     @Test

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFileClaimTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeVirtualFileClaimTest.kt
@@ -1,0 +1,107 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.openapi.project.Project
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Proxy
+
+/**
+ * Pins what happens to a tab the platform revives before any project is open
+ * (issue #312).
+ *
+ * The editor layout is restored while the project is still opening, so the file
+ * has to be built with no owner and adopted later. The risk that buys is a
+ * second file for the same tab — two labels, two addresses, and a browser
+ * component whose parent nobody agrees on. These tests pin the single-instance
+ * rule across that hand-over.
+ */
+class ClaudeCodeVirtualFileClaimTest {
+
+    /**
+     * A Project stand-in usable as a map key.
+     *
+     * The registry only ever uses a Project as a key, so identity is all it
+     * needs; equals/hashCode/toString are answered here because a dynamic proxy
+     * routes even those through the handler.
+     */
+    private fun fakeProject(label: String): Project =
+        Proxy.newProxyInstance(
+            Project::class.java.classLoader,
+            arrayOf(Project::class.java),
+        ) { proxy, method, args ->
+            when (method.name) {
+                "hashCode" -> System.identityHashCode(proxy)
+                "equals" -> proxy === args?.getOrNull(0)
+                "toString" -> label
+                else -> throw AssertionError(
+                    "the tab registry must use a Project as a key only, but it called " +
+                        "Project.${method.name}()",
+                )
+            }
+        } as Project
+
+    @Test
+    fun `a project adopts the very file the platform already revived`() {
+        val tabId = "claim-test-0001"
+        val revived = ClaudeCodeVirtualFile.getOrCreateUnclaimed(tabId)
+
+        val adopted = ClaudeCodeVirtualFile.getOrCreate(fakeProject("p"), tabId)
+
+        assertSame(
+            revived,
+            adopted,
+            "adopting must hand back the restored file, not mint a second one for the same tab",
+        )
+    }
+
+    @Test
+    fun `claim moves the tab under its project, and is repeatable`() {
+        val tabId = "claim-test-0002"
+        val project = fakeProject("p")
+        val revived = ClaudeCodeVirtualFile.getOrCreateUnclaimed(tabId)
+
+        ClaudeCodeVirtualFile.claim(project, tabId)
+        // Second call has nothing left to move; it must not wipe the first.
+        ClaudeCodeVirtualFile.claim(project, tabId)
+
+        assertSame(revived, ClaudeCodeVirtualFile.findExisting(tabId))
+        ClaudeCodeVirtualFile.removeTab(project, tabId)
+        assertNull(
+            ClaudeCodeVirtualFile.findExisting(tabId),
+            "once claimed, closing the tab through its project must drop it",
+        )
+    }
+
+    @Test
+    fun `closing a tab that was never claimed still drops it`() {
+        // A tab revived by the layout restore whose panel never mounted has no
+        // project map to be removed from; without the unclaimed sweep it would be
+        // handed back to every later lookup.
+        val tabId = "claim-test-0003"
+        ClaudeCodeVirtualFile.getOrCreateUnclaimed(tabId)
+
+        ClaudeCodeVirtualFile.removeTab(fakeProject("p"), tabId)
+
+        assertNull(ClaudeCodeVirtualFile.findExisting(tabId))
+    }
+
+    @Test
+    fun `seeding fills a revived tab in, and never overwrites what it already has`() {
+        val revived = ClaudeCodeVirtualFile("seed-test-0001")
+        assertNull(revived.currentPath)
+
+        revived.seedRestoredState("/sessions/abc", "Fix the parser")
+
+        assertEquals("/sessions/abc", revived.currentPath)
+        assertEquals("Fix the parser", revived.name)
+
+        // A tab that already knows where it is keeps it: the pane's own restored
+        // address (ClaudeCodeEditorState) and a live rename both outrank the seed.
+        revived.seedRestoredState("/sessions/stale", "Stale title")
+
+        assertEquals("/sessions/abc", revived.currentPath)
+        assertEquals("Fix the parser", revived.name)
+    }
+}


### PR DESCRIPTION
## The problem

Chat tabs never came back after an IDE restart. The report was about a tab alone in a right split, but the split had nothing to do with it — no chat tab came back, in any layout. This is a regression from #302: before it the plugin reopened tabs itself, so a failure only put them in the wrong pane.

## The cause

The platform resolves a persisted tab URL *before* the project is registered in `openProjects` — measured at 3.8 seconds ahead on IDEA 2026.2:

```
21:26:42,386  openProjects=[]
21:26:42,387  WARN No file exists: claude-code://77816be2-...
21:26:46,167  openProjects=[swttch]
```

`findFileByPath` decided whether a tab existed by scanning that list for it in `EditorTabStateService`, so it always answered null. The platform then drops the tab and removes the now-empty window from its splitter — which is why the reporter's right split vanished along with the chat.

## The fix

Remove the project gate. It was there to stop a closed tab from being resurrected, but the platform only asks about URLs it persisted and a closed tab is already out of that layout, so it bought nothing. A tab with no project waits in an unclaimed registry (one file per tab ID), and `createEditor` claims it and fills in the conversation and title the moment a `Project` exists.

## Verification

On IntelliJ IDEA 2026.2 (same 262 platform as the reported CLion 2026.2.1): the reported layout restores, and so does a nested-splitter case with three panes and four chat tabs — including one tab open in two panes on different conversations. Tests are TDD (3 failing first) plus 4 identity invariants; all three layers pass.

Closes #312