### PR TITLE
Add agent transcript viewer for Background tasks panel

### DIFF
--- a/backend/src/core/features/__tests__/backgroundTaskOutputWatcher.test.ts
+++ b/backend/src/core/features/__tests__/backgroundTaskOutputWatcher.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, appendFile, rm } from 'fs/promises';
+import { realpathSync } from 'fs';
+import { join } from 'path';
+import * as os from 'os';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+
+describe('backgroundTaskOutputWatcher', () => {
+  let tmpDir: string;
+  let originalTmpdir: string | undefined;
+
+  beforeEach(async () => {
+    originalTmpdir = process.env.CLAUDE_CODE_TMPDIR;
+    // loadBackgroundTaskOutput (which the watcher delegates the actual read
+    // to) validates outputFile against getTmpBase() — point that at our
+    // scratch dir so a real file under it is accepted.
+    tmpDir = realpathSync(await mkdtemp(join(os.tmpdir(), 'wtest-')));
+    process.env.CLAUDE_CODE_TMPDIR = tmpDir;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    if (originalTmpdir === undefined) delete process.env.CLAUDE_CODE_TMPDIR;
+    else process.env.CLAUDE_CODE_TMPDIR = originalTmpdir;
+    vi.restoreAllMocks();
+  });
+
+  function makeConnections() {
+    const sent: Array<{ connectionId: string; type: string; payload: Record<string, unknown> }> = [];
+    const connections = {
+      sendTo: (connectionId: string, type: string, payload: Record<string, unknown> = {}) => {
+        sent.push({ connectionId, type, payload });
+      },
+    } as unknown as ConnectionManager;
+    return { connections, sent };
+  }
+
+  it('pushes the current content immediately on watch, then again after the file changes', async () => {
+    const { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } = await import('../backgroundTaskOutputWatcher');
+    const { connections, sent } = makeConnections();
+    const file = join(tmpDir, 'task.output');
+    await writeFile(file, 'count: 1\n');
+
+    watchBackgroundTaskOutput('conn-1', file, connections);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toMatchObject({ connectionId: 'conn-1', type: 'BACKGROUND_TASK_OUTPUT_CHANGED', payload: { outputFile: file, text: 'count: 1\n' } });
+
+    await appendFile(file, 'count: 2\n');
+    await new Promise((resolve) => setTimeout(resolve, 400)); // past the 200ms debounce
+
+    expect(sent.length).toBeGreaterThanOrEqual(2);
+    expect(sent[sent.length - 1].payload.text).toBe('count: 1\ncount: 2\n');
+
+    unwatchBackgroundTaskOutput('conn-1', file);
+  });
+
+  it('debounces rapid successive writes into one push', async () => {
+    const { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } = await import('../backgroundTaskOutputWatcher');
+    const { connections, sent } = makeConnections();
+    const file = join(tmpDir, 'rapid.output');
+    await writeFile(file, '');
+
+    watchBackgroundTaskOutput('conn-1', file, connections);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const afterInitial = sent.length;
+
+    for (let i = 0; i < 5; i++) {
+      await appendFile(file, `line ${i}\n`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // 5 rapid writes inside the 200ms debounce window collapse to one push,
+    // not five — this is the whole point of debouncing a file watcher.
+    expect(sent.length - afterInitial).toBe(1);
+    expect(sent[sent.length - 1].payload.text).toBe('line 0\nline 1\nline 2\nline 3\nline 4\n');
+
+    unwatchBackgroundTaskOutput('conn-1', file);
+  });
+
+  it('does not push after unwatch', async () => {
+    const { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } = await import('../backgroundTaskOutputWatcher');
+    const { connections, sent } = makeConnections();
+    const file = join(tmpDir, 'stop.output');
+    await writeFile(file, 'a\n');
+
+    watchBackgroundTaskOutput('conn-1', file, connections);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    unwatchBackgroundTaskOutput('conn-1', file);
+
+    const countAfterUnwatch = sent.length;
+    await appendFile(file, 'b\n');
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(sent.length).toBe(countAfterUnwatch);
+  });
+
+  it('re-watching the same connection+file is a no-op (no duplicate pushes per change)', async () => {
+    const { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } = await import('../backgroundTaskOutputWatcher');
+    const { connections, sent } = makeConnections();
+    const file = join(tmpDir, 'dup.output');
+    await writeFile(file, '');
+
+    watchBackgroundTaskOutput('conn-1', file, connections);
+    watchBackgroundTaskOutput('conn-1', file, connections); // second call, same key
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const afterInitial = sent.length;
+
+    await appendFile(file, 'x\n');
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    // A duplicate watcher would have doubled every push from here on.
+    expect(sent.length - afterInitial).toBe(1);
+
+    unwatchBackgroundTaskOutput('conn-1', file);
+  });
+
+  it('unwatchAllForConnection stops every watcher for that connection but leaves others watching', async () => {
+    const { watchBackgroundTaskOutput, unwatchAllForConnection, unwatchBackgroundTaskOutput } = await import(
+      '../backgroundTaskOutputWatcher'
+    );
+    const { connections: connA, sent: sentA } = makeConnections();
+    const { connections: connB, sent: sentB } = makeConnections();
+    const fileA = join(tmpDir, 'a.output');
+    const fileB = join(tmpDir, 'b.output');
+    await writeFile(fileA, '');
+    await writeFile(fileB, '');
+
+    watchBackgroundTaskOutput('conn-a', fileA, connA);
+    watchBackgroundTaskOutput('conn-b', fileB, connB);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    unwatchAllForConnection('conn-a');
+
+    const countAAfter = sentA.length;
+    const countBAfter = sentB.length;
+    await appendFile(fileA, 'x\n');
+    await appendFile(fileB, 'y\n');
+    await new Promise((resolve) => setTimeout(resolve, 400));
+
+    expect(sentA.length).toBe(countAAfter); // conn-a's watcher is gone
+    expect(sentB.length).toBeGreaterThan(countBAfter); // conn-b's watcher is untouched
+
+    unwatchBackgroundTaskOutput('conn-b', fileB);
+  });
+
+  it('does not throw when watching a file that does not exist yet', async () => {
+    const { watchBackgroundTaskOutput } = await import('../backgroundTaskOutputWatcher');
+    const { connections } = makeConnections();
+    const file = join(tmpDir, 'not-created-yet.output');
+
+    expect(() => watchBackgroundTaskOutput('conn-1', file, connections)).not.toThrow();
+  });
+});

--- a/backend/src/core/features/__tests__/loadBackgroundTaskOutput.test.ts
+++ b/backend/src/core/features/__tests__/loadBackgroundTaskOutput.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { realpathSync } from 'fs';
+import * as os from 'os';
+
+describe('loadBackgroundTaskOutput', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    // Use realpathSync to resolve symlinks (macOS /var -> /private/var), matching
+    // findBackgroundTaskOutputPath.test.ts's setup for the same tmp-root contract.
+    tmpDir = realpathSync(await mkdtemp(join(os.tmpdir(), 'lbto-test-')));
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('reads the output file content when it is under the tmp root', async () => {
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const outputFile = join(tmpDir, 'tasks', 'b1.output');
+    await mkdir(join(tmpDir, 'tasks'), { recursive: true });
+    await writeFile(outputFile, 'count: 1\ncount: 2\n[exited with code 0]\n');
+
+    const { loadBackgroundTaskOutput } = await import('../loadBackgroundTaskOutput');
+    const result = await loadBackgroundTaskOutput({ outputFile });
+
+    expect(result).toEqual({ text: 'count: 1\ncount: 2\n[exited with code 0]\n', truncated: false });
+  });
+
+  it('returns empty when the file does not exist yet (task just started)', async () => {
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const { loadBackgroundTaskOutput } = await import('../loadBackgroundTaskOutput');
+    const result = await loadBackgroundTaskOutput({ outputFile: join(tmpDir, 'tasks', 'missing.output') });
+    expect(result).toEqual({ text: '', truncated: false });
+  });
+
+  it('returns empty for an empty outputFile', async () => {
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const { loadBackgroundTaskOutput } = await import('../loadBackgroundTaskOutput');
+    const result = await loadBackgroundTaskOutput({ outputFile: '' });
+    expect(result).toEqual({ text: '', truncated: false });
+  });
+
+  it('rejects an outputFile outside the tmp root (path traversal)', async () => {
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const outside = await mkdtemp(join(os.tmpdir(), 'lbto-outside-'));
+    const outsideFile = join(outside, 'secret.output');
+    await writeFile(outsideFile, 'top secret');
+    try {
+      const { loadBackgroundTaskOutput } = await import('../loadBackgroundTaskOutput');
+      const result = await loadBackgroundTaskOutput({ outputFile: outsideFile });
+      expect(result).toEqual({ text: '', truncated: false });
+    } finally {
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates and flags truncated when the log exceeds the cap, keeping the tail', async () => {
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const outputFile = join(tmpDir, 'tasks', 'big.output');
+    await mkdir(join(tmpDir, 'tasks'), { recursive: true });
+    const big = 'x'.repeat(200_000) + 'TAIL_MARKER';
+    await writeFile(outputFile, big);
+
+    const { loadBackgroundTaskOutput } = await import('../loadBackgroundTaskOutput');
+    const result = await loadBackgroundTaskOutput({ outputFile });
+
+    expect(result.truncated).toBe(true);
+    expect(result.text.endsWith('TAIL_MARKER')).toBe(true);
+    expect(result.text.length).toBe(200_000);
+  });
+});

--- a/backend/src/core/features/__tests__/loadWorkflowAgentTranscript.test.ts
+++ b/backend/src/core/features/__tests__/loadWorkflowAgentTranscript.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { loadWorkflowAgentTranscript } from '../loadWorkflowAgentTranscript';
+
+let configDir: string;
+let transcriptDir: string;
+let originalConfigDir: string | undefined;
+
+beforeAll(() => {
+  originalConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  configDir = mkdtempSync(join(tmpdir(), 'agent-transcript-test-'));
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+
+  transcriptDir = join(configDir, 'projects', 'proj-slug', 'sess-1', 'subagents', 'workflows', 'wf_abc123');
+  mkdirSync(transcriptDir, { recursive: true });
+
+  const a1 = [
+    JSON.stringify({ type: 'user', uuid: 'u1', timestamp: '2026-01-01T00:00:00.000Z', message: { role: 'user', content: 'go' } }),
+    JSON.stringify({
+      type: 'assistant',
+      uuid: 'u2',
+      parentUuid: 'u1',
+      timestamp: '2026-01-01T00:00:01.000Z',
+      message: { role: 'assistant', content: [{ type: 'text', text: 'done' }] },
+    }),
+  ].join('\n');
+  writeFileSync(join(transcriptDir, 'agent-a1.jsonl'), a1);
+
+  // Trailing malformed line simulates a running agent's partially-written last line.
+  writeFileSync(
+    join(transcriptDir, 'agent-a2.jsonl'),
+    JSON.stringify({ type: 'user', uuid: 'u3', message: { role: 'user', content: 'go' } }) + '\n{"incomple',
+  );
+});
+
+afterAll(() => {
+  rmSync(configDir, { recursive: true, force: true });
+  if (originalConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = originalConfigDir;
+});
+
+describe('loadWorkflowAgentTranscript', () => {
+  it('loads a completed agent transcript', async () => {
+    const result = await loadWorkflowAgentTranscript({ transcriptDir, agentId: 'a1' });
+    expect(result.truncated).toBe(false);
+    expect(result.entries).toHaveLength(2);
+    expect(result.entries[0]).toMatchObject({ type: 'user', uuid: 'u1' });
+    expect(result.entries[1]).toMatchObject({ type: 'assistant', uuid: 'u2' });
+  });
+
+  it('skips a malformed trailing line (agent still writing)', async () => {
+    const result = await loadWorkflowAgentTranscript({ transcriptDir, agentId: 'a2' });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({ type: 'user', uuid: 'u3' });
+  });
+
+  it('returns empty (not an error) when the agent file does not exist yet', async () => {
+    const result = await loadWorkflowAgentTranscript({ transcriptDir, agentId: 'not-started-yet' });
+    expect(result.entries).toEqual([]);
+    expect(result.truncated).toBe(false);
+  });
+
+  it('rejects an agentId whose traversal still lands inside the projects root (SAFE_AGENT_ID is the only guard that catches it)', async () => {
+    // "agent-<agentId>.jsonl" with agentId="../../../../../../secret" resolves to
+    // .../projects/proj-slug/secret.jsonl — a sibling file still under the
+    // projects root, so the transcriptDir-prefix check alone would allow it.
+    // Only the SAFE_AGENT_ID regex guard rejects this (verified: with that guard
+    // temporarily disabled, this same assertion fails and returns the secret's
+    // contents instead of an empty array).
+    const secretPath = join(configDir, 'projects', 'proj-slug', 'secret.jsonl');
+    writeFileSync(secretPath, JSON.stringify({ type: 'user', message: { role: 'user', content: 'top secret' } }));
+    try {
+      const result = await loadWorkflowAgentTranscript({ transcriptDir, agentId: '../../../../../../secret' });
+      expect(result.entries).toEqual([]);
+    } finally {
+      rmSync(secretPath, { force: true });
+    }
+  });
+
+  it('rejects an agentId that escapes the Claude config dir entirely via traversal', async () => {
+    const result = await loadWorkflowAgentTranscript({ transcriptDir, agentId: '../../etc/passwd' });
+    expect(result.entries).toEqual([]);
+  });
+
+  it('rejects a transcriptDir outside the Claude config projects root (path traversal)', async () => {
+    const outside = join(tmpdir(), 'outside-config-dir');
+    mkdirSync(outside, { recursive: true });
+    writeFileSync(join(outside, 'agent-a1.jsonl'), JSON.stringify({ type: 'user', message: { role: 'user', content: 'x' } }));
+    try {
+      const result = await loadWorkflowAgentTranscript({ transcriptDir: outside, agentId: 'a1' });
+      expect(result.entries).toEqual([]);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('truncates and flags truncated when entries exceed the cap', async () => {
+    const bigDir = join(configDir, 'projects', 'proj-slug', 'sess-2', 'subagents', 'workflows', 'wf_big');
+    mkdirSync(bigDir, { recursive: true });
+    const lines: string[] = [];
+    for (let i = 0; i < 2005; i++) {
+      lines.push(JSON.stringify({ type: 'user', uuid: `u${i}`, message: { role: 'user', content: String(i) } }));
+    }
+    writeFileSync(join(bigDir, 'agent-big.jsonl'), lines.join('\n'));
+
+    const result = await loadWorkflowAgentTranscript({ transcriptDir: bigDir, agentId: 'big' });
+    expect(result.truncated).toBe(true);
+    expect(result.entries).toHaveLength(2000);
+    // Keeps the most recent entries (tail), not the oldest.
+    expect(result.entries[result.entries.length - 1]).toMatchObject({ uuid: 'u2004' });
+  });
+});

--- a/backend/src/core/features/__tests__/workflow-tracker.test.ts
+++ b/backend/src/core/features/__tests__/workflow-tracker.test.ts
@@ -252,4 +252,169 @@ describe('WorkflowProgressTracker stop handling', () => {
     tracker.stopRunning('s1');
     expect(tracker.isRunning('s1', 'toolu_1')).toBe(false);
   });
+
+  // issue #347: the agent-transcript modal needs transcriptDir while the
+  // workflow is still running, not only after a reload. task_progress never
+  // carries it — only the Workflow tool's immediate tool_result does, as an
+  // ordinary type:'user' message rather than a task_* system event.
+  it('picks up transcriptDir from the Workflow tool_result while the workflow is live', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    expect(last().transcriptDir).toBeUndefined();
+
+    const launched =
+      `Workflow launched in background. Task ID: w1\n` +
+      `Transcript dir: /home/user/.claude/projects/p/s/subagents/workflows/wf_live123`;
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: launched }] },
+    });
+
+    const t = last();
+    expect(t.transcriptDir).toBe('/home/user/.claude/projects/p/s/subagents/workflows/wf_live123');
+    expect(t.workflowId).toBe('wf_live123');
+    expect(t.taskId).toBe('w1');
+  });
+
+  it('ignores a user tool_result for an unknown tool_use_id', () => {
+    const { tracker, broadcasts } = makeTracker();
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_unknown', content: 'Transcript dir: /x' }] },
+    });
+    expect(broadcasts).toHaveLength(0);
+  });
+
+  it('does not overwrite transcriptDir once set', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', startedEvent);
+    const first = 'Workflow launched in background. Task ID: w1\nTranscript dir: /first';
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: first }] },
+    });
+    expect(last().transcriptDir).toBe('/first');
+
+    const second = 'Workflow launched in background. Task ID: w1\nTranscript dir: /second';
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_1', content: second }] },
+    });
+    expect(last().transcriptDir).toBe('/first');
+  });
+});
+
+// issue #347: a plain background Bash command (e.g. `run_in_background`) shares
+// the same task_started/task_updated/task_notification event channel as a
+// dynamic Workflow run, distinguished only by task_type. Before taskType was
+// tracked, WorkflowProgressTracker treated every one of these as a workflow —
+// naming it the placeholder "workflow" and later showing an empty "No agents
+// yet." detail modal for something that was never a workflow to begin with.
+describe('WorkflowProgressTracker local_bash background tasks', () => {
+  function makeTracker() {
+    const broadcasts: WorkflowTask[] = [];
+    const connections = {
+      broadcastToSession: (_sessionId: string, _type: string, payload: Record<string, unknown>) => {
+        broadcasts.push(JSON.parse(JSON.stringify(payload)) as WorkflowTask);
+      },
+    } as unknown as ConnectionManager;
+    const tracker = WorkflowProgressTracker.create(connections);
+    return { tracker, broadcasts, last: () => broadcasts[broadcasts.length - 1] };
+  }
+
+  const bashStarted = {
+    type: 'system',
+    subtype: 'task_started',
+    tool_use_id: 'toolu_bash1',
+    task_id: 'b1vd4nw2o',
+    description: '1초마다 카운트 출력하는 60초 백그라운드 작업',
+    task_type: 'local_bash',
+  };
+
+  it('tags task_type and names the task from its description, not the "workflow" placeholder', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', bashStarted);
+    const t = last();
+    expect(t.taskType).toBe('local_bash');
+    expect(t.name).toBe('1초마다 카운트 출력하는 60초 백그라운드 작업');
+    expect(t.name).not.toBe('workflow');
+    expect(t.agents).toEqual([]);
+  });
+
+  it('does not try to JSON-parse a local_bash output file as a workflow envelope', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', bashStarted);
+    tracker.handleEvent('s1', {
+      type: 'system',
+      subtype: 'task_notification',
+      tool_use_id: 'toolu_bash1',
+      task_id: 'b1vd4nw2o',
+      status: 'completed',
+      output_file: join(dir, 'does-not-exist-as-json.output'),
+      summary: 'Background command "1초마다 카운트 출력하는 60초 백그라운드 작업" completed (exit code 0)',
+    });
+    const t = last();
+    expect(t.status).toBe('completed');
+    expect(t.outputFile).toBe(join(dir, 'does-not-exist-as-json.output'));
+    // The plain-text log is read on demand by GET_BACKGROUND_TASK_OUTPUT, not
+    // parsed here as JSON — result must stay unset, and the event's own
+    // summary must survive (readOutputFile would silently return {} for a
+    // non-JSON file and overwrite nothing, but must not run at all here).
+    expect(t.result).toBeUndefined();
+    expect(t.summary).toBe('Background command "1초마다 카운트 출력하는 60초 백그라운드 작업" completed (exit code 0)');
+  });
+
+  it('leaves taskType unset for an ordinary workflow event (backward compatible)', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', {
+      type: 'system',
+      subtype: 'task_started',
+      tool_use_id: 'toolu_wf1',
+      task_id: 'w1',
+      workflow_name: 'demo-flow',
+      task_type: 'local_workflow',
+    });
+    expect(last().taskType).toBe('local_workflow');
+  });
+
+  it('picks up outputFile from a local_bash tool_result while the task is still running (before task_notification)', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', bashStarted);
+    expect(last().outputFile).toBeUndefined();
+
+    const toolResult =
+      'Command running in background with ID: b0i10sn6r. Output is being written to: ' +
+      '/private/tmp/claude-501/-private-tmp-ccg-demo/bf89560d/tasks/b0i10sn6r.output. ' +
+      'You will be notified when it completes. To check interim output, use Read on that file path.';
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_bash1', content: toolResult }] },
+    });
+
+    const t = last();
+    expect(t.outputFile).toBe('/private/tmp/claude-501/-private-tmp-ccg-demo/bf89560d/tasks/b0i10sn6r.output');
+    expect(t.taskId).toBe('b0i10sn6r');
+    // A bash task's tool_result must never be mistaken for a Workflow's
+    // "Transcript dir:" result — no transcriptDir/workflowId should appear.
+    expect(t.transcriptDir).toBeUndefined();
+    expect(t.workflowId).toBeUndefined();
+  });
+
+  it('does not overwrite outputFile once set from the immediate tool_result', () => {
+    const { tracker, last } = makeTracker();
+    tracker.handleEvent('s1', bashStarted);
+    const first = 'Command running in background with ID: b0i10sn6r. Output is being written to: /first.output. more text.';
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_bash1', content: first }] },
+    });
+    expect(last().outputFile).toBe('/first.output');
+
+    const second = 'Command running in background with ID: b0i10sn6r. Output is being written to: /second.output. more text.';
+    tracker.handleEvent('s1', {
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'toolu_bash1', content: second }] },
+    });
+    expect(last().outputFile).toBe('/first.output');
+  });
 });

