### PR TITLE
fix: keep a new chat tab's title from turning into a UUID

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorTabTitleProvider.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorTabTitleProvider.kt
@@ -1,0 +1,49 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.openapi.fileEditor.impl.EditorTabTitleProvider
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.VirtualFile
+
+/**
+ * Labels a chat tab with its conversation name, so the platform never falls back
+ * to disambiguating our tabs by their UUID path.
+ *
+ * `EditorTabPresentationUtil.getEditorTabTitle` resolves a label in three steps:
+ *
+ *  1. the `editorTabTitleProvider` extensions — this class;
+ *  2. the platform's unique-name pass, for when two open tabs share a name;
+ *  3. `VirtualFile.getPresentableName`.
+ *
+ * Step 3 is what we want, but step 2 got there first. Every fresh chat tab is
+ * named "Claude Code" until its conversation reports a title, so opening a
+ * second one with "+" made two open tabs share a name — and the unique-name pass
+ * builds its labels out of `VirtualFile.getPath()` (via `UniqueVFilePathBuilder`,
+ * the same machinery that turns two `Main.kt` into `foo/Main.kt` and
+ * `bar/Main.kt`). Ours is the tab's UUID, deliberately: a stable path is what
+ * makes the persisted `claude-code://<tabId>` URL survive a restart (issue #302).
+ * So both tabs came back labelled `43871f9c-1e0e-4176-8355-f8df1c09b1c7`.
+ *
+ * Claiming step 1 for our own files stops the platform before it ever reaches
+ * step 2. Two untitled tabs both reading "Claude Code" is the intended
+ * presentation, the same as two untitled chats in Cursor — a chat tab has no
+ * containing directory to disambiguate it with, and its UUID means nothing to
+ * the user.
+ *
+ * Every other file answers null, which leaves the platform's own resolution —
+ * unique-name pass included — exactly as it was.
+ */
+class ClaudeCodeEditorTabTitleProvider : EditorTabTitleProvider {
+
+    override fun getEditorTabTitle(project: Project, file: VirtualFile): String? = titleFor(file)
+
+    companion object {
+        /**
+         * The label for [file], or null if it is not one of ours.
+         *
+         * Split out from the extension method because the platform signature
+         * demands a [Project] this resolution never consults — a chat tab's label
+         * is a property of the tab alone — and a plain unit test cannot supply one.
+         */
+        fun titleFor(file: VirtualFile): String? = (file as? ClaudeCodeVirtualFile)?.presentableName
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,12 @@
         <fileEditorProvider
             implementation="com.github.yhk1038.claudecodegui.editor.ClaudeCodeEditorProvider"/>
 
+        <!-- Tab label. Claims the chat tab's title before the platform's
+             unique-name pass can reach it: two untitled tabs share the name
+             "Claude Code", and that pass disambiguates by path — which for us is
+             the tab's UUID, so pressing "+" relabelled both tabs with a UUID. -->
+        <editorTabTitleProvider implementation="com.github.yhk1038.claudecodegui.editor.ClaudeCodeEditorTabTitleProvider"/>
+
         <!-- Project service for session management -->
         <projectService
             serviceImplementation="com.github.yhk1038.claudecodegui.services.ClaudeSessionService"/>

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorTabTitleProviderTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/editor/ClaudeCodeEditorTabTitleProviderTest.kt
@@ -1,0 +1,95 @@
+package com.github.yhk1038.claudecodegui.editor
+
+import com.intellij.testFramework.LightVirtualFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+/**
+ * Pins the tab label a chat tab shows once a SECOND chat tab is open.
+ *
+ * `EditorTabPresentationUtil.getEditorTabTitle` resolves a label in three steps:
+ * the `editorTabTitleProvider` extensions first, then the platform's unique-name
+ * pass, and only then `VirtualFile.getPresentableName`. The middle step is the
+ * problem: when two open tabs share a name — and every fresh chat tab is named
+ * "Claude Code" until the conversation reports a title — it disambiguates them
+ * through `UniqueVFilePathBuilder`, which builds its labels out of
+ * `VirtualFile.getPath()`. Ours is the tab's UUID (deliberately, so a persisted
+ * `claude-code://<tabId>` URL survives a restart — issue #302), so pressing "+"
+ * relabelled BOTH tabs `43871f9c-1e0e-4176-8355-f8df1c09b1c7`.
+ *
+ * Claiming the first step keeps the platform from ever reaching the unique-name
+ * pass for our files. Two tabs named "Claude Code" is the intended presentation
+ * — the same as two untitled chats in Cursor.
+ */
+class ClaudeCodeEditorTabTitleProviderTest {
+
+    private val provider = ClaudeCodeEditorTabTitleProvider()
+
+    @Test
+    fun `a chat tab is labelled by its display name, never by its UUID path`() {
+        val file = ClaudeCodeVirtualFile("43871f9c-1e0e-4176-8355-f8df1c09b1c7", initialTitle = "Fix the parser")
+
+        assertEquals("Fix the parser", ClaudeCodeEditorTabTitleProvider.titleFor(file))
+    }
+
+    @Test
+    fun `an untitled chat tab is labelled with the app name, not its UUID path`() {
+        // The reported symptom: a tab opened with "+" has no conversation title
+        // yet, so it falls back to "Claude Code" — which is exactly the collision
+        // that used to send the platform looking for a unique path.
+        val file = ClaudeCodeVirtualFile("43871f9c-1e0e-4176-8355-f8df1c09b1c7")
+
+        assertEquals("Claude Code", ClaudeCodeEditorTabTitleProvider.titleFor(file))
+    }
+
+    @Test
+    fun `two untitled tabs keep the same label instead of being disambiguated by UUID`() {
+        // The unique-name pass only fires when open tabs share a name, so this is
+        // the case that regressed. Both must still answer the shared label here:
+        // returning it at all is what stops the platform from disambiguating.
+        val first = ClaudeCodeVirtualFile("43871f9c-1e0e-4176-8355-f8df1c09b1c7")
+        val second = ClaudeCodeVirtualFile("ae094c4e-a59e-4682-bb88-a199b154933a")
+
+        assertEquals("Claude Code", ClaudeCodeEditorTabTitleProvider.titleFor(first))
+        assertEquals("Claude Code", ClaudeCodeEditorTabTitleProvider.titleFor(second))
+    }
+
+    @Test
+    fun `a long conversation title is truncated the same way the tab already truncated it`() {
+        // The label still comes from the file's display name, so the existing
+        // truncation is inherited rather than re-implemented here.
+        val file = ClaudeCodeVirtualFile("tab-1", initialTitle = "A conversation title far longer than the tab allows")
+
+        val title = ClaudeCodeEditorTabTitleProvider.titleFor(file)
+
+        assertEquals(file.presentableName, title)
+        assertTrue(title!!.endsWith("…"), "expected the inherited truncation, got: $title")
+    }
+
+    @Test
+    fun `other files are left to the platform`() {
+        // Returning anything for a file that is not ours would hijack every tab in
+        // the IDE — including the unique-name disambiguation that genuinely helps
+        // when two real files share a name.
+        assertNull(ClaudeCodeEditorTabTitleProvider.titleFor(LightVirtualFile("Main.kt", "")))
+    }
+
+    @Test
+    fun `provider is registered in plugin_xml`() {
+        // The class alone changes nothing: the platform only consults providers
+        // declared under the extension point. Same failure mode as the file-system
+        // registration — silent, and only visible once a second tab is open.
+        val pluginXml = File("src/main/resources/META-INF/plugin.xml").readText()
+
+        assertTrue(
+            pluginXml.contains(
+                "<editorTabTitleProvider implementation=\"" +
+                    "com.github.yhk1038.claudecodegui.editor.ClaudeCodeEditorTabTitleProvider\"/>",
+            ),
+            "plugin.xml must register ClaudeCodeEditorTabTitleProvider under editorTabTitleProvider",
+        )
+    }
+}


### PR DESCRIPTION
Opening a second chat tab made both tabs share the name "Claude Code", and the platform's unique-name pass then disambiguated them by path — which for a chat tab is the tab UUID the persisted `claude-code://` URL depends on (#302).

Registering an `editorTabTitleProvider` claims the label before that pass runs, so the tabs keep showing their conversation names.