### PR TITLE
fix: let Option+Arrow reach the chat input (#337)

### DIFF
--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/WebViewKeyboardHandler.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/toolwindow/WebViewKeyboardHandler.kt
@@ -4,6 +4,7 @@ import org.cef.browser.CefBrowser
 import org.cef.handler.CefKeyboardHandler
 import org.cef.handler.CefKeyboardHandlerAdapter
 import org.cef.misc.BoolRef
+import org.cef.misc.EventFlags
 import java.awt.event.KeyEvent
 
 /**
@@ -25,16 +26,6 @@ import java.awt.event.KeyEvent
 class WebViewKeyboardHandler : CefKeyboardHandlerAdapter() {
 
     companion object {
-        // CEF modifier flags (하드코딩된 정수값 - CEF API 경로 의존성 회피)
-        //
-        // 주의: ALT=16 은 실측과 어긋난다. IntelliJ 2024.2 / macOS 에서 Option+F12 의
-        // event.modifiers 를 찍어보면 8 이 나온다(이슈 #333 진단 로그). 즉 아래 Option+Arrow
-        // 분기는 지금 동작하지 않을 가능성이 높다. DevTools 를 F12 에서 떼어내는 이번 변경의
-        // 범위 밖이라 값은 건드리지 않았고, 별도로 실측해 바로잡아야 한다.
-        private const val EVENTFLAG_COMMAND_DOWN = 128  // META/Command key on macOS
-        private const val EVENTFLAG_ALT_DOWN = 16       // Option key on macOS
-        private const val EVENTFLAG_CONTROL_DOWN = 4    // Ctrl key
-
         // Arrow key codes (AWT KeyEvent 상수 사용 - Windows VK code와 동일)
         private val ARROW_KEYS = setOf(
             KeyEvent.VK_LEFT,   // 37
@@ -60,9 +51,9 @@ class WebViewKeyboardHandler : CefKeyboardHandlerAdapter() {
         val keyCode = event.windows_key_code
         val modifiers = event.modifiers
 
-        val isMetaDown = (modifiers and EVENTFLAG_COMMAND_DOWN) != 0
-        val isAltDown = (modifiers and EVENTFLAG_ALT_DOWN) != 0
-        val isCtrlDown = (modifiers and EVENTFLAG_CONTROL_DOWN) != 0
+        val isMetaDown = (modifiers and EventFlags.EVENTFLAG_COMMAND_DOWN) != 0
+        val isAltDown = (modifiers and EventFlags.EVENTFLAG_ALT_DOWN) != 0
+        val isCtrlDown = (modifiers and EventFlags.EVENTFLAG_CONTROL_DOWN) != 0
         val isArrowKey = keyCode in ARROW_KEYS
 
         // macOS: Cmd+Arrow, Option+Arrow (텍스트 내비게이션)

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/WebViewKeyboardHandlerModifierTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/toolwindow/WebViewKeyboardHandlerModifierTest.kt
@@ -1,0 +1,123 @@
+package com.github.yhk1038.claudecodegui.toolwindow
+
+import org.cef.handler.CefKeyboardHandler
+import org.cef.misc.BoolRef
+import org.cef.misc.EventFlags
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.event.KeyEvent
+
+/**
+ * Guards which key combinations [WebViewKeyboardHandler] releases to the webview
+ * (issue #337).
+ *
+ * The handler used to copy CEF's modifier bit values into local constants, and one
+ * copy was wrong: ALT was written as 16, which is actually EVENTFLAG_LEFT_MOUSE_BUTTON.
+ * A keyboard event never carries that bit, so `isAltDown` was permanently false and
+ * Option+Arrow was silently left to the IDE for the whole life of the plugin. The
+ * constants are now read from [EventFlags] rather than transcribed, so no value can
+ * drift again.
+ *
+ * These cases feed real CefKeyEvent instances through the real handler, so they fail
+ * if the wiring regresses, not just if a constant changes. Mirroring the flag values
+ * here would reproduce the original bug inside the test, so [EventFlags] is the source
+ * on both sides.
+ */
+class WebViewKeyboardHandlerModifierTest {
+
+    private val handler = WebViewKeyboardHandler()
+
+    /**
+     * Returns whether the handler released this combination to the webview, i.e. told
+     * CEF to stop treating it as an IDE shortcut.
+     *
+     * The two char arguments are the typed characters, which this hook ignores; NUL
+     * stands in for "no character produced".
+     */
+    private fun reachesWebView(keyCode: Int, modifiers: Int): Boolean {
+        val noCharacter = '\u0000'
+        val event = CefKeyboardHandler.CefKeyEvent(
+            CefKeyboardHandler.CefKeyEvent.EventType.KEYEVENT_RAWKEYDOWN,
+            modifiers,
+            keyCode,
+            0,
+            false,
+            noCharacter,
+            noCharacter,
+            true,
+        )
+        // CEF hands the hook a flag that starts out "yes, this is an IDE shortcut";
+        // the handler clears it for the combinations the composer needs.
+        val isKeyboardShortcut = BoolRef(true)
+        handler.onPreKeyEvent(null, event, isKeyboardShortcut)
+        return !isKeyboardShortcut.get()
+    }
+
+    private val arrowKeys = listOf(
+        KeyEvent.VK_LEFT,
+        KeyEvent.VK_RIGHT,
+        KeyEvent.VK_UP,
+        KeyEvent.VK_DOWN,
+    )
+
+    @Test
+    fun `Option+Arrow reaches the webview so the composer can move by word`() {
+        for (key in arrowKeys) {
+            assertTrue(
+                reachesWebView(key, EventFlags.EVENTFLAG_ALT_DOWN),
+                "Option+$key must reach the composer for word-wise caret movement. " +
+                    "This failed while ALT was hardcoded as 16 (issue #337).",
+            )
+        }
+    }
+
+    @Test
+    fun `Cmd+Arrow reaches the webview`() {
+        for (key in arrowKeys) {
+            assertTrue(
+                reachesWebView(key, EventFlags.EVENTFLAG_COMMAND_DOWN),
+                "Cmd+$key must reach the composer for line-start/end movement",
+            )
+        }
+    }
+
+    @Test
+    fun `Cmd and Ctrl comma reach the webview instead of opening IDE settings`() {
+        val comma = 188 // Windows VK_OEM_COMMA, which is what CEF reports
+        assertTrue(reachesWebView(comma, EventFlags.EVENTFLAG_COMMAND_DOWN), "Cmd+, opens our settings")
+        assertTrue(reachesWebView(comma, EventFlags.EVENTFLAG_CONTROL_DOWN), "Ctrl+, opens our settings")
+    }
+
+    /**
+     * The handler must claim only the combinations it forwards. A bare arrow is
+     * ordinary typing and a bare F12 belongs to the IDE (issue #333).
+     */
+    @Test
+    fun `unmodified keys are left to the IDE`() {
+        for (key in arrowKeys) {
+            assertFalse(
+                reachesWebView(key, EventFlags.EVENTFLAG_NONE),
+                "A bare arrow key must not be claimed as a webview shortcut",
+            )
+        }
+        assertFalse(reachesWebView(123, EventFlags.EVENTFLAG_NONE), "F12 belongs to the IDE (issue #333)")
+        assertFalse(reachesWebView(123, EventFlags.EVENTFLAG_ALT_DOWN), "Alt+F12 belongs to the IDE (issue #333)")
+    }
+
+    /**
+     * The mouse-button bit is what ALT was mistakenly set to. Pinning it keeps a future
+     * edit from reintroducing the same confusion, and documents why 16 was wrong.
+     */
+    @Test
+    fun `the value ALT was mistakenly given belongs to a mouse button`() {
+        assertTrue(
+            EventFlags.EVENTFLAG_ALT_DOWN != EventFlags.EVENTFLAG_LEFT_MOUSE_BUTTON,
+            "ALT and LEFT_MOUSE_BUTTON are different bits",
+        )
+        assertFalse(
+            reachesWebView(KeyEvent.VK_LEFT, EventFlags.EVENTFLAG_LEFT_MOUSE_BUTTON),
+            "The left-mouse-button bit must not be read as Option (issue #337)",
+        )
+    }
+}


### PR DESCRIPTION
## What this fixes

Option+Left / Option+Right did not move the caret by word in the chat input. Every other macOS text field does this; our composer was the exception.

## Cause

The handler copied CEF's modifier bits into its own constants, and one copy was wrong.

`ALT` was written as 16, but 16 is really `EVENTFLAG_LEFT_MOUSE_BUTTON`. A keyboard event never carries that bit, so `isAltDown` had been false for the entire life of the plugin. `COMMAND` (128) and `CONTROL` (4) happened to be transcribed correctly.

## The fix

Rather than correcting 16 to 8, the flags are now read from `org.cef.misc.EventFlags`.

The comment gave "avoid depending on a CEF API path" as the reason for hardcoding, but the same file already imports `org.cef.misc.BoolRef` from that very package — there was no dependency to avoid. Taking the values from the source removes this class of bug, not just this one instance of it.

`EventFlags` is public and carries no annotations. It is JCEF rather than IntelliJ platform API, and Plugin Verifier reports no new usage against either IC-242 or IU-262.

## Tests

Five cases that build real `CefKeyEvent` instances and feed them through the real handler.

The existing test for this class asserts structurally — which methods are overridden — so it could not see a wrong constant. That is why this went unnoticed.

Verified the tests actually fail when ALT is put back to 16 (2 failures, exit 1). They read from `EventFlags` as well, since restating the numbers would reproduce the original bug inside the test.

## Checked by hand

In a sandbox IDE:

- Option+Left / Option+Right move by word in the composer
- Option+Up / Option+Down behave normally
- The editor still gets its own Option+Arrow when focused

The default macOS keymap binds Option+Arrow only to `Editor*` actions such as `EditorPreviousWord`. Those have no caret to act on while the chat input holds focus, so this claims no shortcut the IDE could still use — the difference from the F12 case in #333.

Closes #337