--- a/backend/src/core/features/backgroundTaskOutputWatcher.ts
+++ b/backend/src/core/features/backgroundTaskOutputWatcher.ts
@@ -1,0 +1,118 @@
+import { watch, type FSWatcher } from 'fs';
+import type { ConnectionManager } from '../../ws/connection-manager';
+import { MessageType } from '../../shared';
+import { loadBackgroundTaskOutput } from './loadBackgroundTaskOutput';
+
+const DEBOUNCE_MS = 200;
+// How often to retry starting the fs.watch while the output file doesn't
+// exist yet (a task's tool_result — which is what makes the webview call
+// watchBackgroundTaskOutput at all — can land before the CLI has actually
+// created the file on disk).
+const RETRY_MS = 500;
+
+interface Watcher {
+  fsWatcher?: FSWatcher;
+  debounceTimer?: ReturnType<typeof setTimeout>;
+  retryTimer?: ReturnType<typeof setTimeout>;
+}
+
+// Keyed by `${connectionId}::${outputFile}` so the same file can be watched
+// independently by multiple webview connections (e.g. two IDE windows), and
+// re-watching from the same connection is a no-op rather than a duplicate watch.
+const watchers = new Map<string, Watcher>();
+
+function key(connectionId: string, outputFile: string): string {
+  return `${connectionId}::${outputFile}`;
+}
+
+async function pushOutput(connectionId: string, outputFile: string, connections: ConnectionManager): Promise<void> {
+  const result = await loadBackgroundTaskOutput({ outputFile });
+  connections.sendTo(connectionId, MessageType.BACKGROUND_TASK_OUTPUT_CHANGED, {
+    outputFile,
+    text: result.text,
+    truncated: result.truncated,
+  });
+}
+
+/**
+ * Push a background Bash task's output log to one connection every time the
+ * file changes on disk, instead of the webview polling for it (issue #347
+ * follow-up — the CLI has no event for "a task's log grew a line", so this
+ * backend-side `fs.watch` is what makes the modal genuinely live instead of
+ * re-fetching on a timer). Safe to call again for the same connection+file —
+ * re-watching is a no-op, not a duplicate watcher piling up.
+ */
+export function watchBackgroundTaskOutput(
+  connectionId: string,
+  outputFile: string,
+  connections: ConnectionManager,
+): void {
+  const k = key(connectionId, outputFile);
+  if (watchers.has(k)) return;
+
+  const entry: Watcher = {};
+  watchers.set(k, entry);
+
+  // Send the current content immediately so the caller doesn't have to wait
+  // for the first change to see anything (mirrors an initial GET before
+  // subscribing to updates). A no-op (empty text) if the file doesn't exist
+  // yet — loadBackgroundTaskOutput already treats a missing file as empty.
+  void pushOutput(connectionId, outputFile, connections);
+
+  tryStartWatching(connectionId, outputFile, connections, k, entry);
+}
+
+function tryStartWatching(
+  connectionId: string,
+  outputFile: string,
+  connections: ConnectionManager,
+  k: string,
+  entry: Watcher,
+): void {
+  try {
+    entry.fsWatcher = watch(outputFile, () => {
+      const w = watchers.get(k);
+      if (!w) return;
+      if (w.debounceTimer) clearTimeout(w.debounceTimer);
+      w.debounceTimer = setTimeout(() => {
+        void pushOutput(connectionId, outputFile, connections);
+      }, DEBOUNCE_MS);
+    });
+    entry.fsWatcher.on('error', () => unwatchBackgroundTaskOutput(connectionId, outputFile));
+  } catch {
+    // File doesn't exist yet (task just started, tool_result raced ahead of
+    // the CLI actually creating the file) — nothing to watch yet. Keep
+    // retrying until it appears (or unwatch tears this down); a task that
+    // finishes fast enough is still caught by one of these retries before
+    // completion, since loadBackgroundTaskOutput reads whatever is on disk
+    // at that moment.
+    entry.retryTimer = setTimeout(() => {
+      if (!watchers.has(k)) return; // unwatched while we were waiting
+      tryStartWatching(connectionId, outputFile, connections, k, entry);
+    }, RETRY_MS);
+  }
+}
+
+/** Stop watching one connection's subscription to a task's output log. */
+export function unwatchBackgroundTaskOutput(connectionId: string, outputFile: string): void {
+  const k = key(connectionId, outputFile);
+  const w = watchers.get(k);
+  if (!w) return;
+  if (w.debounceTimer) clearTimeout(w.debounceTimer);
+  if (w.retryTimer) clearTimeout(w.retryTimer);
+  w.fsWatcher?.close();
+  watchers.delete(k);
+}
+
+/** Stop every watcher a connection holds — called when the connection drops. */
+export function unwatchAllForConnection(connectionId: string): void {
+  const prefix = `${connectionId}::`;
+  for (const k of watchers.keys()) {
+    if (!k.startsWith(prefix)) continue;
+    const w = watchers.get(k)!;
+    if (w.debounceTimer) clearTimeout(w.debounceTimer);
+    if (w.retryTimer) clearTimeout(w.retryTimer);
+    w.fsWatcher?.close();
+    watchers.delete(k);
+  }
+}

