### PR TITLE
fix: soft wrap reaches code blocks, and every block gets its own toggle (#179)

### DIFF
--- a/webview/src/i18n/locales/ar/chatTools.json
+++ b/webview/src/i18n/locales/ar/chatTools.json
@@ -3,7 +3,11 @@
     "in": "دخل",
     "out": "خرج",
     "declined": "لقد رفضت هذه الأداة.",
-    "declinedWithInstruction": "لقد رفضت هذه الأداة. طلبت من Claude بدلًا من ذلك: “{{instruction}}”"
+    "declinedWithInstruction": "لقد رفضت هذه الأداة. طلبت من Claude بدلًا من ذلك: “{{instruction}}”",
+    "softWrap": {
+      "wrap": "التفاف الأسطر الطويلة",
+      "unwrap": "إيقاف الالتفاف"
+    }
   },
   "message": {
     "copyMessage": "نسخ الرسالة",

--- a/webview/src/i18n/locales/de/chatTools.json
+++ b/webview/src/i18n/locales/de/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "Du hast dieses Tool abgelehnt.",
-    "declinedWithInstruction": "Du hast dieses Tool abgelehnt. Claude stattdessen gefragt: „{{instruction}}“"
+    "declinedWithInstruction": "Du hast dieses Tool abgelehnt. Claude stattdessen gefragt: „{{instruction}}“",
+    "softWrap": {
+      "wrap": "Lange Zeilen umbrechen",
+      "unwrap": "Umbruch aufheben"
+    }
   },
   "message": {
     "copyMessage": "Nachricht kopieren",

--- a/webview/src/i18n/locales/en/chatTools.json
+++ b/webview/src/i18n/locales/en/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "You declined this tool.",
-    "declinedWithInstruction": "You declined this tool. Asked Claude instead: “{{instruction}}”"
+    "declinedWithInstruction": "You declined this tool. Asked Claude instead: “{{instruction}}”",
+    "softWrap": {
+      "wrap": "Wrap long lines",
+      "unwrap": "Stop wrapping"
+    }
   },
   "message": {
     "copyMessage": "Copy message",

--- a/webview/src/i18n/locales/es/chatTools.json
+++ b/webview/src/i18n/locales/es/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "Rechazaste esta herramienta.",
-    "declinedWithInstruction": "Rechazaste esta herramienta. En su lugar, le pediste a Claude: “{{instruction}}”"
+    "declinedWithInstruction": "Rechazaste esta herramienta. En su lugar, le pediste a Claude: “{{instruction}}”",
+    "softWrap": {
+      "wrap": "Ajustar líneas largas",
+      "unwrap": "Dejar de ajustar"
+    }
   },
   "message": {
     "copyMessage": "Copiar mensaje",

--- a/webview/src/i18n/locales/fa/chatTools.json
+++ b/webview/src/i18n/locales/fa/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "شما این ابزار را رد کردید.",
-    "declinedWithInstruction": "شما این ابزار را رد کردید. در عوض از Claude خواستید: «{{instruction}}»"
+    "declinedWithInstruction": "شما این ابزار را رد کردید. در عوض از Claude خواستید: «{{instruction}}»",
+    "softWrap": {
+      "wrap": "شکستن خطوط بلند",
+      "unwrap": "توقف شکستن خط"
+    }
   },
   "message": {
     "copyMessage": "کپی پیام",

--- a/webview/src/i18n/locales/fr/chatTools.json
+++ b/webview/src/i18n/locales/fr/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "Vous avez refusé cet outil.",
-    "declinedWithInstruction": "Vous avez refusé cet outil. Demande envoyée à Claude à la place : « {{instruction}} »"
+    "declinedWithInstruction": "Vous avez refusé cet outil. Demande envoyée à Claude à la place : « {{instruction}} »",
+    "softWrap": {
+      "wrap": "Renvoyer les lignes longues",
+      "unwrap": "Arrêter le renvoi"
+    }
   },
   "message": {
     "copyMessage": "Copier le message",

--- a/webview/src/i18n/locales/ja/chatTools.json
+++ b/webview/src/i18n/locales/ja/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "このツールを拒否しました。",
-    "declinedWithInstruction": "このツールを拒否しました。代わりにClaudeへ指示: 「{{instruction}}」"
+    "declinedWithInstruction": "このツールを拒否しました。代わりにClaudeへ指示: 「{{instruction}}」",
+    "softWrap": {
+      "wrap": "長い行を折り返す",
+      "unwrap": "折り返しを解除"
+    }
   },
   "message": {
     "copyMessage": "メッセージをコピー",

--- a/webview/src/i18n/locales/ko/chatTools.json
+++ b/webview/src/i18n/locales/ko/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "이 도구를 거부했습니다.",
-    "declinedWithInstruction": "이 도구를 거부했습니다. 대신 Claude에게 다음을 요청했습니다: “{{instruction}}”"
+    "declinedWithInstruction": "이 도구를 거부했습니다. 대신 Claude에게 다음을 요청했습니다: “{{instruction}}”",
+    "softWrap": {
+      "wrap": "긴 줄 접기",
+      "unwrap": "줄바꿈 해제"
+    }
   },
   "message": {
     "copyMessage": "메시지 복사",

--- a/webview/src/i18n/locales/pt/chatTools.json
+++ b/webview/src/i18n/locales/pt/chatTools.json
@@ -3,7 +3,11 @@
     "in": "IN",
     "out": "OUT",
     "declined": "Você recusou esta ferramenta.",
-    "declinedWithInstruction": "Você recusou esta ferramenta. Pediu ao Claude, em vez disso: “{{instruction}}”"
+    "declinedWithInstruction": "Você recusou esta ferramenta. Pediu ao Claude, em vez disso: “{{instruction}}”",
+    "softWrap": {
+      "wrap": "Quebrar linhas longas",
+      "unwrap": "Parar de quebrar"
+    }
   },
   "message": {
     "copyMessage": "Copiar mensagem",

--- a/webview/src/i18n/locales/ru/chatTools.json
+++ b/webview/src/i18n/locales/ru/chatTools.json
@@ -3,7 +3,11 @@
     "in": "ВХОД",
     "out": "ВЫХОД",
     "declined": "Вы отклонили этот инструмент.",
-    "declinedWithInstruction": "Вы отклонили этот инструмент. Вместо этого попросили Claude: «{{instruction}}»"
+    "declinedWithInstruction": "Вы отклонили этот инструмент. Вместо этого попросили Claude: «{{instruction}}»",
+    "softWrap": {
+      "wrap": "Переносить длинные строки",
+      "unwrap": "Отключить перенос"
+    }
   },
   "message": {
     "copyMessage": "Скопировать сообщение",

--- a/webview/src/i18n/locales/zh-TW/chatTools.json
+++ b/webview/src/i18n/locales/zh-TW/chatTools.json
@@ -3,7 +3,11 @@
     "in": "輸入",
     "out": "輸出",
     "declined": "您拒絕了此工具。",
-    "declinedWithInstruction": "您拒絕了此工具，改為告訴 Claude：「{{instruction}}」"
+    "declinedWithInstruction": "您拒絕了此工具，改為告訴 Claude：「{{instruction}}」",
+    "softWrap": {
+      "wrap": "摺疊長行",
+      "unwrap": "取消換行"
+    }
   },
   "message": {
     "copyMessage": "複製訊息",

--- a/webview/src/i18n/locales/zh/chatTools.json
+++ b/webview/src/i18n/locales/zh/chatTools.json
@@ -3,7 +3,11 @@
     "in": "输入",
     "out": "输出",
     "declined": "您拒绝了此工具。",
-    "declinedWithInstruction": "您拒绝了此工具,转而告诉 Claude:“{{instruction}}”"
+    "declinedWithInstruction": "您拒绝了此工具,转而告诉 Claude:“{{instruction}}”",
+    "softWrap": {
+      "wrap": "折叠长行",
+      "unwrap": "取消折行"
+    }
   },
   "message": {
     "copyMessage": "复制消息",

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -673,9 +673,17 @@ body {
 /* Fold long lines to the block's width instead of scrolling them sideways.
    `break-all` because these are paths, JSON and code, which have no spaces to
    break at for long stretches — breaking only at spaces would leave the line
-   overflowing anyway. */
+   overflowing anyway.
+
+   Each block is selected two ways because the class arrives from two places:
+   the setting puts it on <html>, where the block is a descendant, while the
+   per-block toggle (#179 follow-up, useSoftWrapToggle) puts it on the block
+   itself — and an element is not its own descendant. One mechanism, two
+   carriers. */
 .soft-wrap .diff-body-line,
-.soft-wrap .monospace-block {
+.soft-wrap .monospace-block,
+.diff-body-line.soft-wrap,
+.monospace-block.soft-wrap {
   white-space: pre-wrap;
   word-break: break-all;
   overflow-x: hidden;
@@ -687,9 +695,36 @@ body {
   min-width: 0;
 }
 
-.soft-wrap .diff-viewer .diff-code {
+.soft-wrap .diff-viewer .diff-code,
+.diff-viewer.soft-wrap .diff-code {
   white-space: pre-wrap;
   word-break: break-all;
+}
+
+/* The other direction (#179 follow-up): the setting is on and this block is the
+   one the user wants to scroll instead. `.soft-wrap-off` weighs the same as
+   `.soft-wrap`, so it comes last and wins on order. It restores the browser
+   defaults rather than a remembered value, because that is what the unwrapped
+   state is — `pre` and horizontal scrolling. */
+.soft-wrap-off .diff-body-line,
+.soft-wrap-off .monospace-block,
+.diff-body-line.soft-wrap-off,
+.monospace-block.soft-wrap-off {
+  white-space: pre;
+  word-break: normal;
+  overflow-x: auto;
+}
+
+.soft-wrap-off .diff-viewer .diff-code,
+.diff-viewer.soft-wrap-off .diff-code {
+  white-space: pre;
+  word-break: normal;
+}
+
+/* Restores the floor that keeps every row as wide as the longest line, so a
+   row's tint does not stop mid-line once the block scrolls again. */
+.soft-wrap-off .diff-body {
+  min-width: max-content;
 }
 
 /* ============================================

--- a/webview/src/index.css
+++ b/webview/src/index.css
@@ -727,6 +727,42 @@ body {
   min-width: max-content;
 }
 
+/* The wrap button. Off, it sits next to the copy button on a code block and
+   takes that button's chip — same variables, not copied values, so the two stay
+   together if either is retuned. Without a backdrop the glyph floated over the
+   code with nothing marking it as a control. */
+.wrap-toggle-button {
+  background: var(--md-code-copy-btn-bg);
+  border: none;
+  color: var(--md-code-copy-btn-fg);
+  border-radius: 4px;
+  padding: 0.3em 0.4em;
+  cursor: pointer;
+  line-height: 0;
+  transition: all 0.15s ease;
+}
+
+.wrap-toggle-button:hover {
+  background: var(--md-code-copy-btn-bg-hover);
+}
+
+/* On state: the accent, held back to a wash. The glyph does not change — one
+   drawing, two backdrops.
+
+   Two earlier attempts missed on either side. Tinting the glyph on the
+   translucent chip was not legible as a state at this size; the accent at full
+   strength was, but a saturated chip pulls the eye away from the code it sits
+   on top of, and there is one per block. The alpha keeps the hue reading as
+   "on" while letting the block show through. */
+.wrap-toggle-button[aria-pressed='true'] {
+  background: rgb(var(--accent-primary-rgb) / 0.35);
+  color: var(--accent-primary-fg);
+}
+
+.wrap-toggle-button[aria-pressed='true']:hover {
+  background: rgb(var(--accent-primary-rgb) / 0.55);
+}
+
 /* ============================================
    Slash Command Panel Variables (semantic-token wired)
    ============================================ */

--- a/webview/src/pages/ChatPage/DiffViewer.tsx
+++ b/webview/src/pages/ChatPage/DiffViewer.tsx
@@ -1,6 +1,7 @@
 import { parseDiff, Diff, Hunk } from 'react-diff-view';
 import 'react-diff-view/style/index.css';
 import { useTranslation } from '@/i18n';
+import { useSoftWrapToggle } from '@/pages/ChatPage/message-renderers/components/useSoftWrapToggle';
 
 interface DiffViewerProps {
   filePath: string;
@@ -9,6 +10,9 @@ interface DiffViewerProps {
 
 export function DiffViewer({ diffText }: DiffViewerProps) {
   const { t } = useTranslation('chat');
+  // Above the try: the branches below return early, and a hook called inside
+  // one of them would run conditionally.
+  const softWrap = useSoftWrapToggle();
   try {
     const files = parseDiff(diffText);
     const file = files[0];
@@ -22,21 +26,26 @@ export function DiffViewer({ diffText }: DiffViewerProps) {
     }
 
     return (
-      <div className="diff-viewer overflow-x-auto">
-        <Diff
-          viewType="unified"
-          diffType={file.type}
-          hunks={file.hunks || []}
-        >
-          {(hunks) =>
-            hunks.map((hunk) => (
-              <Hunk
-                key={`${hunk.oldStart}-${hunk.newStart}-${hunk.content}`}
-                hunk={hunk}
-              />
-            ))
-          }
-        </Diff>
+      // The button sits outside `.diff-viewer`, which is the element that
+      // scrolls sideways.
+      <div className={`group/wrap relative ${softWrap.blockClassName}`}>
+        {softWrap.button}
+        <div className="diff-viewer overflow-x-auto">
+          <Diff
+            viewType="unified"
+            diffType={file.type}
+            hunks={file.hunks || []}
+          >
+            {(hunks) =>
+              hunks.map((hunk) => (
+                <Hunk
+                  key={`${hunk.oldStart}-${hunk.newStart}-${hunk.content}`}
+                  hunk={hunk}
+                />
+              ))
+            }
+          </Diff>
+        </div>
       </div>
     );
   } catch (error) {

--- a/webview/src/pages/ChatPage/StreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/StreamingMessage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
 import {code} from '../../utils/codePlugin';
@@ -7,6 +7,7 @@ import {ToolWrapper} from "@/pages/ChatPage/message-renderers/ToolRenderers/comm
 import {useWorkingDirOrNull} from '@/contexts/WorkingDirContext';
 import {MARKDOWN_COMPONENTS} from '@/pages/ChatPage/message-renderers/components/MarkdownFileLink';
 import {prepareAssistantMarkdown} from '@/pages/ChatPage/message-renderers/utils/markdownFileLink';
+import {CodeBlockWrapControls} from '@/pages/ChatPage/message-renderers/components/CodeBlockWrapControls';
 
 interface StreamingMessageProps {
     content: string;
@@ -22,6 +23,7 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
     message,
 }) => {
     const [shouldAnimate, setShouldAnimate] = useState(isStreaming);
+    const markdownRef = useRef<HTMLDivElement>(null);
 
     // useWorkingDirOrNull (not useWorkingDir): StreamingMessage is broadly reused
     // and rendered without a WorkingDirProvider in some places (and in tests),
@@ -43,7 +45,7 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
     return (
         <ToolWrapper message={message} className="!mt-0">
             <div className={`streaming-message ${className}`}>
-                <div className={`markdown-content ${shouldAnimate ? 'streaming-animate' : ''}`}>
+                <div ref={markdownRef} className={`markdown-content ${shouldAnimate ? 'streaming-animate' : ''}`}>
                     <Streamdown
                         className="space-y-0"
                         mode={isStreaming ? 'streaming' : 'static'}
@@ -58,6 +60,7 @@ export const StreamingMessage: React.FC<StreamingMessageProps> = ({
                     >
                         {prepareAssistantMarkdown(content, workingDirectory)}
                     </Streamdown>
+                    <CodeBlockWrapControls containerRef={markdownRef} content={content} />
                 </div>
             </div>
         </ToolWrapper>

--- a/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
+++ b/webview/src/pages/ChatPage/ThinkingStreamingMessage.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 import {Streamdown} from 'streamdown';
 import {math} from '../../utils/mathPlugin';
 import {code} from '../../utils/codePlugin';
@@ -11,6 +11,7 @@ import {useAnimatedThinkingTokens} from '../../hooks/useAnimatedThinkingTokens';
 import {useWorkingDirOrNull} from '@/contexts/WorkingDirContext';
 import {MARKDOWN_COMPONENTS} from '@/pages/ChatPage/message-renderers/components/MarkdownFileLink';
 import {prepareAssistantMarkdown} from '@/pages/ChatPage/message-renderers/utils/markdownFileLink';
+import {CodeBlockWrapControls} from '@/pages/ChatPage/message-renderers/components/CodeBlockWrapControls';
 
 interface ThinkingStreamingMessageProps {
     thinking: string;
@@ -33,6 +34,7 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
 }) => {
     const { t } = useTranslation('chat');
     const [shouldAnimate, setShouldAnimate] = useState(isStreaming);
+    const markdownRef = useRef<HTMLDivElement>(null);
     const { isThinkingExpanded, toggleThinkingExpanded } = useChatStreamContext();
     // Null-safe: reasoning blocks may render without a WorkingDirProvider. Used to
     // resolve relative file-link URLs; absolute links work regardless.
@@ -76,6 +78,7 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
                     </div>
 
                     <div
+                        ref={markdownRef}
                         className={`${isThinkingExpanded ? "" : "hidden"} thinking-message markdown-content ${shouldAnimate ? 'streaming-animate' : ''}`}>
                         <Streamdown
                             className="space-y-0"
@@ -91,6 +94,7 @@ export const ThinkingStreamingMessage: React.FC<ThinkingStreamingMessageProps> =
                         >
                             {prepareAssistantMarkdown(thinking, workingDirectory)}
                         </Streamdown>
+                        <CodeBlockWrapControls containerRef={markdownRef} content={thinking} />
                     </div>
                 </div>
 

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/EditRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/EditRenderer.tsx
@@ -3,6 +3,7 @@ import {ToolUseBlockDto} from "@/types";
 import {getAdapter} from "@/adapters";
 import {useTranslation} from "@/i18n";
 import {RendererProps, ResultCaption, ToolHeader, ToolWrapper} from "./common";
+import {useSoftWrapToggle} from "@/pages/ChatPage/message-renderers/components/useSoftWrapToggle";
 import {cn} from "@/utils/cn";
 // @ts-ignore
 import {diffAsText} from "unidiff";
@@ -78,6 +79,7 @@ export function EditRenderer(props: RendererProps) {
     const result = props.toolResult?.toolUseResult as EditToolUseResult | undefined;
 
     const containerRef = useRef<HTMLDivElement>(null);
+    const softWrap = useSoftWrapToggle();
     const [containerWidth, setContainerWidth] = useState<number>(0);
 
     useEffect(() => {
@@ -121,7 +123,10 @@ export function EditRenderer(props: RendererProps) {
                 <ResultCaption>{t('edit.modified')}</ResultCaption>
 
                 {showDiff && (
-                    <div className="rounded overflow-hidden border border-border-default mt-2.5">
+                    // Class and button both on the border box, which does not
+                    // scroll — the <pre> inside it does.
+                    <div className={cn("group/wrap relative rounded overflow-hidden border border-border-default mt-2.5", softWrap.blockClassName)}>
+                        {softWrap.button}
                         <pre dir="ltr" className="text-[0.9230rem] leading-[1.5] font-mono overflow-x-auto m-0">
                             {/* Sized to the longest line rather than to the visible width, so the
                                 rows inside can fill it. A row is a block, so its width resolves

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Filesystem/__tests__/ListAllowedDirectoriesRenderer.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/Filesystem/__tests__/ListAllowedDirectoriesRenderer.test.tsx
@@ -55,6 +55,10 @@ describe('ListAllowedDirectoriesRenderer', () => {
         const { container } = render(
             <ListAllowedDirectoriesRenderer toolUse={makeToolUse()} toolResult={makeResult(text)} />
         );
-        expect(container.querySelectorAll('button')).toHaveLength(0);
+        // Every button except the block's own soft-wrap toggle (#179), which is
+        // chrome on the box rather than a rendering of the payload.
+        const chips = Array.from(container.querySelectorAll('button'))
+            .filter((b) => !b.getAttribute('aria-label')?.match(/wrap/i));
+        expect(chips).toHaveLength(0);
     });
 });

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/_common.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/Mcp/_common.tsx
@@ -1,5 +1,6 @@
 import {ReactNode, useEffect, useRef, useState} from "react";
 import {cn} from "@/utils/cn";
+import {useSoftWrapToggle} from "@/pages/ChatPage/message-renderers/components/useSoftWrapToggle";
 
 /**
  * Convert an MCP tool's raw name into a human-readable label.
@@ -125,15 +126,20 @@ export const CollapsibleBox = (props: CollapsibleBoxProps) => {
 
 export const McpToolRow = (props: {label: string; children?: ReactNode}) => {
     const {label, children} = props;
+    const softWrap = useSoftWrapToggle();
 
+    // The row itself carries the class and hosts the button: it does not
+    // scroll, so the button stays put when the box beside it is scrolled
+    // sideways, and no wrapper is added around the content.
     return (
-        <div className="flex items-start gap-2 p-2 border-b border-border-subtle last:border-b-0">
+        <div className={cn('group/wrap relative flex items-start gap-2 p-2 border-b border-border-subtle last:border-b-0', softWrap.blockClassName)}>
             <span className="text-tool-label-fg uppercase text-[0.7692rem] min-w-[28px] pt-[1px]">
                 {label}
             </span>
+            {softWrap.button}
             <CollapsibleBox
                 collapsedMaxHeight={60}
-                className="monospace-block flex-1 text-text-primary/80 whitespace-pre overflow-x-auto no-scrollbar"
+                className="monospace-block flex-1 min-w-0 text-text-primary/80 whitespace-pre overflow-x-auto no-scrollbar"
             >
                 {children}
             </CollapsibleBox>

--- a/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/ToolRenderers/common/index.tsx
@@ -6,6 +6,7 @@ import {cn} from "@/utils/cn.ts";
 import {useTranslation} from "@/i18n";
 import {ToolUseBlockDto} from "@/dto/message/ContentBlockDto";
 import {useToolStatus, type ToolStatus} from "./toolStatus";
+import {useSoftWrapToggle} from "@/pages/ChatPage/message-renderers/components/useSoftWrapToggle";
 
 /**
  * The tool_use block currently being rendered. ToolRenderer provides it so deep
@@ -148,10 +149,16 @@ export const LabelValue = (props: {
 }) => {
     const [isFocused, setIsFocused] = useState(false);
     const {label = '', children, className = '', maxHeight} = props;
+    const softWrap = useSoftWrapToggle();
 
+    // The row carries the class and hosts the button (#179 follow-up). It does
+    // not scroll, so the button stays put while the value box beside it is
+    // scrolled sideways — an absolutely positioned child of the box itself
+    // would slide away with the content.
     return (
-        <div className={`flex items-start p-2 ${className}`}>
+        <div className={cn('group/wrap relative flex items-start p-2', softWrap.blockClassName, className)}>
             {label && <Label name={label}/>}
+            {softWrap.button}
             <Value
                 isFocused={isFocused}
                 onClick={() => setIsFocused((v) => !v)}
@@ -174,7 +181,7 @@ export const Value = (props: {
     const {isFocused, onClick, children, maxHeight = 'max-h-[105px]'} = props;
 
     return (
-        <div dir="ltr" className={`monospace-block flex-1 text-text-primary/80 whitespace-pre font-mono overflow-y-hidden overflow-x-auto no-scrollbar cursor-pointer ${isFocused ? '' : maxHeight}`} onClick={onClick}>
+        <div dir="ltr" className={cn('monospace-block flex-1 min-w-0 text-text-primary/80 whitespace-pre font-mono overflow-y-hidden overflow-x-auto no-scrollbar cursor-pointer', isFocused ? '' : maxHeight)} onClick={onClick}>
             {children}
         </div>
     );

--- a/webview/src/pages/ChatPage/message-renderers/components/CodeBlockWrapControls.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/CodeBlockWrapControls.tsx
@@ -94,12 +94,12 @@ const CodeBlockWrapButton = ({header}: {header: HTMLElement}) => {
         aria-pressed={wrapped}
         onClick={() => setOverride(!wrapped)}
         className={cn(
-          'cursor-pointer rounded p-1 opacity-0 transition-all',
-          'text-muted-foreground hover:text-text-primary',
+          // Same chip as the copy button it sits beside — see .wrap-toggle-button.
+          'wrap-toggle-button opacity-0 transition-all',
           'group-hover:opacity-100 focus-visible:opacity-100',
         )}
       >
-        <WrapIcon active={wrapped} />
+        <WrapIcon />
       </button>
     </Tooltip>,
     slot,

--- a/webview/src/pages/ChatPage/message-renderers/components/CodeBlockWrapControls.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/CodeBlockWrapControls.tsx
@@ -1,0 +1,107 @@
+import {RefObject, useEffect, useState} from 'react';
+import {createPortal} from 'react-dom';
+import {Tooltip} from '@/components';
+import {cn} from '@/utils/cn.ts';
+import {useTranslation} from '@/i18n';
+import {useSettingsOrNull} from '@/contexts/SettingsContext';
+import {SettingKey} from '@/types/settings';
+import {WrapIcon} from './WrapIcon';
+
+/**
+ * Per-block wrap buttons for the fenced code blocks inside an assistant message
+ * (#179 follow-up).
+ *
+ * The other blocks get their button from useSoftWrapToggle, which hands the
+ * caller a class and a button to place. A fenced block cannot: Streamdown owns
+ * the whole
+ * `code-block` subtree — header, copy button and all — and neither
+ * `components` (it never reaches the code path; an override there only lands on
+ * the pre-highlight fallback) nor `controls` (booleans that turn its own
+ * buttons off) lets us add one. Re-implementing the subtree would mean owning
+ * its copy button and language label forever.
+ *
+ * So the button is portalled into the header Streamdown already rendered, and
+ * the fold is a class on the `code-block` element — the same `.soft-wrap` /
+ * `.soft-wrap-off` pair every other block uses.
+ */
+export const CodeBlockWrapControls = ({containerRef, content}: {
+  containerRef: RefObject<HTMLElement | null>;
+  /** Re-scan when the message text changes — blocks appear as it streams in. */
+  content: string;
+}) => {
+  const [headers, setHeaders] = useState<HTMLElement[]>([]);
+
+  useEffect(() => {
+    const root = containerRef.current;
+    if (!root) return;
+
+    // Streamdown swaps the highlighted block in asynchronously, so the headers
+    // are not there on the first pass after `content` changes.
+    const scan = () => {
+      const found = Array.from(
+        root.querySelectorAll<HTMLElement>('[data-streamdown="code-block-header"]'),
+      );
+      setHeaders((prev) =>
+        prev.length === found.length && prev.every((el, i) => el === found[i]) ? prev : found,
+      );
+    };
+
+    scan();
+    const observer = new MutationObserver(scan);
+    observer.observe(root, {childList: true, subtree: true});
+    return () => observer.disconnect();
+  }, [containerRef, content]);
+
+  return (
+    <>
+      {headers.map((header, i) => (
+        <CodeBlockWrapButton key={i} header={header} />
+      ))}
+    </>
+  );
+};
+
+const CodeBlockWrapButton = ({header}: {header: HTMLElement}) => {
+  const {t} = useTranslation('chatTools');
+  const settings = useSettingsOrNull();
+  const defaultWrapped = settings?.settings[SettingKey.SOFT_WRAP] === true;
+  const [override, setOverride] = useState<boolean | null>(null);
+  const wrapped = override ?? defaultWrapped;
+
+  // The class goes on the `code-block` wrapper rather than the <pre>, so the
+  // same descendant selectors the global setting uses apply unchanged.
+  const block = header.closest<HTMLElement>('[data-streamdown="code-block"]');
+  useEffect(() => {
+    if (!block) return;
+    block.classList.toggle('soft-wrap', wrapped);
+    block.classList.toggle('soft-wrap-off', !wrapped);
+    return () => {
+      block.classList.remove('soft-wrap', 'soft-wrap-off');
+    };
+  }, [block, wrapped]);
+
+  const label = wrapped ? t('tool.softWrap.unwrap') : t('tool.softWrap.wrap');
+
+  // Into the header's button row, so it sits beside Copy instead of floating
+  // over the code.
+  const slot = header.lastElementChild ?? header;
+
+  return createPortal(
+    <Tooltip content={label}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={wrapped}
+        onClick={() => setOverride(!wrapped)}
+        className={cn(
+          'cursor-pointer rounded p-1 opacity-0 transition-all',
+          'text-muted-foreground hover:text-text-primary',
+          'group-hover:opacity-100 focus-visible:opacity-100',
+        )}
+      >
+        <WrapIcon active={wrapped} />
+      </button>
+    </Tooltip>,
+    slot,
+  );
+};

--- a/webview/src/pages/ChatPage/message-renderers/components/WrapIcon.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/WrapIcon.tsx
@@ -1,11 +1,15 @@
-import {cn} from '@/utils/cn.ts';
-
 /**
- * An arrow folding back onto the line below it — the editor convention for
- * wrapping. Inline rather than from an icon package: the webview ships none,
- * and every other icon here is written the same way.
+ * The wrap button's glyph (#179 follow-up).
+ *
+ * Three text lines, the second turning back on itself through an arrow — the
+ * editor convention for a wrapped line.
+ *
+ * One drawing for both states. What separates them is the chip behind it: the
+ * copy button's translucent backdrop while the block scrolls, the accent fill
+ * while it folds. A second glyph would say the same thing twice and make the
+ * pair read as two different controls.
  */
-export const WrapIcon = ({active}: {active: boolean}) => (
+export const WrapIcon = () => (
   <svg
     width="14"
     height="14"
@@ -16,11 +20,10 @@ export const WrapIcon = ({active}: {active: boolean}) => (
     strokeLinecap="round"
     strokeLinejoin="round"
     aria-hidden="true"
-    className={cn(active && 'text-accent-fg')}
   >
     <path d="M2 4h12" />
-    <path d="M2 12h5" />
-    <path d="M2 8h9a2.5 2.5 0 0 1 0 5h-2" />
-    <path d="M6.5 11 4.5 13l2 2" />
+    <path d="M2 8h9a2.5 2.5 0 0 1 0 5H7" />
+    <path d="M9 11l-2 2 2 2" />
+    <path d="M2 12h2" />
   </svg>
 );

--- a/webview/src/pages/ChatPage/message-renderers/components/WrapIcon.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/WrapIcon.tsx
@@ -1,0 +1,26 @@
+import {cn} from '@/utils/cn.ts';
+
+/**
+ * An arrow folding back onto the line below it — the editor convention for
+ * wrapping. Inline rather than from an icon package: the webview ships none,
+ * and every other icon here is written the same way.
+ */
+export const WrapIcon = ({active}: {active: boolean}) => (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.4"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    className={cn(active && 'text-accent-fg')}
+  >
+    <path d="M2 4h12" />
+    <path d="M2 12h5" />
+    <path d="M2 8h9a2.5 2.5 0 0 1 0 5h-2" />
+    <path d="M6.5 11 4.5 13l2 2" />
+  </svg>
+);

--- a/webview/src/pages/ChatPage/message-renderers/components/__tests__/CodeBlockWrapControls.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/__tests__/CodeBlockWrapControls.test.tsx
@@ -1,0 +1,106 @@
+import {describe, it, expect} from 'vitest';
+import {render, waitFor, act} from '@testing-library/react';
+import {useRef} from 'react';
+import {CodeBlockWrapControls} from '../CodeBlockWrapControls';
+
+/**
+ * The fenced code blocks in an assistant message are the one place the #179
+ * per-block toggle cannot wrap the block itself — Streamdown owns that subtree,
+ * so the button is portalled into the header it already rendered and the fold
+ * is a class on the `code-block` element.
+ *
+ * These cases assert that wiring against the DOM Streamdown actually produces
+ * (captured from a real render): a `code-block` wrapper holding a
+ * `code-block-header` with a button row, and a `code-block-body` <pre>.
+ */
+function CodeBlockFixture({count, content = 'x'}: {count: number; content?: string}) {
+  const ref = useRef<HTMLDivElement>(null);
+  return (
+    <div>
+      <div ref={ref}>
+        {Array.from({length: count}, (_, i) => (
+          <div key={i} data-streamdown="code-block">
+            <div data-streamdown="code-block-header">
+              <span className="font-mono lowercase">json</span>
+              <div>
+                <button data-streamdown="code-block-copy-button">copy</button>
+              </div>
+            </div>
+            <pre data-streamdown="code-block-body">
+              <code>
+                <span className="block">{'{"a": 1}'}</span>
+              </code>
+            </pre>
+          </div>
+        ))}
+      </div>
+      <CodeBlockWrapControls containerRef={ref} content={content} />
+    </div>
+  );
+}
+
+const buttonsIn = (root: HTMLElement) =>
+  Array.from(root.querySelectorAll<HTMLButtonElement>('button[aria-pressed]'));
+
+describe('CodeBlockWrapControls (#179 follow-up)', () => {
+  it('puts a button in every code block header', async () => {
+    const {container} = render(<CodeBlockFixture count={3} />);
+
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(3));
+
+    // Beside Copy in the header, not floating over the code: a button inside
+    // the <pre> would scroll away with the content.
+    for (const btn of buttonsIn(container)) {
+      expect(btn.closest('[data-streamdown="code-block-header"]')).not.toBeNull();
+      expect(btn.closest('[data-streamdown="code-block-body"]')).toBeNull();
+    }
+  });
+
+  it('leaves the copy button Streamdown rendered alone', async () => {
+    const {container} = render(<CodeBlockFixture count={1} />);
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(1));
+    expect(
+      container.querySelectorAll('[data-streamdown="code-block-copy-button"]'),
+    ).toHaveLength(1);
+  });
+
+  it('folds only the block whose button was pressed', async () => {
+    const {container} = render(<CodeBlockFixture count={2} />);
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(2));
+
+    const blocks = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-streamdown="code-block"]'),
+    );
+    // The setting is off in this environment, so both start opted out.
+    expect(blocks.map((b) => b.classList.contains('soft-wrap-off'))).toEqual([true, true]);
+
+    act(() => buttonsIn(container)[0].click());
+
+    expect(blocks[0].classList.contains('soft-wrap')).toBe(true);
+    expect(blocks[0].classList.contains('soft-wrap-off')).toBe(false);
+    // The other block is untouched — this is a per-block control.
+    expect(blocks[1].classList.contains('soft-wrap-off')).toBe(true);
+  });
+
+  it('flips back and forth', async () => {
+    const {container} = render(<CodeBlockFixture count={1} />);
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(1));
+    const block = container.querySelector<HTMLElement>('[data-streamdown="code-block"]')!;
+
+    act(() => buttonsIn(container)[0].click());
+    expect(block.classList.contains('soft-wrap')).toBe(true);
+
+    act(() => buttonsIn(container)[0].click());
+    expect(block.classList.contains('soft-wrap-off')).toBe(true);
+  });
+
+  it('reaches blocks that appear after the first render', async () => {
+    // Streamdown swaps the highlighted block in asynchronously and appends more
+    // as the message streams, so a one-shot scan would miss them.
+    const {container, rerender} = render(<CodeBlockFixture count={1} content="a" />);
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(1));
+
+    rerender(<CodeBlockFixture count={3} content="b" />);
+    await waitFor(() => expect(buttonsIn(container)).toHaveLength(3));
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/components/__tests__/useSoftWrapToggle.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/__tests__/useSoftWrapToggle.test.tsx
@@ -1,0 +1,83 @@
+import {describe, it, expect, afterEach} from 'vitest';
+import {render, act} from '@testing-library/react';
+import {useSoftWrapToggle} from '../useSoftWrapToggle';
+
+/**
+ * The per-block toggle (#179 follow-up) is a class swap, so what these cases
+ * pin down is which class the block carries and where the button ends up — the
+ * CSS that reads those classes is covered by theme/__tests__/softWrap.css.test.
+ */
+function Host() {
+  const softWrap = useSoftWrapToggle();
+  return (
+    // The shape every call site uses: a non-scrolling element carries the class
+    // and hosts the button, with the scrolling block beside/below it.
+    <div data-testid="row" className={`group/wrap relative ${softWrap.blockClassName}`}>
+      {softWrap.button}
+      <div data-testid="block" className="monospace-block overflow-x-auto">
+        content
+      </div>
+    </div>
+  );
+}
+
+const btn = (c: HTMLElement) => c.querySelector<HTMLButtonElement>('button[aria-pressed]')!;
+const row = (c: HTMLElement) => c.querySelector<HTMLElement>('[data-testid="row"]')!;
+
+afterEach(() => {
+  document.documentElement.classList.remove('soft-wrap');
+});
+
+describe('useSoftWrapToggle (#179 follow-up)', () => {
+  it('starts opted out when the setting is off', () => {
+    const {container} = render(<Host />);
+    expect(row(container).classList.contains('soft-wrap-off')).toBe(true);
+    expect(btn(container).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('folds the block when pressed, and unfolds it when pressed again', () => {
+    const {container} = render(<Host />);
+
+    act(() => btn(container).click());
+    expect(row(container).classList.contains('soft-wrap')).toBe(true);
+    expect(btn(container).getAttribute('aria-pressed')).toBe('true');
+
+    act(() => btn(container).click());
+    expect(row(container).classList.contains('soft-wrap-off')).toBe(true);
+    expect(btn(container).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('keeps the button out of the element that scrolls', () => {
+    // An absolutely positioned child of a scroll container scrolls with the
+    // content and slides off screen; the button has to be a sibling.
+    const {container} = render(<Host />);
+    const block = container.querySelector<HTMLElement>('[data-testid="block"]')!;
+    expect(block.contains(btn(container))).toBe(false);
+  });
+
+  it('does not swallow the click into the block underneath', () => {
+    // The tool blocks expand on click. Without stopPropagation the same click
+    // that folds the lines also resizes the box under the pointer.
+    let outerClicks = 0;
+    function Wrapped() {
+      return (
+        <div onClick={() => {outerClicks++;}}>
+          <Host />
+        </div>
+      );
+    }
+    const {container} = render(<Wrapped />);
+    act(() => btn(container).click());
+    expect(outerClicks).toBe(0);
+  });
+
+  it('labels the action rather than the state', () => {
+    const {container} = render(<Host />);
+    const unfolded = btn(container).getAttribute('aria-label');
+    act(() => btn(container).click());
+    const folded = btn(container).getAttribute('aria-label');
+    expect(unfolded).toBeTruthy();
+    expect(folded).toBeTruthy();
+    expect(folded).not.toBe(unfolded);
+  });
+});

--- a/webview/src/pages/ChatPage/message-renderers/components/__tests__/useSoftWrapToggle.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/__tests__/useSoftWrapToggle.test.tsx
@@ -80,4 +80,29 @@ describe('useSoftWrapToggle (#179 follow-up)', () => {
     expect(folded).toBeTruthy();
     expect(folded).not.toBe(unfolded);
   });
+
+  it('keeps one glyph and lets the chip carry the state', () => {
+    // The drawing stays put; `aria-pressed` is what the stylesheet keys the
+    // accent fill off (see softWrap.css.test). Swapping the glyph too would
+    // make the two states read as two different controls.
+    const {container} = render(<Host />);
+    const paths = () =>
+      Array.from(btn(container).querySelectorAll('path'))
+        .map((p) => p.getAttribute('d'))
+        .join('|');
+
+    const off = paths();
+    act(() => btn(container).click());
+
+    expect(off).toBeTruthy();
+    expect(paths()).toBe(off);
+    expect(btn(container).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  it('wears the same chip as the copy button it sits beside', () => {
+    // `.wrap-toggle-button` pulls the copy button's own CSS variables. Without
+    // it the glyph floated over the code with no backdrop marking it a control.
+    const {container} = render(<Host />);
+    expect(btn(container).classList.contains('wrap-toggle-button')).toBe(true);
+  });
 });

--- a/webview/src/pages/ChatPage/message-renderers/components/useSoftWrapToggle.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/useSoftWrapToggle.tsx
@@ -65,12 +65,12 @@ export function useSoftWrapToggle(): {
           setOverride(!wrapped);
         }}
         className={cn(
-          'absolute end-1 top-1 z-10 rounded p-1 opacity-0 transition-opacity',
-          'text-text-tertiary hover:text-text-primary hover:bg-surface-hover',
+          // Same chip as the code block's copy button — see .wrap-toggle-button.
+          'wrap-toggle-button absolute end-1 top-1 z-10 opacity-0 transition-opacity',
           'group-hover/wrap:opacity-100 focus-visible:opacity-100',
         )}
       >
-        <WrapIcon active={wrapped} />
+        <WrapIcon />
       </button>
     </Tooltip>
   );

--- a/webview/src/pages/ChatPage/message-renderers/components/useSoftWrapToggle.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/components/useSoftWrapToggle.tsx
@@ -1,0 +1,83 @@
+import {ReactNode, useState} from 'react';
+import {Tooltip} from '@/components';
+import {cn} from '@/utils/cn.ts';
+import {useTranslation} from '@/i18n';
+import {useSettingsOrNull} from '@/contexts/SettingsContext';
+import {SettingKey} from '@/types/settings';
+import {WrapIcon} from './WrapIcon';
+
+/**
+ * Per-block soft-wrap control (#179 follow-up).
+ *
+ * `Settings > Appearance > Soft Wrap` already folds every monospace block at
+ * once, but the reporter reads most blocks fine and only wants to fold the one
+ * they are on: "default to off, so you don't waste screen soft-wrapping, but if
+ * you click something, it softwraps".
+ *
+ * The switch is a class, not a piece of state the block reports upwards: the
+ * CSS already keys off `.soft-wrap`, so putting that same class on one block
+ * reuses every rule the global setting uses. `soft-wrap-off` is the mirror case
+ * — the setting is on and this is the block the user wants to scroll instead.
+ *
+ * Returns the pieces for the caller to place rather than wrapping the block
+ * itself: the call sites are shaped differently (a flex child, a bordered box,
+ * a `<pre>`), and where the class and the button each have to go depends on
+ * which element scrolls.
+ *
+ * The button must NOT be inside the element that scrolls sideways — an
+ * absolutely positioned child of a scroll container scrolls with the content
+ * and slides off screen. Put it on a non-scrolling ancestor that also carries
+ * `group/wrap relative`.
+ */
+export function useSoftWrapToggle(): {
+  /**
+   * Goes on the block or any ancestor of it. `.soft-wrap`/`.soft-wrap-off`
+   * match the block both as itself and as a descendant.
+   */
+  blockClassName: string;
+  wrapped: boolean;
+  button: ReactNode;
+} {
+  const {t} = useTranslation('chatTools');
+  // useSettingsOrNull, not useSettings: these blocks render in places without a
+  // SettingsProvider (and in tests), where useSettings throws. No provider means
+  // the setting's own default — unwrapped.
+  const settings = useSettingsOrNull();
+  const defaultWrapped = settings?.settings[SettingKey.SOFT_WRAP] === true;
+
+  // `null` = untouched, so the block keeps following the setting. Storing the
+  // resolved boolean instead would freeze this block at whatever the setting
+  // was on first render and stop tracking later changes to it.
+  const [override, setOverride] = useState<boolean | null>(null);
+  const wrapped = override ?? defaultWrapped;
+  const label = wrapped ? t('tool.softWrap.unwrap') : t('tool.softWrap.wrap');
+
+  const button = (
+    <Tooltip content={label}>
+      <button
+        type="button"
+        aria-label={label}
+        aria-pressed={wrapped}
+        onClick={(e) => {
+          // The tool blocks expand on click; without this the same click that
+          // folds the lines also resizes the box under the pointer.
+          e.stopPropagation();
+          setOverride(!wrapped);
+        }}
+        className={cn(
+          'absolute end-1 top-1 z-10 rounded p-1 opacity-0 transition-opacity',
+          'text-text-tertiary hover:text-text-primary hover:bg-surface-hover',
+          'group-hover/wrap:opacity-100 focus-visible:opacity-100',
+        )}
+      >
+        <WrapIcon active={wrapped} />
+      </button>
+    </Tooltip>
+  );
+
+  return {
+    blockClassName: wrapped ? 'soft-wrap' : 'soft-wrap-off',
+    wrapped,
+    button,
+  };
+}

--- a/webview/src/pages/ChatPage/streaming.css
+++ b/webview/src/pages/ChatPage/streaming.css
@@ -243,6 +243,19 @@
   text-indent: -2.5rem;
 }
 
+/* Per-block override (#179 follow-up) — see the note in index.css. Last wins:
+   this class and `.soft-wrap` both sit on an ancestor and weigh the same. */
+.soft-wrap-off [data-streamdown="code-block-body"] {
+  white-space: pre;
+  word-break: normal;
+  overflow-x: auto;
+}
+
+.soft-wrap-off [data-streamdown="code-block-body"] > code > span {
+  padding-left: 0;
+  text-indent: 0;
+}
+
 /* Shiki token spans. Colour is deliberately NOT set here: the highlighter
    (webview/src/utils/codePlugin.ts) writes each token's colour inline, and an
    `!important` rule at this level would repaint every token in one flat colour

--- a/webview/src/pages/ChatPage/streaming.css
+++ b/webview/src/pages/ChatPage/streaming.css
@@ -220,6 +220,29 @@
   border: none !important;
 }
 
+/* Soft wrap (#179) reaches the diff and tool blocks through `.soft-wrap` on
+   <html>, but those rules select `.monospace-block` / `.diff-body-line`, and a
+   fenced block in an assistant message is neither — Streamdown renders its own
+   <pre>, so the setting left markdown code blocks scrolling sideways.
+
+   `break-all` matches the other blocks: this is JSON, paths and code, which run
+   for long stretches with no space to break at.
+
+   Each line is a <span class="block"> carrying its line number in a `::before`
+   of `w-6 mr-4` (1.5rem + 1rem). Wrapping a line without accounting for that
+   marker would run the continuation underneath the numbers; the hanging indent
+   holds it in the code column, where the eye expects it. */
+.soft-wrap [data-streamdown="code-block-body"] {
+  white-space: pre-wrap;
+  word-break: break-all;
+  overflow-x: hidden;
+}
+
+.soft-wrap [data-streamdown="code-block-body"] > code > span {
+  padding-left: 2.5rem;
+  text-indent: -2.5rem;
+}
+
 /* Shiki token spans. Colour is deliberately NOT set here: the highlighter
    (webview/src/utils/codePlugin.ts) writes each token's colour inline, and an
    `!important` rule at this level would repaint every token in one flat colour

--- a/webview/src/theme/__tests__/softWrap.css.test.ts
+++ b/webview/src/theme/__tests__/softWrap.css.test.ts
@@ -43,8 +43,45 @@ describe('soft wrap — stylesheet structure (#179)', () => {
   });
 
   it('wraps the diff viewer used by the diff card', () => {
-    const rule = block('.soft-wrap .diff-viewer .diff-code {');
+    const rule = block('.soft-wrap .diff-viewer .diff-code,');
     expect(rule).toMatch(/white-space:\s*pre-wrap/);
+  });
+});
+
+/**
+ * The per-block toggle (#179 follow-up) puts the same classes on the block
+ * instead of on <html>, so every selector needs both forms. A rule written only
+ * as `.soft-wrap .x` silently does nothing when the class lands on `.x` itself
+ * — which is how the first attempt shipped a toggle that flipped its label and
+ * changed no layout.
+ */
+describe('soft wrap — the classes work on the block itself, not just as an ancestor', () => {
+  const carriers = [
+    ['.diff-body-line', 'soft-wrap'],
+    ['.monospace-block', 'soft-wrap'],
+    ['.diff-body-line', 'soft-wrap-off'],
+    ['.monospace-block', 'soft-wrap-off'],
+  ] as const;
+
+  it.each(carriers)('selects %s when it carries .%s itself', (target, cls) => {
+    expect(css).toContain(`${target}.${cls}`);
+  });
+
+  it('selects the diff viewer both ways', () => {
+    expect(css).toContain('.soft-wrap .diff-viewer .diff-code');
+    expect(css).toContain('.diff-viewer.soft-wrap .diff-code');
+  });
+
+  it('undoes the fold when a block opts out while the setting is on', () => {
+    const rule = block('.soft-wrap-off .diff-body-line,');
+    expect(rule).toMatch(/white-space:\s*pre\b/);
+    expect(rule).toMatch(/word-break:\s*normal/);
+    // Back to scrolling — the text no longer fits the box.
+    expect(rule).toMatch(/overflow-x:\s*auto/);
+  });
+
+  it('restores the diff body floor when a block opts out', () => {
+    expect(block('.soft-wrap-off .diff-body {')).toMatch(/min-width:\s*max-content/);
   });
 });
 
@@ -74,5 +111,18 @@ describe('soft wrap — markdown code blocks (#179 follow-up)', () => {
     );
     expect(rule).toMatch(/padding-left:\s*2\.5rem/);
     expect(rule).toMatch(/text-indent:\s*-2\.5rem/);
+  });
+
+  it('lets one code block opt back out while the setting is on', () => {
+    const rule = blockIn(streamingCss, '.soft-wrap-off [data-streamdown="code-block-body"] {');
+    expect(rule).toMatch(/white-space:\s*pre\b/);
+    expect(rule).toMatch(/overflow-x:\s*auto/);
+    // The hanging indent only makes sense while lines fold.
+    const lines = blockIn(
+      streamingCss,
+      '.soft-wrap-off [data-streamdown="code-block-body"] > code > span {',
+    );
+    expect(lines).toMatch(/padding-left:\s*0/);
+    expect(lines).toMatch(/text-indent:\s*0/);
   });
 });

--- a/webview/src/theme/__tests__/softWrap.css.test.ts
+++ b/webview/src/theme/__tests__/softWrap.css.test.ts
@@ -86,6 +86,35 @@ describe('soft wrap — the classes work on the block itself, not just as an anc
 });
 
 /**
+ * The button first shipped with no backdrop, so the glyph floated over the code
+ * with nothing marking it as a control, and the two states looked identical.
+ */
+describe('soft wrap — the button reads as a control, and as on or off', () => {
+  it('takes the copy button\'s chip by variable, not by copied value', () => {
+    // Copying the values would let the two drift apart the next time either is
+    // retuned, and light/dark each define their own.
+    const rule = block('.wrap-toggle-button {');
+    expect(rule).toMatch(/background:\s*var\(--md-code-copy-btn-bg\)/);
+    expect(rule).toMatch(/color:\s*var\(--md-code-copy-btn-fg\)/);
+    expect(block('.wrap-toggle-button:hover {'))
+      .toMatch(/background:\s*var\(--md-code-copy-btn-bg-hover\)/);
+  });
+
+  it('washes the chip with the accent when wrapping is on', () => {
+    // One glyph, two backdrops — the state lives here, not in the drawing. Held
+    // under full strength: one chip sits on every block, and a saturated one
+    // pulls the eye off the code underneath.
+    const rule = block(".wrap-toggle-button[aria-pressed='true'] {");
+    const bg = rule.match(/background:\s*([^;]+);/)?.[1] ?? '';
+    expect(bg).toContain('var(--accent-primary-rgb)');
+    const alpha = Number(bg.match(/\/\s*([\d.]+)\s*\)/)?.[1]);
+    expect(alpha).toBeGreaterThan(0);
+    expect(alpha).toBeLessThan(1);
+    expect(rule).toMatch(/color:\s*var\(--accent-primary-fg\)/);
+  });
+});
+
+/**
  * The reporter turned the setting on and still hit a block that scrolled
  * sideways: a fenced code block in an assistant message. Streamdown renders it
  * as its own <pre data-streamdown="code-block-body">, which carries none of the

--- a/webview/src/theme/__tests__/softWrap.css.test.ts
+++ b/webview/src/theme/__tests__/softWrap.css.test.ts
@@ -9,14 +9,21 @@ import { describe, it, expect } from 'vitest';
 // `?raw` rather than node:fs — the webview tsconfig targets DOM only. Requires
 // index.css in `test.css.include` (vitest.config.ts).
 import css from '../../index.css?raw';
+// Markdown code blocks are styled in streaming.css, not index.css — the wrap
+// rule for them lives next to the rest of their styling.
+import streamingCss from '../../pages/ChatPage/streaming.css?raw';
 
 /** Extracts the body of the first CSS block whose selector matches. */
-function block(selectorStartsWith: string): string {
-  const start = css.indexOf(selectorStartsWith);
+function blockIn(source: string, selectorStartsWith: string): string {
+  const start = source.indexOf(selectorStartsWith);
   if (start === -1) throw new Error(`selector not found: ${selectorStartsWith}`);
-  const open = css.indexOf('{', start);
-  const close = css.indexOf('\n}', open);
-  return css.slice(open + 1, close);
+  const open = source.indexOf('{', start);
+  const close = source.indexOf('\n}', open);
+  return source.slice(open + 1, close);
+}
+
+function block(selectorStartsWith: string): string {
+  return blockIn(css, selectorStartsWith);
 }
 
 describe('soft wrap — stylesheet structure (#179)', () => {
@@ -38,5 +45,34 @@ describe('soft wrap — stylesheet structure (#179)', () => {
   it('wraps the diff viewer used by the diff card', () => {
     const rule = block('.soft-wrap .diff-viewer .diff-code {');
     expect(rule).toMatch(/white-space:\s*pre-wrap/);
+  });
+});
+
+/**
+ * The reporter turned the setting on and still hit a block that scrolled
+ * sideways: a fenced code block in an assistant message. Streamdown renders it
+ * as its own <pre data-streamdown="code-block-body">, which carries none of the
+ * classes the rules above select, so the setting never reached it.
+ */
+describe('soft wrap — markdown code blocks (#179 follow-up)', () => {
+  it('folds the fenced block Streamdown renders', () => {
+    const rule = blockIn(streamingCss, '.soft-wrap [data-streamdown="code-block-body"] {');
+    expect(rule).toMatch(/white-space:\s*pre-wrap/);
+    expect(rule).toMatch(/word-break:\s*break-all/);
+    // The <pre> is the scroll container; leaving it scrollable would keep a
+    // sideways scrollbar under text that no longer overflows.
+    expect(rule).toMatch(/overflow-x:\s*hidden/);
+  });
+
+  it('keeps a wrapped continuation clear of the line-number gutter', () => {
+    // Each line is a <span class="block"> whose line number sits in a ::before
+    // of `w-6 mr-4` (1.5rem + 1rem). Without the hanging indent the folded part
+    // of a line starts under those numbers.
+    const rule = blockIn(
+      streamingCss,
+      '.soft-wrap [data-streamdown="code-block-body"] > code > span {',
+    );
+    expect(rule).toMatch(/padding-left:\s*2\.5rem/);
+    expect(rule).toMatch(/text-indent:\s*-2\.5rem/);
   });
 });


### PR DESCRIPTION
Two follow-ups from what the reporter found after trying v0.28.3.

**Code blocks did not fold.** With the setting on, a fenced code block in
an answer still scrolled sideways. The existing rules select
`.monospace-block` and `.diff-body-line`, and the block Streamdown renders
is neither. They fold now, and on a block with line numbers the folded
remainder no longer runs underneath the numbers.

**Toggle it from the chat.** Every block now has its own button. It
appears next to the copy button on hover, and pressing it folds or
unfolds that block alone. The default follows the setting; only the block
you pressed differs. While it is on, the button wears an accent chip.

The switch is a class, not state. The CSS already keys off `.soft-wrap`,
so putting the same class on one block reuses every rule the setting uses.

Measured in the browser: pressing it took a block from scrollWidth 793 to
1975, pressing again returned it, the other blocks kept their state, and
the button held its position across a sideways scroll. 2582 tests across
272 files pass.

Closes #179
