### PR TITLE
fix: keep the composer's glyphs and caret where the user put them (#329)

### DIFF
--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -55,6 +55,26 @@
    path tokens in chips. Both layers share identical font/padding/wrapping
    (Tailwind LAYOUT_CLASSES) so the mirror glyphs sit exactly under the caret.
    ============================================ */
+/* Reserve the scrollbar gutter on BOTH layers so their content boxes stay the
+   same width (issue #329).
+
+   Only the editable layer scrolls (overflow-y-auto); the mirror is clipped
+   (overflow-hidden). Where the platform draws a classic, space-taking scrollbar
+   — Windows/Linux JCEF & Chromium, unlike macOS overlay scrollbars (see the
+   color-scheme note under :root, issue #200) — the editable layer's content box
+   would narrow by the scrollbar's width once the text overflows. The two layers
+   would then wrap at different points, so the same glyph could land a line
+   apart. That misalignment is invisible while the editable glyphs are
+   transparent, but ::selection paints them opaque, which is exactly how it was
+   reported: highlighted text drawn one line off.
+
+   `stable` reserves the gutter on both layers whether or not a scrollbar is
+   showing, so the content widths match in every state. */
+.richInputEditable,
+.richInputMirror {
+  scrollbar-gutter: stable;
+}
+
 .richInputEditable {
   /* Hide the editable glyphs — the mirror paints them — but keep the caret. */
   color: transparent;

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/RichInput.test.tsx
@@ -383,3 +383,41 @@ describe('RichInput — placeholder', () => {
     expect(el.childNodes.length).toBe(0);
   });
 });