--- a/backend/src/core/features/loadBackgroundTaskOutput.ts
+++ b/backend/src/core/features/loadBackgroundTaskOutput.ts
@@ -1,0 +1,53 @@
+import { realpathSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { resolve, sep } from 'path';
+import { getTmpBase } from '../handlers/findBackgroundTaskOutputPath';
+
+// Cap how much of a long-running Bash task's log we return in one shot —
+// mirrors loadWorkflowAgentTranscript's MAX_ENTRIES safety valve. Counted in
+// characters here since the file is plain text, not JSONL.
+const MAX_CHARS = 200_000;
+
+export interface BackgroundTaskOutput {
+  text: string;
+  truncated: boolean;
+}
+
+/**
+ * Read a background Bash task's raw stdout/stderr log (issue #347: the
+ * Background tasks detail modal shows this for task_type 'local_bash', which
+ * has no agents to render a transcript for). `outputFile` is server-issued
+ * (WorkflowTask.outputFile) but round-tripped through the client, so it is
+ * revalidated against the tmp root here rather than trusted.
+ */
+export async function loadBackgroundTaskOutput(payload: { outputFile: string }): Promise<BackgroundTaskOutput> {
+  const { outputFile } = payload;
+  if (!outputFile) return { text: '', truncated: false };
+
+  let tmpRoot: string;
+  try {
+    tmpRoot = realpathSync(getTmpBase());
+  } catch {
+    return { text: '', truncated: false };
+  }
+
+  const resolved = resolve(outputFile);
+  let real: string;
+  try {
+    real = realpathSync(resolved);
+  } catch {
+    // Not written yet (task just started) — not an error, nothing to show.
+    return { text: '', truncated: false };
+  }
+  if (real !== tmpRoot && !real.startsWith(tmpRoot + sep)) return { text: '', truncated: false };
+
+  let text: string;
+  try {
+    text = await readFile(real, 'utf-8');
+  } catch {
+    return { text: '', truncated: false };
+  }
+
+  const truncated = text.length > MAX_CHARS;
+  return { text: truncated ? text.slice(-MAX_CHARS) : text, truncated };
+}

--- a/backend/src/core/features/loadWorkflowAgentTranscript.ts
+++ b/backend/src/core/features/loadWorkflowAgentTranscript.ts
@@ -1,0 +1,77 @@
+import { realpathSync } from 'fs';
+import { join, resolve, sep } from 'path';
+import { readJsonlEntries, type JsonlEntry } from './readJsonlEntries';
+import { getClaudeConfigDir } from './claudeConfigDir';
+
+const SAFE_AGENT_ID = /^[a-zA-Z0-9_-]+$/;
+
+// Cap the returned entries so a runaway/huge agent transcript cannot blow up the
+// IPC payload or browser memory. Real transcripts observed so far are tens of KB
+// (a few hundred lines); this is a generous ceiling, not a real paging scheme.
+const MAX_ENTRIES = 2000;
+
+export interface WorkflowAgentTranscript {
+  entries: JsonlEntry[];
+  truncated: boolean;
+}
+
+/**
+ * Resolve `transcriptDir` against the Claude config dir's `projects` root and
+ * reject anything that escapes it (path traversal defense — `transcriptDir` is
+ * server-issued but round-tripped through the client, so it must be revalidated
+ * here rather than trusted, matching findBackgroundTaskOutputPath.ts).
+ */
+function resolveTranscriptDir(transcriptDir: string): string | null {
+  const projectsRoot = join(getClaudeConfigDir(), 'projects');
+  let realProjectsRoot: string;
+  try {
+    realProjectsRoot = realpathSync(projectsRoot);
+  } catch {
+    return null;
+  }
+
+  const resolved = resolve(transcriptDir);
+  let real: string;
+  try {
+    real = realpathSync(resolved);
+  } catch {
+    // Directory may not exist yet if the workflow just started — fall back to
+    // the resolved (unverified-on-disk) path for the prefix check.
+    real = resolved;
+  }
+
+  if (real !== realProjectsRoot && !real.startsWith(realProjectsRoot + sep)) return null;
+  return real;
+}
+
+/**
+ * Load one workflow agent's full transcript (`agent-<id>.jsonl` under
+ * `transcriptDir`) as raw JSONL entries, ready for LoadedMessageDto conversion
+ * on the webview side. Mirrors computeAgentStats' read of the same file in
+ * workflow-tracker.ts, but returns entries instead of aggregated stats.
+ */
+export async function loadWorkflowAgentTranscript(payload: {
+  transcriptDir: string;
+  agentId: string;
+}): Promise<WorkflowAgentTranscript> {
+  const { transcriptDir, agentId } = payload;
+
+  if (!transcriptDir || !agentId) return { entries: [], truncated: false };
+  if (!SAFE_AGENT_ID.test(agentId)) return { entries: [], truncated: false };
+
+  const dir = resolveTranscriptDir(transcriptDir);
+  if (!dir) return { entries: [], truncated: false };
+
+  const file = join(dir, `agent-${agentId}.jsonl`);
+  let entries: JsonlEntry[];
+  try {
+    entries = await readJsonlEntries(file);
+  } catch {
+    // Not present yet (e.g. a running agent that hasn't written its first line) —
+    // not an error, just nothing to show yet.
+    return { entries: [], truncated: false };
+  }
+
+  const truncated = entries.length > MAX_ENTRIES;
+  return { entries: truncated ? entries.slice(-MAX_ENTRIES) : entries, truncated };
+}

--- a/backend/src/core/features/workflow-tracker.ts
+++ b/backend/src/core/features/workflow-tracker.ts
@@ -108,11 +108,25 @@ function scriptPathName(scriptPath: string | undefined): string | undefined {
   return base.replace(/\.[cm]?[jt]s$/i, '');
 }
 
-/** Parse the immediate "launched in background" tool_result text. */
+/** Parse the immediate "launched in background" tool_result text for a Workflow run. */
 function parseImmediateResult(text: string): { taskId?: string; transcriptDir?: string } {
   const taskId = text.match(/Task ID:\s*(\S+)/)?.[1];
   const transcriptDir = text.match(/Transcript dir:\s*(.+)/)?.[1]?.trim();
   return { taskId, transcriptDir };
+}
+
+/**
+ * Parse the immediate "Command running in background" tool_result text for a
+ * plain Bash background task — a different shape from the Workflow tool's
+ * (e.g. "Command running in background with ID: b0i10sn6r. Output is being
+ * written to: /tmp/.../b0i10sn6r.output. …"). Read live rather than waiting for
+ * the terminal task_notification, so the output log is fetchable immediately —
+ * mirroring how transcriptDir is available before a workflow finishes (#347).
+ */
+function parseImmediateBashResult(text: string): { taskId?: string; outputFile?: string } {
+  const taskId = text.match(/Command running in background with ID:\s*(\S+?)\.?\s/)?.[1];
+  const outputFile = text.match(/Output is being written to:\s*(.+?)\.\s/)?.[1]?.trim();
+  return { taskId, outputFile };
 }
 
 function num(v: unknown): number {
@@ -369,11 +383,14 @@ export class WorkflowProgressTracker {
   /** Feed every CLI stream event here (side-effect only; never throws). */
   handleEvent(sessionId: string, event: Record<string, unknown>): void {
     try {
-      if (event['type'] !== 'system') return;
-      const subtype = event['subtype'];
-      if (subtype === 'task_started') this.onStarted(sessionId, event);
-      else if (subtype === 'task_progress' || subtype === 'task_updated') this.onProgress(sessionId, event);
-      else if (subtype === 'task_notification') this.onNotification(sessionId, event);
+      if (event['type'] === 'system') {
+        const subtype = event['subtype'];
+        if (subtype === 'task_started') this.onStarted(sessionId, event);
+        else if (subtype === 'task_progress' || subtype === 'task_updated') this.onProgress(sessionId, event);
+        else if (subtype === 'task_notification') this.onNotification(sessionId, event);
+      } else if (event['type'] === 'user') {
+        this.onImmediateResult(sessionId, event);
+      }
     } catch (err) {
       console.error('[node-backend]', 'workflow-tracker handleEvent failed:', err);
     }
@@ -404,9 +421,17 @@ export class WorkflowProgressTracker {
     const t = entry.task;
     const prompt = typeof event['prompt'] === 'string' ? (event['prompt'] as string) : undefined;
     if (typeof event['task_id'] === 'string') t.taskId = event['task_id'] as string;
+    const taskType = event['task_type'];
+    if (taskType === 'local_workflow' || taskType === 'local_bash') t.taskType = taskType;
+    const description = typeof event['description'] === 'string' ? (event['description'] as string) : undefined;
+    if (description) t.description = description;
     const wfName = typeof event['workflow_name'] === 'string' ? (event['workflow_name'] as string) : '';
-    t.name = wfName || parseMetaName(prompt) || t.name;
-    if (typeof event['description'] === 'string') t.description = event['description'] as string;
+    // A plain background Bash command has no workflow_name/meta script to name
+    // itself with — fall back to its description rather than leaving the
+    // placeholder 'workflow' (issue #347: that placeholder is what made the
+    // panel mislabel bash tasks as "workflow" with a transcript modal that had
+    // nothing to show).
+    t.name = wfName || parseMetaName(prompt) || description || t.name;
     if (t.phases.length === 0) t.phases = parseMetaPhases(prompt);
     t.startedAt = Date.now();
     this.broadcast(entry);
@@ -481,9 +506,16 @@ export class WorkflowProgressTracker {
     const outputFile = typeof event['output_file'] === 'string' ? (event['output_file'] as string) : undefined;
     if (outputFile) {
       t.outputFile = outputFile;
-      const parsed = readOutputFile(outputFile);
-      if (parsed.summary && !event['summary']) t.summary = parsed.summary;
-      if (parsed.result !== undefined) t.result = parsed.result;
+      // Only a dynamic workflow's output file is the JSON envelope
+      // readOutputFile expects ({summary, result}); a plain background Bash
+      // task's output file is its raw stdout/stderr log (issue #347) — its
+      // summary/status already came from this event, and its "result" is the
+      // log itself, read separately by GET_BACKGROUND_TASK_OUTPUT on demand.
+      if (t.taskType !== 'local_bash') {
+        const parsed = readOutputFile(outputFile);
+        if (parsed.summary && !event['summary']) t.summary = parsed.summary;
+        if (parsed.result !== undefined) t.result = parsed.result;
+      }
     }
 
     const usage = event['usage'] as Record<string, unknown> | undefined;
@@ -495,6 +527,47 @@ export class WorkflowProgressTracker {
     };
     t.endedAt = Date.now();
     this.broadcast(entry);
+  }
+
+  /**
+   * The Workflow tool's immediate tool_result (not a `task_*` system event —
+   * an ordinary `type:'user'` message) carries `transcriptDir` in its text
+   * ("Transcript dir: …"). `task_progress` never repeats it, so without this
+   * the live task never learns its transcriptDir until a reload runs
+   * reconstructWorkflowTasks — leaving the agent-transcript modal unable to
+   * fetch anything for a workflow that is still running (issue #347).
+   */
+  private onImmediateResult(sessionId: string, event: Record<string, unknown>): void {
+    for (const block of getContentBlocks(event)) {
+      if (block['type'] !== 'tool_result') continue;
+      const toolUseId = block['tool_use_id'];
+      if (typeof toolUseId !== 'string') continue;
+      const entry = this.entries.get(this.key(sessionId, toolUseId));
+      if (!entry) continue;
+      const content = block['content'];
+      const text = typeof content === 'string' ? content : getEventText(event);
+
+      if (entry.task.taskType === 'local_bash') {
+        // A plain background Bash task has no transcriptDir/agents — its
+        // output log path is available immediately, same as a workflow's
+        // transcriptDir, well before the terminal task_notification (#347).
+        if (entry.task.outputFile) continue;
+        const { taskId, outputFile } = parseImmediateBashResult(text);
+        if (!outputFile) continue;
+        entry.task.taskId = taskId ?? entry.task.taskId;
+        entry.task.outputFile = outputFile;
+        this.broadcast(entry);
+        continue;
+      }
+
+      if (entry.task.transcriptDir) continue;
+      const { taskId, transcriptDir } = parseImmediateResult(text);
+      if (!transcriptDir) continue;
+      entry.task.taskId = taskId ?? entry.task.taskId;
+      entry.task.transcriptDir = transcriptDir;
+      entry.task.workflowId = transcriptDir.split(/[\\/]/).pop();
+      this.broadcast(entry);
+    }
   }
 
   private broadcast(entry: WatchEntry): void {

--- a/backend/src/core/handlers/__tests__/getAgentTranscript.test.ts
+++ b/backend/src/core/handlers/__tests__/getAgentTranscript.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../features/loadWorkflowAgentTranscript', () => ({
+  loadWorkflowAgentTranscript: vi.fn(),
+}));
+
+import { getAgentTranscriptHandler } from '../getAgentTranscript';
+import { loadWorkflowAgentTranscript } from '../../features/loadWorkflowAgentTranscript';
+import { MessageType } from '../../../shared';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+function createMockConnections() {
+  return { sendTo: vi.fn() } as unknown as ConnectionManager;
+}
+
+describe('getAgentTranscriptHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('acks with entries and truncated on success', async () => {
+    vi.mocked(loadWorkflowAgentTranscript).mockResolvedValue({
+      entries: [{ type: 'user', uuid: 'u1' }],
+      truncated: false,
+    });
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: MessageType.GET_AGENT_TRANSCRIPT,
+      payload: { transcriptDir: '/x/y', agentId: 'a1' },
+      timestamp: 0,
+      requestId: 'req-1',
+    };
+
+    await getAgentTranscriptHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(loadWorkflowAgentTranscript).toHaveBeenCalledWith({ transcriptDir: '/x/y', agentId: 'a1' });
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', MessageType.ACK, {
+      requestId: 'req-1',
+      status: 'ok',
+      entries: [{ type: 'user', uuid: 'u1' }],
+      truncated: false,
+    });
+  });
+
+  it('acks with status error when the loader throws', async () => {
+    vi.mocked(loadWorkflowAgentTranscript).mockRejectedValue(new Error('boom'));
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: MessageType.GET_AGENT_TRANSCRIPT,
+      payload: { transcriptDir: '/x/y', agentId: 'a1' },
+      timestamp: 0,
+      requestId: 'req-2',
+    };
+
+    await getAgentTranscriptHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(connections.sendTo).toHaveBeenCalledWith('conn-1', MessageType.ACK, {
+      requestId: 'req-2',
+      status: 'error',
+      error: 'boom',
+    });
+  });
+
+  it('defaults missing transcriptDir/agentId payload fields to empty strings', async () => {
+    vi.mocked(loadWorkflowAgentTranscript).mockResolvedValue({ entries: [], truncated: false });
+    const connections = createMockConnections();
+    const message: IPCMessage = {
+      type: MessageType.GET_AGENT_TRANSCRIPT,
+      payload: {},
+      timestamp: 0,
+      requestId: 'req-3',
+    };
+
+    await getAgentTranscriptHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(loadWorkflowAgentTranscript).toHaveBeenCalledWith({ transcriptDir: '', agentId: '' });
+  });
+});

