### PR TITLE
No more � characters on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Runtime shell assets must stay LF no matter what core.autocrlf a contributor has.
+# win-bash-env.sh is sourced by bash (via BASH_ENV) rather than run by Windows, and it
+# is copied verbatim into every distributable — a CRLF checkout would ship CRLF. Git
+# Bash tolerates the CR, but the GNU bash a WSL user gets does not have to.
+backend/src/core/win-bash-env.sh text eol=lf

--- a/backend/esbuild.mjs
+++ b/backend/esbuild.mjs
@@ -86,4 +86,11 @@ await build({ ...common, entryPoints: ['src/cli/account.ts'], outfile: 'dist/acc
 // syncResources, standalone tgz) copy it from dist/ alongside backend.mjs.
 copyFileSync('src/core/win-job-wrapper.ps1', 'dist/win-job-wrapper.ps1');
 
+// Same deal for the BASH_ENV script the CLI's bash sources on every non-interactive
+// start (win-job.ts `utf8BashEnv`). It is what keeps CJK console output from reaching
+// the chat as U+FFFD, and utf8BashEnv stays SILENT when the file is absent — so a
+// distributable that forgets to carry it degrades invisibly. Keep all three copy
+// sites (here, gradle syncResources, standalone tgz) in step.
+copyFileSync('src/core/win-bash-env.sh', 'dist/win-bash-env.sh');
+
 console.log('Backend bundled successfully');

--- a/backend/src/core/__tests__/claude.test.ts
+++ b/backend/src/core/__tests__/claude.test.ts
@@ -266,6 +266,53 @@ describe('Claude', () => {
 // — exactly like CLAUDE_CONFIG_DIR before it (#123) — the value is projected when a
 // context LOADS rather than being cached per call site. applyConfigDir is that
 // load-time hook and already runs on every entry point, so the CLI path rides along.
+// `where` / `claude` run through cmd.exe, which writes non-ASCII on stdout in the system's
+// legacy OEM codepage rather than UTF-8. Letting Node decode that as utf8 turns an install
+// path under a Korean or Chinese user directory into U+FFFD, and the launcher we resolve
+// from it can no longer be spawned. See console-encoding.ts.
+describe('console output decoding on win32 paths', () => {
+  // which() caches its win32 result; changing cliPath is how the class drops that cache,
+  // so each test here starts from a cold resolve rather than a stale hit.
+  async function coldLauncherCache(): Promise<void> {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { cliPath: 'claude' }, overrides: [] });
+    await Claude.applyConfigDir('/cold/a');
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { cliPath: null }, overrides: [] });
+    await Claude.applyConfigDir('/cold/b');
+    vi.clearAllMocks();
+  }
+
+  afterEach(async () => {
+    const { readMergedSettings } = await import('../features/settings');
+    vi.mocked(readMergedSettings).mockResolvedValue({ settings: { cliPath: null }, overrides: [] });
+    vi.clearAllMocks();
+  });
+
+  it('asks execFile for raw bytes instead of Node default utf8 decoding', async () => {
+    await coldLauncherCache();
+    await Claude.which();
+
+    const opts = vi.mocked(cpExecFile).mock.calls[0][2] as { encoding?: string };
+    expect(opts.encoding).toBe('buffer');
+  });
+
+  it('resolves a launcher path delivered as a Buffer (locale-independent)', async () => {
+    await coldLauncherCache();
+    vi.mocked(cpExecFile).mockImplementationOnce(((
+      _cmd: string,
+      _args: unknown,
+      _opts: unknown,
+      cb?: (e: unknown, o: Buffer, s: Buffer) => void,
+    ) => {
+      cb?.(null, Buffer.from(`${FAKE_CLAUDE_CMD}
+`, 'utf8'), Buffer.alloc(0));
+      return { on: vi.fn() };
+    }) as unknown as typeof cpExecFile);
+
+    expect(await Claude.which()).toBe(FAKE_CLAUDE_CMD);
+  });
+});
+
 describe('Claude.applyConfigDir — per-project cliPath', () => {
   afterEach(() => {
     vi.clearAllMocks();

--- a/backend/src/core/__tests__/console-encoding.test.ts
+++ b/backend/src/core/__tests__/console-encoding.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { legacyDecoderCandidates, decodeConsoleOutput } from '../console-encoding';
+
+/**
+ * Windows console programs (tasklist, netstat, ...) emit their localized messages in the
+ * system's legacy OEM codepage, not UTF-8. Decoding those bytes as UTF-8 turns every
+ * non-ASCII character into U+FFFD, which is what users see as garbled output.
+ */
+describe('legacyDecoderCandidates', () => {
+  it('maps Korean to the CP949-compatible decoder', () => {
+    expect(legacyDecoderCandidates('ko-KR')).toEqual(['euc-kr']);
+  });
+
+  it('maps Japanese to Shift-JIS', () => {
+    expect(legacyDecoderCandidates('ja-JP')).toEqual(['shift_jis']);
+  });
+
+  it('maps Simplified Chinese to GBK before GB18030 (GBK is the CP936 default)', () => {
+    expect(legacyDecoderCandidates('zh-CN')).toEqual(['gbk', 'gb18030']);
+  });
+
+  it('maps Traditional Chinese to Big5', () => {
+    expect(legacyDecoderCandidates('zh-TW')).toEqual(['big5']);
+    expect(legacyDecoderCandidates('zh-Hant-HK')).toEqual(['big5']);
+  });
+
+  it('falls back to windows-1252 for Western locales', () => {
+    expect(legacyDecoderCandidates('en-US')).toEqual(['windows-1252']);
+  });
+
+  it('is case-insensitive and tolerates a bare language tag', () => {
+    expect(legacyDecoderCandidates('KO')).toEqual(['euc-kr']);
+    expect(legacyDecoderCandidates('zh')).toEqual(['gbk', 'gb18030']);
+  });
+});
+
+describe('decodeConsoleOutput', () => {
+  it('returns UTF-8 text untouched when the bytes are valid UTF-8', () => {
+    const buf = Buffer.from('한글-中文-テスト', 'utf8');
+    expect(decodeConsoleOutput(buf, 'ko-KR')).toBe('한글-中文-テスト');
+  });
+
+  it('recovers Korean CP949 bytes that UTF-8 would turn into U+FFFD', () => {
+    // "이미지 이름" as emitted by `tasklist` on a Korean Windows console.
+    const cp949 = Buffer.from([0xc0, 0xcc, 0xb9, 0xcc, 0xc1, 0xf6, 0x20, 0xc0, 0xcc, 0xb8, 0xa7]);
+    expect(cp949.toString('utf8')).toContain('\uFFFD');
+    expect(decodeConsoleOutput(cp949, 'ko-KR')).toBe('이미지 이름');
+  });
+
+  it('recovers Simplified Chinese GBK bytes', () => {
+    const gbk = Buffer.from([0xd6, 0xd0, 0xce, 0xc4]); // 中文
+    expect(gbk.toString('utf8')).toContain('\uFFFD');
+    expect(decodeConsoleOutput(gbk, 'zh-CN')).toBe('中文');
+  });
+
+  it('leaves pure ASCII alone regardless of locale', () => {
+    const buf = Buffer.from('Image Name    PID', 'utf8');
+    expect(decodeConsoleOutput(buf, 'ja-JP')).toBe('Image Name    PID');
+  });
+
+  it('preserves the UTF-8 reading when no candidate decoder yields a clean result', () => {
+    // A lone 0xFF is invalid in UTF-8 AND in euc-kr — we must not lose the output.
+    const buf = Buffer.from([0x41, 0xff, 0x42]);
+    const out = decodeConsoleOutput(buf, 'ko-KR');
+    expect(out).toContain('A');
+    expect(out).toContain('B');
+  });
+
+  it('accepts a string and passes it through unchanged (already decoded upstream)', () => {
+    expect(decodeConsoleOutput('already text', 'ko-KR')).toBe('already text');
+  });
+});

--- a/backend/src/core/__tests__/win-exec.test.ts
+++ b/backend/src/core/__tests__/win-exec.test.ts
@@ -102,6 +102,48 @@ describe('execViaCmdArgv', () => {
     await expect(execViaCmdArgv('%LAUNCHER%.cmd', ['update'])).rejects.toThrow(/%/);
     expect(vi.mocked(cpExecFile)).not.toHaveBeenCalled();
   });
+
+  // cmd.exe writes non-ASCII on stdout in the system's legacy OEM codepage, not UTF-8.
+  // Taking Node's default utf8 decoding turns a Korean/Chinese install path into U+FFFD,
+  // so we must receive raw bytes and decode them ourselves (see console-encoding.ts).
+  it('asks execFile for raw bytes instead of Node default utf8 decoding', async () => {
+    await execViaCmdArgv('npm.cmd', ['view', 'pkg']);
+
+    const opts = vi.mocked(cpExecFile).mock.calls[0][2] as { encoding?: string };
+    expect(opts.encoding).toBe('buffer');
+  });
+
+  it('decodes a Buffer stdout rather than returning "[object Object]"', async () => {
+    vi.mocked(cpExecFile).mockImplementationOnce(((
+      _cmd: string,
+      _args: unknown,
+      _opts: unknown,
+      cb?: (e: unknown, o: Buffer, s: Buffer) => void,
+    ) => {
+      cb?.(null, Buffer.from('C:\tools\claude.cmd', 'utf8'), Buffer.alloc(0));
+      return { on: vi.fn() };
+    }) as unknown as typeof cpExecFile);
+
+    const result = await execViaCmdArgv('where.exe', ['claude']);
+    expect(result.stdout).toBe('C:\tools\claude.cmd');
+    expect(result.stderr).toBe('');
+  });
+
+  it('keeps valid UTF-8 bytes intact (locale-independent)', async () => {
+    const text = 'C:\사용자\claude.cmd';
+    vi.mocked(cpExecFile).mockImplementationOnce(((
+      _cmd: string,
+      _args: unknown,
+      _opts: unknown,
+      cb?: (e: unknown, o: Buffer, s: Buffer) => void,
+    ) => {
+      cb?.(null, Buffer.from(text, 'utf8'), Buffer.alloc(0));
+      return { on: vi.fn() };
+    }) as unknown as typeof cpExecFile);
+
+    const result = await execViaCmdArgv('where.exe', ['claude']);
+    expect(result.stdout).toBe(text);
+  });
 });
 
 describe('assertNoCmdPercentExpansion', () => {

--- a/backend/src/core/__tests__/win-job.test.ts
+++ b/backend/src/core/__tests__/win-job.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { buildWin32CmdLine } from '../win-job';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Mock fs so the BASH_ENV tests can decide whether the shipped script "exists"
+// without depending on where the suite happens to run from.
+vi.mock('fs', () => ({ existsSync: vi.fn(() => true) }));
+
+import { existsSync } from 'fs';
+import { buildWin32CmdLine, toMsysPath, utf8BashEnv } from '../win-job';
 
 describe('buildWin32CmdLine', () => {
   it('joins command + args with single spaces (mirrors Node win32 shell:true)', () => {
@@ -21,5 +27,75 @@ describe('buildWin32CmdLine', () => {
 
   it('returns the bare command when there are no args', () => {
     expect(buildWin32CmdLine('claude', [])).toBe('claude');
+  });
+});
+
+describe('toMsysPath', () => {
+  it('rewrites a drive letter into the /c/ form git-bash resolves', () => {
+    expect(toMsysPath('C:\\Users\\me\\ccg\\win-bash-env.sh'))
+      .toBe('/c/Users/me/ccg/win-bash-env.sh');
+  });
+
+  it('lowercases the drive letter (bash mount points are lowercase)', () => {
+    expect(toMsysPath('D:\\tools\\x.sh')).toBe('/d/tools/x.sh');
+  });
+
+  it('accepts a forward-slash drive path, which is what import.meta.url yields', () => {
+    expect(toMsysPath('C:/Users/me/x.sh')).toBe('/c/Users/me/x.sh');
+  });
+
+  it('still normalizes separators on a path that carries no drive letter', () => {
+    expect(toMsysPath('\\\\server\\share\\x.sh')).toBe('//server/share/x.sh');
+  });
+});
+
+/**
+ * The CLI's Bash tool decodes its subprocess output as UTF-8, but Windows console
+ * programs print localized text in the legacy OEM codepage, so non-ASCII arrives as
+ * U+FFFD. Setting the codepage when we spawn the CLI does NOT survive — measured on
+ * ko-KR, it reads 65001 in cmd and in a bash launched from it, but drops back to 949
+ * once the CLI launches the tool's own bash. bash sources $BASH_ENV on every
+ * non-interactive start, which is the one hook that runs INSIDE that bash.
+ */
+describe('utf8BashEnv', () => {
+  const realPlatform = process.platform;
+
+  const setPlatform = (value: string) => {
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+  };
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+    vi.mocked(existsSync).mockReturnValue(true);
+  });
+
+  it('points BASH_ENV at the shipped script, in the path form bash understands', () => {
+    setPlatform('win32');
+    const result = utf8BashEnv({});
+    expect(result.BASH_ENV).toMatch(/^\/[a-z]\//);
+    expect(result.BASH_ENV).toContain('win-bash-env.sh');
+  });
+
+  it('carries an existing BASH_ENV aside so the script can source it back', () => {
+    setPlatform('win32');
+    const result = utf8BashEnv({ BASH_ENV: '/home/me/.bashenv' });
+    expect(result.CCG_PREV_BASH_ENV).toBe('/home/me/.bashenv');
+    expect(result.BASH_ENV).toContain('win-bash-env.sh');
+  });
+
+  it('leaves CCG_PREV_BASH_ENV unset when the user had no BASH_ENV', () => {
+    setPlatform('win32');
+    expect(utf8BashEnv({})).not.toHaveProperty('CCG_PREV_BASH_ENV');
+  });
+
+  it('does nothing off win32, where console codepages do not exist', () => {
+    setPlatform('darwin');
+    expect(utf8BashEnv({ BASH_ENV: '/home/me/.bashenv' })).toEqual({});
+  });
+
+  it('does nothing when the script is missing — a lost asset must never break chat', () => {
+    setPlatform('win32');
+    vi.mocked(existsSync).mockReturnValue(false);
+    expect(utf8BashEnv({})).toEqual({});
   });
 });

--- a/backend/src/core/claude.ts
+++ b/backend/src/core/claude.ts
@@ -5,6 +5,7 @@ import {
   type ChildProcess,
   type SpawnOptions,
   type ExecFileOptions,
+  type ExecFileOptionsWithBufferEncoding,
 } from 'child_process';
 import { readMergedSettings, resolveClaudeConfigDirOverride } from './features/settings';
 import { getStrippableAuthEnvKeys } from './features/claude-settings';
@@ -12,7 +13,8 @@ import { augmentedPath } from './augmented-path';
 import { resolveWslCwd } from './wsl-path';
 import { execViaCmdArgv } from './win-exec';
 import { pickWin32Launcher } from './which-launcher';
-import { spawnWin32JobCli } from './win-job';
+import { spawnWin32JobCli, utf8BashEnv } from './win-job';
+import { decodeConsoleOutput } from './console-encoding';
 
 export class Claude {
   private static cliPath: string | null = null;
@@ -102,7 +104,8 @@ export class Claude {
    */
   static spawn(args: string[], options?: SpawnOptions, win32JobSessionId?: string): ChildProcess {
     const cwd = resolveWslCwd(options?.cwd);
-    const env = { ...Claude.env, ...options?.env };
+    const merged = { ...Claude.env, ...options?.env };
+    const env = { ...merged, ...utf8BashEnv(merged) };
     if (process.platform === 'win32' && win32JobSessionId) {
       return spawnWin32JobCli(Claude.command, args, win32JobSessionId, { ...options, cwd, env });
     }
@@ -224,9 +227,14 @@ export class Claude {
     options?: ExecFileOptions,
   ): Promise<{ stdout: string; stderr: string }> {
     return new Promise((resolve, reject) => {
-      cpExecFile(command, args, {
+      // encoding:'buffer' — on win32 this runs through cmd.exe, whose own messages (and any
+      // non-ASCII path echoed back) arrive in the system's legacy OEM codepage, not UTF-8.
+      // Node's default utf8 decoding would replace those bytes with U+FFFD before we could
+      // recover them; decodeConsoleOutput below reads them with the right codepage.
+      const execOptions: ExecFileOptionsWithBufferEncoding = {
         timeout: 10000,
         ...options,
+        encoding: 'buffer',
         cwd: resolveWslCwd(options?.cwd),
         // On Windows the `claude` launcher is a .cmd/.ps1 wrapper that execFile
         // cannot run without a shell (it fails with ENOENT). spawn() already
@@ -239,9 +247,10 @@ export class Claude {
           ...Claude.env,
           ...options?.env,
         },
-      }, (err, stdout, stderr) => {
-        const out = stdout?.toString() ?? '';
-        const errText = stderr?.toString() ?? '';
+      };
+      cpExecFile(command, args, execOptions, (err, stdout, stderr) => {
+        const out = decodeConsoleOutput(stdout ?? '');
+        const errText = decodeConsoleOutput(stderr ?? '');
         if (err) {
           // Preserve captured output on the rejected error so callers can tell a
           // clean non-zero exit that still printed valid data (e.g. `auth status`
@@ -310,11 +319,17 @@ export class Claude {
       return Promise.resolve(Claude.resolvedWin32Path);
     }
     const cmd = process.platform === 'win32' ? 'where' : 'which';
+    // encoding:'buffer' — `where` prints the launcher path in the console's legacy OEM
+    // codepage. Under a Korean/Chinese user directory, utf8-decoding it yields a path full
+    // of U+FFFD that no longer exists on disk, so the launcher we resolve cannot be spawned.
+    const whichOptions: ExecFileOptionsWithBufferEncoding = {
+      env: Claude.env,
+      timeout: 5000,
+      encoding: 'buffer',
+    };
     return new Promise((resolve) => {
-      cpExecFile(cmd, [Claude.command], {
-        env: Claude.env,
-        timeout: 5000,
-      }, (err, stdout) => {
+      cpExecFile(cmd, [Claude.command], whichOptions, (err, stdout) => {
+        const out = decodeConsoleOutput(stdout ?? '');
         let resolved: string | null;
         if (err) {
           resolved = null;
@@ -322,7 +337,7 @@ export class Claude {
           // `where` also lists the extension-less MSYS script (`...\npm\claude`);
           // pick the launcher cmd.exe actually runs (first PATHEXT match) so
           // which() agrees with the binary spawn()/exec() resolve through cmd.exe.
-          resolved = pickWin32Launcher(stdout?.toString() ?? '');
+          resolved = pickWin32Launcher(out);
         } else {
           resolved = (stdout?.toString() ?? '').trim().split('\n')[0]?.trim() || null;
         }

--- a/backend/src/core/console-encoding.ts
+++ b/backend/src/core/console-encoding.ts
@@ -1,0 +1,65 @@
+/**
+ * Recovery for Windows console output that is not UTF-8.
+ *
+ * Windows console programs (`tasklist`, `netstat`, `where`, ...) print their localized
+ * messages in the system's legacy OEM codepage — CP949 on Korean Windows, CP936 on
+ * Simplified Chinese, CP932 on Japanese — never UTF-8. Node decodes child stdout as UTF-8,
+ * so every non-ASCII byte becomes U+FFFD and the text arrives unreadable.
+ *
+ * Scope: this covers output the BACKEND itself decodes. Output produced inside the Claude
+ * CLI's own Bash tool is decoded by the CLI before it ever reaches us, so it cannot be
+ * repaired here — that path is addressed by switching the console codepage at spawn time
+ * (see `withUtf8ConsoleCodepage` in win-job.ts).
+ */
+
+/** The system locale, used to pick which legacy codepage to try. */
+function systemLocale(): string {
+  return Intl.DateTimeFormat().resolvedOptions().locale;
+}
+
+/**
+ * The legacy decoders worth trying for [locale], most likely first.
+ *
+ * Deliberately keyed on the system language rather than hardcoding one market's codepage:
+ * a Korean machine garbles in CP949 exactly as a Chinese one garbles in CP936, and picking
+ * only the latter would leave every other CJK user with the same broken output.
+ *
+ * `cp949` is not a WHATWG encoding label; `euc-kr` is its registered superset name and is
+ * what TextDecoder accepts for the same byte range.
+ */
+export function legacyDecoderCandidates(locale: string): string[] {
+  const tag = String(locale || '').toLowerCase();
+  const language = tag.split('-')[0];
+  if (language === 'ko') return ['euc-kr'];
+  if (language === 'ja') return ['shift_jis'];
+  if (language === 'zh') {
+    // Traditional-Chinese regions run CP950 (Big5); everything else CP936 (GBK).
+    const traditional = /(^|-)(hant|tw|hk|mo)(-|$)/.test(tag);
+    return traditional ? ['big5'] : ['gbk', 'gb18030'];
+  }
+  return ['windows-1252'];
+}
+
+/**
+ * Decode console output, falling back to the system's legacy codepage when the bytes are
+ * not valid UTF-8. A string passes through untouched (it was decoded upstream already).
+ *
+ * If nothing decodes cleanly the UTF-8 reading is returned as-is: a lossy result still
+ * carries the ASCII parts (paths, PIDs, numbers) that callers usually parse, so degrading
+ * is always better than throwing away the output.
+ */
+export function decodeConsoleOutput(value: Buffer | string, locale?: string): string {
+  if (typeof value === 'string') return value;
+  const utf8 = value.toString('utf8');
+  if (!utf8.includes('\uFFFD')) return utf8;
+
+  for (const label of legacyDecoderCandidates(locale ?? systemLocale())) {
+    try {
+      const decoded = new TextDecoder(label).decode(value);
+      if (!decoded.includes('\uFFFD')) return decoded;
+    } catch {
+      // A Node built without full ICU cannot construct this decoder — try the next label.
+    }
+  }
+  return utf8;
+}

--- a/backend/src/core/win-bash-env.sh
+++ b/backend/src/core/win-bash-env.sh
@@ -1,0 +1,19 @@
+# CCG: force the console to UTF-8 for every non-interactive bash the Claude CLI spawns.
+#
+# The CLI's Bash tool decodes its subprocess output as UTF-8, but Windows console
+# programs print localized text in the legacy OEM codepage (CP949/CP936/CP932), so
+# every non-ASCII character reaches the chat as U+FFFD. Setting the codepage at
+# CLI spawn time does not survive: measured on ko-KR, the codepage is 65001 in cmd
+# and in bash launched from it, but drops back to 949 once the CLI launches the
+# tool's bash. bash sources $BASH_ENV on every non-interactive start, which is the
+# one hook that runs inside that bash — so the codepage is set there instead.
+#
+# Under 65001 those programs cannot load their localized string resources and fall
+# back to English: readable ASCII instead of garbled text.
+
+# Keep whatever the user already had configured.
+if [ -n "$CCG_PREV_BASH_ENV" ] && [ -f "$CCG_PREV_BASH_ENV" ]; then
+  . "$CCG_PREV_BASH_ENV"
+fi
+
+chcp.com 65001 > /dev/null 2>&1

--- a/backend/src/core/win-exec.ts
+++ b/backend/src/core/win-exec.ts
@@ -1,4 +1,9 @@
-import { execFile as cpExecFile, type ExecFileOptions } from 'child_process';
+import {
+  execFile as cpExecFile,
+  type ExecFileOptions,
+  type ExecFileOptionsWithBufferEncoding,
+} from 'child_process';
+import { decodeConsoleOutput } from './console-encoding';
 
 /**
  * Windows-only: run an external launcher through cmd.exe with an argv ARRAY so
@@ -41,29 +46,30 @@ export async function execViaCmdArgv(
   const comspec = process.env.ComSpec || 'cmd.exe';
   // `/d` skips AutoRun, `/s` keeps quoting predictable, `/c` runs then exits.
   const cmdArgs = ['/d', '/s', '/c', command, ...args];
+  // encoding:'buffer' is pinned AFTER ...options on purpose. cmd.exe writes non-ASCII on
+  // stdout in the system's legacy OEM codepage (CP949/CP936/CP932), never UTF-8, so Node's
+  // default utf8 decoding would turn a Korean or Chinese install path into U+FFFD before we
+  // ever see it — losing the bytes decodeConsoleOutput needs to recover the text.
+  const execOptions: ExecFileOptionsWithBufferEncoding = {
+    // Match Claude.exec's historic 10s default; callers (CLI update, which
+    // downloads + links) pass their own longer timeout to override it.
+    timeout: 10000,
+    ...options,
+    encoding: 'buffer',
+    // shell:false — Node spawns cmd.exe directly, not nested in another shell.
+    // windowsVerbatimArguments stays false so Node's standard quoting applies
+    // (verbatim mode would pass args raw and re-expose `& | < >` to cmd).
+    shell: false,
+    windowsVerbatimArguments: false,
+  };
   return new Promise((resolve) => {
-    cpExecFile(
-      comspec,
-      cmdArgs,
-      {
-        // Match Claude.exec's historic 10s default; callers (CLI update, which
-        // downloads + links) pass their own longer timeout to override it.
-        timeout: 10000,
-        ...options,
-        // shell:false — Node spawns cmd.exe directly, not nested in another shell.
-        // windowsVerbatimArguments stays false so Node's standard quoting applies
-        // (verbatim mode would pass args raw and re-expose `& | < >` to cmd).
-        shell: false,
-        windowsVerbatimArguments: false,
-      },
-      (err, stdout, stderr) => {
-        resolve({
-          err: err ?? null,
-          stdout: stdout?.toString() ?? '',
-          stderr: stderr?.toString() ?? '',
-        });
-      },
-    );
+    cpExecFile(comspec, cmdArgs, execOptions, (err, stdout, stderr) => {
+      resolve({
+        err: err ?? null,
+        stdout: decodeConsoleOutput(stdout ?? ''),
+        stderr: decodeConsoleOutput(stderr ?? ''),
+      });
+    });
   });
 }
 

--- a/backend/src/core/win-job.ts
+++ b/backend/src/core/win-job.ts
@@ -44,15 +44,48 @@ export function spawnWin32JobCli(
   sessionId: string,
   options: SpawnOptions,
 ): ChildProcess {
+  const cmdline = buildWin32CmdLine(command, args);
   const wrapper = jobWrapperPath();
   if (!existsSync(wrapper)) {
     console.error('[node-backend]', `Job wrapper not found at ${wrapper} — spawning without a job (orphan guard degraded)`);
     return cpSpawn(command, args, { ...options, shell: true });
   }
-  const cmdline = buildWin32CmdLine(command, args);
   return cpSpawn(
     'powershell.exe',
     ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', wrapper, sessionId],
     { ...options, shell: false, env: { ...options.env, CCG_JOB_CMDLINE: cmdline } },
   );
+}
+
+/** Absolute path to the shipped BASH_ENV script, resolved next to the running bundle. */
+export function bashEnvScriptPath(): string {
+  return fileURLToPath(new URL('./win-bash-env.sh', import.meta.url));
+}
+
+/**
+ * Rewrite a win32 path into the MSYS form git-bash understands (`C:\a\b` -> `/c/a/b`).
+ * bash reads $BASH_ENV with its own path rules, so a drive-letter path would not resolve.
+ */
+export function toMsysPath(win32Path: string): string {
+  const drive = /^([A-Za-z]):[\\/]/.exec(win32Path);
+  if (!drive) return win32Path.split('\\').join('/');
+  return `/${drive[1].toLowerCase()}/${win32Path.slice(3).split('\\').join('/')}`;
+}
+
+/**
+ * The BASH_ENV overrides that make the CLI's Bash tool emit UTF-8 (see win-bash-env.sh).
+ *
+ * Returns nothing off win32, or when the script is missing — a missing script must never
+ * break chat, it only lets the garbling back in. Any BASH_ENV the user already set is
+ * carried in CCG_PREV_BASH_ENV so the script can source it instead of silently dropping it.
+ */
+export function utf8BashEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  if (process.platform !== 'win32') return {};
+  const script = bashEnvScriptPath();
+  if (!existsSync(script)) return {};
+  const previous = env.BASH_ENV;
+  return {
+    ...(previous ? { CCG_PREV_BASH_ENV: previous } : {}),
+    BASH_ENV: toMsysPath(script),
+  };
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -402,9 +402,11 @@ tasks {
         inputs.dir(file("webview/dist"))
         inputs.file(file("backend/dist/backend.mjs"))
         inputs.file(file("backend/dist/win-job-wrapper.ps1"))
+        inputs.file(file("backend/dist/win-bash-env.sh"))
         outputs.dir(file("src/main/resources/webview"))
         outputs.file(file("src/main/resources/backend/backend.mjs"))
         outputs.file(file("src/main/resources/backend/win-job-wrapper.ps1"))
+        outputs.file(file("src/main/resources/backend/win-bash-env.sh"))
         doLast {
             // WebView 정적 파일 동기화 (stale 파일 방지를 위해 기존 디렉토리 삭제 후 복사)
             file("src/main/resources/webview").deleteRecursively()
@@ -412,11 +414,12 @@ tasks {
                 from(file("webview/dist"))
                 into(file("src/main/resources/webview"))
             }
-            // Node.js 백엔드 번들 복사 (+ win32 Job Object 래퍼 자산)
+            // Node.js 백엔드 번들 복사 (+ win32 Job Object 래퍼 / BASH_ENV 자산)
             file("src/main/resources/backend").mkdirs()
             copy {
                 from(file("backend/dist/backend.mjs"))
                 from(file("backend/dist/win-job-wrapper.ps1"))
+                from(file("backend/dist/win-bash-env.sh"))
                 into(file("src/main/resources/backend"))
             }
         }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -210,9 +210,10 @@ case "${1:-}" in
     cp "$ROOT/backend/dist/backend.mjs" "$stage/"
     cp "$ROOT/backend/dist/account-cli.mjs" "$stage/"
     cp "$ROOT/backend/dist/win-job-wrapper.ps1" "$stage/"
+    cp "$ROOT/backend/dist/win-bash-env.sh" "$stage/"
     cp -R "$ROOT/webview/dist/." "$stage/webview/"
     out="$ROOT/dist/claude-code-gui-standalone-v$version.tgz"
-    tar -czf "$out" -C "$stage" account-cli.mjs backend.mjs win-job-wrapper.ps1 webview
+    tar -czf "$out" -C "$stage" account-cli.mjs backend.mjs win-job-wrapper.ps1 win-bash-env.sh webview
     rm -rf "$stage"
     echo "Created: $out"
     ;;


### PR DESCRIPTION
## TL;DR;

It's good news to Windows users.
I almost solved � problem !

### As-is:
<img width="693" height="215" alt="image" src="https://github.com/user-attachments/assets/b0248fc3-7d0c-44b9-bcf8-3342ef531f4f" />

### To-be:
<img width="691" height="210" alt="image" src="https://github.com/user-attachments/assets/8fea8c94-1e2f-453c-986a-c0e23891a70b" />

### Known limitation
- WSL mode is not covered (most case is better than PowerShell but a little points left..)

## What happend?

Windows console programs (`tasklist`, `where`, `dir`, ...) print their localized
messages in the system's legacy OEM codepage — CP949 on Korean Windows, CP936 on
Simplified Chinese, CP932 on Japanese — never UTF-8. Reading that output as UTF-8
turns every non-ASCII character into U+FFFD, which is what reaches the chat as a
row of diamonds. Two separate layers were affected.

## Layer 1 — output from the CLI's Bash tool

The CLI decodes its own subprocess output before it ever reaches the backend, so
that text cannot be repaired downstream. Setting the console codepage when we
spawn the CLI does not reach it either. Measured on ko-KR through the job-wrapper
path, reading the active codepage at each level:

| chain | active codepage |
|---|---|
| wrapper → cmd | 65001 |
| wrapper → cmd → node | 65001 |
| wrapper → cmd → **bash** | 65001 |
| wrapper → cmd → **claude** → bash | **949** |

Within one cmd process the line before reads 65001, and going through the CLI
reads 949 — the CLI's own bash starts from the system default again.

bash sources `$BASH_ENV` on every non-interactive start, and that is the one hook
that runs *inside* that bash, so the codepage is set from there instead. Measured
through the CLI over a directory of Korean, Chinese, Japanese and Latin-extended
filenames: before, every non-ASCII name is garbled and drops out of the listing;
after, every name is intact. Any `BASH_ENV` the user already set is carried aside
in `CCG_PREV_BASH_ENV` and sourced back by the script.

## Layer 2 — output the backend decodes itself

`where claude` and cmd.exe diagnostics are now read as raw bytes and decoded with
the system's legacy codepage when the UTF-8 reading fails — 21 U+FFFD down to 0 on
a real `tasklist`. Previously a launcher path under a Korean or Chinese user
directory came back full of U+FFFD and could no longer be spawned. The decoder is
keyed on the system *language* rather than one market's codepage, so Korean,
Japanese, and both Chinese scripts are covered.

## Known limitation — WSL mode is not covered

| situation | result |
|---|---|
| Linux programs inside WSL (`ls`, ...) | fine — the WSL locale is `C.UTF-8` |
| a Windows exe inside WSL (`tasklist.exe`) | **garbled** — 32 non-ASCII bytes, raw CP949 |
| `chcp.com 65001` first, inside WSL | **no effect** — the very next `chcp` reads 949 again |
| Windows `BASH_ENV` reaching WSL | not passed (absent from `WSLENV`) |

WSL interop launches each Windows exe with its own console context, so `chcp` is
not a handle there at all — that is prior to the `BASH_ENV` delivery problem, not
a consequence of it. That output is likewise already decoded by the CLI, so
Layer 2 cannot recover it either. Work inside WSL is mostly Linux programs and
stays fine, but WSL ships `appendWindowsPath=true` by default, so a user can
invoke a Windows exe directly and hit this. Fixing it needs a different approach
than this PR takes, so it is documented here rather than half-solved.

## Build-asset note

`win-bash-env.sh` is a runtime asset resolved beside the bundle, so it is
registered in all three copy sites (esbuild, gradle `syncResources`, standalone
tgz). `utf8BashEnv` stays silent when the file is absent so a lost asset can never
break chat — which also means a distributable that forgets to carry it would
degrade invisibly. `.gitattributes` pins the script to LF: it is sourced by bash,
not run by Windows, and the repo had no `.gitattributes`, leaving it at the mercy
of each contributor's `core.autocrlf`.

## Verification

- Backend suite: 1369 passing (26 pre-existing Windows failures, identical on `main`)
- New tests cover `toMsysPath` and `utf8BashEnv` (platform branch, preserving a
  user's `BASH_ENV`, and staying inert when the asset is missing)
- `full-build` green; confirmed `win-bash-env.sh` lands in
  `src/main/resources/backend/` via syncResources
- Confirmed end to end in the running app on Korean Windows, before and after

Closes #338