+
+/**
+ * Issue #329 — the two layers must wrap identically.
+ *
+ * Only the editable layer scrolls, so on platforms that draw a classic,
+ * space-taking scrollbar (Windows/Linux JCEF & Chromium) its content box would
+ * narrow once the text overflows, while the clipped mirror stays full width.
+ * The layers then wrap at different points and the same glyph lands a line
+ * apart — invisible until ::selection paints the transparent editable glyphs.
+ *
+ * jsdom has no layout engine, so the wrap itself cannot be measured here. The
+ * markup half of the contract is assertable: both layers carry the same
+ * width-affecting layout classes. The stylesheet half (the scrollbar gutter)
+ * is guarded in theme/__tests__/richInputGutter.css.test.ts.
+ */
+describe('RichInput — mirror/editable wrap parity (issue #329)', () => {
+  /** Classes that change how wide the content box is, and thus where text wraps. */
+  const WIDTH_AFFECTING = [
+    'w-full',
+    'ps-3',
+    'pe-11',
+    'text-base',
+    'leading-normal',
+    'whitespace-pre-wrap',
+    'break-words',
+  ];
+
+  it('gives both layers the same width-affecting layout classes', () => {
+    const { container, getByRole } = render(<RichInput value="hello" onChange={() => {}} />);
+    const editable = getByRole('textbox');
+    const mirror = container.querySelector('.richInputMirror');
+
+    for (const cls of WIDTH_AFFECTING) {
+      expect(editable.classList.contains(cls), `editable is missing ${cls}`).toBe(true);
+      expect(mirror?.classList.contains(cls), `mirror is missing ${cls}`).toBe(true);
+    }
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/index.tsx
@@ -57,6 +57,12 @@ interface Props {
  * layers MUST agree on font, padding, line-height and wrapping so the visible
  * (mirror) glyphs land exactly under the (transparent) editable glyphs and the
  * caret. Keep this list the single source of truth for both layers.
+ *
+ * One thing they must also agree on lives in CSS instead: only the editable
+ * layer scrolls, so `scrollbar-gutter: stable` is applied to BOTH layers
+ * (index.css) to keep their content boxes equally wide where the platform draws
+ * a space-taking scrollbar. Without it they wrap at different points and the
+ * same glyph lands a line apart (issue #329).
  */
 const LAYOUT_CLASSES = [
   // pe-11 keeps text clear of the mic button, which floats over the box's top

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -253,7 +253,6 @@ export function ChatInput() {
     onStop: () => void dictation.stop(),
   });
   const { cycle: cycleEffort } = useEffort();
-  const lastMetaArrowTime = useRef<number>(0);
   const [showAttachMenu, setShowAttachMenu] = useState(false);
   const [showModelSwitch, setShowModelSwitch] = useState(false);
   const [modelSwitchQuery, setModelSwitchQuery] = useState<string | null>(null);
@@ -597,16 +596,6 @@ export function ChatInput() {
     return () => window.removeEventListener('keydown', handleEscKey);
   }, [isInterruptible, onStop, textareaRef, showSchedulePopover, confirmStopBackgroundTasks]);
 
-  // [KeyDebug] window 캡처 단계 Arrow 키 로깅
-  useEffect(() => {
-    const handleArrowCapture = (e: globalThis.KeyboardEvent) => {
-      if (!e.key.startsWith('Arrow')) return;
-      console.log('[KeyDebug:window-capture]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
-    };
-    window.addEventListener('keydown', handleArrowCapture, true);
-    return () => window.removeEventListener('keydown', handleArrowCapture, true);
-  }, []);
-
   // Populate input history from session messages on session change.
   // Read messages via ref to avoid re-running this effect on every streaming token —
   // we only care about the messages snapshot at session-switch time.
@@ -633,22 +622,12 @@ export function ChatInput() {
   }, [onChange, palette, mention, textareaRef]);
 
   const handleKeyDown = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
-    if (e.key.startsWith('Arrow')) console.log('[KeyDebug:textarea-keydown]', e.key, { altKey: e.altKey, metaKey: e.metaKey, ctrlKey: e.ctrlKey, shiftKey: e.shiftKey, defaultPrevented: e.defaultPrevented });
-
     // Feed the IME truth: keyCode 229 means the IME is still processing this
     // keystroke, so mark composition active before any Enter decision runs.
     ime.noteKeyDown(e.nativeEvent.keyCode);
 
     // 받아쓰기 토글은 여기서 처리하지 않는다. useGlobalShortcut이 window의
     // capture 단계에서 먼저 가로채므로, 포커스가 어디에 있든 동작한다.
-
-    // JCEF workaround: Cmd+Arrow 처리 후 발생하는 순수 Arrow 유령 이벤트 무시
-    const isArrowKey = e.key.startsWith('Arrow');
-    const hasModifier = e.metaKey || e.altKey || e.ctrlKey;
-    if (isArrowKey && !hasModifier && Date.now() - lastMetaArrowTime.current < 50) {
-      e.preventDefault();
-      return;
-    }
 
     // Shift+Tab: 모드 전환
     if (e.shiftKey && e.key === 'Tab') {
@@ -657,30 +636,15 @@ export function ChatInput() {
       return;
     }
 
-    // JCEF workaround: Cmd+Arrow (macOS 줄 처음/끝 이동) 수동 처리
-    // shiftKey가 있으면 선택 영역 확장이므로 기본 동작에 맡김
-    if (e.metaKey && !e.altKey && !e.ctrlKey && !e.shiftKey && isArrowKey) {
-      const editor = e.currentTarget;
-      const pos = getCaretOffset(editor);
-      const text = editor.textContent ?? '';
-
-      e.preventDefault();
-      lastMetaArrowTime.current = Date.now();
-
-      if (e.key === 'ArrowLeft') {
-        const lineStart = text.lastIndexOf('\n', pos - 1) + 1;
-        setCaretOffset(editor, lineStart);
-      } else if (e.key === 'ArrowRight') {
-        let lineEnd = text.indexOf('\n', pos);
-        if (lineEnd === -1) lineEnd = text.length;
-        setCaretOffset(editor, lineEnd);
-      } else if (e.key === 'ArrowUp') {
-        setCaretOffset(editor, 0);
-      } else if (e.key === 'ArrowDown') {
-        setCaretOffset(editor, text.length);
-      }
-      return;
-    }
+    // Cmd+Arrow is left to the browser. It moves by *visual* line — the same
+    // unit Up/Down and Cmd+Shift+Arrow already use — and scrolls the caret into
+    // view on its way. Handling it here once meant a <textarea> under JCEF
+    // ignored the native binding and emitted a ghost Arrow afterwards; with the
+    // composer now a contentEditable (RichInput) neither happens, and taking it
+    // over cost more than it bought: line start/end were computed by scanning
+    // for "\n", so a soft-wrapped paragraph jumped to the paragraph's edge
+    // rather than the visual line's, and moving the caret by hand left the
+    // scroll position behind.
 
     // Mention interaction (must precede slash command handling)
     if (mention.isActive && mention.handleKeyDown(e)) return;
@@ -731,7 +695,6 @@ export function ChatInput() {
       }
       return;
     } else if (e.key === 'ArrowUp' && !palette.showSlashCommands) {
-      console.log('[KeyDebug:history-up-triggered]');
       // 복수행: 커서가 첫 번째 줄에 있을 때만 히스토리 탐색
       const pos = getCaretOffset(e.currentTarget);
       if (value.lastIndexOf('\n', pos - 1) !== -1) return;
@@ -741,7 +704,6 @@ export function ChatInput() {
       e.preventDefault();
       onChange(historyValue);
     } else if (e.key === 'ArrowDown' && !palette.showSlashCommands) {
-      console.log('[KeyDebug:history-down-triggered]');
       // 복수행: 커서가 마지막 줄에 있을 때만 히스토리 탐색
       const pos = getCaretOffset(e.currentTarget);
       if (value.indexOf('\n', pos) !== -1) return;

--- a/webview/src/theme/__tests__/richInputGutter.css.test.ts
+++ b/webview/src/theme/__tests__/richInputGutter.css.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Structural guard for the composer's scrollbar gutter in index.css (#329).
+ *
+ * RichInput stacks two layers that must wrap at the same points: the editable
+ * div (real text, transparent glyphs) and the mirror behind it (visible glyphs).
+ * Only the editable layer scrolls, so where the platform draws a classic,
+ * space-taking scrollbar — Windows/Linux JCEF & Chromium, unlike macOS overlay
+ * scrollbars — its content box narrows once the text overflows while the
+ * clipped mirror stays full width. The layers then wrap differently and the
+ * same glyph lands a line apart, which surfaces the moment ::selection paints
+ * the editable glyphs opaque.
+ *
+ * Reserving the gutter on BOTH layers keeps their content widths equal in every
+ * state. jsdom does no layout, so a component test cannot catch a regression
+ * here — only the rule itself can be guarded.
+ */
+import { describe, it, expect } from 'vitest';
+// `?raw` rather than node:fs — the webview tsconfig targets DOM only. Requires
+// index.css in `test.css.include` (vitest.config.ts).
+import css from '../../index.css?raw';
+
+/** Selector lists of every rule that reserves a stable scrollbar gutter. */
+function stableGutterSelectors(): string[] {
+  // Comments first: the prose above a rule would otherwise be captured as part
+  // of its selector list and no selector would ever match.
+  const withoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  return [
+    ...withoutComments.matchAll(/([^{}]+)\{[^{}]*scrollbar-gutter\s*:\s*stable[^{}]*\}/g),
+  ].map((m) => m[1]);
+}
+
+/** Whether some stable-gutter rule applies to exactly this selector. */
+function hasStableGutter(selector: string): boolean {
+  return stableGutterSelectors().some((list) =>
+    list.split(',').some((s) => s.trim() === selector),
+  );
+}
+
+describe('RichInput scrollbar gutter — stylesheet structure (#329)', () => {
+  it('reserves the gutter on the editable layer', () => {
+    expect(hasStableGutter('.richInputEditable')).toBe(true);
+  });
+
+  it('reserves the gutter on the mirror layer too', () => {
+    // The mirror never scrolls, so it is the easy one to forget — and forgetting
+    // it is exactly the bug: only the editable layer would lose width.
+    expect(hasStableGutter('.richInputMirror')).toBe(true);
+  });
+});

--- a/webview/src/utils/__tests__/domSelection.test.ts
+++ b/webview/src/utils/__tests__/domSelection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {
   textOffsetToPoint,
   pointToTextOffset,
@@ -380,5 +380,113 @@ describe('Layer B Selection wrappers (smoke tests)', () => {
     // Don't attach to body — simulates out-of-document element
     // Should not throw
     expect(() => setSelectionRange(root, 0, 3)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Caret scrolling
+// ---------------------------------------------------------------------------
+
+/**
+ * Moving the caret through the Selection API does not scroll the box — the
+ * browser only does that for a move it performed itself. So a paste, a history
+ * recall or any programmatic jump would leave the caret off-screen with the
+ * view still parked where it was.
+ *
+ * jsdom lays nothing out, so the scroll cannot be observed for real. Stubbing
+ * the two rects the logic reads makes the decision itself testable: does it
+ * scroll up when the caret sits above the visible box, down when below, and
+ * stay put when the caret is already inside.
+ */
+describe('caret scrolling on programmatic moves', () => {
+  /**
+   * Give `root` a fixed viewport box and force every Range inside it to report
+   * `caretTop`, so the caret can be placed above, below or within the box.
+   */
+  function stubLayout(root: HTMLElement, box: { top: number; bottom: number }, caretTop: number) {
+    root.getBoundingClientRect = () =>
+      ({ top: box.top, bottom: box.bottom, height: box.bottom - box.top, width: 300 }) as DOMRect;
+    const caretRect = {
+      top: caretTop,
+      bottom: caretTop + 20,
+      height: 20,
+      width: 0,
+    } as DOMRect;
+    Range.prototype.getClientRects = () => [caretRect] as unknown as DOMRectList;
+    Range.prototype.getBoundingClientRect = () => caretRect;
+  }
+
+  const originalRects = Range.prototype.getClientRects;
+  const originalBounding = Range.prototype.getBoundingClientRect;
+  afterEach(() => {
+    Range.prototype.getClientRects = originalRects;
+    Range.prototype.getBoundingClientRect = originalBounding;
+  });
+
+  it('scrolls up when the caret sits above the visible box', () => {
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    // Box spans 100..300; caret is 40px above its top edge.
+    stubLayout(root, { top: 100, bottom: 300 }, 60);
+    root.scrollTop = 500;
+
+    setCaretOffset(root, 3);
+
+    expect(root.scrollTop).toBe(460);
+    document.body.removeChild(root);
+  });
+
+  it('scrolls down when the caret sits below the visible box', () => {
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    // Caret's bottom (350+20) overshoots the box's bottom (300) by 70.
+    stubLayout(root, { top: 100, bottom: 300 }, 350);
+    root.scrollTop = 0;
+
+    setCaretOffset(root, 3);
+
+    expect(root.scrollTop).toBe(70);
+    document.body.removeChild(root);
+  });
+
+  it('leaves the scroll alone when the caret is already visible', () => {
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    stubLayout(root, { top: 100, bottom: 300 }, 150);
+    root.scrollTop = 42;
+
+    setCaretOffset(root, 3);
+
+    expect(root.scrollTop).toBe(42);
+    document.body.removeChild(root);
+  });
+
+  it('follows the end of a selection, not its start', () => {
+    // The caret rests at the end of a selection, so that is what must be
+    // brought into view — scrolling to the start would strand it.
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    stubLayout(root, { top: 100, bottom: 300 }, 350);
+    root.scrollTop = 0;
+
+    setSelectionRange(root, 0, 5);
+
+    expect(root.scrollTop).toBe(70);
+    document.body.removeChild(root);
+  });
+
+  it('does nothing where the environment reports no layout', () => {
+    // Guards the jsdom/headless path: an all-zero root rect must not be read as
+    // "the caret is out of view" and trigger a bogus scroll.
+    const root = makeDiv('hello world');
+    document.body.appendChild(root);
+    root.getBoundingClientRect = () =>
+      ({ top: 0, bottom: 0, height: 0, width: 0 }) as DOMRect;
+    root.scrollTop = 17;
+
+    setCaretOffset(root, 3);
+
+    expect(root.scrollTop).toBe(17);
+    document.body.removeChild(root);
   });
 });

--- a/webview/src/utils/domSelection.ts
+++ b/webview/src/utils/domSelection.ts
@@ -169,7 +169,42 @@ export function getCaretOffset(root: HTMLElement): number {
 }
 
 /**
- * Move the caret to `offset` (plain-text, relative to `root.textContent`).
+ * Scroll `root` so the caret sitting at `range` is visible.
+ *
+ * Moving the caret through the Selection API does not scroll — that only comes
+ * free when the browser moves it itself, in response to a key it handled. So
+ * every caret jump we perform (paste, history recall, programmatic insert) has
+ * to bring the caret back into view or it lands off-screen while the box stays
+ * where it was.
+ *
+ * A collapsed range has no width, and in some engines no rects at all, so the
+ * caret's own rect is not dependable; the enclosing line's rect is. Compared in
+ * viewport coordinates against `root`'s own box, then applied as a `scrollTop`
+ * delta, which needs no layout support beyond rects and so degrades quietly
+ * where they are unavailable (jsdom returns zeroes and this becomes a no-op).
+ */
+function scrollCaretIntoView(root: HTMLElement, range: Range): void {
+  // `getClientRects` on a collapsed range yields the caret line in browsers
+  // that support it; fall back to the bounding rect, then give up.
+  const caretRect = range.getClientRects?.()?.[0] ?? range.getBoundingClientRect?.();
+  if (!caretRect) return;
+
+  const rootRect = root.getBoundingClientRect();
+  // All-zero rects mean the environment does no layout — nothing to scroll to.
+  if (rootRect.height === 0 && rootRect.width === 0) return;
+
+  const above = caretRect.top - rootRect.top;
+  const below = caretRect.bottom - rootRect.bottom;
+  if (above < 0) {
+    root.scrollTop += above;
+  } else if (below > 0) {
+    root.scrollTop += below;
+  }
+}
+
+/**
+ * Move the caret to `offset` (plain-text, relative to `root.textContent`) and
+ * scroll it into view.
  * No-op if there is no Selection API or if `root` has no content at that offset.
  */
 export function setCaretOffset(root: HTMLElement, offset: number): void {
@@ -183,6 +218,7 @@ export function setCaretOffset(root: HTMLElement, offset: number): void {
     range.collapse(true);
     selection.removeAllRanges();
     selection.addRange(range);
+    scrollCaretIntoView(root, range);
   } catch {
     // Silently ignore if DOM is in an unexpected state
   }
@@ -220,7 +256,8 @@ export function getSelectionRange(root: HTMLElement): TextRange {
 
 /**
  * Set the selection to [start, end] (plain-text offsets, relative to
- * `root.textContent`). Silently ignores errors (e.g., root not in document).
+ * `root.textContent`) and scroll its end into view.
+ * Silently ignores errors (e.g., root not in document).
  */
 export function setSelectionRange(
   root: HTMLElement,
@@ -238,6 +275,13 @@ export function setSelectionRange(
     range.setEnd(endPoint.node, endPoint.offset);
     selection.removeAllRanges();
     selection.addRange(range);
+
+    // Follow the end of the selection, which is where the caret rests and what
+    // the user is expected to keep typing from.
+    const caret = document.createRange();
+    caret.setStart(endPoint.node, endPoint.offset);
+    caret.collapse(true);
+    scrollCaretIntoView(root, caret);
   } catch {
     // Silently ignore if DOM is not attached or in an unexpected state
   }


### PR DESCRIPTION
Closes #329
Closes #180

## The problem

Three ways the composer showed the user one thing and put the caret somewhere else.

**Selected text was drawn a line below the text it belonged to.** Reported on
Windows 11 / IntelliJ 2026.2.1, after pasting a prompt: highlight it and the
highlighted copy appears one line off, overlapping the line beneath.

**`Cmd+Left/Right` jumped to the edge of the whole paragraph.** In a
soft-wrapped paragraph — one long sentence folded across several rows — the
caret went to the paragraph's start or end rather than the visual row's. Up/Down
move by visual row, and so does `Cmd+Shift+Arrow`, so the same caret answered to
two different ideas of "line" depending on which key was pressed.

**The view did not follow the caret when we moved it.** Paste a long block or
recall a history entry and the caret landed off-screen with the box still parked
where it was.

## Cause

### The two layers stopped wrapping alike

`RichInput` stacks an editable div (real text, transparent glyphs, visible caret)
over a mirror that paints the visible glyphs and path chips. They must wrap at
the same points or a glyph in one lands on a different line than in the other.

Only the editable layer scrolls (`overflow-y-auto`); the mirror is clipped
(`overflow-hidden`). Where the platform draws a classic, space-taking scrollbar —
Windows/Linux JCEF and Chromium, unlike macOS overlay scrollbars — the editable
layer's content box narrows by the scrollbar's width as soon as the text
overflows, while the mirror keeps its full width. From then on they wrap
differently.

That stays invisible while the editable glyphs are transparent, which is why it
only surfaced on selection: `::selection` paints them opaque. Reproducing it
needs enough text to overflow the box, matching the report's "write 20 lines into
the prompt box".

Measured in the composer, content width of each layer with a space-taking
scrollbar:

| | editable | mirror |
| --- | --- | --- |
| Before | 522 | **537** |
| After | 522 | 522 |

### A workaround outlived what it was working around

The composer had been handling `Cmd+Arrow` itself since `4012c4e`, when a
`<textarea>` under JCEF ignored the native binding and emitted a ghost Arrow
event afterwards. Taking the key over meant reimplementing it, and the
reimplementation scanned for `\n` — hence paragraph edges rather than visual line
edges — and moved the caret without scrolling to it.

That predates `f524800`, which replaced the textarea with a contentEditable. The
premise is gone: under `RichInput`, JCEF handles `Cmd+Arrow` natively and emits
no ghost event.

```
[KeyDebug:window-capture]   ArrowLeft {metaKey: true}
[KeyDebug:textarea-keydown] ArrowLeft {metaKey: true}
```

One keydown, seen at two points on its way; nothing follows it. And
`Cmd+Shift+Arrow` — the case the workaround already passed through to the browser
via its `!e.shiftKey` guard — has been selecting to the visual line edge
correctly all along, in the same IDE and the same input.

### Moving the caret is not the same as showing it

Scrolling to the caret comes free only when the browser moves it, in response to
a key it handled. `setCaretOffset` went through the Selection API and stopped
there, so all eleven call sites left the view behind.

## The fix

**Reserve the scrollbar gutter on both layers** so their content boxes stay
equally wide whether or not a scrollbar is showing. Putting it only on the
scrolling layer would leave the widths unequal — the mirror never scrolls, so it
is the easy one to forget, and forgetting it is the bug.

**Delete the `Cmd+Arrow` handler rather than repair it.** The browser moves by
visual line and scrolls the caret into view on the way, which is what was wanted
in the first place. The ghost-event guard and the timestamp ref it needed go with
it — 47 lines and one piece of state removed.

Four `[KeyDebug]` `console.log` statements go too. They were shipping to users'
consoles on every arrow key, and having served to confirm the ghost event is
gone, they have no reason to stay.

**Scroll the caret into view in `setCaretOffset` and `setSelectionRange`,** so
the eleven call sites are covered at once instead of each remembering to. A
collapsed range has no width, and in some engines no rects at all, so the
enclosing line's rect is used and compared against the container's box in
viewport coordinates. The result is applied as a `scrollTop` delta, which needs
no layout support beyond rects: an all-zero container rect means "this
environment lays nothing out", not "the caret is out of view", and is left alone.
For a selection it is the end that is followed — that is where the caret rests.

## Tests

Three layers green: webview 2558, typecheck clean, `full-build` successful.

Each new guard was verified to actually fail without the fix:

- Removing the gutter rule fails, and so does covering only the editable layer —
  the half-fix that would leave the widths unequal.
- Removing the scroll calls fails three of the five caret-scrolling cases.

jsdom lays nothing out, so neither the wrap nor the scroll can be measured there.
What is assertable is guarded instead: both layers carry the same
width-affecting classes, the stylesheet reserves the gutter on both, and the
scroll decision is exercised against stubbed rects (caret above the box, below
it, inside it, and a no-layout environment).

## Checked by hand

`Cmd+Left/Right` move by visual row in a soft-wrapped paragraph, and the view
follows the caret on paste and history recall — confirmed in a sandbox IDE.

The composer's two layers could not be checked here: macOS draws overlay
scrollbars, so the widths never diverge and the bug does not reproduce. Forcing a
space-taking scrollbar through CSS does not work either — the platform ignores
it. The measurements above come from making the width difference by hand.

## Also closes #180

The second half of #180 — "the input box content is invisible, but the content is
there" — is the same defect seen from the other side, and the GIF attached to
that report shows it directly.

Before the text grows past the wrap point, everything lines up. Once it does, the
caret detaches: the glyphs end one line up while the caret sits on the line
below, which is what "typed it but cannot see it" looks like when the visible
glyphs and the caret live in different layers. Selecting the text then draws the
sentence twice, one line apart — the same picture as #329.

The report matches on every side condition too: Windows 11, a scrollbar visible
in the frame, and "after entering multiple lines (about 5)" as the trigger, which
is the point the box starts to overflow.

An earlier reply on that issue put it down to scroll sync in the chat input. The
direction was right; the mechanism is the width the scrollbar takes, which is
what makes the two layers wrap differently in the first place.