--- a/backend/src/core/handlers/__tests__/watchBackgroundTaskOutput.test.ts
+++ b/backend/src/core/handlers/__tests__/watchBackgroundTaskOutput.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../features/backgroundTaskOutputWatcher', () => ({
+  watchBackgroundTaskOutput: vi.fn(),
+  unwatchBackgroundTaskOutput: vi.fn(),
+}));
+
+import { watchBackgroundTaskOutputHandler, unwatchBackgroundTaskOutputHandler } from '../watchBackgroundTaskOutput';
+import { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } from '../../features/backgroundTaskOutputWatcher';
+import { MessageType } from '../../../shared';
+import type { ConnectionManager } from '../../../ws/connection-manager';
+import type { Bridge } from '../../../bridge/bridge-interface';
+import type { IPCMessage } from '../../types';
+
+describe('watchBackgroundTaskOutputHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to watchBackgroundTaskOutput with connectionId, outputFile, connections', () => {
+    const connections = {} as ConnectionManager;
+    const message: IPCMessage = {
+      type: MessageType.WATCH_BACKGROUND_TASK_OUTPUT,
+      payload: { outputFile: '/x/y.output' },
+      timestamp: 0,
+    };
+
+    watchBackgroundTaskOutputHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(watchBackgroundTaskOutput).toHaveBeenCalledWith('conn-1', '/x/y.output', connections);
+  });
+
+  it('does nothing when outputFile is missing from the payload', () => {
+    const connections = {} as ConnectionManager;
+    const message: IPCMessage = { type: MessageType.WATCH_BACKGROUND_TASK_OUTPUT, payload: {}, timestamp: 0 };
+
+    watchBackgroundTaskOutputHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(watchBackgroundTaskOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe('unwatchBackgroundTaskOutputHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to unwatchBackgroundTaskOutput with connectionId and outputFile', () => {
+    const connections = {} as ConnectionManager;
+    const message: IPCMessage = {
+      type: MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT,
+      payload: { outputFile: '/x/y.output' },
+      timestamp: 0,
+    };
+
+    unwatchBackgroundTaskOutputHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(unwatchBackgroundTaskOutput).toHaveBeenCalledWith('conn-1', '/x/y.output');
+  });
+
+  it('does nothing when outputFile is missing from the payload', () => {
+    const connections = {} as ConnectionManager;
+    const message: IPCMessage = { type: MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT, payload: {}, timestamp: 0 };
+
+    unwatchBackgroundTaskOutputHandler('conn-1', message, connections, {} as Bridge);
+
+    expect(unwatchBackgroundTaskOutput).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/core/handlers/findBackgroundTaskOutputPath.ts
+++ b/backend/src/core/handlers/findBackgroundTaskOutputPath.ts
@@ -13,7 +13,7 @@ function sanitizeProjectKey(workingDir: string): string {
   return workingDir.replace(/[^a-zA-Z0-9_-]/g, '-');
 }
 
-function getTmpBase(): string {
+export function getTmpBase(): string {
   const envVal = process.env.CLAUDE_CODE_TMPDIR;
   if (envVal && envVal.length > 0) return envVal;
   if (process.platform === 'win32') return process.env.TEMP ?? 'C:\\Temp';

--- a/backend/src/core/handlers/getAgentTranscript.ts
+++ b/backend/src/core/handlers/getAgentTranscript.ts
@@ -1,0 +1,38 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { MessageType } from '../../shared';
+import { loadWorkflowAgentTranscript } from '../features/loadWorkflowAgentTranscript';
+
+/**
+ * GET_AGENT_TRANSCRIPT — load one workflow agent's full transcript (raw JSONL
+ * entries) for the Background tasks detail modal (issue #347).
+ */
+export async function getAgentTranscriptHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): Promise<void> {
+  try {
+    const payload = message.payload as { transcriptDir?: string; agentId?: string } | undefined;
+    const transcriptDir = payload?.transcriptDir;
+    const agentId = payload?.agentId;
+    const result = await loadWorkflowAgentTranscript({
+      transcriptDir: transcriptDir ?? '',
+      agentId: agentId ?? '',
+    });
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'ok',
+      entries: result.entries,
+      truncated: result.truncated,
+    });
+  } catch (err) {
+    connections.sendTo(connectionId, MessageType.ACK, {
+      requestId: message.requestId,
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/backend/src/core/handlers/index.ts
+++ b/backend/src/core/handlers/index.ts
@@ -14,6 +14,8 @@ import { getSessionsHandler } from './getSessions';
 import { loadSessionHandler } from './loadSession';
 import { deleteSessionHandler } from './deleteSession';
 import { renameSessionHandler } from './renameSession';
+import { getAgentTranscriptHandler } from './getAgentTranscript';
+import { watchBackgroundTaskOutputHandler, unwatchBackgroundTaskOutputHandler } from './watchBackgroundTaskOutput';
 import { getSettingsHandler } from './getSettings';
 import { saveSettingsHandler } from './saveSettings';
 import { getClaudeConfigDirHandler } from './getClaudeConfigDir';
@@ -178,6 +180,15 @@ export async function handleMessage(
       break;
     case MessageType.RENAME_SESSION:
       await renameSessionHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.GET_AGENT_TRANSCRIPT:
+      await getAgentTranscriptHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.WATCH_BACKGROUND_TASK_OUTPUT:
+      watchBackgroundTaskOutputHandler(connectionId, message, connections, bridge);
+      break;
+    case MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT:
+      unwatchBackgroundTaskOutputHandler(connectionId, message, connections, bridge);
       break;
     case MessageType.GET_SETTINGS:
       await getSettingsHandler(connectionId, message, connections, bridge, bridges);

--- a/backend/src/core/handlers/watchBackgroundTaskOutput.ts
+++ b/backend/src/core/handlers/watchBackgroundTaskOutput.ts
@@ -1,0 +1,32 @@
+import type { ConnectionManager } from '../../ws/connection-manager';
+import type { Bridge } from '../../bridge/bridge-interface';
+import type { IPCMessage } from '../types';
+import { watchBackgroundTaskOutput, unwatchBackgroundTaskOutput } from '../features/backgroundTaskOutputWatcher';
+
+/**
+ * WATCH_BACKGROUND_TASK_OUTPUT — subscribe this connection to a background
+ * Bash task's output log; the backend pushes BACKGROUND_TASK_OUTPUT_CHANGED
+ * on every file change (issue #347 follow-up, replacing client-side polling).
+ */
+export function watchBackgroundTaskOutputHandler(
+  connectionId: string,
+  message: IPCMessage,
+  connections: ConnectionManager,
+  _bridge: Bridge,
+): void {
+  const outputFile = (message.payload as { outputFile?: string } | undefined)?.outputFile;
+  if (!outputFile) return;
+  watchBackgroundTaskOutput(connectionId, outputFile, connections);
+}
+
+/** UNWATCH_BACKGROUND_TASK_OUTPUT — stop pushing updates for this file to this connection. */
+export function unwatchBackgroundTaskOutputHandler(
+  connectionId: string,
+  message: IPCMessage,
+  _connections: ConnectionManager,
+  _bridge: Bridge,
+): void {
+  const outputFile = (message.payload as { outputFile?: string } | undefined)?.outputFile;
+  if (!outputFile) return;
+  unwatchBackgroundTaskOutput(connectionId, outputFile);
+}

--- a/backend/src/shared/message-type.ts
+++ b/backend/src/shared/message-type.ts
@@ -72,6 +72,16 @@ export enum MessageType {
   /** Rename a session's title. */
   RENAME_SESSION = 'RENAME_SESSION',
 
+  // -- Workflow agent transcripts (Background tasks detail modal) --
+  /** Load one workflow agent's full transcript (agent-<id>.jsonl under transcriptDir). inbound webview→backend */
+  GET_AGENT_TRANSCRIPT = 'GET_AGENT_TRANSCRIPT',
+  /** Subscribe to a background Bash task's raw output log (task_type 'local_bash', which has no agents) — the backend watches the file and pushes BACKGROUND_TASK_OUTPUT_CHANGED on every change, sending the current content immediately on subscribe. inbound webview→backend */
+  WATCH_BACKGROUND_TASK_OUTPUT = 'WATCH_BACKGROUND_TASK_OUTPUT',
+  /** Unsubscribe from a background Bash task's output log (e.g. the detail modal closed). inbound webview→backend */
+  UNWATCH_BACKGROUND_TASK_OUTPUT = 'UNWATCH_BACKGROUND_TASK_OUTPUT',
+  /** A watched background Bash task's output log changed on disk — carries the full current text. outbound backend→webview */
+  BACKGROUND_TASK_OUTPUT_CHANGED = 'BACKGROUND_TASK_OUTPUT_CHANGED',
+
   // -- IDE settings (terminal/theme/etc., ~/.claude GUI settings) --
   /** Read merged or scope-specific GUI settings. */
   GET_SETTINGS = 'GET_SETTINGS',

--- a/backend/src/shared/workflow.ts
+++ b/backend/src/shared/workflow.ts
@@ -33,12 +33,23 @@ export interface WorkflowUsage {
   durationMs?: number;
 }
 
-/** Live + final state of a single background dynamic workflow. */
+/**
+ * CLI's `task_type` for a background task: a dynamic Workflow-tool run
+ * (`local_workflow`, has agents/phases/transcriptDir) or a plain background
+ * Bash command (`local_bash`, has only an output log — no agents). The
+ * Background tasks panel shows both under one list; the detail view branches
+ * on this to show agent transcripts vs. the raw output log (issue #347).
+ */
+export type BackgroundTaskType = 'local_workflow' | 'local_bash';
+
+/** Live + final state of a single background task (dynamic workflow or plain Bash). */
 export interface WorkflowTask {
   /** Workflow tool_use id — the stable key correlating card, panel and events. */
   toolUseId: string;
   /** Background task id (e.g. "w94mspihl") from the immediate tool_result. */
   taskId?: string;
+  /** CLI's task_type; undefined for tasks reconstructed before this field existed. */
+  taskType?: BackgroundTaskType;
   /** Workflow run id (e.g. "wf_ce882bfa-ddf"), the transcript dir basename. */
   workflowId?: string;
   name: string;

--- a/backend/src/ws/ws-server.ts
+++ b/backend/src/ws/ws-server.ts
@@ -15,6 +15,7 @@ import { isJetBrainsMode } from '../config/environment';
 import { getPluginVersion } from '../core/handlers/getVersion';
 import { cancelLogin } from '../core/handlers/login';
 import { releaseDictation } from '../core/handlers/dictation';
+import { unwatchAllForConnection } from '../core/features/backgroundTaskOutputWatcher';
 import { reportBackendError, trackActivity } from '../core/features/telemetry';
 import { tunnelPairing, issueLocalPairCode } from '../core/features/tunnel-pairing';
 import { LogWebSocketServer } from '../logging/log-ws';
@@ -349,6 +350,9 @@ export function startWebSocketServer(
         // Same reasoning for dictation: the transcription socket is ours, not
         // the webview's, so a closed tab would leave it open and billing.
         releaseDictation(connectionId);
+        // And for background-task output watchers: fs.watch handles are ours
+        // too, so a closed tab must not leave them running forever.
+        unwatchAllForConnection(connectionId);
         connections.removeConnection(connectionId);
       });
     });

--- a/webview/src/components/AgentTranscriptModal/AgentTabList.tsx
+++ b/webview/src/components/AgentTranscriptModal/AgentTabList.tsx
@@ -1,0 +1,35 @@
+import type { WorkflowAgent } from '@/shared';
+import { agentDotClass } from '@/utils/workflowFormat';
+
+interface Props {
+  agents: WorkflowAgent[];
+  selectedAgentId: string | undefined;
+  onSelect: (agentId: string) => void;
+}
+
+export function AgentTabList(props: Props) {
+  const { agents, selectedAgentId, onSelect } = props;
+
+  return (
+    <div className="flex flex-wrap gap-1 px-4 pt-3 pb-2 border-b border-border-subtle flex-shrink-0">
+      {agents.map((agent) => {
+        const active = agent.agentId === selectedAgentId;
+        return (
+          <button
+            key={agent.agentId}
+            onClick={() => onSelect(agent.agentId)}
+            className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[0.8461rem] transition-colors max-w-[10rem] ${
+              active
+                ? 'bg-surface-hover text-text-primary'
+                : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+            }`}
+            title={agent.label}
+          >
+            <span className={`inline-block w-1.5 h-1.5 rounded-full shrink-0 ${agentDotClass(agent.status)}`} />
+            <span className="truncate">{agent.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/webview/src/components/AgentTranscriptModal/AgentTranscriptBody.tsx
+++ b/webview/src/components/AgentTranscriptModal/AgentTranscriptBody.tsx
@@ -1,0 +1,74 @@
+import { useMemo } from 'react';
+import { ArrowPathIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from '@/i18n';
+import type { WorkflowAgent } from '@/shared';
+import { useAgentTranscript } from '@/hooks/useAgentTranscript';
+import { toInstance } from '@/dto/common';
+import { LoadedMessageDto } from '@/types';
+import { mergeToolResults } from '@/pages/ChatPage/mergeToolResults';
+import { MessageBubble } from '@/pages/ChatPage/MessageBubble';
+
+interface Props {
+  transcriptDir: string | undefined;
+  agent: WorkflowAgent | undefined;
+}
+
+export function AgentTranscriptBody(props: Props) {
+  const { transcriptDir, agent } = props;
+  const { t } = useTranslation('chat');
+
+  // Changes whenever the agent's live stats change, so a running agent's
+  // transcript refetches as WORKFLOW_PROGRESS updates arrive (see useAgentTranscript).
+  const fingerprint = agent ? `${agent.tokens}:${agent.tools}:${Math.floor(agent.durationMs / 2000)}` : undefined;
+
+  const { data, isPending, isError, isFetching } = useAgentTranscript(transcriptDir, agent?.agentId, fingerprint);
+
+  const messages = useMemo(() => {
+    if (!data) return [];
+    const converted = data.entries.map((entry) => toInstance(LoadedMessageDto, entry));
+    return mergeToolResults(converted);
+  }, [data]);
+
+  if (!agent) {
+    return <div className="flex-1 flex items-center justify-center text-text-primary/50 text-[0.9230rem]">{t('backgroundTasks.transcriptModal.noAgents')}</div>;
+  }
+
+  if (isPending) {
+    return (
+      <div className="flex-1 flex items-center justify-center gap-2 text-text-primary/50 text-[0.9230rem]">
+        <ArrowPathIcon className="w-4 h-4 animate-spin" />
+        {t('backgroundTasks.transcriptModal.loading')}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return <div className="flex-1 flex items-center justify-center text-red-500 text-[0.9230rem]">{t('backgroundTasks.transcriptModal.error')}</div>;
+  }
+
+  if (messages.length === 0) {
+    return <div className="flex-1 flex items-center justify-center text-text-primary/50 text-[0.9230rem]">{t('backgroundTasks.transcriptModal.empty')}</div>;
+  }
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+      {data?.truncated && (
+        <div className="text-[0.8461rem] text-text-primary/50 text-center pb-2">
+          {t('backgroundTasks.transcriptModal.truncated', { count: messages.length })}
+        </div>
+      )}
+      {messages.map((message) => (
+        <MessageBubble key={message.uuid ?? `${message.type}-${message.timestamp}`} message={message} />
+      ))}
+      {/* Agent is still running and a background refetch is in flight — a
+          small "live" cue rather than a jarring full-screen loader, since the
+          messages above are still valid while the refresh lands (#347 follow-up). */}
+      {agent.status === 'running' && isFetching && (
+        <div className="flex items-center gap-1.5 text-[0.7692rem] text-text-tertiary pt-1">
+          <ArrowPathIcon className="w-3 h-3 animate-spin" />
+          {t('backgroundTasks.transcriptModal.updating')}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webview/src/components/AgentTranscriptModal/BackgroundTaskOutputBody.tsx
+++ b/webview/src/components/AgentTranscriptModal/BackgroundTaskOutputBody.tsx
@@ -1,0 +1,181 @@
+import { useEffect, useRef, useState } from 'react';
+import { ArrowPathIcon, ArrowDownIcon, ClipboardDocumentIcon, ClipboardDocumentCheckIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from '@/i18n';
+import type { WorkflowTask } from '@/shared';
+import { useBackgroundTaskOutput } from '@/hooks/useBackgroundTaskOutput';
+
+interface Props {
+  task: WorkflowTask;
+}
+
+/** How close to the bottom (px) counts as "already at the bottom" for auto-scroll. */
+const BOTTOM_THRESHOLD_PX = 24;
+
+/**
+ * A copy-to-run shell command for the task's own output file: `tail -f` while
+ * running (this modal is effectively doing that watching itself already — this
+ * lets the user watch it in their own terminal too), `cat` once finished
+ * (tailing a file nothing will ever append to again is a command that just
+ * hangs, so switching commands here isn't cosmetic — a running tail left
+ * open past completion is a resource that never lets go).
+ */
+function CommandLine(props: { outputFile: string; isRunning: boolean }) {
+  const { outputFile, isRunning } = props;
+  const { t } = useTranslation('chat');
+  const [copied, setCopied] = useState(false);
+  const command = isRunning ? `tail -f -n +1 ${outputFile}` : `cat ${outputFile}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(command).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <div className="mt-2 flex items-center gap-2 rounded-md bg-surface-base border border-border-subtle px-2.5 py-1.5">
+      <code className="flex-1 min-w-0 truncate font-mono text-[0.8461rem] text-text-primary/80">{command}</code>
+      <button
+        onClick={handleCopy}
+        className="shrink-0 p-1 rounded hover:bg-surface-hover transition-colors"
+        title={t('backgroundTasks.transcriptModal.copyCommand')}
+      >
+        {copied ? (
+          <ClipboardDocumentCheckIcon className="w-4 h-4 text-state-success-fg" />
+        ) : (
+          <ClipboardDocumentIcon className="w-4 h-4 text-text-tertiary" />
+        )}
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Detail body for a plain background Bash task (task_type 'local_bash') —
+ * shown instead of AgentTranscriptBody, since these have no agents to pick a
+ * transcript from, only a raw stdout/stderr log (issue #347).
+ */
+export function BackgroundTaskOutputBody(props: Props) {
+  const { task } = props;
+  const { t } = useTranslation('chat');
+  const isRunning = task.status === 'running';
+
+  const { text, truncated, loading } = useBackgroundTaskOutput(task.outputFile);
+
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Whether the user was already at (or near) the bottom right before this
+  // render's text landed — decided once per text change, not tracked as its
+  // own piece of state, so a manual scroll-up during a live tail isn't
+  // fought by an effect re-pulling the view back down.
+  const wasAtBottomRef = useRef(true);
+  const [showJumpToBottom, setShowJumpToBottom] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (wasAtBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+      setShowJumpToBottom(false);
+    } else {
+      setShowJumpToBottom(true);
+    }
+  }, [text]);
+
+  const handleScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_THRESHOLD_PX;
+    wasAtBottomRef.current = atBottom;
+    if (atBottom) setShowJumpToBottom(false);
+  };
+
+  const jumpToBottom = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    wasAtBottomRef.current = true;
+    setShowJumpToBottom(false);
+  };
+
+  if (!task.outputFile) {
+    // The command just started — its immediate tool_result (which carries the
+    // output file path) hasn't landed yet. Distinct from "loading" below: this
+    // is "nothing to fetch yet", not "fetching and waiting".
+    return (
+      <div className="flex-1 flex items-center justify-center gap-2 text-text-primary/50 text-[0.9230rem]">
+        <ArrowPathIcon className="w-4 h-4 animate-spin" />
+        {t('backgroundTasks.transcriptModal.starting')}
+      </div>
+    );
+  }
+
+  return (
+    // The command box stays fixed (shrink-0); only the terminal pane below it
+    // scrolls. Both used to share one overflow-y-auto container, so scrolling
+    // the log also scrolled the command box off-screen — a detail view isn't
+    // supposed to hide the very thing it's showing detail about.
+    <div className="flex-1 min-h-0 px-4 py-3 flex flex-col">
+      <div className="shrink-0">
+        <CommandLine outputFile={task.outputFile} isRunning={isRunning} />
+      </div>
+
+      <div className="relative mt-3 h-[60vh] shrink-0">
+        {/* absolute inset-0 instead of h-full: a percentage height on a flex
+            item whose own height comes from flex-grow (not an explicit CSS
+            height) does not reliably resolve through this many nested flex
+            containers — it measured out to the content's full height instead
+            of the 414px the parent actually renders at, so the scrollbar
+            never engaged and the command box above got pushed off-screen by
+            a "scrolling" pane that was actually just growing forever. */}
+        <div ref={scrollRef} onScroll={handleScroll} className="absolute inset-0 overflow-y-auto">
+          {loading ? (
+            <div className="h-full flex items-center justify-center gap-2 text-text-primary/50 text-[0.9230rem]">
+              <ArrowPathIcon className="w-4 h-4 animate-spin" />
+              {t('backgroundTasks.transcriptModal.loading')}
+            </div>
+          ) : !text ? (
+            <div className="h-full flex items-center justify-center text-text-primary/50 text-[0.9230rem]">
+              {isRunning ? (
+                <span className="flex items-center gap-2">
+                  <ArrowPathIcon className="w-4 h-4 animate-spin" />
+                  {t('backgroundTasks.transcriptModal.starting')}
+                </span>
+              ) : (
+                t('backgroundTasks.transcriptModal.empty')
+              )}
+            </div>
+          ) : (
+            <>
+              {truncated && (
+                <div className="text-[0.8461rem] text-text-primary/50 text-center pb-2">
+                  {t('backgroundTasks.transcriptModal.truncated', { count: text.length })}
+                </div>
+              )}
+              {/* Terminal styling (near-black bg, green-on-black text) so this
+                  reads as a shell output pane, not a chat message — the same
+                  cue the CommandLine box above sets up. min-h-full: a short
+                  log (e.g. 5 lines) would otherwise leave the terminal box
+                  only as tall as its text, with a stretch of plain modal
+                  background below it that reads as a rendering glitch rather
+                  than "empty terminal" — filling the pane makes it look like
+                  what it is, a shell window with a few lines in it. */}
+              <pre className="min-h-full rounded-md bg-black/90 border border-border-subtle p-3 whitespace-pre-wrap break-words font-mono text-[0.8461rem] text-emerald-400/90 leading-relaxed">
+                {text}
+              </pre>
+            </>
+          )}
+        </div>
+
+        {showJumpToBottom && (
+          <button
+            onClick={jumpToBottom}
+            className="absolute bottom-3 start-1/2 -translate-x-1/2 flex items-center gap-1 px-3 py-1.5 rounded-full bg-surface-raised border border-border-default shadow-lg text-[0.8461rem] text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors"
+          >
+            <ArrowDownIcon className="w-3.5 h-3.5" />
+            {t('backgroundTasks.transcriptModal.jumpToBottom')}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/webview/src/components/AgentTranscriptModal/__tests__/BackgroundTaskOutputBody.test.tsx
+++ b/webview/src/components/AgentTranscriptModal/__tests__/BackgroundTaskOutputBody.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import type { WorkflowTask } from '@/shared';
+
+const sendRawMock = vi.fn();
+const handlers = new Map<string, (message: { type: string; payload?: Record<string, unknown> }) => void>();
+const unsubscribeMock = vi.fn();
+const subscribeMock = vi.fn((type: string, handler: (message: { type: string; payload?: Record<string, unknown> }) => void) => {
+  handlers.set(type, handler);
+  return unsubscribeMock;
+});
+
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ sendRaw: sendRawMock, subscribe: subscribeMock }),
+}));
+
+const writeTextMock = vi.fn().mockResolvedValue(undefined);
+Object.assign(navigator, { clipboard: { writeText: writeTextMock } });
+
+import { BackgroundTaskOutputBody } from '../BackgroundTaskOutputBody';
+import { MessageType } from '@/shared';
+
+function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    toolUseId: 'toolu_1',
+    taskType: 'local_bash',
+    outputFile: '/tmp/tasks/b1.output',
+    name: 'Print count every second',
+    status: 'running',
+    startedAt: 0,
+    phases: [],
+    agents: [],
+    ...overrides,
+  };
+}
+
+function emitChange(outputFile: string, text: string, truncated = false) {
+  const handler = handlers.get(MessageType.BACKGROUND_TASK_OUTPUT_CHANGED);
+  handler?.({ type: MessageType.BACKGROUND_TASK_OUTPUT_CHANGED, payload: { outputFile, text, truncated } });
+}
+
+describe('BackgroundTaskOutputBody', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers.clear();
+  });
+
+  it('shows a starting state when outputFile is not yet known', () => {
+    render(<BackgroundTaskOutputBody task={makeTask({ outputFile: undefined })} />);
+    expect(screen.getByText('Starting task…')).toBeInTheDocument();
+    expect(sendRawMock).not.toHaveBeenCalled();
+  });
+
+  it('watches the file and shows a tail -f command while running', () => {
+    render(<BackgroundTaskOutputBody task={makeTask({ status: 'running' })} />);
+
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.WATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/tmp/tasks/b1.output' });
+    expect(screen.getByText('tail -f -n +1 /tmp/tasks/b1.output')).toBeInTheDocument();
+  });
+
+  it('shows a cat command for a finished task', () => {
+    render(<BackgroundTaskOutputBody task={makeTask({ status: 'completed' })} />);
+    expect(screen.getByText('cat /tmp/tasks/b1.output')).toBeInTheDocument();
+  });
+
+  it('copies the command to the clipboard when the copy button is clicked', async () => {
+    render(<BackgroundTaskOutputBody task={makeTask({ status: 'running' })} />);
+
+    fireEvent.click(screen.getByTitle('Copy command'));
+
+    await waitFor(() => expect(writeTextMock).toHaveBeenCalledWith('tail -f -n +1 /tmp/tasks/b1.output'));
+  });
+
+  it('renders the log text pushed from BACKGROUND_TASK_OUTPUT_CHANGED', () => {
+    render(<BackgroundTaskOutputBody task={makeTask()} />);
+
+    act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\ncount: 2\n'));
+
+    expect(screen.getByText(/count: 1/)).toBeInTheDocument();
+  });
+
+  it('stops watching (unwatch) when the modal body unmounts', () => {
+    const { unmount } = render(<BackgroundTaskOutputBody task={makeTask()} />);
+    unmount();
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/tmp/tasks/b1.output' });
+  });
+
+  it('shows the truncated notice when the pushed payload says so', () => {
+    render(<BackgroundTaskOutputBody task={makeTask()} />);
+    act(() => emitChange('/tmp/tasks/b1.output', 'count: 999\n', true));
+    expect(screen.getByText(/Showing the most recent/)).toBeInTheDocument();
+  });
+
+  describe('auto-scroll', () => {
+    // jsdom never lays anything out, so scrollHeight/clientHeight/scrollTop
+    // are always 0 — stub them so the "was I at the bottom" math has real
+    // numbers to compare, the same way the browser would supply them.
+    function stubScrollMetrics(el: HTMLElement, { scrollHeight, clientHeight, scrollTop }: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+      Object.defineProperty(el, 'scrollHeight', { configurable: true, value: scrollHeight });
+      Object.defineProperty(el, 'clientHeight', { configurable: true, value: clientHeight });
+      let top = scrollTop;
+      Object.defineProperty(el, 'scrollTop', {
+        configurable: true,
+        get: () => top,
+        set: (v) => { top = v; },
+      });
+    }
+
+    it('auto-scrolls to the bottom when a push arrives while already at the bottom', () => {
+      render(<BackgroundTaskOutputBody task={makeTask()} />);
+      const scrollEl = document.querySelector('.overflow-y-auto') as HTMLElement;
+      stubScrollMetrics(scrollEl, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 }); // already at bottom
+
+      act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\n'));
+
+      expect(scrollEl.scrollTop).toBe(1000);
+      expect(screen.queryByText('Jump to bottom')).not.toBeInTheDocument();
+    });
+
+    it('shows "Jump to bottom" instead of forcing scroll when a push arrives while scrolled up', () => {
+      render(<BackgroundTaskOutputBody task={makeTask()} />);
+      const scrollEl = document.querySelector('.overflow-y-auto') as HTMLElement;
+
+      // First push lands while at the bottom (the initial auto-scroll baseline)...
+      stubScrollMetrics(scrollEl, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+      act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\n'));
+
+      // ...then the user scrolls up to read earlier output.
+      Object.defineProperty(scrollEl, 'scrollTop', { configurable: true, value: 0, writable: true });
+      fireEvent.scroll(scrollEl);
+
+      // A new push arrives while they're up there — must not yank them back down.
+      act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\ncount: 2\n'));
+
+      expect(scrollEl.scrollTop).toBe(0);
+      expect(screen.getByText('Jump to bottom')).toBeInTheDocument();
+    });
+
+    it('clicking "Jump to bottom" scrolls down and hides the button', () => {
+      render(<BackgroundTaskOutputBody task={makeTask()} />);
+      const scrollEl = document.querySelector('.overflow-y-auto') as HTMLElement;
+
+      stubScrollMetrics(scrollEl, { scrollHeight: 1000, clientHeight: 300, scrollTop: 700 });
+      act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\n'));
+      Object.defineProperty(scrollEl, 'scrollTop', { configurable: true, value: 0, writable: true });
+      fireEvent.scroll(scrollEl);
+      act(() => emitChange('/tmp/tasks/b1.output', 'count: 1\ncount: 2\n'));
+      expect(screen.getByText('Jump to bottom')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByText('Jump to bottom'));
+
+      expect(scrollEl.scrollTop).toBe(1000);
+      expect(screen.queryByText('Jump to bottom')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/webview/src/components/AgentTranscriptModal/__tests__/index.test.tsx
+++ b/webview/src/components/AgentTranscriptModal/__tests__/index.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { createTestQueryClient } from '@/hooks/queries/__tests__/testQueryClient';
+import type { WorkflowTask } from '@/shared';
+
+const sendMock = vi.fn();
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ send: sendMock }),
+}));
+
+// UserMessageRenderer (reused inside AgentTranscriptBody via MessageBubble)
+// reads useCliConfig(), which the real app provides via AppProviders far above
+// BackgroundTasksPanel. This modal is tested standalone, so it needs the same
+// provider — a no-op value is enough since these tests don't exercise slash
+// command parsing.
+vi.mock('@/contexts/CliConfigContext', () => ({
+  useCliConfig: () => ({ controlResponse: null, isLoading: false, refresh: vi.fn() }),
+}));
+
+// useBackgroundTaskActions pulls in Bridge/Session/ChatStream/WorkflowState
+// context, none of which this standalone modal test wires up. The cancel
+// button's own wiring is exercised directly below; here it only needs to not
+// throw on mount.
+const cancelTaskMock = vi.fn();
+vi.mock('@/hooks/useBackgroundTaskActions', () => ({
+  useBackgroundTaskActions: () => ({ cancelTask: cancelTaskMock }),
+}));
+
+import { AgentTranscriptModal } from '../index';
+
+function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    toolUseId: 'toolu_1',
+    transcriptDir: '/wf/dir',
+    name: 'demo-workflow',
+    status: 'completed',
+    startedAt: 0,
+    phases: [],
+    agents: [
+      { agentId: 'a1', label: 'Agent One', status: 'done', tokens: 100, tools: 2, durationMs: 5000 },
+      { agentId: 'a2', label: 'Agent Two', status: 'running', tokens: 50, tools: 1, durationMs: 3000 },
+    ],
+    ...overrides,
+  };
+}
+
+function renderModal(task: WorkflowTask, onClose = vi.fn()) {
+  const client = createTestQueryClient();
+  return {
+    onClose,
+    ...render(
+      <QueryClientProvider client={client}>
+        <AgentTranscriptModal task={task} onClose={onClose} />
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe('AgentTranscriptModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cancelTaskMock.mockClear();
+  });
+
+  it('requests the first agent transcript by default and renders its messages', async () => {
+    sendMock.mockResolvedValue({
+      status: 'ok',
+      entries: [{ type: 'user', uuid: 'u1', message: { role: 'user', content: 'hello agent' } }],
+      truncated: false,
+    });
+
+    renderModal(makeTask());
+
+    await waitFor(() => expect(sendMock).toHaveBeenCalled());
+    const [, payload] = sendMock.mock.calls[0];
+    expect(payload).toMatchObject({ transcriptDir: '/wf/dir', agentId: 'a1' });
+
+    await waitFor(() => expect(screen.getByText('hello agent')).toBeInTheDocument());
+  });
+
+  it('switches to the second agent transcript when its tab is clicked', async () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    renderModal(makeTask());
+
+    await waitFor(() => expect(sendMock).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByTitle('Agent Two'));
+
+    await waitFor(() => {
+      const lastCall = sendMock.mock.calls[sendMock.mock.calls.length - 1];
+      expect(lastCall[1]).toMatchObject({ transcriptDir: '/wf/dir', agentId: 'a2' });
+    });
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    const { onClose } = renderModal(makeTask());
+
+    fireEvent.click(screen.getByTitle('Close'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape', async () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    const { onClose } = renderModal(makeTask());
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the empty state when the workflow has no agents yet', () => {
+    renderModal(makeTask({ agents: [] }));
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(screen.getByText('No agents yet.')).toBeInTheDocument();
+  });
+
+  // The modal is the detail view for a panel card; it must not show less
+  // information than the summary card that opened it (issue #347 follow-up).
+  it('shows the same summary info the panel card shows: status, agent count, tokens, description', () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    renderModal(makeTask({ description: 'Explore two files in parallel' }));
+
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText('2 agents')).toBeInTheDocument();
+    expect(screen.getByText('Explore two files in parallel')).toBeInTheDocument();
+  });
+
+  it('shows a cancel button only while running, and it calls cancelTask with the task', () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    const { rerender } = renderModal(makeTask({ status: 'running' }));
+
+    const cancelButton = screen.getByText('Cancel this task');
+    fireEvent.click(cancelButton);
+    expect(cancelTaskMock).toHaveBeenCalledWith(expect.objectContaining({ toolUseId: 'toolu_1' }));
+
+    rerender(
+      <QueryClientProvider client={createTestQueryClient()}>
+        <AgentTranscriptModal task={makeTask({ status: 'completed' })} onClose={vi.fn()} />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByText('Cancel this task')).not.toBeInTheDocument();
+  });
+
+  it('resizes the modal by dragging the resize handle', () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    renderModal(makeTask());
+
+    const handle = screen.getByTitle('Drag to resize');
+    // The height lives on the handle's own sibling wrapper (relative div),
+    // not the handle itself. It's calc(60vh + offset) — only the offset
+    // moves when dragging, the 60vh term stays fixed.
+    const wrapper = handle.parentElement as HTMLElement;
+    const initialHeight = wrapper.style.height;
+    // jsdom normalizes calc() term order (px before vh) on the way back out
+    // of style.height — this is a jsdom serialization quirk, not what a real
+    // browser does, but it's what this test observes either way.
+    expect(initialHeight).toBe('calc(180px + 60vh)');
+
+    fireEvent.pointerDown(handle, { clientY: 500 });
+    fireEvent.pointerMove(window, { clientY: 510 }); // dragged down 10px, well under the max
+    expect(wrapper.style.height).toBe('calc(190px + 60vh)');
+
+    fireEvent.pointerUp(window);
+    fireEvent.pointerMove(window, { clientY: 700 }); // no active drag — ignored
+    expect(wrapper.style.height).toBe('calc(190px + 60vh)');
+  });
+
+  it('clamps the resized height to the configured min/max', () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    renderModal(makeTask());
+
+    const handle = screen.getByTitle('Drag to resize');
+    const wrapper = handle.parentElement as HTMLElement;
+
+    fireEvent.pointerDown(handle, { clientY: 500 });
+    fireEvent.pointerMove(window, { clientY: -5000 }); // drag far above the top
+    expect(wrapper.style.height).toBe('calc(-84px + 60vh)');
+  });
+});

--- a/webview/src/components/AgentTranscriptModal/index.tsx
+++ b/webview/src/components/AgentTranscriptModal/index.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef, useState } from 'react';
+import { XMarkIcon, StopCircleIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from '@/i18n';
+import { Portal } from '@/components/Portal';
+import type { WorkflowTask } from '@/shared';
+import { useBackgroundTaskActions } from '@/hooks/useBackgroundTaskActions';
+import { useNow } from '@/hooks/useNow';
+import { useVerticalResize } from '@/hooks/useVerticalResize';
+import { WorkflowTaskSummary } from '@/pages/ChatPage/BackgroundTasksPanel/WorkflowTaskSummary';
+import { AgentTabList } from './AgentTabList';
+import { AgentTranscriptBody } from './AgentTranscriptBody';
+import { BackgroundTaskOutputBody } from './BackgroundTaskOutputBody';
+
+interface Props {
+  task: WorkflowTask;
+  onClose: () => void;
+}
+
+// The modal's height is `calc(60vh + <offset>px)` — the 60vh keeps it
+// scaling with the window, and the offset is the only part the resize handle
+// drags. useVerticalResize only knows how to drag a plain px number, so it
+// manages the offset alone; the 60vh is spliced back in at render time.
+const DEFAULT_HEIGHT_OFFSET_PX = 180;
+const MIN_HEIGHT_OFFSET_PX = -84;
+// Must stay above DEFAULT_HEIGHT_OFFSET_PX so the drag handle can still grow
+// the modal from its default — leaves 300px of headroom to drag into.
+const MAX_HEIGHT_OFFSET_PX = DEFAULT_HEIGHT_OFFSET_PX + 300;
+
+/**
+ * Detail modal for a Background tasks panel row (issue #347): shows what each
+ * of a workflow's agents actually did — prompts, replies, tool calls — reusing
+ * the same message renderers the main chat uses. `task` is passed down live
+ * from WorkflowStateContext by the parent, so agent tabs/stats update in place
+ * as the workflow progresses (see AgentTranscriptBody for the transcript body's
+ * own live-refetch trigger).
+ */
+export function AgentTranscriptModal(props: Props) {
+  const { task, onClose } = props;
+  const { t } = useTranslation('chat');
+  const [selectedAgentId, setSelectedAgentId] = useState<string | undefined>(task.agents[0]?.agentId);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const isRunning = task.status === 'running';
+  const now = useNow(isRunning);
+  const { cancelTask } = useBackgroundTaskActions();
+  const { height: heightOffset, startResize, wasJustResizing } = useVerticalResize({
+    initialHeight: DEFAULT_HEIGHT_OFFSET_PX,
+    minHeight: MIN_HEIGHT_OFFSET_PX,
+    maxHeight: MAX_HEIGHT_OFFSET_PX,
+  });
+
+  // Keep a valid selection if the agent list changes (e.g. more agents appear
+  // as a running workflow progresses) and nothing was selected yet.
+  useEffect(() => {
+    if (selectedAgentId === undefined && task.agents.length > 0) {
+      setSelectedAgentId(task.agents[0].agentId);
+    }
+  }, [selectedAgentId, task.agents]);
+
+  // Focus trap, mirroring McpModal: without it, clicking inside this modal
+  // yanks focus back to the chat composer's auto-focus timers.
+  useEffect(() => {
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    dialogRef.current?.focus();
+
+    const handleFocusIn = (e: FocusEvent) => {
+      const dialog = dialogRef.current;
+      if (dialog && e.target instanceof Node && !dialog.contains(e.target)) {
+        dialog.focus();
+      }
+    };
+    document.addEventListener('focusin', handleFocusIn);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  const selectedAgent = task.agents.find((a) => a.agentId === selectedAgentId);
+  // A plain background Bash task (task_type 'local_bash') has no agents — it
+  // is a single process, not a workflow of subagents — so its detail is the
+  // raw output log instead of a transcript picker (issue #347).
+  const isBashTask = task.taskType === 'local_bash';
+
+  return (
+    <Portal>
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-overlay-scrim"
+        onClick={(e) => {
+          // A resize drag that ends off the thin handle lands on this overlay
+          // and looks identical to a real outside-click — skip the very next
+          // one so finishing a resize doesn't close the modal it just resized.
+          if (wasJustResizing()) return;
+          if (e.target === e.currentTarget) onClose();
+        }}
+      >
+        <div className="relative w-full max-w-2xl" style={{ height: `calc(60vh + ${heightOffset}px)` }}>
+          <div
+            ref={dialogRef}
+            tabIndex={-1}
+            className="h-full bg-surface-raised border border-border-default rounded-xl shadow-2xl overflow-hidden flex flex-col focus:outline-none"
+          >
+            <div className="flex items-center justify-between px-4 pt-4 pb-2 flex-shrink-0">
+              <h2 className="text-lg font-semibold text-text-primary truncate">
+                {t('backgroundTasks.transcriptModal.title', { name: task.name })}
+              </h2>
+              <button
+                onClick={onClose}
+                className="w-8 h-8 flex items-center justify-center rounded text-gray-400 hover:bg-gray-500/50 transition-colors shrink-0"
+                title={t('backgroundTasks.close')}
+              >
+                <XMarkIcon className="w-5 h-5" />
+              </button>
+            </div>
+
+            {/* Everything the panel card's summary shows (status, agents/tokens/
+                time, description, phases) must also be here — the modal is the
+                detail view, so it must never carry less information than the
+                summary card it was opened from. */}
+            <div className="px-4 pb-3 flex-shrink-0 border-b border-border-subtle">
+              <WorkflowTaskSummary task={task} now={now} showPhases={isBashTask ? false : true} />
+              {isRunning && (
+                <button
+                  onClick={() => cancelTask(task)}
+                  className="mt-2 flex items-center gap-1.5 px-2.5 py-1 rounded-md text-[0.8461rem] text-text-secondary hover:text-text-primary hover:bg-surface-hover transition-colors border border-border-subtle"
+                >
+                  <StopCircleIcon className="w-4 h-4" />
+                  {t('backgroundTasks.cancelRunning')}
+                </button>
+              )}
+            </div>
+
+            {isBashTask ? (
+              <BackgroundTaskOutputBody task={task} />
+            ) : (
+              <>
+                {task.agents.length > 0 && (
+                  <AgentTabList agents={task.agents} selectedAgentId={selectedAgentId} onSelect={setSelectedAgentId} />
+                )}
+                <AgentTranscriptBody transcriptDir={task.transcriptDir} agent={selectedAgent} />
+              </>
+            )}
+          </div>
+
+          {/* Drag-to-resize handle. A thin hit target with a wider invisible
+              padding, mirroring how resizable panels are usually grabbed —
+              the visible bar alone would be too thin to grab reliably. */}
+          <div
+            onPointerDown={startResize}
+            className="absolute left-0 right-0 -bottom-1.5 h-3 cursor-ns-resize group flex items-center justify-center"
+            title={t('backgroundTasks.transcriptModal.resize')}
+          >
+            <div className="w-10 h-1 rounded-full bg-border-default group-hover:bg-text-tertiary transition-colors" />
+          </div>
+        </div>
+      </div>
+    </Portal>
+  );
+}

--- a/webview/src/hooks/__tests__/useAgentTranscript.test.ts
+++ b/webview/src/hooks/__tests__/useAgentTranscript.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+
+const sendMock = vi.fn();
+
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ send: sendMock }),
+}));
+
+import { useAgentTranscript } from '../useAgentTranscript';
+import { MessageType } from '@/shared';
+import { createTestQueryClient, makeQueryWrapper } from '@/hooks/queries/__tests__/testQueryClient';
+
+describe('useAgentTranscript', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests the transcript with transcriptDir/agentId and returns entries', async () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [{ type: 'user', uuid: 'u1' }], truncated: false });
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useAgentTranscript('/x/y', 'a1'), { wrapper: makeQueryWrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sendMock).toHaveBeenCalledWith(MessageType.GET_AGENT_TRANSCRIPT, { transcriptDir: '/x/y', agentId: 'a1' });
+    expect(result.current.data).toEqual({ entries: [{ type: 'user', uuid: 'u1' }], truncated: false });
+  });
+
+  it('does not fire the request when transcriptDir or agentId is missing', () => {
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useAgentTranscript(undefined, undefined), { wrapper: makeQueryWrapper(client) });
+
+    expect(sendMock).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('surfaces a status:error ack as a query error', async () => {
+    sendMock.mockResolvedValue({ status: 'error', error: 'boom' });
+    const client = createTestQueryClient();
+    const { result } = renderHook(() => useAgentTranscript('/x/y', 'a1'), { wrapper: makeQueryWrapper(client) });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe('boom');
+  });
+
+  it('uses a distinct query key per fingerprint so live updates refetch', async () => {
+    sendMock.mockResolvedValue({ status: 'ok', entries: [], truncated: false });
+    const client = createTestQueryClient();
+    const { result, rerender } = renderHook(
+      ({ fingerprint }: { fingerprint: string }) => useAgentTranscript('/x/y', 'a1', fingerprint),
+      { wrapper: makeQueryWrapper(client), initialProps: { fingerprint: '0:0:0' } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(sendMock).toHaveBeenCalledTimes(1);
+
+    rerender({ fingerprint: '10:1:2' });
+    await waitFor(() => expect(sendMock).toHaveBeenCalledTimes(2));
+  });
+});

--- a/webview/src/hooks/__tests__/useBackgroundTaskOutput.test.ts
+++ b/webview/src/hooks/__tests__/useBackgroundTaskOutput.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const sendRawMock = vi.fn();
+// Keyed by message type so multiple subscriptions (unlikely here, but keeps
+// the mock honest) don't clobber each other.
+const handlers = new Map<string, (message: { type: string; payload?: Record<string, unknown> }) => void>();
+const unsubscribeMock = vi.fn();
+const subscribeMock = vi.fn((type: string, handler: (message: { type: string; payload?: Record<string, unknown> }) => void) => {
+  handlers.set(type, handler);
+  return unsubscribeMock;
+});
+
+vi.mock('@/hooks/useBridge', () => ({
+  useBridge: () => ({ sendRaw: sendRawMock, subscribe: subscribeMock }),
+}));
+
+import { useBackgroundTaskOutput } from '../useBackgroundTaskOutput';
+import { MessageType } from '@/shared';
+
+function emitChange(outputFile: string, text: string, truncated = false) {
+  const handler = handlers.get(MessageType.BACKGROUND_TASK_OUTPUT_CHANGED);
+  handler?.({ type: MessageType.BACKGROUND_TASK_OUTPUT_CHANGED, payload: { outputFile, text, truncated } });
+}
+
+describe('useBackgroundTaskOutput', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    handlers.clear();
+  });
+
+  it('starts loading and does nothing when outputFile is undefined', () => {
+    const { result } = renderHook(() => useBackgroundTaskOutput(undefined));
+    expect(sendRawMock).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ text: '', truncated: false, loading: true });
+  });
+
+  it('subscribes and sends WATCH_BACKGROUND_TASK_OUTPUT when outputFile is given', () => {
+    renderHook(() => useBackgroundTaskOutput('/x/y.output'));
+
+    expect(subscribeMock).toHaveBeenCalledWith(MessageType.BACKGROUND_TASK_OUTPUT_CHANGED, expect.any(Function));
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.WATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/x/y.output' });
+  });
+
+  it('applies a BACKGROUND_TASK_OUTPUT_CHANGED push for the same file', () => {
+    const { result } = renderHook(() => useBackgroundTaskOutput('/x/y.output'));
+
+    act(() => emitChange('/x/y.output', 'count: 1\n', false));
+
+    expect(result.current).toEqual({ text: 'count: 1\n', truncated: false, loading: false });
+  });
+
+  it('ignores a push for a different outputFile', () => {
+    const { result } = renderHook(() => useBackgroundTaskOutput('/x/y.output'));
+
+    act(() => emitChange('/other/file.output', 'unrelated\n', false));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.text).toBe('');
+  });
+
+  it('unsubscribes and sends UNWATCH_BACKGROUND_TASK_OUTPUT on unmount', () => {
+    const { unmount } = renderHook(() => useBackgroundTaskOutput('/x/y.output'));
+
+    unmount();
+
+    expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/x/y.output' });
+  });
+
+  it('unwatches the old file and watches the new one when outputFile changes', () => {
+    const { rerender } = renderHook(({ file }: { file: string }) => useBackgroundTaskOutput(file), {
+      initialProps: { file: '/x/y.output' },
+    });
+
+    rerender({ file: '/x/z.output' });
+
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/x/y.output' });
+    expect(sendRawMock).toHaveBeenCalledWith(MessageType.WATCH_BACKGROUND_TASK_OUTPUT, { outputFile: '/x/z.output' });
+  });
+});

--- a/webview/src/hooks/__tests__/useVerticalResize.test.ts
+++ b/webview/src/hooks/__tests__/useVerticalResize.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useVerticalResize } from '../useVerticalResize';
+
+function firePointerMove(clientY: number) {
+  window.dispatchEvent(new PointerEvent('pointermove', { clientY }));
+}
+
+function firePointerUp() {
+  window.dispatchEvent(new PointerEvent('pointerup'));
+}
+
+function makeStartEvent(clientY: number) {
+  return { clientY, preventDefault: () => {} } as unknown as React.PointerEvent;
+}
+
+describe('useVerticalResize', () => {
+  const OPTIONS = { initialHeight: 800, minHeight: 300, maxHeight: 1000 };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    // The hook restores these on unmount too, but a test that asserts mid-drag
+    // and never unmounts would otherwise leak into the next test.
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+  });
+
+  it('starts at initialHeight and not resizing', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+    expect(result.current.height).toBe(800);
+    expect(result.current.isResizing).toBe(false);
+  });
+
+  it('grows the height by the drag delta when dragging down', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    expect(result.current.isResizing).toBe(true);
+
+    act(() => firePointerMove(560)); // dragged down 60px
+    expect(result.current.height).toBe(860);
+  });
+
+  it('shrinks the height when dragging up', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(420)); // dragged up 80px
+
+    expect(result.current.height).toBe(720);
+  });
+
+  it('clamps to maxHeight when dragged past it', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(2000)); // way past max
+
+    expect(result.current.height).toBe(1000);
+  });
+
+  it('clamps to minHeight when dragged past it', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(-2000)); // way past min
+
+    expect(result.current.height).toBe(300);
+  });
+
+  it('stops resizing and further pointer moves have no effect after pointerup', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(550));
+    expect(result.current.height).toBe(850);
+
+    act(() => firePointerUp());
+    expect(result.current.isResizing).toBe(false);
+
+    act(() => firePointerMove(700)); // should be ignored — no active drag
+    expect(result.current.height).toBe(850);
+  });
+
+  it('sets body user-select/cursor while resizing and restores them after pointerup', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    expect(document.body.style.userSelect).toBe('none');
+    expect(document.body.style.cursor).toBe('ns-resize');
+
+    act(() => firePointerUp());
+    expect(document.body.style.userSelect).toBe('');
+    expect(document.body.style.cursor).toBe('');
+  });
+
+  it('a second drag starts from the height the first drag left off, not the original initialHeight', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(600)); // +100 -> 900
+    act(() => firePointerUp());
+    expect(result.current.height).toBe(900);
+
+    act(() => result.current.startResize(makeStartEvent(200)));
+    act(() => firePointerMove(150)); // -50 from the new drag's start
+    expect(result.current.height).toBe(850);
+  });
+
+  it('wasJustResizing() is true right after pointerup, then false again next tick', () => {
+    const { result } = renderHook(() => useVerticalResize(OPTIONS));
+
+    expect(result.current.wasJustResizing()).toBe(false);
+
+    act(() => result.current.startResize(makeStartEvent(500)));
+    act(() => firePointerMove(560));
+    // Marks the drag's tail end so a synthesized click landing on whatever's
+    // behind the thin handle — e.g. a modal's click-outside-to-close overlay
+    // — can be told apart from a real outside click and ignored.
+    act(() => firePointerUp());
+    expect(result.current.wasJustResizing()).toBe(true);
+
+    act(() => vi.advanceTimersByTime(0));
+    expect(result.current.wasJustResizing()).toBe(false);
+  });
+});

--- a/webview/src/hooks/useAgentTranscript.ts
+++ b/webview/src/hooks/useAgentTranscript.ts
@@ -1,0 +1,40 @@
+import { useQuery } from '@tanstack/react-query';
+import { useBridge } from './useBridge';
+import { MessageType } from '@/shared';
+
+interface AgentTranscriptData {
+  entries: Record<string, unknown>[];
+  truncated: boolean;
+}
+
+/**
+ * Load one workflow agent's full transcript for the Background tasks detail
+ * modal (issue #347). `fingerprint` should change whenever the agent's live
+ * stats (tokens/tools/durationMs) change, so a running agent's transcript
+ * refetches as WORKFLOW_PROGRESS updates arrive — no separate polling needed.
+ */
+export function useAgentTranscript(
+  transcriptDir: string | undefined,
+  agentId: string | undefined,
+  fingerprint?: string | number,
+) {
+  const { send } = useBridge();
+
+  return useQuery({
+    queryKey: ['agent-transcript', transcriptDir, agentId, fingerprint],
+    queryFn: async (): Promise<AgentTranscriptData> => {
+      const res = await send<{
+        status: string;
+        entries?: Record<string, unknown>[];
+        truncated?: boolean;
+        error?: string;
+      }>(MessageType.GET_AGENT_TRANSCRIPT, { transcriptDir, agentId });
+      if (res.status !== 'ok') throw new Error(res.error ?? 'Failed to load transcript');
+      return { entries: res.entries ?? [], truncated: !!res.truncated };
+    },
+    enabled: !!transcriptDir && !!agentId,
+    // A short stale window throttles refetch when WORKFLOW_PROGRESS ticks land
+    // several times a second, while still following the workflow closely.
+    staleTime: 2000,
+  });
+}

--- a/webview/src/hooks/useBackgroundTaskOutput.ts
+++ b/webview/src/hooks/useBackgroundTaskOutput.ts
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { useBridge } from './useBridge';
+import { MessageType } from '@/shared';
+
+interface BackgroundTaskOutputState {
+  text: string;
+  truncated: boolean;
+  loading: boolean;
+}
+
+const INITIAL_STATE: BackgroundTaskOutputState = { text: '', truncated: false, loading: true };
+
+/**
+ * Live-subscribe to a background Bash task's raw output log (issue #347
+ * follow-up: task_type 'local_bash' has no agents to show a transcript for).
+ *
+ * Push, not poll: the CLI has no event for "a task's log grew a line", so
+ * unlike a workflow agent's transcript (refetched off WORKFLOW_PROGRESS), a
+ * client-side interval was the only way to approximate live for a plain Bash
+ * task — this instead asks the backend to `fs.watch` the file and push
+ * BACKGROUND_TASK_OUTPUT_CHANGED, so there is nothing to fetch and no timer
+ * ticking while nothing has changed.
+ */
+export function useBackgroundTaskOutput(outputFile: string | undefined) {
+  const { sendRaw, subscribe } = useBridge();
+  const [state, setState] = useState<BackgroundTaskOutputState>(INITIAL_STATE);
+
+  useEffect(() => {
+    if (!outputFile) {
+      setState(INITIAL_STATE);
+      return;
+    }
+    setState(INITIAL_STATE);
+
+    const unsubscribe = subscribe(MessageType.BACKGROUND_TASK_OUTPUT_CHANGED, (message) => {
+      const payload = message.payload as { outputFile?: string; text?: string; truncated?: boolean } | undefined;
+      if (payload?.outputFile !== outputFile) return; // another watched task's update
+      setState({ text: payload.text ?? '', truncated: !!payload.truncated, loading: false });
+    });
+
+    sendRaw(MessageType.WATCH_BACKGROUND_TASK_OUTPUT, { outputFile });
+
+    return () => {
+      unsubscribe();
+      sendRaw(MessageType.UNWATCH_BACKGROUND_TASK_OUTPUT, { outputFile });
+    };
+  }, [outputFile, sendRaw, subscribe]);
+
+  return state;
+}

--- a/webview/src/hooks/useNow.ts
+++ b/webview/src/hooks/useNow.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Re-render every second while `active` so a live duration display keeps
+ * ticking. Shared by the Background tasks panel's cards and
+ * AgentTranscriptModal's header (issue #347 follow-up) so both read the same
+ * running-duration clock.
+ */
+export function useNow(active: boolean): number {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [active]);
+  return now;
+}

--- a/webview/src/hooks/useVerticalResize.ts
+++ b/webview/src/hooks/useVerticalResize.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface Options {
+  initialHeight: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+/**
+ * Drag-to-resize a panel's height from a handle at its bottom edge. Height is
+ * plain component state (not measured from the DOM), so nothing needs a
+ * ResizeObserver just to know its own size — the drag delta is added directly
+ * to the height that was already state.
+ */
+export function useVerticalResize(options: Options) {
+  const { initialHeight, minHeight, maxHeight } = options;
+  const [height, setHeight] = useState(initialHeight);
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStartRef = useRef<{ startY: number; startHeight: number } | null>(null);
+
+  const clamp = useCallback((h: number) => Math.min(maxHeight, Math.max(minHeight, h)), [minHeight, maxHeight]);
+
+  // A resize drag routinely ends with the pointer off the thin handle — often
+  // over whatever's behind it, e.g. this modal's click-outside-to-close
+  // overlay. The browser synthesizes a click on that element right after
+  // pointerup, at the same coordinates, which reads as "the user clicked
+  // outside the modal" and closes it the instant a resize finishes (issue:
+  // dragging closed the modal it was resizing). This flag marks the brief
+  // window between pointerup and that synthesized click so callers — the
+  // overlay's onClick — can tell a real outside-click from a drag's tail end.
+  const justFinishedRef = useRef(false);
+
+  const startResize = useCallback(
+    (e: React.PointerEvent) => {
+      e.preventDefault();
+      dragStartRef.current = { startY: e.clientY, startHeight: height };
+      setIsResizing(true);
+    },
+    [height],
+  );
+
+  useEffect(() => {
+    if (!isResizing) return;
+
+    const handleMove = (e: PointerEvent) => {
+      const drag = dragStartRef.current;
+      if (!drag) return;
+      setHeight(clamp(drag.startHeight + (e.clientY - drag.startY)));
+    };
+    const handleUp = () => {
+      dragStartRef.current = null;
+      setIsResizing(false);
+      justFinishedRef.current = true;
+      // The synthesized click fires synchronously right after pointerup, so
+      // this only needs to survive one tick — cleared on the next one.
+      setTimeout(() => {
+        justFinishedRef.current = false;
+      }, 0);
+    };
+
+    // The drag handle is thin — the pointer strays outside it constantly
+    // while dragging. Without this, that stray movement selects surrounding
+    // text and shows the wrong cursor between handle hit-tests.
+    const previousUserSelect = document.body.style.userSelect;
+    const previousCursor = document.body.style.cursor;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'ns-resize';
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleUp);
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleUp);
+      document.body.style.userSelect = previousUserSelect;
+      document.body.style.cursor = previousCursor;
+    };
+  }, [isResizing, clamp]);
+
+  // Read fresh at call time (not a plain boolean return) — the overlay calls
+  // this from inside its own click handler, after this hook's justFinishedRef
+  // was set, so it needs the current value rather than one captured at the
+  // render that produced this closure.
+  const wasJustResizing = useCallback(() => justFinishedRef.current, []);
+
+  return { height, isResizing, startResize, wasJustResizing };
+}

--- a/webview/src/i18n/locales/ar/chat.json
+++ b/webview/src/i18n/locales/ar/chat.json
@@ -213,6 +213,7 @@
       "confirm": "إيقاف الكل"
     },
     "workflowLabel": "مهمة سير العمل",
+    "bashLabel": "مهمة Bash",
     "agentsCount": "{{count}} وكلاء",
     "agentsCount_zero": "لا وكلاء",
     "agentsCount_one": "وكيل واحد",
@@ -227,6 +228,19 @@
       "tokens": "الرموز",
       "tools": "الأدوات",
       "time": "الوقت"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "لا يوجد وكلاء بعد.",
+      "loading": "جارٍ تحميل النص…",
+      "empty": "لا توجد رسائل بعد.",
+      "error": "فشل تحميل النص.",
+      "truncated": "عرض أحدث {{count}} إدخال.",
+      "starting": "جارٍ بدء المهمة…",
+      "updating": "جارٍ التحديث…",
+      "jumpToBottom": "الانتقال إلى الأسفل",
+      "copyCommand": "نسخ الأمر",
+      "resize": "اسحب لتغيير الحجم"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/de/chat.json
+++ b/webview/src/i18n/locales/de/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Alle stoppen"
     },
     "workflowLabel": "Workflow",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} Agenten",
     "agentsCount_one": "{{count}} Agent",
     "agentsCount_other": "{{count}} Agenten",
@@ -223,6 +224,19 @@
       "tokens": "Tokens",
       "tools": "Tools",
       "time": "Zeit"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "Noch keine Agenten.",
+      "loading": "Transkript wird geladen…",
+      "empty": "Noch keine Nachrichten.",
+      "error": "Transkript konnte nicht geladen werden.",
+      "truncated": "Zeigt die letzten {{count}} Einträge.",
+      "starting": "Aufgabe wird gestartet…",
+      "updating": "Wird aktualisiert…",
+      "jumpToBottom": "Nach unten springen",
+      "copyCommand": "Befehl kopieren",
+      "resize": "Zum Ändern der Größe ziehen"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/en/chat.json
+++ b/webview/src/i18n/locales/en/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Stop all"
     },
     "workflowLabel": "Workflow",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} agents",
     "agentsCount_one": "{{count}} agent",
     "agentsCount_other": "{{count}} agents",
@@ -223,6 +224,19 @@
       "tokens": "Tokens",
       "tools": "Tools",
       "time": "Time"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "No agents yet.",
+      "loading": "Loading transcript…",
+      "empty": "No messages yet.",
+      "error": "Failed to load transcript.",
+      "truncated": "Showing the most recent {{count}} entries.",
+      "starting": "Starting task…",
+      "updating": "Updating…",
+      "jumpToBottom": "Jump to bottom",
+      "copyCommand": "Copy command",
+      "resize": "Drag to resize"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/es/chat.json
+++ b/webview/src/i18n/locales/es/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Detener todas"
     },
     "workflowLabel": "Flujo de trabajo",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} agentes",
     "agentsCount_one": "{{count}} agente",
     "agentsCount_other": "{{count}} agentes",
@@ -223,6 +224,19 @@
       "tokens": "Tokens",
       "tools": "Herramientas",
       "time": "Tiempo"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "Aún no hay agentes.",
+      "loading": "Cargando transcripción…",
+      "empty": "Aún no hay mensajes.",
+      "error": "No se pudo cargar la transcripción.",
+      "truncated": "Mostrando las {{count}} entradas más recientes.",
+      "starting": "Iniciando tarea…",
+      "updating": "Actualizando…",
+      "jumpToBottom": "Ir al final",
+      "copyCommand": "Copiar comando",
+      "resize": "Arrastra para redimensionar"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/fa/chat.json
+++ b/webview/src/i18n/locales/fa/chat.json
@@ -213,6 +213,7 @@
       "confirm": "توقف همه"
     },
     "workflowLabel": "جریان کاری",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} ایجنت",
     "agentsCount_one": "{{count}} ایجنت",
     "agentsCount_other": "{{count}} ایجنت",
@@ -223,6 +224,19 @@
       "tokens": "توکن‌ها",
       "tools": "ابزارها",
       "time": "زمان"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "هنوز ایجنتی وجود ندارد.",
+      "loading": "در حال بارگذاری رونوشت…",
+      "empty": "هنوز پیامی وجود ندارد.",
+      "error": "بارگذاری رونوشت ناموفق بود.",
+      "truncated": "نمایش {{count}} مورد اخیر.",
+      "starting": "در حال شروع وظیفه…",
+      "updating": "در حال به‌روزرسانی…",
+      "jumpToBottom": "پرش به پایین",
+      "copyCommand": "کپی دستور",
+      "resize": "برای تغییر اندازه بکشید"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/fr/chat.json
+++ b/webview/src/i18n/locales/fr/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Tout arrêter"
     },
     "workflowLabel": "Workflow",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} agents",
     "agentsCount_one": "{{count}} agent",
     "agentsCount_other": "{{count}} agents",
@@ -223,6 +224,19 @@
       "tokens": "Tokens",
       "tools": "Outils",
       "time": "Temps"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "Aucun agent pour l'instant.",
+      "loading": "Chargement de la transcription…",
+      "empty": "Aucun message pour l'instant.",
+      "error": "Échec du chargement de la transcription.",
+      "truncated": "Affichage des {{count}} entrées les plus récentes.",
+      "starting": "Démarrage de la tâche…",
+      "updating": "Mise à jour…",
+      "jumpToBottom": "Aller en bas",
+      "copyCommand": "Copier la commande",
+      "resize": "Glisser pour redimensionner"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/ja/chat.json
+++ b/webview/src/i18n/locales/ja/chat.json
@@ -213,6 +213,7 @@
       "confirm": "すべて停止"
     },
     "workflowLabel": "ワークフロー",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} エージェント",
     "agentsCount_one": "{{count}} エージェント",
     "agentsCount_other": "{{count}} エージェント",
@@ -223,6 +224,19 @@
       "tokens": "トークン",
       "tools": "ツール",
       "time": "時間"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "まだエージェントがいません。",
+      "loading": "記録を読み込み中…",
+      "empty": "まだメッセージがありません。",
+      "error": "記録の読み込みに失敗しました。",
+      "truncated": "最新の{{count}}件を表示しています。",
+      "starting": "タスクを開始しています…",
+      "updating": "更新中…",
+      "jumpToBottom": "最新へ移動",
+      "copyCommand": "コマンドをコピー",
+      "resize": "ドラッグしてサイズ変更"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/ko/chat.json
+++ b/webview/src/i18n/locales/ko/chat.json
@@ -213,6 +213,7 @@
       "confirm": "전부 중지"
     },
     "workflowLabel": "워크플로",
+    "bashLabel": "Bash",
     "agentsCount": "에이전트 {{count}}명",
     "agentsCount_one": "에이전트 {{count}}명",
     "agentsCount_other": "에이전트 {{count}}명",
@@ -223,6 +224,19 @@
       "tokens": "토큰",
       "tools": "도구",
       "time": "시간"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "아직 에이전트가 없습니다.",
+      "loading": "transcript 불러오는 중…",
+      "empty": "아직 메시지가 없습니다.",
+      "error": "transcript를 불러오지 못했습니다.",
+      "truncated": "최근 {{count}}개 항목만 표시합니다.",
+      "starting": "작업 시작하는 중…",
+      "updating": "업데이트 중…",
+      "jumpToBottom": "맨 아래로 이동",
+      "copyCommand": "명령어 복사",
+      "resize": "드래그해서 크기 조절"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/pt/chat.json
+++ b/webview/src/i18n/locales/pt/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Parar todas"
     },
     "workflowLabel": "Fluxo de trabalho",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} agentes",
     "agentsCount_one": "{{count}} agente",
     "agentsCount_other": "{{count}} agentes",
@@ -223,6 +224,19 @@
       "tokens": "Tokens",
       "tools": "Ferramentas",
       "time": "Tempo"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "Ainda não há agentes.",
+      "loading": "Carregando transcrição…",
+      "empty": "Ainda não há mensagens.",
+      "error": "Falha ao carregar a transcrição.",
+      "truncated": "Mostrando as {{count}} entradas mais recentes.",
+      "starting": "Iniciando tarefa…",
+      "updating": "Atualizando…",
+      "jumpToBottom": "Ir para o final",
+      "copyCommand": "Copiar comando",
+      "resize": "Arraste para redimensionar"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/ru/chat.json
+++ b/webview/src/i18n/locales/ru/chat.json
@@ -213,6 +213,7 @@
       "confirm": "Остановить все"
     },
     "workflowLabel": "Рабочий процесс",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} агентов",
     "agentsCount_one": "{{count}} агент",
     "agentsCount_few": "{{count}} агента",
@@ -225,6 +226,19 @@
       "tokens": "Токены",
       "tools": "Инструменты",
       "time": "Время"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "Пока нет агентов.",
+      "loading": "Загрузка стенограммы…",
+      "empty": "Пока нет сообщений.",
+      "error": "Не удалось загрузить стенограмму.",
+      "truncated": "Показаны последние {{count}} записей.",
+      "starting": "Запуск задачи…",
+      "updating": "Обновление…",
+      "jumpToBottom": "Перейти вниз",
+      "copyCommand": "Копировать команду",
+      "resize": "Перетащите, чтобы изменить размер"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/zh-TW/chat.json
+++ b/webview/src/i18n/locales/zh-TW/chat.json
@@ -213,6 +213,7 @@
       "confirm": "全部停止"
     },
     "workflowLabel": "工作流程",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} 個代理程式",
     "agentsCount_one": "{{count}} 個代理程式",
     "agentsCount_other": "{{count}} 個代理程式",
@@ -223,6 +224,19 @@
       "tokens": "Token",
       "tools": "工具",
       "time": "時間"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "尚無代理程式。",
+      "loading": "正在載入記錄…",
+      "empty": "尚無訊息。",
+      "error": "載入記錄失敗。",
+      "truncated": "僅顯示最近 {{count}} 筆記錄。",
+      "starting": "正在啟動任務…",
+      "updating": "正在更新…",
+      "jumpToBottom": "跳至底部",
+      "copyCommand": "複製指令",
+      "resize": "拖曳以調整大小"
     }
   },
   "scheduledMessages": {

--- a/webview/src/i18n/locales/zh/chat.json
+++ b/webview/src/i18n/locales/zh/chat.json
@@ -213,6 +213,7 @@
       "confirm": "全部停止"
     },
     "workflowLabel": "工作流",
+    "bashLabel": "Bash",
     "agentsCount": "{{count}} 个智能体",
     "agentsCount_one": "{{count}} 个智能体",
     "agentsCount_other": "{{count}} 个智能体",
@@ -223,6 +224,19 @@
       "tokens": "Token",
       "tools": "工具",
       "time": "时间"
+    },
+    "transcriptModal": {
+      "title": "{{name}}",
+      "noAgents": "暂无智能体。",
+      "loading": "正在加载记录…",
+      "empty": "暂无消息。",
+      "error": "加载记录失败。",
+      "truncated": "仅显示最近 {{count}} 条记录。",
+      "starting": "正在启动任务…",
+      "updating": "正在更新…",
+      "jumpToBottom": "跳转到底部",
+      "copyCommand": "复制命令",
+      "resize": "拖动以调整大小"
     }
   },
   "scheduledMessages": {

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/WorkflowTaskSummary.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/WorkflowTaskSummary.tsx
@@ -1,0 +1,125 @@
+import { useTranslation } from '@/i18n';
+import type { WorkflowTask } from '@/shared';
+import { agentDotClass, formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
+
+interface Props {
+    task: WorkflowTask;
+    now: number;
+    /** Show the phases list — the panel card always does; the modal header omits
+     *  it since the agent tabs below already convey progress per-phase. */
+    showPhases?: boolean;
+}
+
+/**
+ * The summary block a Background tasks panel card shows for one task: status,
+ * agents/tokens/time, description, phases. Shared with AgentTranscriptModal's
+ * header (issue #347 follow-up) so the detail view — which is supposed to be
+ * the fuller view — is never missing information the summary card already has.
+ */
+export function WorkflowTaskSummary(props: Props) {
+    const { task, now, showPhases = true } = props;
+    const { t } = useTranslation('chat');
+
+    const isRunning = task.status === 'running';
+    const statusColor = WORKFLOW_STATUS_COLOR[task.status] || 'text-text-primary/60';
+    const agentCount = task.agents.length || task.usage?.agentCount;
+    const durationMs = task.usage?.durationMs ?? (isRunning ? now - task.startedAt : undefined);
+    const duration = formatDuration(durationMs);
+    // Authoritative workflow-level total first; per-agent sum is only a fallback
+    // (see WorkflowRenderer) so the header stays consistent with the agent table.
+    const liveTokens = task.agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
+    const tokens = formatTokens(task.usage?.subagentTokens || liveTokens);
+
+    return (
+        <div>
+            <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.8461rem]">
+                <span className={`font-medium ${statusColor}`}>
+                    {isRunning && (
+                        <span className="inline-block w-1.5 h-1.5 rounded-full bg-current me-1.5 align-middle animate-pulse" />
+                    )}
+                    {task.status}
+                </span>
+                <span className="text-text-tertiary">·</span>
+                <span className="text-text-primary/60">
+                    {task.taskType === 'local_bash' ? t('backgroundTasks.bashLabel') : t('backgroundTasks.workflowLabel')}
+                </span>
+                {agentCount !== undefined && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span className="text-text-primary/60">{t('backgroundTasks.agentsCount', { count: agentCount })}</span>
+                    </>
+                )}
+                {tokens && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span className="text-text-primary/60">{t('backgroundTasks.tokensLabel', { tokens })}</span>
+                    </>
+                )}
+                {duration && (
+                    <>
+                        <span className="text-text-tertiary">·</span>
+                        <span className="text-text-primary/60">{duration}</span>
+                    </>
+                )}
+            </div>
+
+            {task.description && (
+                <div className="mt-1 text-[0.8461rem] text-text-primary/50">{task.description}</div>
+            )}
+
+            {showPhases && task.phases.length > 0 && (
+                <div className="mt-2">
+                    <div className="text-[0.7692rem] uppercase tracking-wide text-text-tertiary mb-1">{t('backgroundTasks.phasesLabel')}</div>
+                    <div className="space-y-0.5">
+                        {task.phases.map((p, i) => (
+                            <div key={i} className="flex items-center gap-2 text-[0.8461rem] text-text-primary/70">
+                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-text-tertiary" />
+                                <span className="truncate">{p.title}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+/** Standalone agents table, split out so the panel card can keep showing it
+ *  (issue #347 follow-up left this out of the shared summary — the modal
+ *  already renders per-agent detail via its tabs, so repeating the table
+ *  there would duplicate the same numbers right below). */
+export function WorkflowAgentsTable(props: { task: WorkflowTask }) {
+    const { task } = props;
+    const { t } = useTranslation('chat');
+    if (task.agents.length === 0) return null;
+
+    return (
+        <div className="mt-2 overflow-x-auto no-scrollbar">
+            <table className="w-full text-[0.8461rem] font-mono">
+                <thead>
+                    <tr className="text-text-tertiary text-start">
+                        <th className="font-normal pb-1 pe-2">{t('backgroundTasks.tableHeader.agent')}</th>
+                        <th className="font-normal pb-1 px-2 text-end">{t('backgroundTasks.tableHeader.tokens')}</th>
+                        <th className="font-normal pb-1 px-2 text-end">{t('backgroundTasks.tableHeader.tools')}</th>
+                        <th className="font-normal pb-1 ps-2 text-end">{t('backgroundTasks.tableHeader.time')}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {task.agents.map((a) => (
+                        <tr key={a.agentId} className="text-text-primary/75">
+                            <td className="py-0.5 pe-2 max-w-[10rem] truncate">
+                                <span
+                                    className={`inline-block w-1.5 h-1.5 rounded-full me-1.5 align-middle ${agentDotClass(a.status)}`}
+                                />
+                                {a.label}
+                            </td>
+                            <td className="py-0.5 px-2 text-end">{formatTokens(a.tokens) ?? '0'}</td>
+                            <td className="py-0.5 px-2 text-end">{a.tools}</td>
+                            <td className="py-0.5 ps-2 text-end">{formatDuration(a.durationMs) ?? '—'}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/__tests__/WorkflowTaskSummary.test.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/__tests__/WorkflowTaskSummary.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { WorkflowTask } from '@/shared';
+import { WorkflowTaskSummary, WorkflowAgentsTable } from '../WorkflowTaskSummary';
+
+function makeTask(overrides: Partial<WorkflowTask> = {}): WorkflowTask {
+  return {
+    toolUseId: 'toolu_1',
+    name: 'demo-flow',
+    status: 'completed',
+    startedAt: 0,
+    phases: [{ title: 'Explore' }],
+    agents: [{ agentId: 'a1', label: 'Agent One', status: 'done', tokens: 1500, tools: 3, durationMs: 4200 }],
+    usage: { agentCount: 1, subagentTokens: 1500, toolUses: 3, durationMs: 4200 },
+    ...overrides,
+  };
+}
+
+describe('WorkflowTaskSummary', () => {
+  it('shows status, workflow label, agent count, tokens, and duration', () => {
+    render(<WorkflowTaskSummary task={makeTask()} now={0} />);
+
+    expect(screen.getByText('completed')).toBeInTheDocument();
+    expect(screen.getByText('Workflow')).toBeInTheDocument();
+    expect(screen.getByText('1 agent')).toBeInTheDocument();
+  });
+
+  it('shows the Bash label instead of Workflow for a local_bash task', () => {
+    render(<WorkflowTaskSummary task={makeTask({ taskType: 'local_bash', agents: [], usage: undefined })} now={0} />);
+    expect(screen.getByText('Bash')).toBeInTheDocument();
+    expect(screen.queryByText('Workflow')).not.toBeInTheDocument();
+  });
+
+  it('shows the description when present', () => {
+    render(<WorkflowTaskSummary task={makeTask({ description: 'Read two files in parallel' })} now={0} />);
+    expect(screen.getByText('Read two files in parallel')).toBeInTheDocument();
+  });
+
+  it('shows phases by default and hides them when showPhases is false', () => {
+    const { rerender } = render(<WorkflowTaskSummary task={makeTask()} now={0} />);
+    expect(screen.getByText('Explore')).toBeInTheDocument();
+
+    rerender(<WorkflowTaskSummary task={makeTask()} now={0} showPhases={false} />);
+    expect(screen.queryByText('Explore')).not.toBeInTheDocument();
+  });
+});
+
+describe('WorkflowAgentsTable', () => {
+  it('renders one row per agent with its stats', () => {
+    render(<WorkflowAgentsTable task={makeTask()} />);
+    expect(screen.getByText('Agent One')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no agents', () => {
+    const { container } = render(<WorkflowAgentsTable task={makeTask({ agents: [] })} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
+++ b/webview/src/pages/ChatPage/BackgroundTasksPanel/index.tsx
@@ -3,20 +3,11 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Portal } from '@/components/Portal';
 import { useWorkflowState } from '@/contexts/WorkflowStateContext';
 import { useBackgroundTaskActions } from '@/hooks/useBackgroundTaskActions';
+import { useNow } from '@/hooks/useNow';
 import type { WorkflowTask } from '@/shared';
-import { agentDotClass, formatDuration, formatTokens, WORKFLOW_STATUS_COLOR } from '@/utils/workflowFormat';
 import { useTranslation } from '@/i18n';
-
-/** Re-render every second while `active` so running timers tick. */
-function useNow(active: boolean): number {
-    const [now, setNow] = useState(() => Date.now());
-    useEffect(() => {
-        if (!active) return;
-        const id = setInterval(() => setNow(Date.now()), 1000);
-        return () => clearInterval(id);
-    }, [active]);
-    return now;
-}
+import { AgentTranscriptModal } from '@/components/AgentTranscriptModal';
+import { WorkflowTaskSummary, WorkflowAgentsTable } from './WorkflowTaskSummary';
 
 function WorkflowTaskRow({
     task,
@@ -24,12 +15,14 @@ function WorkflowTaskRow({
     focused,
     onDismiss,
     onCancel,
+    onOpenTranscript,
 }: {
     task: WorkflowTask;
     now: number;
     focused: boolean;
     onDismiss: (toolUseId: string) => void;
     onCancel: (task: WorkflowTask) => void;
+    onOpenTranscript: (task: WorkflowTask) => void;
 }) {
     const ref = useRef<HTMLDivElement>(null);
     const { t } = useTranslation('chat');
@@ -38,20 +31,12 @@ function WorkflowTaskRow({
     }, [focused]);
 
     const isRunning = task.status === 'running';
-    const statusColor = WORKFLOW_STATUS_COLOR[task.status] || 'text-text-primary/60';
-    const agentCount = task.agents.length || task.usage?.agentCount;
-    const durationMs =
-        task.usage?.durationMs ?? (isRunning ? now - task.startedAt : undefined);
-    const duration = formatDuration(durationMs);
-    // Authoritative workflow-level total first; per-agent sum is only a fallback
-    // (see WorkflowRenderer) so the header stays consistent with the agent table.
-    const liveTokens = task.agents.reduce((sum, a) => sum + (a.tokens || 0), 0);
-    const tokens = formatTokens(task.usage?.subagentTokens || liveTokens);
 
     return (
         <div
             ref={ref}
-            className={`rounded-lg border bg-surface-base px-3 py-2.5 ${
+            onClick={() => onOpenTranscript(task)}
+            className={`rounded-lg border bg-surface-base px-3 py-2.5 cursor-pointer hover:border-border-focus transition-colors ${
                 focused ? 'border-border-focus' : 'border-border-subtle'
             }`}
         >
@@ -59,11 +44,14 @@ function WorkflowTaskRow({
                 <div className="min-w-0 flex-1 text-text-primary text-[0.9230rem] font-semibold truncate">
                     {task.name}
                 </div>
-                <span className={`text-[0.8461rem] shrink-0 ${statusColor}`}>{task.status}</span>
                 {/* Running: cancel the task (issue #330). Finished: it is over,
-                    so the same ✕ only takes the row out of the list. */}
+                    so the same ✕ only takes the row out of the list. stopPropagation
+                    keeps this from also opening the transcript modal (issue #347). */}
                 <button
-                    onClick={() => (isRunning ? onCancel(task) : onDismiss(task.toolUseId))}
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        isRunning ? onCancel(task) : onDismiss(task.toolUseId);
+                    }}
                     className="shrink-0 p-0.5 rounded hover:bg-surface-hover transition-colors"
                     title={isRunning ? t('backgroundTasks.cancelRunning') : t('backgroundTasks.dismiss')}
                 >
@@ -71,85 +59,25 @@ function WorkflowTaskRow({
                 </button>
             </div>
 
-            <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[0.8461rem] text-text-primary/60">
-                <span>{t('backgroundTasks.workflowLabel')}</span>
-                {agentCount !== undefined && (
-                    <>
-                        <span className="text-text-tertiary">·</span>
-                        <span>{t('backgroundTasks.agentsCount', { count: agentCount })}</span>
-                    </>
-                )}
-                {tokens && (
-                    <>
-                        <span className="text-text-tertiary">·</span>
-                        <span>{t('backgroundTasks.tokensLabel', { tokens })}</span>
-                    </>
-                )}
-                {duration && (
-                    <>
-                        <span className="text-text-tertiary">·</span>
-                        <span>{duration}</span>
-                    </>
-                )}
+            <div className="mt-0.5">
+                <WorkflowTaskSummary task={task} now={now} />
             </div>
 
-            {task.description && (
-                <div className="mt-1 text-[0.8461rem] text-text-primary/50">{task.description}</div>
-            )}
-
-            {task.phases.length > 0 && (
-                <div className="mt-2">
-                    <div className="text-[0.7692rem] uppercase tracking-wide text-text-tertiary mb-1">{t('backgroundTasks.phasesLabel')}</div>
-                    <div className="space-y-0.5">
-                        {task.phases.map((p, i) => (
-                            <div key={i} className="flex items-center gap-2 text-[0.8461rem] text-text-primary/70">
-                                <span className="inline-block w-1.5 h-1.5 rounded-full bg-text-tertiary" />
-                                <span className="truncate">{p.title}</span>
-                            </div>
-                        ))}
-                    </div>
-                </div>
-            )}
-
-            {task.agents.length > 0 && (
-                <div className="mt-2 overflow-x-auto no-scrollbar">
-                    <table className="w-full text-[0.8461rem] font-mono">
-                        <thead>
-                            <tr className="text-text-tertiary text-start">
-                                <th className="font-normal pb-1 pe-2">{t('backgroundTasks.tableHeader.agent')}</th>
-                                <th className="font-normal pb-1 px-2 text-end">{t('backgroundTasks.tableHeader.tokens')}</th>
-                                <th className="font-normal pb-1 px-2 text-end">{t('backgroundTasks.tableHeader.tools')}</th>
-                                <th className="font-normal pb-1 ps-2 text-end">{t('backgroundTasks.tableHeader.time')}</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            {task.agents.map((a) => (
-                                <tr key={a.agentId} className="text-text-primary/75">
-                                    <td className="py-0.5 pe-2 max-w-[10rem] truncate">
-                                        <span
-                                            className={`inline-block w-1.5 h-1.5 rounded-full me-1.5 align-middle ${agentDotClass(a.status)}`}
-                                        />
-                                        {a.label}
-                                    </td>
-                                    <td className="py-0.5 px-2 text-end">{formatTokens(a.tokens) ?? '0'}</td>
-                                    <td className="py-0.5 px-2 text-end">{a.tools}</td>
-                                    <td className="py-0.5 ps-2 text-end">{formatDuration(a.durationMs) ?? '—'}</td>
-                                </tr>
-                            ))}
-                        </tbody>
-                    </table>
-                </div>
-            )}
-
+            <WorkflowAgentsTable task={task} />
         </div>
     );
 }
 
 export function BackgroundTasksPanel() {
     const { t } = useTranslation('chat');
-    const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, dismissTask, focusedToolUseId } =
+    const { panelOpen, closePanel, runningTasks, finishedTasks, clearFinished, dismissTask, focusedToolUseId, getByToolUseId } =
         useWorkflowState();
     const [showFinished, setShowFinished] = useState(true);
+    // Store only the id and re-look-up the task each render, so the modal keeps
+    // showing the live WorkflowTask (updated agents/stats) as the workflow
+    // progresses instead of a frozen snapshot taken at click time (issue #347).
+    const [transcriptToolUseId, setTranscriptToolUseId] = useState<string | null>(null);
+    const transcriptTask = transcriptToolUseId ? getByToolUseId(transcriptToolUseId) ?? null : null;
     const panelRef = useRef<HTMLDivElement>(null);
     const now = useNow(panelOpen && runningTasks.length > 0);
 
@@ -209,6 +137,7 @@ export function BackgroundTasksPanel() {
                                     focused={task.toolUseId === focusedToolUseId}
                                     onDismiss={dismissTask}
                                     onCancel={cancelTask}
+                                    onOpenTranscript={(t) => setTranscriptToolUseId(t.toolUseId)}
                                 />
                             ))}
                         </section>
@@ -239,12 +168,17 @@ export function BackgroundTasksPanel() {
                                         focused={task.toolUseId === focusedToolUseId}
                                         onDismiss={dismissTask}
                                     onCancel={cancelTask}
+                                    onOpenTranscript={(t) => setTranscriptToolUseId(t.toolUseId)}
                                     />
                                 ))}
                         </section>
                     )}
                 </div>
             </div>
+
+            {transcriptTask && (
+                <AgentTranscriptModal task={transcriptTask} onClose={() => setTranscriptToolUseId(null)} />
+            )}
         </Portal>
     );
 }

--- a/webview/src/shared/message-type.ts
+++ b/webview/src/shared/message-type.ts
@@ -72,6 +72,16 @@ export enum MessageType {
   /** Rename a session's title. */
   RENAME_SESSION = 'RENAME_SESSION',
 
+  // -- Workflow agent transcripts (Background tasks detail modal) --
+  /** Load one workflow agent's full transcript (agent-<id>.jsonl under transcriptDir). inbound webview→backend */
+  GET_AGENT_TRANSCRIPT = 'GET_AGENT_TRANSCRIPT',
+  /** Subscribe to a background Bash task's raw output log (task_type 'local_bash', which has no agents) — the backend watches the file and pushes BACKGROUND_TASK_OUTPUT_CHANGED on every change, sending the current content immediately on subscribe. inbound webview→backend */
+  WATCH_BACKGROUND_TASK_OUTPUT = 'WATCH_BACKGROUND_TASK_OUTPUT',
+  /** Unsubscribe from a background Bash task's output log (e.g. the detail modal closed). inbound webview→backend */
+  UNWATCH_BACKGROUND_TASK_OUTPUT = 'UNWATCH_BACKGROUND_TASK_OUTPUT',
+  /** A watched background Bash task's output log changed on disk — carries the full current text. outbound backend→webview */
+  BACKGROUND_TASK_OUTPUT_CHANGED = 'BACKGROUND_TASK_OUTPUT_CHANGED',
+
   // -- IDE settings (terminal/theme/etc., ~/.claude GUI settings) --
   /** Read merged or scope-specific GUI settings. */
   GET_SETTINGS = 'GET_SETTINGS',

--- a/webview/src/shared/workflow.ts
+++ b/webview/src/shared/workflow.ts
@@ -33,12 +33,23 @@ export interface WorkflowUsage {
   durationMs?: number;
 }
 
-/** Live + final state of a single background dynamic workflow. */
+/**
+ * CLI's `task_type` for a background task: a dynamic Workflow-tool run
+ * (`local_workflow`, has agents/phases/transcriptDir) or a plain background
+ * Bash command (`local_bash`, has only an output log — no agents). The
+ * Background tasks panel shows both under one list; the detail view branches
+ * on this to show agent transcripts vs. the raw output log (issue #347).
+ */
+export type BackgroundTaskType = 'local_workflow' | 'local_bash';
+
+/** Live + final state of a single background task (dynamic workflow or plain Bash). */
 export interface WorkflowTask {
   /** Workflow tool_use id — the stable key correlating card, panel and events. */
   toolUseId: string;
   /** Background task id (e.g. "w94mspihl") from the immediate tool_result. */
   taskId?: string;
+  /** CLI's task_type; undefined for tasks reconstructed before this field existed. */
+  taskType?: BackgroundTaskType;
   /** Workflow run id (e.g. "wf_ce882bfa-ddf"), the transcript dir basename. */
   workflowId?: string;
   name: string;


### PR DESCRIPTION
## Summary
- Clicking a row in the Background tasks panel now opens a detail modal instead of leaving prompts, tool calls, and per-agent progress only inferable from the summary card.
- Workflow tasks get a per-agent transcript picker that reuses the main chat's own message renderers (tool calls render exactly as they do in the primary conversation).
- Plain background Bash tasks get a live, terminal-styled output pane. The backend pushes updates via `fs.watch` instead of the webview polling, so it stays in sync with the file on disk without a timer.
- The modal is resizable via a drag handle (`calc(60vh + offset)`, so it still scales with the window) and always shows every stat the summary card carries — status, agent count/tokens/time, description, phases — so opening it never loses information the collapsed row already had.

Fixes #347

## Test plan
- [x] `be-build`, `be-test` (132 files / 1462 passed, 8 skipped)
- [x] `wv-lint`, `wv-build`, `wv-test` (276 files / 2602 passed)
- [x] Manually ran a `local_bash` background task and confirmed the modal shows live output while running, not just after completion
- [x] Manually ran a 2-agent parallel workflow and confirmed both agent tabs render their real transcripts (prompt, tool calls, progress)
- [x] Verified the resize handle no longer closes the modal when a drag ends off the thin handle (was landing a synthesized click on the click-outside-to-close overlay)