### PR TITLE
fix: the misbehaviours introduced in v0.29.0

### DIFF
--- a/backend/src/core/claude-process.ts
+++ b/backend/src/core/claude-process.ts
@@ -8,6 +8,7 @@ import { WorkflowProgressTracker } from './features/workflow-tracker';
 import { isWslUncPath } from './wsl-path';
 import { reportBackendError } from './features/telemetry';
 import { restoreSchedulesForSession } from './features/scheduled-messages';
+import { takeMessagesForFinishedTurn, clearMessagesForSession } from './features/afterTurn';
 import {
   openDiffForPermission,
   openDiffTabForPermission,
@@ -493,6 +494,11 @@ export async function ensureClaudeProcess(
     try {
       console.error('[node-backend]', `Claude CLI process exited with code: ${code}`);
 
+      // Nothing held for this session will ever be delivered now — there is no
+      // turn left to end. Dropped rather than kept, so it cannot surface in
+      // whatever session reuses the id.
+      clearMessagesForSession(targetSessionId);
+
       // We killed this process ourselves to respawn it under a new permission mode.
       // The user asked to switch modes, not to end anything, and a replacement CLI is
       // already being spawned — so skip the failure reporting and the STREAM_END that
@@ -968,6 +974,39 @@ function handleStreamEvent(
     const errorData = event.error as { message?: string } | null;
     if (errorData?.message) {
       diagnoseAuthError(targetSessionId, errorData.message, connections).catch(() => {});
+    }
+
+    /*
+     * Anything that had to wait for this turn to end — see afterTurn.
+     *
+     * Sent here and nowhere earlier: the CLI clears its own pending-message
+     * queue as a turn finishes, so a message written to stdin while the turn
+     * was still running is discarded rather than delivered. This is the first
+     * moment at which an ordinary user message would survive.
+     */
+    for (const content of takeMessagesForFinishedTurn(targetSessionId)) {
+      const sent = sendMessageToProcess(connections, targetSessionId, content);
+      /*
+       * Told to the chat as well as to the CLI, the way an ordinary user
+       * message is (see sendMessage: it writes to stdin AND broadcasts).
+       *
+       * Writing to stdin alone puts the message in the transcript and in front
+       * of the model, but NOT in the chat's own list: the CLI does not echo
+       * user messages back on stdout — measured, only `tool_result` entries
+       * come back that way — so the webview never learns about anything it did
+       * not send itself. The reminder was reaching Claude and staying invisible
+       * to the session it belonged to.
+       */
+      if (sent) {
+        connections.broadcastToSession(targetSessionId, MessageType.USER_MESSAGE_BROADCAST, {
+          content,
+          sessionId: targetSessionId,
+        });
+      }
+      console.error(
+        '[node-backend]',
+        `Held message for ${targetSessionId} after turn: ${sent ? 'sent' : 'FAILED to send'}`,
+      );
     }
   }
 

--- a/backend/src/core/features/__tests__/afterTurn.test.ts
+++ b/backend/src/core/features/__tests__/afterTurn.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Messages held until a turn ends.
+ *
+ * The reason this exists is measured, not assumed: the CLI enqueues a user
+ * message that arrives mid-turn and then REMOVES it as the turn finishes, so
+ * anything sent alongside a permission answer is discarded. The edit notice
+ * went enqueue → remove in 183ms while the same session's ordinary message went
+ * enqueue → dequeue, and the model never read it.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  sendAfterTurn,
+  takeMessagesForFinishedTurn,
+  clearMessagesForSession,
+  clearAllPendingMessages,
+} from '../afterTurn';
+
+beforeEach(() => clearAllPendingMessages());
+
+describe('holding a message for the end of a turn', () => {
+  it('hands it back when the turn is reported finished', () => {
+    sendAfterTurn('sess-1', 'notice');
+
+    expect(takeMessagesForFinishedTurn('sess-1')).toEqual(['notice']);
+  });
+
+  it('hands back nothing for a session that queued nothing', () => {
+    // Every turn end asks, and almost none of them have anything waiting.
+    expect(takeMessagesForFinishedTurn('sess-quiet')).toEqual([]);
+  });
+
+  it('hands each message back once', () => {
+    // The queue is drained, not read: a notice delivered twice would have the
+    // model correct itself a second time for an edit it already knows about.
+    sendAfterTurn('sess-1', 'notice');
+    takeMessagesForFinishedTurn('sess-1');
+
+    expect(takeMessagesForFinishedTurn('sess-1')).toEqual([]);
+  });
+
+  it('keeps the order they were queued in', () => {
+    // Two answers in one turn — a diff resolved twice before the CLI reports
+    // back — read in the order the reviewer gave them.
+    sendAfterTurn('sess-1', 'first');
+    sendAfterTurn('sess-1', 'second');
+
+    expect(takeMessagesForFinishedTurn('sess-1')).toEqual(['first', 'second']);
+  });
+
+  it('keeps sessions apart', () => {
+    // Two reviews in two sessions at once: one turn ending must not deliver the
+    // other session's notice into it.
+    sendAfterTurn('sess-1', 'for one');
+    sendAfterTurn('sess-2', 'for two');
+
+    expect(takeMessagesForFinishedTurn('sess-1')).toEqual(['for one']);
+    expect(takeMessagesForFinishedTurn('sess-2')).toEqual(['for two']);
+  });
+
+  it('drops what a dead session was holding', () => {
+    // No turn will ever end for it. Kept, the notice would surface in whatever
+    // session reuses the id — a correction about an edit made somewhere else.
+    sendAfterTurn('sess-1', 'notice');
+
+    clearMessagesForSession('sess-1');
+
+    expect(takeMessagesForFinishedTurn('sess-1')).toEqual([]);
+  });
+});

--- a/backend/src/core/features/__tests__/editedProposalNotice.test.ts
+++ b/backend/src/core/features/__tests__/editedProposalNotice.test.ts
@@ -57,8 +57,13 @@ describe('buildEditedProposalNotice', () => {
   });
 
   it('stays far smaller than quoting the proposal twice', () => {
+    // Measured on the QUOTED CHANGE, not the whole notice. The instructions
+    // around it are a fixed cost that does not grow with the file, and folding
+    // them into this budget would make a two-line correction to a short file
+    // look like a regression in how much the diff quotes.
     const notice = buildEditedProposalNotice({ oldText: proposed, newText: applied })!;
-    expect(notice.length).toBeLessThan(proposed.length * 2);
+    const quoted = notice.split('```diff')[1].split('```')[0];
+    expect(quoted.length).toBeLessThan(proposed.length * 2);
   });
 
   it('is wrapped so the chat never shows it', () => {
@@ -67,10 +72,25 @@ describe('buildEditedProposalNotice', () => {
     expect(notice.trimEnd().endsWith('</system-reminder>')).toBe(true);
   });
 
-  it('asks for silence, and names the one reply worth making', () => {
+  it('asks for silence about the notice itself', () => {
     const notice = buildEditedProposalNotice({ oldText: 'a\n', newText: 'b\n' })!;
     expect(notice).toContain('Do not explain or ask about this notice.');
-    expect(notice).toContain('I have taken your edits into account.');
+  });
+
+  it('tells the assistant to revisit what it said before the edit', () => {
+    // Acknowledging is not enough: the reply that came BEFORE this notice may
+    // describe a change that was never applied, so the assistant is sent back
+    // to read what actually landed rather than moving on.
+    const notice = buildEditedProposalNotice({ oldText: 'a\n', newText: 'b\n' })!;
+    expect(notice).toContain('may not match');
+    expect(notice).toContain('review the actual edits');
+  });
+
+  it('asks for that acknowledgement in the user\'s own language', () => {
+    // A fixed English sentence answered a Korean user in English. The reply is
+    // the user's to read, so it follows their language, not the notice's.
+    const notice = buildEditedProposalNotice({ oldText: 'a\n', newText: 'b\n' })!;
+    expect(notice).toContain("THE USER'S OWN LANGUAGE");
   });
 
   it('still says something when the whole file was replaced', () => {

--- a/backend/src/core/features/__tests__/partialApproval.test.ts
+++ b/backend/src/core/features/__tests__/partialApproval.test.ts
@@ -182,3 +182,54 @@ describe('buildPartialApproval with an edited proposal', () => {
   });
 });
 
+
+describe('an edited proposal together with a hunk selection', () => {
+  const oldContent = 'a\nb\nc\nd\n';
+  const newContent = 'A\nb\nC\nd\n'; // two separate changes: line 1 and line 3
+
+  const preview = {
+    toolName: 'Write',
+    filePath: '/tmp/f.txt',
+    oldContent,
+    newContent,
+    input: { file_path: '/tmp/f.txt', content: newContent },
+  } as never;
+
+  /** Keep only the first change (line 1), deny the second (line 3). */
+  const firstOnly = [{ oldStart: 0, oldEnd: 1, newStart: 0, newEnd: 1 }];
+
+  it('honours the denial while taking the edit', () => {
+    // The bug: the edited text was used wholesale, so a hunk the reviewer had
+    // denied got written anyway — silently, with nothing on screen to say so.
+    const editedContent = 'EDITED\nb\nC\nd\n';
+
+    const result = buildPartialApproval(preview, firstOnly, editedContent);
+
+    // Line 1 comes from the edit; line 3 stays as it is on disk.
+    expect(result?.content).toBe('EDITED\nb\nc\nd\n');
+  });
+
+  it('carries the resulting file, not just the amended input', () => {
+    // What Claude is told about is the result, and an Edit's input only carries
+    // the region that changed.
+    const result = buildPartialApproval(preview, firstOnly, 'EDITED\nb\nC\nd\n');
+
+    expect(result?.content).toBe('EDITED\nb\nc\nd\n');
+  });
+
+  it('falls back to the whole edited text when the line count changed', () => {
+    // Ranges address proposal line numbers; an added line moves every one of
+    // them, and guessing where a boundary went is worse than taking the text.
+    const withExtraLine = 'A\nEXTRA\nb\nC\nd\n';
+
+    const result = buildPartialApproval(preview, firstOnly, withExtraLine);
+
+    expect(result?.content).toBe(withExtraLine);
+  });
+
+  it('still applies the picking when nothing was typed', () => {
+    const result = buildPartialApproval(preview, firstOnly, undefined);
+
+    expect(result?.content).toBe('A\nb\nc\nd\n');
+  });
+});

--- a/backend/src/core/features/__tests__/resolveDiff.test.ts
+++ b/backend/src/core/features/__tests__/resolveDiff.test.ts
@@ -14,7 +14,20 @@ vi.mock('../../claude-process', () => ({
 }));
 
 import { parseResolveDiffParams, resolveDiffReview } from '../resolveDiff';
+import { takeMessagesForFinishedTurn, clearAllPendingMessages } from '../afterTurn';
 import { rememberPreview, clearPreviews, takePreview } from '../diffPreview';
+
+/**
+ * What Claude was told, read from where it now waits.
+ *
+ * The notice is HELD until the turn ends rather than written to stdin straight
+ * away — the CLI discards user messages queued mid-turn (see afterTurn), and
+ * answering a permission request is always mid-turn. So the assertion is on
+ * what is waiting for that session, not on a stdin call.
+ */
+function noticesFor(sessionId: string): string[] {
+  return takeMessagesForFinishedTurn(sessionId);
+}
 import { computeHunks, type AcceptedRange } from '../hunks';
 import { USER_DECLINED_PREFIX } from '../../../shared';
 
@@ -45,6 +58,7 @@ function pending(toolUseId: string) {
 beforeEach(() => {
   sendControlResponseToProcess.mockClear();
   sendMessageToProcess.mockClear();
+  clearAllPendingMessages();
   clearPreviews();
 });
 
@@ -235,34 +249,39 @@ describe('resolveDiffReview', () => {
       acceptedRanges: [R_DEBUG, R_TIMEOUT], editedContent: typed,
     });
 
-    expect(sendMessageToProcess).toHaveBeenCalledTimes(1);
-    const [, sessionId, text] = sendMessageToProcess.mock.calls[0];
+    const held = noticesFor('sess-1');
+    expect(held).toHaveLength(1);
+    const sessionId = 'sess-1';
+    const text = held[0];
     expect(sessionId).toBe('sess-1');
     // Hidden from the chat: our webview strips this tag before rendering.
     expect(text).toContain('<system-reminder>');
     expect(text).toContain('The user edited your proposed change');
     // Quotes the applied text rather than summarising it.
     expect(text).toContain('debug: MAYBE');
-    expect(text).toContain('I have taken your edits into account.');
+    // And sends the assistant back to what it said before the edit, rather than
+    // letting it acknowledge the notice and move on.
+    expect(text).toContain('review the actual edits');
   });
 
-  it('sends the reminder only after the request has been answered', () => {
-    // Arriving while the CLI waits on the control_response would read as an
-    // answer to a different question.
+  it('answers the request now and holds the reminder for later', () => {
+    // The control_response cannot wait — the CLI is blocked on it. The notice
+    // must, because a user message written while that turn finishes is enqueued
+    // by the CLI and then dropped as it clears the queue (measured).
     pending('t-order');
     const typed = original.replace('debug: false', 'debug: MAYBE');
-    const order: string[] = [];
-    sendControlResponseToProcess.mockImplementation(() => order.push('control_response'));
-    sendMessageToProcess.mockImplementation(() => order.push('reminder'));
 
     resolveDiffReview(connections(), {
       toolUseId: 't-order', controlRequestId: 'ctrl-1', sessionId: 'sess-1',
       acceptedRanges: [R_DEBUG], editedContent: typed,
     });
 
-    expect(order).toEqual(['control_response', 'reminder']);
-    sendControlResponseToProcess.mockReset();
-    sendMessageToProcess.mockReset();
+    // Answered immediately...
+    expect(sendControlResponseToProcess).toHaveBeenCalled();
+    // ...and nothing written to stdin as a user message in the same breath.
+    expect(sendMessageToProcess).not.toHaveBeenCalled();
+    // The notice is waiting for the turn to end.
+    expect(noticesFor('sess-1')).toHaveLength(1);
   });
 
   it('reports only what the reviewer changed about the proposal', () => {
@@ -276,23 +295,24 @@ describe('resolveDiffReview', () => {
       acceptedRanges: [R_DEBUG, R_TIMEOUT], editedContent: typed,
     });
 
-    const [, , text] = sendMessageToProcess.mock.calls[0];
+    const text = noticesFor('sess-1')[0];
     expect(text).toContain('debug: MAYBE');
     // The untouched lines of the proposal stay out of it.
     expect(text).not.toContain('pad-4');
     expect(text).not.toContain('timeout: 60');
   });
 
-  it('says nothing when the reviewer only picked hunks', () => {
-    // Picking hunks changes how much of the proposal lands, not what it says,
-    // so the model can still describe its own proposal truthfully.
+  it('reports a partial accept, where less landed than was proposed', () => {
+    // Silence here left Claude believing the whole change was written, and the
+    // next turn was built on a file that does not exist. Telling it is the rule;
+    // saying nothing is the exception, and the exception is a FULL accept.
     pending('t-quiet');
     resolveDiffReview(connections(), {
       toolUseId: 't-quiet', controlRequestId: 'ctrl-1', sessionId: 'sess-1',
       acceptedRanges: [R_DEBUG],
     });
 
-    expect(sendMessageToProcess).not.toHaveBeenCalled();
+    expect(noticesFor('sess-1')).toHaveLength(1);
   });
 
   it('says nothing when an edit reproduced the proposal', () => {
@@ -303,7 +323,7 @@ describe('resolveDiffReview', () => {
       acceptedRanges: [R_DEBUG, R_TIMEOUT], editedContent: proposed,
     });
 
-    expect(sendMessageToProcess).not.toHaveBeenCalled();
+    expect(noticesFor('sess-1')).toHaveLength(0);
   });
 
   it('says nothing when the reviewer rejected the change', () => {
@@ -313,7 +333,7 @@ describe('resolveDiffReview', () => {
       acceptedRanges: [], editedContent: original,
     });
 
-    expect(sendMessageToProcess).not.toHaveBeenCalled();
+    expect(noticesFor('sess-1')).toHaveLength(0);
   });
 
   it('quotes the request id the CLI is waiting on', () => {

--- a/backend/src/core/features/afterTurn.ts
+++ b/backend/src/core/features/afterTurn.ts
@@ -1,0 +1,66 @@
+/**
+ * Messages that must reach Claude, but only once the turn they belong to is
+ * over.
+ *
+ * The CLI keeps a queue of its own for user messages that arrive mid-turn, and
+ * it EMPTIES that queue when the turn ends rather than delivering what is in it.
+ * Measured on a real session: the edit notice was written to stdin at .477,
+ * enqueued by the CLI at .586, and removed at .769 — while the same session's
+ * ordinary user message went `enqueue` → `dequeue`. So a message sent during a
+ * turn is not merely late; it is dropped, and nothing reports that it was.
+ *
+ * Answering a permission request is exactly that moment: the reviewer's answer
+ * arrives while the CLI is still finishing the turn that asked, so anything
+ * sent alongside the `control_response` lands in the queue that is about to be
+ * cleared.
+ *
+ * Holding it here until the CLI reports `result` puts it on the far side of
+ * that cleanup, where an ordinary user message would be.
+ */
+
+/** Messages waiting for their session's current turn to finish. */
+const pending = new Map<string, string[]>();
+
+/**
+ * Hold [content] until [sessionId]'s current turn ends, then send it.
+ *
+ * Queued rather than sent even when no turn appears to be running: "appears" is
+ * the whole difficulty — the answer to a permission request is given while the
+ * CLI is mid-turn by definition, and the streaming flag has already been
+ * cleared by then on some paths. Waiting for the next `result` is the one
+ * signal that means the CLI is done with the queue.
+ */
+export function sendAfterTurn(sessionId: string, content: string): void {
+  const queue = pending.get(sessionId);
+  if (queue) queue.push(content);
+  else pending.set(sessionId, [content]);
+}
+
+/**
+ * Everything held for [sessionId], in the order it was queued, and clear it.
+ *
+ * Called when the CLI reports `result` for that session. Returns an empty array
+ * when nothing was waiting, which is the ordinary case.
+ */
+export function takeMessagesForFinishedTurn(sessionId: string): string[] {
+  const queue = pending.get(sessionId);
+  if (!queue) return [];
+  pending.delete(sessionId);
+  return queue;
+}
+
+/**
+ * Drop anything held for [sessionId] without sending it.
+ *
+ * For a session that ends before its turn reports a result — the process died,
+ * or the user closed it. Holding the message would leak it into whatever
+ * session reuses the id.
+ */
+export function clearMessagesForSession(sessionId: string): void {
+  pending.delete(sessionId);
+}
+
+/** Test seam: forget every held message. */
+export function clearAllPendingMessages(): void {
+  pending.clear();
+}

--- a/backend/src/core/features/editedProposalNotice.ts
+++ b/backend/src/core/features/editedProposalNotice.ts
@@ -53,11 +53,20 @@ export function buildEditedProposalNotice(change: EditedProposalChange | null): 
     '```',
     '',
     // Without this the assistant tends to narrate the correction back, which
-    // reads as a second answer to a question already settled. Given that a
-    // reply may come anyway, the wording steers it to one that is at least
-    // true and short.
-    'Do not explain or ask about this notice. If you must reply at all, say only',
-    '"I have taken your edits into account." — otherwise continue without comment.',
+    // reads as a second answer to a question already settled.
+    'Do not explain or ask about this notice.',
+    '',
+    // The previous wording stopped at "say only <one fixed English sentence>",
+    // which left two things wrong. It answered in English to a user writing in
+    // another language, and it treated the notice as something to acknowledge
+    // and move past — while the reply that PRECEDED it may now be describing an
+    // edit that was never applied. Acknowledging is not enough; the assistant
+    // has to go back and read what actually landed.
+    'If the user did not approve your proposal as-is but applied it with edits of',
+    'their own, then what you said in your previous response may not match the',
+    'change that was actually approved. In that case, send the message',
+    '"I will check the additional edits you made." in THE USER\'S OWN LANGUAGE,',
+    'and then review the actual edits where they differ from what you proposed.',
   ].join('\n');
 
   return `<system-reminder>\n${body}\n</system-reminder>`;

--- a/backend/src/core/features/partialApproval.ts
+++ b/backend/src/core/features/partialApproval.ts
@@ -21,6 +21,15 @@ import type { StoredPreview } from './diffPreview';
 export interface PartialApproval {
   /** The amended input to hand back as `updatedInput`, in the tool's own shape. */
   input: Record<string, unknown>;
+  /**
+   * The whole file as it will end up, which the amended input only describes in
+   * part — an Edit carries the changed region, not the result.
+   *
+   * Carried out because what Claude has to be told about is the result, and
+   * re-deriving it from an `old_string`/`new_string` pair outside would be
+   * reconstructing what was already computed here.
+   */
+  content: string;
 }
 
 /**
@@ -31,19 +40,50 @@ export interface PartialApproval {
  * Claude's own input already says it. Rejecting everything is NOT expressed
  * here — that is a denial, and denying is the caller's job.
  *
- * [editedContent], when given, is the reviewer's own text for the whole file
- * and replaces the reassembly entirely (#305).
+ * [editedContent], when given, is the reviewer's own text for the proposed side
+ * (#305). It replaces the proposal, NOT the picking: the hunks the reviewer
+ * denied stay denied, and the ones they kept are taken from the edited text.
  */
 export function buildPartialApproval(
   preview: StoredPreview,
   accepted: readonly AcceptedRange[],
   editedContent?: string,
 ): PartialApproval | null {
-  // What the reviewer edited outranks what was proposed (#305). The viewer's
-  // text IS the answer: hunk ranges describe the proposal it started from, so
-  // reassembling from them would discard whatever was typed over it.
-  const content =
-    editedContent ?? applyAcceptedRanges(preview.oldContent, preview.newContent, accepted);
+  /*
+   * Both answers, not one of them.
+   *
+   * The reviewer's text supersedes the proposal, so it is what the accepted
+   * regions are read from — but which regions those are is still the picking's
+   * to say. Taking the edited text wholesale ignored every Deny: a reviewer who
+   * refused one hunk and corrected a typo in another got BOTH written, silently.
+   *
+   * The ranges address lines on the proposed side, so they only survive an edit
+   * that leaves the line count alone (a typo, a changed constant — what this
+   * feature is for). An edit that adds or removes lines shifts every range after
+   * it, and there is no honest way to re-derive where a hunk boundary moved to;
+   * there the text is the whole answer, which is what it was before ranges
+   * entered the picture.
+   */
+  const proposedSide = editedContent ?? preview.newContent;
+
+  /*
+   * Reassemble by range only when the ranges can still be trusted to say where
+   * the reviewer's text belongs. Two cases where they cannot:
+   *
+   *  - The edit changed the line count, so every range after the insertion
+   *    addresses a line that moved.
+   *  - Nothing was ticked at all, yet something was typed. Reassembling from an
+   *    empty list yields the file untouched and drops the edit silently; an
+   *    edit with no picking is a whole-file answer, which is what it was before
+   *    ranges entered the picture.
+   */
+  const rangesStillApply =
+    editedContent === undefined ||
+    (accepted.length > 0 && lineCount(editedContent) === lineCount(preview.newContent));
+
+  const content = rangesStillApply
+    ? applyAcceptedRanges(preview.oldContent, proposedSide, accepted)
+    : proposedSide;
   if (content === null) return null;
 
   // Keeping everything reproduces the proposal, so let the original call
@@ -53,7 +93,7 @@ export function buildPartialApproval(
 
   // Write already states the whole file, so the subset just replaces it.
   if (preview.toolName === 'Write') {
-    return { input: { ...preview.input, content } };
+    return { input: { ...preview.input, content }, content };
   }
 
   // Edit and MultiEdit must stay in Edit shape (see the module note). Narrow
@@ -70,6 +110,7 @@ export function buildPartialApproval(
       new_string: pair.newText,
       replace_all: false,
     },
+    content,
   };
 }
 
@@ -117,3 +158,10 @@ export function narrowToDifference(
   return { oldText, newText };
 }
 
+
+/** Lines in [text], counting the way AcceptedRange coordinates do. */
+function lineCount(text: string): number {
+  if (text === '') return 0;
+  const withoutTrailing = text.endsWith('\n') ? text.slice(0, -1) : text;
+  return withoutTrailing.split('\n').length;
+}

--- a/backend/src/core/features/resolveDiff.ts
+++ b/backend/src/core/features/resolveDiff.ts
@@ -22,7 +22,8 @@ import type { Bridge } from '../../bridge/bridge-interface';
 import { buildPartialApproval, narrowToDifference } from './partialApproval';
 import { buildEditedProposalNotice, type EditedProposalChange } from './editedProposalNotice';
 import type { AcceptedRange } from './hunks';
-import { sendControlResponseToProcess, sendMessageToProcess } from '../claude-process';
+import { sendControlResponseToProcess } from '../claude-process';
+import { sendAfterTurn } from './afterTurn';
 
 export interface ResolveDiffParams {
   toolUseId: string;
@@ -115,6 +116,13 @@ export function resolveDiffReview(
   // answered). Let it through as an ordinary approval rather than inventing a
   // decision the user did not make.
   if (!preview) {
+    // Logged because everything downstream — the picking, the edit, the notice
+    // to Claude — depends on this being present, and its absence is silent
+    // otherwise: the write goes through as proposed and nothing says why.
+    console.error(
+      '[node-backend]',
+      `Diff resolved for ${params.toolUseId}: no stored preview, letting the original call through`,
+    );
     respond({ behavior: 'allow', updatedInput: {} });
     notifyResolved(connections, params);
     return;
@@ -145,35 +153,56 @@ export function resolveDiffReview(
 
   notifyResolved(connections, params);
 
-  // Only for an edit. A hunk selection changes how much of the proposal lands,
-  // not what it says, and the model can still describe its own proposal
-  // truthfully; typing over it makes that description wrong.
-  //
-  // Measured before this existed: the model went on reporting the value it had
-  // proposed (20000) after the reviewer applied 15000. With the reminder it
-  // reports 15000, which is what is on disk.
-  if (edited !== undefined) {
-    tellClaudeAboutTheEdit(connections, params.sessionId, preview, edited);
+  /*
+   * Told whenever what landed is not what was proposed — edited, picked, or
+   * both. Silence is the exception, and it has exactly one case: the whole
+   * proposal went in untouched, where Claude's own account of it is already
+   * true.
+   *
+   * `amended` is that test, and a precise one: buildPartialApproval returns
+   * null when the answer reproduces the proposal exactly, and an input to send
+   * in its place otherwise. So it is null on a full accept, and on an edit that
+   * was typed and then undone.
+   *
+   * Reporting only edits was too narrow. A reviewer who denies half a change
+   * leaves Claude believing all of it was written, and the next turn is built
+   * on a file that does not exist — measured with an edit before this existed:
+   * the model kept reporting the value it had proposed (20000) after the
+   * reviewer applied 15000, and a denied hunk is the same mistake in a form
+   * nothing corrected.
+   */
+  if (amended !== null) {
+    tellClaudeAboutTheEdit(connections, params.sessionId, preview, amended.content);
   }
 }
 
 /**
- * Send the reminder about a corrected proposal, once the request itself has
- * been answered.
+ * Report a corrected proposal to Claude, once the turn that proposed it is over.
  *
- * After, never before: the CLI is waiting on the control_response, and a user
- * message that arrives while it waits would be read as an answer to a different
- * question.
+ * Held rather than sent (see afterTurn). Answering a permission request happens
+ * mid-turn by definition — the CLI is blocked on the control_response — and the
+ * CLI clears its pending-message queue as that turn ends, so a notice written
+ * to stdin now is enqueued and then discarded. Measured: written at .477,
+ * enqueued at .586, removed at .769, while an ordinary user message in the same
+ * session went enqueue → dequeue. The model never read it, and went on
+ * describing the value it had proposed rather than the one the reviewer applied.
  */
 function tellClaudeAboutTheEdit(
-  connections: ConnectionManager,
+  _connections: ConnectionManager,
   sessionId: string,
   preview: StoredPreview,
   applied: string,
 ): void {
   const notice = buildEditedProposalNotice(describeCorrection(preview.newContent, applied));
-  if (!notice) return;
-  sendMessageToProcess(connections, sessionId, notice);
+  if (!notice) {
+    // Nothing to report means the applied text matched the proposal exactly.
+    // Logged because "the reminder never arrived" and "there was nothing to
+    // say" look identical from the chat, and only one of them is a bug.
+    console.error('[node-backend]', `Edit notice for ${sessionId}: nothing to report`);
+    return;
+  }
+  sendAfterTurn(sessionId, notice);
+  console.error('[node-backend]', `Edit notice for ${sessionId}: held until the turn ends`);
 }
 
 /**

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -368,6 +368,13 @@ async function main() {
       console.error('[node-backend]', 'RESOLVE_DIFF ignored: malformed params');
       return;
     }
+    // Logged like the webview's own handler does. Without it the two answering
+    // paths are indistinguishable in the log, and "the IDE never sent it" reads
+    // the same as "the backend dropped it".
+    console.error(
+      '[node-backend]',
+      `Received: RESOLVE_DIFF from the IDE (session=${parsed.sessionId}, edited=${parsed.editedContent !== undefined})`,
+    );
     resolveDiffReview(connections, parsed, jetbrainsBridge);
   });
 

--- a/webview/src/App.tsx
+++ b/webview/src/App.tsx
@@ -12,6 +12,7 @@ import { usePairingStatus } from './hooks/usePairingStatus';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { useKeyboardShortcuts } from './hooks/useKeyboardShortcuts';
 import { useZoomControls } from './hooks/useZoomControls';
+import { useCaretBoundaryKeys } from './hooks/useCaretBoundaryKeys';
 import { ZoomIndicator } from './components/ZoomIndicator';
 import { usePanelFocusReporter } from './hooks/usePanelFocusReporter';
 import { useSettingsOverlayNavigation } from './hooks/useSettingsOverlayNavigation';
@@ -24,6 +25,9 @@ function AppContent() {
   useKeyboardShortcuts();
   // CmdOrCtrl +/-/0 and CmdOrCtrl + wheel scale the whole UI (issue #169).
   useZoomControls();
+  // Cmd+Arrow moves the caret to the line's or text's edge in every text field.
+  // JCEF's off-screen rendering drops the macOS binding these keys rely on.
+  useCaretBoundaryKeys();
   // Tell the backend which panel is active so panel-scoped pushes route here.
   usePanelFocusReporter();
   // Lets non-React callers (toasts, palette items) open settings as an overlay.

--- a/webview/src/hooks/__tests__/useCaretBoundaryKeys.test.tsx
+++ b/webview/src/hooks/__tests__/useCaretBoundaryKeys.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useCaretBoundaryKeys } from '../useCaretBoundaryKeys';
+
+vi.mock('@/config/environment', () => ({ isMac: () => true }));
+
+/**
+ * Cmd+Arrow has to work in every text field, not just the composer: under JCEF's
+ * off-screen rendering the macOS binding is missing app-wide, and the first fix
+ * for it reached the chat input alone — leaving the session search, the settings
+ * fields and everything else still stuck.
+ *
+ * `<input>`/`<textarea>` are the half that can be asserted in jsdom, since their
+ * selection is character offsets rather than a laid-out Selection.
+ */
+describe('useCaretBoundaryKeys', () => {
+  let field: HTMLInputElement;
+
+  beforeEach(() => {
+    renderHook(() => useCaretBoundaryKeys());
+    field = document.createElement('input');
+    field.value = 'hello world';
+    document.body.appendChild(field);
+    field.focus();
+  });
+
+  afterEach(() => {
+    field.remove();
+  });
+
+  function pressOn(target: HTMLElement, key: string, mods: { shiftKey?: boolean; altKey?: boolean } = {}) {
+    const event = new KeyboardEvent('keydown', {
+      key,
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      ...mods,
+    });
+    target.dispatchEvent(event);
+    return event;
+  }
+
+  it('sends the caret to the start of an input', () => {
+    field.setSelectionRange(7, 7);
+
+    const event = pressOn(field, 'ArrowLeft');
+
+    expect(field.selectionStart).toBe(0);
+    expect(field.selectionEnd).toBe(0);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('sends the caret to the end of an input', () => {
+    field.setSelectionRange(3, 3);
+
+    pressOn(field, 'ArrowRight');
+
+    expect(field.selectionStart).toBe('hello world'.length);
+  });
+
+  it('selects up to the edge when Shift is held', () => {
+    field.setSelectionRange(6, 6);
+
+    pressOn(field, 'ArrowLeft', { shiftKey: true });
+
+    // The anchor stays where the user started; the caret end travels.
+    expect(field.selectionStart).toBe(0);
+    expect(field.selectionEnd).toBe(6);
+  });
+
+  it('leaves Option+Arrow to the browser', () => {
+    field.setSelectionRange(6, 6);
+
+    const event = pressOn(field, 'ArrowLeft', { altKey: true });
+
+    // Word-wise movement is Chromium's own and still works under OSR, so this
+    // must pass through untouched rather than jumping to the line edge.
+    expect(event.defaultPrevented).toBe(false);
+    expect(field.selectionStart).toBe(6);
+  });
+
+  it('ignores keystrokes that did not land in a text field', () => {
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    const event = pressOn(button, 'ArrowLeft');
+
+    expect(event.defaultPrevented).toBe(false);
+    button.remove();
+  });
+
+  it('stops a hard newline from being crossed in a textarea', () => {
+    const area = document.createElement('textarea');
+    area.value = 'first line\nsecond line';
+    document.body.appendChild(area);
+    area.setSelectionRange(17, 17); // inside "second line"
+
+    pressOn(area, 'ArrowLeft');
+
+    // The start of the line the caret is on, not the start of the whole value.
+    expect(area.selectionStart).toBe('first line\n'.length);
+    area.remove();
+  });
+});

--- a/webview/src/hooks/useCaretBoundaryKeys.ts
+++ b/webview/src/hooks/useCaretBoundaryKeys.ts
@@ -1,0 +1,109 @@
+import { useEffect } from 'react';
+import { isMac } from '@/config/environment';
+import { typingTargetOf } from '@/utils/typingTarget';
+import { CaretBoundary, CaretDirection, moveCaretToBoundary } from '@/utils/domSelection';
+import { caretBoundaryMoveFor } from '@/utils/caretBoundaryKey';
+
+/**
+ * Cmd+Arrow caret movement for every text field in the app, on macOS.
+ *
+ * Under JCEF's off-screen rendering — the default since IDE 2025.1, so what
+ * most users are on — Chromium performs no such move. On macOS these are not
+ * Chromium's own shortcuts: they arrive as NSResponder selectors
+ * (`moveToBeginningOfLine:` and friends) that the OS sends to a native view,
+ * and OSR has none. The keystroke reaches the page with its modifiers intact
+ * and nothing prevents it, and then the caret simply does not move.
+ *
+ * Option+Arrow is untouched: word-wise movement *is* built into Chromium and
+ * keeps working. That asymmetry is what identified the cause, and claiming
+ * Option here would replace something that works with a reimplementation.
+ *
+ * Registered once at the app root rather than per field. Every input is missing
+ * the same behaviour for the same reason, and wiring them one at a time would
+ * leave the next one added broken again.
+ *
+ * The listener runs in the capture phase so it settles the key before a field's
+ * own handler reads it — the composer's history navigation, for one, acts on a
+ * bare ArrowUp and must not see a Cmd+ArrowUp that means "go to the top".
+ */
+export function useCaretBoundaryKeys(): void {
+  useEffect(() => {
+    // Windows and Linux have no such binding to restore: Ctrl+Arrow is word-wise
+    // there (Chromium's own) and Home/End do the line, both of which work.
+    if (!isMac()) return;
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      const move = caretBoundaryMoveFor(e);
+      if (!move) return;
+
+      const target = typingTargetOf(e);
+      if (!target) return;
+
+      // A form field keeps its selection in character offsets, and
+      // `Selection.modify` does not reach inside one.
+      if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
+        e.preventDefault();
+        moveFormFieldCaret(target, move.direction, move.boundary, move.extend);
+        return;
+      }
+
+      e.preventDefault();
+      moveCaretToBoundary(target, move.direction, move.boundary, move.extend);
+    };
+
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
+  }, []);
+}
+
+/**
+ * The same move inside an `<input>` or `<textarea>`.
+ *
+ * A single-line `<input>` has one line, so its line edges and its text's edges
+ * are the same positions — both granularities collapse to offset 0 or the
+ * length, which is what macOS does there too.
+ *
+ * A `<textarea>` wraps, and its visual rows cannot be found from the value:
+ * where a row breaks is a layout fact, and the value only records the hard
+ * newlines. The line edge is taken as the paragraph's edge, which is exact for
+ * text that has not wrapped and is the closest reachable answer for text that
+ * has. The composer is a contentEditable and so takes the exact path above;
+ * this is for the plain textareas elsewhere in the app.
+ */
+function moveFormFieldCaret(
+  field: HTMLInputElement | HTMLTextAreaElement,
+  direction: CaretDirection,
+  boundary: CaretBoundary,
+  extend: boolean,
+): void {
+  const value = field.value;
+  const backward = direction === CaretDirection.Backward;
+  // The end being moved is the one the caret sits at, which `selectionDirection`
+  // tells apart for a selection made with Shift.
+  const caret = (field.selectionDirection === 'backward' ? field.selectionStart : field.selectionEnd) ?? 0;
+
+  let next: number;
+  if (boundary === CaretBoundary.Document) {
+    next = backward ? 0 : value.length;
+  } else if (backward) {
+    next = value.lastIndexOf('\n', Math.max(0, caret - 1)) + 1;
+  } else {
+    const nextBreak = value.indexOf('\n', caret);
+    next = nextBreak === -1 ? value.length : nextBreak;
+  }
+
+  if (!extend) {
+    field.setSelectionRange(next, next);
+    return;
+  }
+
+  // Keep the anchor — the end the user started from — and drag the other.
+  const anchor = field.selectionDirection === 'backward'
+    ? (field.selectionEnd ?? 0)
+    : (field.selectionStart ?? 0);
+  field.setSelectionRange(
+    Math.min(anchor, next),
+    Math.max(anchor, next),
+    next < anchor ? 'backward' : 'forward',
+  );
+}

--- a/webview/src/pages/ChatPage/ApprovalPanel/useApprovalKeyboard.ts
+++ b/webview/src/pages/ChatPage/ApprovalPanel/useApprovalKeyboard.ts
@@ -1,33 +1,8 @@
 import { useCallback, useEffect } from 'react';
 import { isMobile } from '@/config/environment';
-
-/**
- * Whether this keystroke is somebody typing, rather than an answer to the
- * panel.
- *
- * Reads the composed path rather than `e.target`, because the review diff's
- * editable side lives in a shadow root: the platform retargets `e.target` to
- * the host element, so a digit typed into a proposed edit looked like a digit
- * pressed at the panel and picked an option instead of reaching the text. The
- * path still holds the real element.
- *
- * `contenteditable` counts for the same reason a textarea does — it is where
- * characters are meant to land.
- */
-function isTypingTarget(event: globalThis.KeyboardEvent): boolean {
-  const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
-  for (const node of path) {
-    if (!(node instanceof HTMLElement)) continue;
-    if (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA') return true;
-    // The attribute as well as the resolved property: jsdom does not implement
-    // `isContentEditable`, and the renderer marks its editable side with the
-    // attribute either way.
-    const attr = node.getAttribute('contenteditable');
-    if (attr !== null && attr !== 'false') return true;
-    if (node.isContentEditable) return true;
-  }
-  return false;
-}
+// Shared with the caret-boundary keys, which need the same answer about the
+// same events — see the helper for why the composed path is read.
+import { isTypingTarget } from '@/utils/typingTarget';
 
 interface UseApprovalKeyboardParams {
   optionCount: number;

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -636,15 +636,11 @@ export function ChatInput() {
       return;
     }
 
-    // Cmd+Arrow is left to the browser. It moves by *visual* line — the same
-    // unit Up/Down and Cmd+Shift+Arrow already use — and scrolls the caret into
-    // view on its way. Handling it here once meant a <textarea> under JCEF
-    // ignored the native binding and emitted a ghost Arrow afterwards; with the
-    // composer now a contentEditable (RichInput) neither happens, and taking it
-    // over cost more than it bought: line start/end were computed by scanning
-    // for "\n", so a soft-wrapped paragraph jumped to the paragraph's edge
-    // rather than the visual line's, and moving the caret by hand left the
-    // scroll position behind.
+    // Cmd+Arrow is not handled here. useCaretBoundaryKeys claims it at the
+    // window in the capture phase, for every text field in the app at once —
+    // including this one, and including the history navigation below, which
+    // reads a bare ArrowUp and must not see a Cmd+ArrowUp meaning "go to the
+    // top of the text".
 
     // Mention interaction (must precede slash command handling)
     if (mention.isActive && mention.handleKeyDown(e)) return;

--- a/webview/src/pages/ChatPage/ReviewDiffSurface.tsx
+++ b/webview/src/pages/ChatPage/ReviewDiffSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { FileDiff, EditProvider, type FileContents } from '@pierre/diffs/react';
 import type { DiffLineAnnotation, EditorChange, EditorChangeEvent } from '@pierre/diffs';
 import { parseDiffFromFile } from '@pierre/diffs';
@@ -94,8 +94,23 @@ export default function ReviewDiffSurface({
    * a hunk starts three lines of context earlier, and a control sitting beside
    * an unchanged line reads as deciding that line. See firstChangedLine.
    */
+  /*
+   * Keyed on whether there are controls at all, NOT on the decisions object.
+   *
+   * The renderer compares this array by identity and rebuilds the whole view
+   * when it changes — which restarts the edit session underneath, so the
+   * proposed side goes read-only again a frame after every render. `decisions`
+   * is a fresh object on every render (useHunkDecisions returns a literal), so
+   * depending on it handed the renderer a new array every time and the session
+   * never survived long enough to type into.
+   *
+   * Nothing inside these annotations reads the decisions: each carries a hunk
+   * index, and the control re-reads the current state when it draws. So the
+   * array only has to change when the diff does.
+   */
+  const hasDecisions = decisions !== undefined;
   const lineAnnotations = useMemo<DiffLineAnnotation<HunkAnnotation>[]>(() => {
-    if (!decisions) return [];
+    if (!hasDecisions) return EMPTY_ANNOTATIONS;
     // From the ORIGINAL diff, not the resolved one: an answered block collapses
     // to context there, and its control has to stay put so Back can reach it.
     return changeBlocksOf(originalDiff).map((block) => ({
@@ -103,7 +118,7 @@ export default function ReviewDiffSurface({
       lineNumber: blockAnchorLine(block),
       metadata: { hunkIndex: block.index },
     }));
-  }, [decisions, originalDiff]);
+  }, [hasDecisions, originalDiff]);
 
   // An answered hunk collapses to context, so what stays on screen is what is
   // left to decide. Replayed from the original every time — see useResolvedDiff.
@@ -116,6 +131,22 @@ export default function ReviewDiffSurface({
     (options: ConstructorParameters<typeof Editor>[0]) => new Editor(options),
     [],
   );
+
+  /*
+   * Turned on one commit AFTER mount, never with it.
+   *
+   * The renderer attaches the editor from an effect keyed on this flag alone,
+   * and only if its diff instance already exists — an instance built in a ref
+   * callback on the same commit. Passed `true` from the first render there is
+   * one attempt, and if it lands before the instance is ready nothing retries:
+   * the flag never changes again, so neither does the effect, and the proposed
+   * side stays read-only for the life of the review.
+   *
+   * Flipping it here gives the effect a second run with the instance in place.
+   * false → true is the only transition, so the editor is still attached once.
+   */
+  const [editable, setEditable] = useState(false);
+  useLayoutEffect(() => setEditable(true), []);
 
   const editorOptions = useMemo(
     () => ({
@@ -157,7 +188,7 @@ export default function ReviewDiffSurface({
         <FileDiff
           fileDiff={fileDiff}
           options={options}
-          edit
+          edit={editable}
           editorOptions={editorOptions}
           lineAnnotations={lineAnnotations}
           renderAnnotation={renderAnnotation}
@@ -169,3 +200,11 @@ export default function ReviewDiffSurface({
 
 /** Narrower than this and each side of a split view is too thin to read. */
 const SPLIT_MIN_WIDTH = 720;
+
+/**
+ * One array for "no controls", so that case keeps a stable identity too.
+ *
+ * A fresh `[]` each time is a change as far as the renderer is concerned, and a
+ * change costs the edit session — see lineAnnotations.
+ */
+const EMPTY_ANNOTATIONS: DiffLineAnnotation<HunkAnnotation>[] = [];

--- a/webview/src/pages/ChatPage/__tests__/ReviewDiffSurface.edit.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/ReviewDiffSurface.edit.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Whether the proposed side actually becomes editable.
+ *
+ * The rest of the edit path is covered on DiffPage, but with this surface
+ * mocked — so nothing asserted that the surface turns editing ON. That gap is
+ * why "the proposed side is editable" could stop working without a test saying
+ * so.
+ *
+ * Asserted against the library's own contract rather than by typing: the
+ * editor attaches inside a shadow root that jsdom does not lay out, so what can
+ * be checked here is that we hand `FileDiff` an editable configuration and an
+ * EditProvider for it to use. Typing into it belongs to a browser check.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from '@testing-library/react';
+import type { DiffPreview } from '@/api/modules/ToolsApi';
+
+/** What FileDiff was rendered with, captured per test. */
+let lastProps: Record<string, unknown> | null = null;
+/** Whether an EditProvider was wrapped around it. */
+let editProviderSeen = false;
+/** Every value `edit` took, in order — the retry edge is a sequence, not a value. */
+const editSeen: boolean[] = [];
+
+vi.mock('@pierre/diffs/react', () => ({
+  FileDiff: (props: Record<string, unknown>) => {
+    lastProps = props;
+    editSeen.push(props.edit as boolean);
+    return null;
+  },
+  EditProvider: ({ children }: { children: React.ReactNode }) => {
+    editProviderSeen = true;
+    return children;
+  },
+}));
+
+vi.mock('@pierre/diffs/edit', () => ({
+  Editor: class {
+    edit() {
+      return () => {};
+    }
+    cleanUp() {}
+  },
+}));
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useThemeContext: () => ({ isDark: true }),
+}));
+
+const before = 'const timeout = 20000;\nconst retries = 3;\n';
+const after = 'const timeout = 15000;\nconst retries = 3;\n';
+
+const preview: DiffPreview = {
+  filePath: '/tmp/config.ts',
+  oldContent: before,
+  newContent: after,
+} as DiffPreview;
+
+async function renderSurface() {
+  const { default: ReviewDiffSurface } = await import('../ReviewDiffSurface');
+  render(
+    <ReviewDiffSurface
+      preview={preview}
+      proposedContents={after}
+      onEdit={() => {}}
+    />,
+  );
+}
+
+beforeEach(() => {
+  lastProps = null;
+  editProviderSeen = false;
+});
+
+describe('the proposed side of a review diff', () => {
+  it('is handed to the renderer in edit mode', async () => {
+    // The reported symptom: typing into the proposed side did nothing. If this
+    // is false the surface is read-only however the rest of the path behaves.
+    await renderSurface();
+
+    expect(lastProps?.edit).toBe(true);
+  });
+
+  it('turns edit on only after the first commit, so the attach retries', async () => {
+    // The renderer attaches its editor from an effect keyed on `edit` alone,
+    // and only if its instance exists. Handed `true` from the very first render
+    // there is one attempt and no retry — this asserts the false → true edge
+    // that gives the effect a second run with the instance in place.
+    editSeen.length = 0;
+
+    await renderSurface();
+
+    expect(editSeen[0]).toBe(false);
+    expect(editSeen[editSeen.length - 1]).toBe(true);
+  });
+
+  it('comes with the EditProvider the renderer requires for it', async () => {
+    // `edit` alone throws "FileDiff: EditContext is not attached" — the two are
+    // one feature, so a test for either has to hold both.
+    await renderSurface();
+
+    expect(editProviderSeen).toBe(true);
+  });
+
+  it('reports what was typed, so the answer can carry it', async () => {
+    // The edit is only worth enabling if it reaches resolve(). This is the hand-
+    // off point: the renderer calls onChange, and we turn it into onEdit.
+    const onEdit = vi.fn();
+    const { default: ReviewDiffSurface } = await import('../ReviewDiffSurface');
+    render(
+      <ReviewDiffSurface preview={preview} proposedContents={after} onEdit={onEdit} />,
+    );
+
+    const options = lastProps?.editorOptions as {
+      onChange: (file: { contents: string }, a: unknown, e: { changes: unknown[] }) => void;
+    };
+    options.onChange({ contents: 'const timeout = 12345;\n' }, null, { changes: [] });
+
+    expect(onEdit).toHaveBeenCalledWith('const timeout = 12345;\n', []);
+  });
+});

--- a/webview/src/pages/ChatPage/__tests__/ReviewDiffSurface.rerender.test.tsx
+++ b/webview/src/pages/ChatPage/__tests__/ReviewDiffSurface.rerender.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * What the renderer is told when the reviewer answers a hunk.
+ *
+ * The renderer redraws on identity: it compares the `fileDiff` it was handed
+ * with the one it holds, and the `lineAnnotations` array likewise. Hand it the
+ * same objects and it keeps what is on screen — which is correct while nothing
+ * has changed, and a bug the moment something has.
+ *
+ * Answering a hunk changes the diff (the block collapses to context), so a new
+ * `fileDiff` has to arrive. Answering does NOT change where the controls live,
+ * so the same annotations array should. Both halves are asserted here because
+ * getting either backwards is invisible until you click Accept and nothing
+ * happens.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { parseDiffFromFile } from '@pierre/diffs';
+import type { DiffPreview } from '@/api/modules/ToolsApi';
+import { useHunkDecisions } from '../../DiffPage/useHunkDecisions';
+import { changeBlocksOf } from '../../DiffPage/changeBlocks';
+
+/** Every (fileDiff, lineAnnotations) pair the renderer was handed, in order. */
+const handed: { fileDiff: unknown; lineAnnotations: unknown }[] = [];
+
+vi.mock('@pierre/diffs/react', () => ({
+  FileDiff: (props: Record<string, unknown>) => {
+    handed.push({ fileDiff: props.fileDiff, lineAnnotations: props.lineAnnotations });
+    return null;
+  },
+  EditProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+vi.mock('@pierre/diffs/edit', () => ({
+  Editor: class {
+    edit() {
+      return () => {};
+    }
+    cleanUp() {}
+  },
+}));
+
+vi.mock('@/contexts/ThemeContext', () => ({
+  useThemeContext: () => ({ isDark: true }),
+}));
+
+// Two edits far apart, so there are two blocks to answer independently.
+const before = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+const after = before.replace('line 5', 'FIVE').replace('line 16', 'SIXTEEN');
+
+const preview = {
+  filePath: '/tmp/f.txt',
+  oldContent: before,
+  newContent: after,
+} as DiffPreview;
+
+const blocks = changeBlocksOf(
+  parseDiffFromFile({ name: 'f.txt', contents: before }, { name: 'f.txt', contents: after }),
+);
+
+/** Drives the surface the way DiffPage does, exposing `keep` to the test. */
+function Harness({ onReady }: { onReady: (keep: (i: number) => void) => void }) {
+  const decisions = useHunkDecisions(blocks);
+  onReady(decisions.keep);
+  // Imported lazily so the mocks above are in place first.
+  const Surface = Surfaces.current!;
+  return (
+    <Surface
+      preview={preview}
+      proposedContents={after}
+      onEdit={() => {}}
+      decisions={decisions}
+    />
+  );
+}
+
+const Surfaces: { current: React.ComponentType<Record<string, unknown>> | null } = {
+  current: null,
+};
+
+beforeEach(async () => {
+  handed.length = 0;
+  const mod = await import('../ReviewDiffSurface');
+  Surfaces.current = mod.default as unknown as React.ComponentType<Record<string, unknown>>;
+});
+
+describe('when the reviewer answers a hunk', () => {
+  it('hands the renderer a new fileDiff, so the answered block leaves the screen', () => {
+    // The reported symptom: Accept flips the controls to Reset/Back — that is
+    // local state — but the diff underneath keeps showing the hunk, because the
+    // renderer was handed the object it already had and redrew nothing.
+    let keep!: (i: number) => void;
+    render(<Harness onReady={(k) => { keep = k; }} />);
+
+    const before_ = handed[handed.length - 1].fileDiff;
+    act(() => keep(0));
+    const after_ = handed[handed.length - 1].fileDiff;
+
+    expect(after_).not.toBe(before_);
+  });
+
+  it('hands it the same annotations array, so the edit session survives', () => {
+    // The other half. A new array here rebuilds the whole view and takes the
+    // reviewer's edit session with it — which is what made typing impossible.
+    let keep!: (i: number) => void;
+    render(<Harness onReady={(k) => { keep = k; }} />);
+
+    const before_ = handed[handed.length - 1].lineAnnotations;
+    act(() => keep(0));
+    const after_ = handed[handed.length - 1].lineAnnotations;
+
+    expect(after_).toBe(before_);
+  });
+
+  it('keeps handing the same objects while nothing is answered', () => {
+    // A re-render that changes nothing must change neither, or the session dies
+    // on every unrelated render — the state this page was in before the fix.
+    const { rerender } = render(<Harness onReady={() => {}} />);
+
+    const first = handed[handed.length - 1];
+    rerender(<Harness onReady={() => {}} />);
+    const second = handed[handed.length - 1];
+
+    expect(second.fileDiff).toBe(first.fileDiff);
+    expect(second.lineAnnotations).toBe(first.lineAnnotations);
+  });
+});

--- a/webview/src/pages/ChatPage/index.tsx
+++ b/webview/src/pages/ChatPage/index.tsx
@@ -304,9 +304,28 @@ export function ChatPage() {
   // 빈 영역 클릭 시 textarea로 포커스 이동
   // mousedown 시점에 확인해야 포커스 이동 전 activeElement를 비교할 수 있음
   const handleContainerMouseDown = useCallback((e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('button, a, input, textarea, select, [role="button"], [contenteditable]')) {
-      return;
+    /*
+     * Read the composed path, not `e.target`.
+     *
+     * The review diff draws its editable side inside a shadow root, and the
+     * platform retargets `e.target` to the host element — `<diffs-container>`,
+     * which matches none of the selectors below. So a click meant to put the
+     * caret in a proposed edit read as a click on empty space: this handler
+     * called preventDefault and moved focus to the composer, and the proposed
+     * side could never be typed into. `closest()` cannot see past a shadow
+     * boundary; the path holds the real element.
+     *
+     * Same fix, same reason as isTypingTarget in useApprovalKeyboard — that one
+     * was for keystrokes leaking into the approval panel, this one for the click
+     * that should have focused the editor in the first place.
+     */
+    const path = typeof e.nativeEvent.composedPath === 'function'
+      ? e.nativeEvent.composedPath()
+      : [e.target];
+    const CONTROLS = 'button, a, input, textarea, select, [role="button"], [contenteditable]';
+    for (const node of path) {
+      if (!(node instanceof HTMLElement)) continue;
+      if (node.matches(CONTROLS)) return;
     }
     if (document.activeElement === textareaRef.current) {
       // 이미 포커스 상태 → 브라우저가 포커스를 빼앗지 못하게 방지

--- a/webview/src/pages/DiffPage/DiffOverlay.tsx
+++ b/webview/src/pages/DiffPage/DiffOverlay.tsx
@@ -108,10 +108,16 @@ export function DiffOverlay({ toolUseId, onClose }: Props) {
           twice. The settings modal caps its width because a settings form stops
           improving past a certain measure; this does not.
 
-          Height is a ceiling rather than a size, so that collapsing the diff
-          shrinks this box to the header it leaves behind. Fixed at h-full it
-          stayed full-screen with nothing in it, which hid the conversation the
-          collapse was meant to uncover.
+          Expanded it takes the full height, short diff or not. Sized to its
+          content instead, a two-hunk review drew a stub of a box crouched at the
+          bottom of an empty screen — anchored low by the items-end below, which
+          is there for the collapsed bar. Empty room above the diff costs
+          nothing; a modal that changes size with the diff inside it reads as a
+          different component each time.
+
+          Collapsed it goes back to a ceiling, so the box shrinks to the header
+          it leaves behind. Held at h-full it stayed full-screen with nothing in
+          it, hiding the conversation the collapse was meant to uncover.
         */}
         {/* pointer-events-auto: the layer above gives up the mouse when
             collapsed, and this takes it back — otherwise the chevron that
@@ -129,8 +135,8 @@ export function DiffOverlay({ toolUseId, onClose }: Props) {
           prompt does not.
         */}
         <div
-          className={`pointer-events-auto flex max-h-full w-full flex-col overflow-hidden border border-border-default bg-surface-base shadow-2xl ${
-            collapsed ? 'rounded-lg' : 'rounded-xl'
+          className={`pointer-events-auto flex w-full flex-col overflow-hidden border border-border-default bg-surface-base shadow-2xl ${
+            collapsed ? 'max-h-full rounded-lg' : 'h-full rounded-xl'
           }`}
           style={collapsed ? { maxWidth: COLLAPSED_WIDTH } : undefined}
         >

--- a/webview/src/pages/DiffPage/HunkActions.tsx
+++ b/webview/src/pages/DiffPage/HunkActions.tsx
@@ -37,6 +37,13 @@ interface Props {
  * Absolutely positioned rather than laid out in the flow: an element that took
  * a row of its own would push the two sides of the diff apart and add a line to
  * a file the reviewer is trying to read.
+ *
+ * `absolute` and not `sticky`, even though sticky would keep the controls in
+ * view when a hunk is wide enough to scroll sideways. Sticky occupies a row —
+ * the renderer's annotation element is `min-height: 0` precisely so an absolute
+ * child leaves it collapsed, and a sticky child inflates it back into a blank
+ * line wedged between the code and the hunk it belongs to. Losing the line is
+ * worse than losing the anchoring: every hunk pays for it, scrolling or not.
  */
 export function HunkActions({ decision, isEdited, onAccept, onDeny, onReset, onBack }: Props) {
   const { t } = useTranslation('chat');
@@ -72,10 +79,15 @@ export function HunkActions({ decision, isEdited, onAccept, onDeny, onReset, onB
           <button type="button" onClick={onDeny} className={SECONDARY_BUTTON}>
             {t('diffPage.hunk.deny')}
           </button>
+          {/* Opaque, unlike the other controls: `--state-success-bg` is a 15%
+              green in dark themes, and these buttons float over the addition
+              side of a diff — itself tinted green. Tint over tint left the one
+              affirmative control barely visible against the rows it decides.
+              Its own surface, so what it sits on cannot wash it out. */}
           <button
             type="button"
             onClick={onAccept}
-            className="pointer-events-auto rounded border border-state-success-fg/40 bg-state-success-bg px-2 py-0.5 text-xs text-state-success-fg shadow-sm transition-colors hover:brightness-110"
+            className="pointer-events-auto rounded border border-state-success-fg/40 bg-surface-overlay px-2 py-0.5 text-xs text-state-success-fg shadow-sm transition-colors hover:bg-surface-hover"
           >
             {t('diffPage.hunk.accept')}
           </button>

--- a/webview/src/pages/DiffPage/__tests__/DiffPage.test.tsx
+++ b/webview/src/pages/DiffPage/__tests__/DiffPage.test.tsx
@@ -45,6 +45,7 @@ vi.mock('../../ChatPage/ReviewDiffSurface', () => ({
   default: ({
     onEdit,
     decisions,
+    onResetHunk,
   }: {
     onEdit: (contents: string, changes: readonly { range: unknown }[]) => void;
     decisions?: {
@@ -53,6 +54,7 @@ vi.mock('../../ChatPage/ReviewDiffSurface', () => ({
       reset: (i: number) => void;
       total: number;
     };
+    onResetHunk?: (i: number) => void;
   }) => (
     <>
       {/* The editor reports the whole text plus the ranges it replaced; the
@@ -75,6 +77,9 @@ vi.mock('../../ChatPage/ReviewDiffSurface', () => ({
               <button type="button" onClick={() => decisions.keep(i)}>{`keep-${i}`}</button>
               <button type="button" onClick={() => decisions.undo(i)}>{`undo-${i}`}</button>
               <button type="button" onClick={() => decisions.reset(i)}>{`reset-${i}`}</button>
+              {/* What the Reset CONTROL calls, which is a different path from
+                  decisions.reset above — see the page's own resetHunk. */}
+              <button type="button" onClick={() => onResetHunk?.(i)}>{`reset-control-${i}`}</button>
             </span>
           ))
         : null}
@@ -269,6 +274,22 @@ describe('DiffPage', () => {
 
       fireEvent.click(confirm);
       expect(resolveDiff).not.toHaveBeenCalled();
+    });
+
+    it('reopens an answered hunk when the Reset control is used', async () => {
+      // Reset discards the edit AND reopens the question. Wired to the edit
+      // tracking alone it did neither on a hunk that was never typed into: the
+      // reviewer pressed it and the hunk stayed accepted, with no way back
+      // except Back — a different button with a different promise.
+      render(<DiffPage toolUseId="toolu_1" />);
+      fireEvent.click(await screen.findByText('undo-0'));
+      fireEvent.click(screen.getByText('undo-1'));
+      // Both undone, so there is nothing left to write and Confirm is off.
+      expect(screen.getByText('diffPage.confirm')).toBeDisabled();
+
+      fireEvent.click(screen.getByText('reset-control-0'));
+
+      expect(screen.getByText('diffPage.confirm')).toBeEnabled();
     });
 
     it('confirms again once an undone hunk is reset', async () => {

--- a/webview/src/pages/DiffPage/__tests__/useEditedProposal.test.ts
+++ b/webview/src/pages/DiffPage/__tests__/useEditedProposal.test.ts
@@ -118,3 +118,64 @@ describe('useEditedProposal', () => {
     });
   });
 });
+
+describe('resetting one hunk', () => {
+  it('puts that hunk back to what Claude proposed', () => {
+    // The whole point of Reset, and what it never actually did: it dropped the
+    // "this was typed into" mark and left the text alone, so the button was
+    // there, the reviewer pressed it, and nothing on screen changed.
+    const { result } = renderHook(() => useEditedProposal(PROPOSAL, HUNKS));
+
+    act(() => result.current.applyEdit('line 1\nTYPED\nline 3\n', [change(1, 1)]));
+    expect(result.current.contents).toBe('line 1\nTYPED\nline 3\n');
+
+    act(() => result.current.resetHunk(0));
+
+    expect(result.current.contents).toBe(PROPOSAL);
+  });
+
+  it('stops reporting that hunk as edited', () => {
+    const { result } = renderHook(() => useEditedProposal(PROPOSAL, HUNKS));
+    act(() => result.current.applyEdit('line 1\nTYPED\nline 3\n', [change(1, 1)]));
+    expect(result.current.isHunkEdited(0)).toBe(true);
+
+    act(() => result.current.resetHunk(0));
+
+    expect(result.current.isHunkEdited(0)).toBe(false);
+  });
+
+  it('leaves what was typed outside the hunk alone', () => {
+    // Resetting a hunk is not abandoning the review. Line 1 sits outside the
+    // hunk's span, so it survives.
+    const { result } = renderHook(() => useEditedProposal(PROPOSAL, HUNKS));
+
+    act(() => result.current.applyEdit('OUTSIDE\nTYPED\nline 3\n', [change(0, 1)]));
+    act(() => result.current.resetHunk(0));
+
+    expect(result.current.contents).toBe('OUTSIDE\nline 2\nline 3\n');
+  });
+
+  it('reports nothing edited once the only edit is reset', () => {
+    // `isEdited` decides whether the text is sent at all, so it has to agree
+    // with the text rather than with the hunk marks.
+    const { result } = renderHook(() => useEditedProposal(PROPOSAL, HUNKS));
+    act(() => result.current.applyEdit('line 1\nTYPED\nline 3\n', [change(1, 1)]));
+
+    act(() => result.current.resetHunk(0));
+
+    expect(result.current.isEdited).toBe(false);
+  });
+
+  it('leaves the text alone when an edit changed the line count', () => {
+    // A hunk's span is stated in proposal line numbers. Once a line has been
+    // added those numbers point somewhere else, and restoring by them would
+    // overwrite whatever the reviewer typed at the shifted position.
+    const { result } = renderHook(() => useEditedProposal(PROPOSAL, HUNKS));
+    const withExtraLine = 'line 1\nTYPED\nEXTRA\nline 3\n';
+    act(() => result.current.applyEdit(withExtraLine, [change(1, 1)]));
+
+    act(() => result.current.resetHunk(0));
+
+    expect(result.current.contents).toBe(withExtraLine);
+  });
+});

--- a/webview/src/pages/DiffPage/__tests__/useResolvedDiff.test.ts
+++ b/webview/src/pages/DiffPage/__tests__/useResolvedDiff.test.ts
@@ -1,55 +1,35 @@
 /**
  * Replaying the reviewer's answers onto the original diff.
  *
- * Two properties this depends on, both of them the library's behaviour rather
- * than ours, and neither visible in a type signature:
+ * The property everything here turns on: this page counts CHANGE BLOCKS, and a
+ * hunk may hold several of them. `changeBlocksOf` numbers the blocks, the
+ * controls carry those numbers, the decisions are stored under them, and the
+ * ranges sent to the backend are built from them — so the resolved diff has to
+ * be indexed the same way. It was not, and answering a block the library had no
+ * matching hunk for threw `Invalid hunk index`.
  *
- *  1. `diffAcceptRejectHunk` does not mutate its input, which is what lets a
- *     resolved hunk come back — Reset just replays a different answer set onto
- *     the untouched original.
- *  2. Resolving a hunk renumbers the ones after it, so answers have to be
- *     applied from the last hunk backwards. Forwards, the second answer lands
- *     on a hunk that has already shifted out from under its index.
- *
- * If either changes in a library upgrade, the review writes the wrong lines to
- * a file — so both are asserted here directly against the library.
+ * Two edits a few lines apart are the case that separates the two numberings,
+ * so that is what most of this file is built on.
  */
 import { describe, it, expect } from 'vitest';
-import { parseDiffFromFile, diffAcceptRejectHunk, type FileDiffMetadata } from '@pierre/diffs';
+import { renderHook } from '@testing-library/react';
+import { parseDiffFromFile, type FileDiffMetadata } from '@pierre/diffs';
+import { useResolvedDiff } from '../useResolvedDiff';
+import { changeBlocksOf } from '../changeBlocks';
+import type { HunkDecision, HunkDecisions } from '../useHunkDecisions';
 
 const before = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
-const after = before.replace('line 5', 'FIVE').replace('line 16', 'SIXTEEN');
 
-function makeDiff(): FileDiffMetadata {
+/** Two edits three lines apart: git-style grouping puts both in ONE hunk. */
+const near = before.replace('line 5', 'FIVE').replace('line 7', 'SEVEN');
+
+/** Two edits far apart: one hunk each. */
+const far = before.replace('line 5', 'FIVE').replace('line 16', 'SIXTEEN');
+
+function makeDiff(after: string): FileDiffMetadata {
   return parseDiffFromFile(
     { name: 'f.txt', contents: before },
     { name: 'f.txt', contents: after },
-  );
-}
-
-/**
- * What each hunk still shows as changed.
- *
- * Read from `hunkContent[].type`, NOT from `additionCount`/`deletionCount`.
- * Those two count every line the hunk displays, context included, so they are
- * identical before and after a hunk is resolved — measuring with them says
- * "nothing happened" no matter what you do.
- *
- * Resolving turns a `change` entry into `context`, which is the difference this
- * page draws and therefore the one worth asserting.
- */
-function shape(diff: FileDiffMetadata): string {
-  return JSON.stringify(
-    (diff as unknown as { hunks: { hunkContent: { type: string }[] }[] }).hunks.map((h) =>
-      h.hunkContent.map((c) => c.type),
-    ),
-  );
-}
-
-/** Whether [diff] still has anything left for the reviewer to answer. */
-function hasOpenChanges(diff: FileDiffMetadata): boolean {
-  return (diff as unknown as { hunks: { hunkContent: { type: string }[] }[] }).hunks.some((h) =>
-    h.hunkContent.some((c) => c.type === 'change'),
   );
 }
 
@@ -57,73 +37,177 @@ function hunkCount(diff: FileDiffMetadata): number {
   return (diff as unknown as { hunks: unknown[] }).hunks.length;
 }
 
-describe('diffAcceptRejectHunk, as this page relies on it', () => {
-  it('splits two distant edits into separate hunks', () => {
-    // The rest of this file is meaningless with only one hunk.
-    expect(hunkCount(makeDiff())).toBe(2);
+/** The addition/deletion text the renderer actually paints, as one string. */
+export function painted(diff: FileDiffMetadata): string {
+  const d = diff as unknown as { additionLines: string[]; deletionLines: string[] };
+  return JSON.stringify([d.additionLines, d.deletionLines]);
+}
+
+/** How many blocks are still drawn as changes, i.e. still awaiting an answer. */
+function openBlocks(diff: FileDiffMetadata): number {
+  const hunks = (diff as unknown as { hunks: { hunkContent?: { type: string }[] }[] }).hunks;
+  return hunks.reduce(
+    (n, h) => n + (h.hunkContent ?? []).filter((c) => c.type === 'change').length,
+    0,
+  );
+}
+
+/** A decisions object holding exactly [answers], keyed by block number. */
+function decisionsOf(
+  diff: FileDiffMetadata,
+  answers: ReadonlyMap<number, HunkDecision>,
+): HunkDecisions {
+  const total = changeBlocksOf(diff).length;
+  return {
+    decisionFor: (index: number) => answers.get(index),
+    keep: () => {},
+    undo: () => {},
+    reset: () => {},
+    acceptAll: () => {},
+    resetAll: () => {},
+    allAccepted: answers.size === total,
+    openCount: total - answers.size,
+    keptCount: total,
+    total,
+    acceptedRanges: [],
+  };
+}
+
+function resolve(diff: FileDiffMetadata, answers: ReadonlyMap<number, HunkDecision>) {
+  return renderHook(() => useResolvedDiff(diff, decisionsOf(diff, answers))).result.current;
+}
+
+/** Every block answered `keep`, which is what Select all does. */
+function acceptAll(diff: FileDiffMetadata): ReadonlyMap<number, HunkDecision> {
+  return new Map(changeBlocksOf(diff).map((b) => [b.index, 'keep' as const]));
+}
+
+describe('the two numberings this page has to keep straight', () => {
+  it('puts two nearby edits in one hunk but two blocks', () => {
+    // The premise of the bug, and of most of this file. If grouping ever changes
+    // so that these are two hunks, the regression tests below stop covering
+    // anything and need a closer pair of edits.
+    const diff = makeDiff(near);
+    expect(hunkCount(diff)).toBe(1);
+    expect(changeBlocksOf(diff)).toHaveLength(2);
+  });
+
+  it('puts two distant edits in one hunk each', () => {
+    const diff = makeDiff(far);
+    expect(hunkCount(diff)).toBe(2);
+    expect(changeBlocksOf(diff)).toHaveLength(2);
+  });
+});
+
+describe('useResolvedDiff', () => {
+  it('settles every block when Select all answers more blocks than there are hunks', () => {
+    // The reported crash: two blocks, one hunk. Answering block 1 used to be
+    // read as hunk 1, which does not exist — `Invalid hunk index`, and the whole
+    // review went to the error boundary.
+    const diff = makeDiff(near);
+    expect(openBlocks(diff)).toBe(2);
+
+    const resolved = resolve(diff, acceptAll(diff));
+
+    expect(openBlocks(resolved)).toBe(0);
+  });
+
+  it('leaves a shared hunk drawn until its blocks agree', () => {
+    // The library resolves a hunk whole — it rewrites the addition and deletion
+    // lines — so there is no way to settle one block of a hunk and keep drawing
+    // the other. Answering one of two therefore changes nothing on screen, and
+    // that is the honest outcome: what is still open stays visible. The ranges
+    // sent to the backend come from the decisions, not from this, so the answer
+    // itself is not lost.
+    const diff = makeDiff(near);
+
+    const resolved = resolve(diff, new Map([[0, 'keep']]));
+
+    expect(openBlocks(resolved)).toBe(2);
+  });
+
+  it('settles a shared hunk once both blocks are kept', () => {
+    const diff = makeDiff(near);
+
+    const resolved = resolve(diff, new Map([[0, 'keep'], [1, 'keep']]));
+
+    expect(openBlocks(resolved)).toBe(0);
+  });
+
+  it('settles a shared hunk once both blocks are undone', () => {
+    // Undo settles it the same way; which side won is carried by
+    // acceptedRanges, not by the diff on screen.
+    const diff = makeDiff(near);
+
+    const resolved = resolve(diff, new Map([[0, 'undo'], [1, 'undo']]));
+
+    expect(openBlocks(resolved)).toBe(0);
+  });
+
+  it('leaves a shared hunk drawn when its blocks disagree', () => {
+    // Keep one, undo the other: the hunk cannot be half-rewritten, so it stays.
+    const diff = makeDiff(near);
+
+    const resolved = resolve(diff, new Map([[0, 'keep'], [1, 'undo']]));
+
+    expect(openBlocks(resolved)).toBe(2);
+  });
+
+  it('settles each block independently when they are in separate hunks', () => {
+    // The ordinary case, and the one the reviewer meets most: distant edits get
+    // a hunk each, so answering one takes it off the screen on its own.
+    const diff = makeDiff(far);
+
+    const resolved = resolve(diff, new Map([[0, 'keep']]));
+
+    expect(openBlocks(resolved)).toBe(1);
+  });
+
+  it('still settles everything when the blocks are in separate hunks', () => {
+    // The case that happened to work before, kept so the fix does not trade one
+    // numbering for the other.
+    const diff = makeDiff(far);
+
+    const resolved = resolve(diff, acceptAll(diff));
+
+    expect(openBlocks(resolved)).toBe(0);
   });
 
   it('leaves the diff it was given untouched', () => {
     // The whole basis for Reset: the original stays available to replay onto.
-    const original = makeDiff();
-    const snapshot = shape(original);
+    const diff = makeDiff(near);
 
-    diffAcceptRejectHunk(original, 0, 'accept');
+    resolve(diff, acceptAll(diff));
 
-    expect(shape(original)).toBe(snapshot);
+    expect(openBlocks(diff)).toBe(2);
   });
 
-  it('returns a new object rather than the one passed in', () => {
-    const original = makeDiff();
-    expect(diffAcceptRejectHunk(original, 0, 'accept')).not.toBe(original);
+  it('hands back the very same object when nothing has been answered', () => {
+    // The renderer holds an edit session keyed off this object. A fresh copy on
+    // every render would restart it and lose the reviewer's typing.
+    const diff = makeDiff(near);
+
+    expect(resolve(diff, new Map())).toBe(diff);
   });
 
-  it('keeps a resolved hunk in the list, as context', () => {
-    // The control has to stay somewhere, so Reset has a place to live. A hunk
-    // that vanished from the array entirely would take its own undo with it.
-    const resolved = diffAcceptRejectHunk(makeDiff(), 0, 'accept');
-    expect(hunkCount(resolved)).toBe(hunkCount(makeDiff()));
+  it('rewrites the lines the renderer paints, not just their labels', () => {
+    // The bug this test exists for: retyping a `change` entry to `context`
+    // leaves `additionLines`/`deletionLines` untouched, and those are what get
+    // drawn — so the answered hunk stayed on screen while the header counted it
+    // as decided. Asserting on the painted text is the only way to see that.
+    const diff = makeDiff(far);
+    const before_ = painted(diff);
+
+    const resolved = resolve(diff, acceptAll(diff));
+
+    expect(painted(resolved)).not.toBe(before_);
   });
 
-  it('resolves every hunk the same way whichever end you start from', () => {
-    // If this ever fails, the replay order in useResolvedDiff is load-bearing
-    // in a way this test no longer describes — read it before changing it.
-    const total = hunkCount(makeDiff());
+  it('hands back the original when there are no decisions at all', () => {
+    // A change the backend could not split reviews whole-file: no per-block
+    // controls, nothing to replay.
+    const diff = makeDiff(near);
 
-    let backwards = makeDiff();
-    for (let i = total - 1; i >= 0; i--) {
-      backwards = diffAcceptRejectHunk(backwards, i, 'accept');
-    }
-
-    let forwards = makeDiff();
-    for (let i = 0; i < total; i++) {
-      forwards = diffAcceptRejectHunk(forwards, i, 'accept');
-    }
-
-    expect(shape(backwards)).toBe(shape(forwards));
-  });
-
-  it('settles both hunks when the answers differ', () => {
-    // The case that matters: keep one, undo the other. Applied backwards, which
-    // is what useResolvedDiff does.
-    expect(hasOpenChanges(makeDiff())).toBe(true);
-
-    const mixed = diffAcceptRejectHunk(
-      diffAcceptRejectHunk(makeDiff(), 1, 'reject'),
-      0,
-      'accept',
-    );
-
-    expect(hasOpenChanges(mixed)).toBe(false);
-  });
-
-  it('leaves the other hunk open when only one is answered', () => {
-    // Half-answered is the ordinary state of a review, and the half that is
-    // still open has to stay drawn as a change.
-    const one = diffAcceptRejectHunk(makeDiff(), 0, 'accept');
-
-    const types = (one as unknown as { hunks: { hunkContent: { type: string }[] }[] }).hunks;
-    expect(types[0].hunkContent.some((c) => c.type === 'change')).toBe(false);
-    expect(types[1].hunkContent.some((c) => c.type === 'change')).toBe(true);
+    expect(renderHook(() => useResolvedDiff(diff)).result.current).toBe(diff);
   });
 });

--- a/webview/src/pages/DiffPage/index.tsx
+++ b/webview/src/pages/DiffPage/index.tsx
@@ -149,6 +149,26 @@ export function DiffPage(props: Props) {
   const decisions = useHunkDecisions(blocks);
 
   /*
+   * Reset puts one hunk back to untouched — both halves of that.
+   *
+   * The edit tracking is only half: dropping the "this hunk was typed into"
+   * mark leaves an ANSWERED hunk answered, so on a hunk that was accepted and
+   * never typed into (the ordinary case) Reset did nothing at all — the button
+   * was there, the reviewer pressed it, and the hunk stayed decided.
+   *
+   * Reopening the question is the other half, and it is what separates Reset
+   * from Back: Back keeps what was typed and only reopens, Reset discards the
+   * edit as well. Both have to reopen, or neither undoes anything visible.
+   */
+  const resetHunk = useCallback(
+    (index: number) => {
+      edited.resetHunk(index);
+      decisions.reset(index);
+    },
+    [edited, decisions],
+  );
+
+  /*
    * Whether the reviewer can pick parts of this change.
    *
    * They cannot when the change has no separable blocks — a whole-file rewrite
@@ -356,7 +376,7 @@ export function DiffPage(props: Props) {
             proposedContents={edited.contents}
             onEdit={edited.applyEdit}
             isHunkEdited={edited.isHunkEdited}
-            onResetHunk={edited.resetHunk}
+            onResetHunk={resetHunk}
             // Omitted when there is no split to pick from, which is what keeps
             // the per-hunk controls off that diff entirely.
             decisions={canPickHunks ? decisions : undefined}

--- a/webview/src/pages/DiffPage/useEditedProposal.ts
+++ b/webview/src/pages/DiffPage/useEditedProposal.ts
@@ -76,16 +76,40 @@ export function useEditedProposal(proposal: string, hunks: readonly Hunk[]): Edi
     [hunks, proposal],
   );
 
-  const resetHunk = useCallback((hunkIndex: number) => {
-    setEditedHunks((prev) => {
-      if (!prev.has(hunkIndex)) return prev;
-      const next = new Set(prev);
-      next.delete(hunkIndex);
-      return next;
-    });
-    // The text itself is restored by the caller, which owns the proposal this
-    // hunk should go back to — see DiffPage.
-  }, []);
+  /*
+   * Put one hunk's lines back to what Claude proposed, and forget it was typed
+   * into.
+   *
+   * The text half used to be left to the caller — the comment here said so, and
+   * no caller ever did it, so Reset dropped a flag and changed nothing anyone
+   * could see. It belongs here regardless: this is what holds the text and the
+   * proposal it came from, and a caller doing it would need both.
+   *
+   * Only the hunk's own lines are restored. Everything typed elsewhere in the
+   * file stays, which is the difference between resetting a hunk and abandoning
+   * the review.
+   */
+  const resetHunk = useCallback(
+    (hunkIndex: number) => {
+      setEditedHunks((prev) => {
+        if (!prev.has(hunkIndex)) return prev;
+        const next = new Set(prev);
+        next.delete(hunkIndex);
+        return next;
+      });
+
+      const hunk = hunks.find((h) => h.index === hunkIndex);
+      if (hunk === undefined) return;
+
+      setEdits((prev) => {
+        const current = prev.seededFrom === proposal ? prev.contents : proposal;
+        const restored = restoreHunkLines(current, proposal, hunk);
+        if (restored === null || restored === current) return prev;
+        return { seededFrom: proposal, contents: restored };
+      });
+    },
+    [hunks, proposal],
+  );
 
   const isHunkEdited = useCallback((hunkIndex: number) => editedHunks.has(hunkIndex), [editedHunks]);
 
@@ -118,4 +142,30 @@ function overlapsHunk(change: EditorChange, hunk: Hunk): boolean {
   const hunkStart = hunk.newStart - 1;
   const hunkEnd = hunkStart + hunk.newLines - 1;
   return changeStart <= hunkEnd && changeEnd >= hunkStart;
+}
+
+/**
+ * [current] with the lines [hunk] covers put back to what [proposal] has there,
+ * or null when that cannot be done safely.
+ *
+ * A hunk's span is stated in PROPOSAL line numbers, so it only addresses the
+ * same lines in `current` while the two have the same number of them. An edit
+ * that added or removed a line moves every hunk after it, and restoring by
+ * those stale coordinates would overwrite whatever the reviewer typed at the
+ * shifted position — worse than leaving Reset unable to act, which is what null
+ * means here.
+ */
+function restoreHunkLines(current: string, proposal: string, hunk: Hunk): string | null {
+  const currentLines = current.split('\n');
+  const proposalLines = proposal.split('\n');
+  if (currentLines.length !== proposalLines.length) return null;
+
+  // The hunk counts from one; the array counts from zero.
+  const start = hunk.newStart - 1;
+  const end = start + hunk.newLines;
+  if (start < 0 || end > proposalLines.length) return null;
+
+  const restored = [...currentLines];
+  for (let i = start; i < end; i++) restored[i] = proposalLines[i];
+  return restored.join('\n');
 }

--- a/webview/src/pages/DiffPage/useHunkDecisions.ts
+++ b/webview/src/pages/DiffPage/useHunkDecisions.ts
@@ -101,17 +101,28 @@ export function useHunkDecisions(hunks: readonly ChangeBlock[]): HunkDecisions {
     [kept],
   );
 
-  return {
-    decisionFor,
-    keep,
-    undo,
-    reset,
-    acceptAll,
-    resetAll,
-    allAccepted: hunks.length > 0 && hunks.every((h) => decisions.get(h.index) === 'keep'),
-    openCount,
-    keptCount: kept.length,
-    total: hunks.length,
-    acceptedRanges,
-  };
+  /*
+   * Memoized, because consumers key render decisions off this object.
+   *
+   * A literal here is a new object on every render, and the review diff passes
+   * values derived from it to a renderer that compares by identity and rebuilds
+   * on change — taking the reviewer's edit session down with it every time.
+   * Nothing here is cheap to rebuild, but identity is what actually matters.
+   */
+  return useMemo(
+    () => ({
+      decisionFor,
+      keep,
+      undo,
+      reset,
+      acceptAll,
+      resetAll,
+      allAccepted: hunks.length > 0 && hunks.every((h) => decisions.get(h.index) === 'keep'),
+      openCount,
+      keptCount: kept.length,
+      total: hunks.length,
+      acceptedRanges,
+    }),
+    [decisionFor, keep, undo, reset, acceptAll, resetAll, hunks, decisions, openCount, kept.length, acceptedRanges],
+  );
 }

--- a/webview/src/pages/DiffPage/useResolvedDiff.ts
+++ b/webview/src/pages/DiffPage/useResolvedDiff.ts
@@ -2,41 +2,101 @@ import { useMemo } from 'react';
 import { diffAcceptRejectHunk, type FileDiffMetadata } from '@pierre/diffs';
 import type { HunkDecisions } from './useHunkDecisions';
 
+/** The shape this module reads out of FileDiffMetadata. See changeBlocks. */
+interface RawHunk {
+  hunkContent?: { type: string }[];
+}
+
 /**
  * The diff as it should look right now, given what the reviewer has answered.
  *
- * An answered hunk stops being drawn as a change: keeping it collapses to the
+ * An answered block stops being drawn as a change: keeping it collapses to the
  * proposed lines, undoing it collapses to the lines on disk. Either way it
  * becomes context, so what is left on screen is exactly what is left to decide.
  *
- * Recomputed from [original] on every change rather than accumulated, which is
- * what makes Reset work: `diffAcceptRejectHunk` does not touch its input, so the
- * untouched original is always available to replay a different set of answers
- * onto. Accumulating instead would destroy the hunk on the first answer and
- * leave nothing to go back to.
+ * Resolved by the library rather than by hand. A `change` entry carries only
+ * COORDINATES — `{additions, deletions, additionLineIndex, deletionLineIndex}` —
+ * and the text lives in the diff's top-level `additionLines`/`deletionLines`.
+ * Retyping the entry to `context` therefore changes nothing anyone draws: the
+ * renderer keeps painting a deletion beside an addition, and the reviewer sees
+ * a hunk they have already answered sitting exactly where it was.
+ * `diffAcceptRejectHunk` rewrites those line arrays too, which is what actually
+ * takes the block off the screen.
  *
  * Applied high index first. Resolving a hunk renumbers the ones after it, so
  * walking forwards would apply each later decision to a hunk that had shifted
  * out from under its index.
+ *
+ * Recomputed from [original] on every change rather than accumulated, which is
+ * what makes Reset work: `diffAcceptRejectHunk` does not touch its input, so the
+ * untouched original is always available to replay a different set of answers
+ * onto. Accumulating instead would destroy the block on the first answer and
+ * leave nothing to go back to.
  */
 export function useResolvedDiff(
   original: FileDiffMetadata,
-  // Optional because a change the backend could not split has no per-hunk
+  // Optional because a change the backend could not split has no per-block
   // decisions to replay; that review is whole-file and the diff is the original.
   decisions?: HunkDecisions,
 ): FileDiffMetadata {
   const decisionFor = decisions?.decisionFor;
-  const total = decisions?.total ?? 0;
 
   return useMemo(() => {
     if (!decisionFor) return original;
+
+    // The library resolves a whole HUNK; this page decides per change BLOCK,
+    // and a hunk holds every block within three lines of the last. So a hunk is
+    // only resolvable once its blocks agree — see hunkVerdicts.
+    const verdicts = hunkVerdicts(original, decisionFor);
+
     let diff = original;
-    for (let index = total - 1; index >= 0; index--) {
-      const decision = decisionFor(index);
-      if (!decision) continue;
+    for (let hunk = verdicts.length - 1; hunk >= 0; hunk--) {
+      const verdict = verdicts[hunk];
+      if (!verdict) continue;
       // keep → the proposal wins here; undo → the file on disk wins.
-      diff = diffAcceptRejectHunk(diff, index, decision === 'keep' ? 'accept' : 'reject');
+      diff = diffAcceptRejectHunk(diff, hunk, verdict === 'keep' ? 'accept' : 'reject');
     }
     return diff;
-  }, [original, decisionFor, total]);
+  }, [original, decisionFor]);
+}
+
+/**
+ * What each hunk of [diff] should become, or undefined to leave it alone.
+ *
+ * A hunk resolves only when every block inside it got the SAME answer. Mixed —
+ * one kept, one undone, or one still open — leaves it drawn, because the
+ * library resolves hunks whole and there is no way to say "this half of it".
+ * Leaving it is the honest outcome: the blocks that are settled keep their
+ * controls in the Reset/Back state, and what still needs an answer stays on
+ * screen. The ranges sent to the backend are built from the decisions
+ * themselves, so a hunk left drawn here still writes exactly what was chosen.
+ *
+ * Blocks are walked in the same order `changeBlocksOf` numbers them — both read
+ * `hunkContent` in file order — so the counter here IS that block's index.
+ */
+function hunkVerdicts(
+  diff: FileDiffMetadata,
+  decisionFor: (index: number) => 'keep' | 'undo' | undefined,
+): (('keep' | 'undo') | undefined)[] {
+  const hunks = (diff as unknown as { hunks?: RawHunk[] }).hunks ?? [];
+  let block = 0;
+
+  return hunks.map((hunk) => {
+    let verdict: 'keep' | 'undo' | undefined;
+    let first = true;
+    let mixed = false;
+
+    for (const entry of hunk.hunkContent ?? []) {
+      if (entry.type !== 'change') continue;
+      const decision = decisionFor(block++);
+      if (first) {
+        verdict = decision;
+        first = false;
+      } else if (decision !== verdict) {
+        mixed = true;
+      }
+    }
+
+    return mixed ? undefined : verdict;
+  });
 }

--- a/webview/src/utils/__tests__/caretBoundaryKey.test.ts
+++ b/webview/src/utils/__tests__/caretBoundaryKey.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { caretBoundaryMoveFor } from '../caretBoundaryKey';
+import { CaretBoundary, CaretDirection } from '@/utils/domSelection';
+
+/**
+ * Cmd+Arrow moves the caret to the edge of the line under off-screen rendering,
+ * where Chromium performs no such move of its own (the composer is left holding
+ * a keystroke with its modifiers intact and nothing to do it).
+ *
+ * What is pinned here is which keys the composer claims and what it asks for.
+ * The pair that matters most is Cmd (claimed) against Option (not): taking
+ * Option would swap Chromium's working word-wise movement for our own.
+ */
+
+function press(key: string, mods: Partial<Record<'metaKey' | 'altKey' | 'ctrlKey' | 'shiftKey', boolean>> = {}) {
+  return caretBoundaryMoveFor({
+    key,
+    metaKey: mods.metaKey ?? false,
+    altKey: mods.altKey ?? false,
+    ctrlKey: mods.ctrlKey ?? false,
+    shiftKey: mods.shiftKey ?? false,
+  });
+}
+
+describe('caretBoundaryMoveFor', () => {
+  it('sends Cmd+Left and Cmd+Right to the line edges', () => {
+    expect(press('ArrowLeft', { metaKey: true })).toEqual({
+      direction: CaretDirection.Backward,
+      boundary: CaretBoundary.Line,
+      extend: false,
+    });
+    expect(press('ArrowRight', { metaKey: true })).toEqual({
+      direction: CaretDirection.Forward,
+      boundary: CaretBoundary.Line,
+      extend: false,
+    });
+  });
+
+  it('sends Cmd+Up and Cmd+Down to the ends of the text', () => {
+    expect(press('ArrowUp', { metaKey: true })?.boundary).toBe(CaretBoundary.Document);
+    expect(press('ArrowDown', { metaKey: true })?.boundary).toBe(CaretBoundary.Document);
+  });
+
+  it('extends the selection when Shift is held', () => {
+    // Cmd+Shift+Arrow is broken under OSR in the same way and for the same
+    // reason as Cmd+Arrow, so it is claimed here too.
+    expect(press('ArrowLeft', { metaKey: true, shiftKey: true })?.extend).toBe(true);
+    expect(press('ArrowLeft', { metaKey: true })?.extend).toBe(false);
+  });
+
+  it('leaves Option+Arrow alone', () => {
+    // Word-wise movement is Chromium's own and survives OSR. Claiming it would
+    // mean reimplementing something that already works.
+    expect(press('ArrowLeft', { altKey: true })).toBeNull();
+    expect(press('ArrowLeft', { metaKey: true, altKey: true })).toBeNull();
+  });
+
+  it('leaves bare arrows and Ctrl+Arrow alone', () => {
+    expect(press('ArrowLeft')).toBeNull();
+    expect(press('ArrowRight')).toBeNull();
+    // Ctrl+Arrow is Mission Control on macOS.
+    expect(press('ArrowLeft', { ctrlKey: true })).toBeNull();
+  });
+
+  it('ignores keys that are not arrows', () => {
+    expect(press('a', { metaKey: true })).toBeNull();
+    expect(press('Enter', { metaKey: true })).toBeNull();
+  });
+});

--- a/webview/src/utils/__tests__/domSelection.test.ts
+++ b/webview/src/utils/__tests__/domSelection.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   textOffsetToPoint,
   pointToTextOffset,
@@ -6,6 +6,9 @@ import {
   setCaretOffset,
   getSelectionRange,
   setSelectionRange,
+  moveCaretToBoundary,
+  CaretBoundary,
+  CaretDirection,
 } from '../domSelection';
 
 // jsdom is available via vitest's jsdom environment.
@@ -488,5 +491,64 @@ describe('caret scrolling on programmatic moves', () => {
 
     expect(root.scrollTop).toBe(17);
     document.body.removeChild(root);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// moveCaretToBoundary
+// ---------------------------------------------------------------------------
+
+/**
+ * These assert the granularity handed to `Selection.modify`, which is the whole
+ * of what this function decides. jsdom does not implement `modify` (nor any
+ * layout to observe a caret with), so it is stubbed and the call is read back.
+ *
+ * The granularity is the part worth pinning: 'lineboundary' follows a soft wrap
+ * to the edge of the visual row, while the implementation this replaced scanned
+ * for "\n" and so ran on to the end of the paragraph. A test that only checked
+ * "the caret moved" would pass for both.
+ */
+describe('moveCaretToBoundary', () => {
+  let modify: ReturnType<typeof vi.fn>;
+  let originalGetSelection: typeof window.getSelection;
+
+  beforeEach(() => {
+    modify = vi.fn();
+    originalGetSelection = window.getSelection;
+    window.getSelection = () => ({ modify, rangeCount: 0 }) as unknown as Selection;
+  });
+
+  afterEach(() => {
+    window.getSelection = originalGetSelection;
+  });
+
+  const root = () => document.createElement('div');
+
+  it('moves to the edge of the visual line, not of the paragraph', () => {
+    moveCaretToBoundary(root(), CaretDirection.Backward, CaretBoundary.Line, false);
+
+    expect(modify).toHaveBeenCalledWith('move', 'backward', 'lineboundary');
+  });
+
+  it('extends the selection instead of moving it when Shift is held', () => {
+    moveCaretToBoundary(root(), CaretDirection.Forward, CaretBoundary.Line, true);
+
+    expect(modify).toHaveBeenCalledWith('extend', 'forward', 'lineboundary');
+  });
+
+  it('reaches the whole text for the vertical arrows', () => {
+    moveCaretToBoundary(root(), CaretDirection.Forward, CaretBoundary.Document, false);
+
+    expect(modify).toHaveBeenCalledWith('move', 'forward', 'documentboundary');
+  });
+
+  it('does nothing where the engine has no modify()', () => {
+    window.getSelection = () => ({ rangeCount: 0 }) as unknown as Selection;
+
+    // The caret staying put is the wanted outcome: without `modify` there is no
+    // way to find a visual line's edge, and guessing one would move it wrongly.
+    expect(() =>
+      moveCaretToBoundary(root(), CaretDirection.Backward, CaretBoundary.Line, false),
+    ).not.toThrow();
   });
 });

--- a/webview/src/utils/caretBoundaryKey.ts
+++ b/webview/src/utils/caretBoundaryKey.ts
@@ -1,0 +1,77 @@
+import { CaretBoundary, CaretDirection } from '@/utils/domSelection';
+
+/** The move a Cmd+Arrow press asks for. */
+export interface CaretBoundaryMove {
+  direction: CaretDirection;
+  boundary: CaretBoundary;
+  /** Shift was held, so drag the selection's end rather than move the caret. */
+  extend: boolean;
+}
+
+/** The parts of a keydown this decision reads. */
+export interface CaretBoundaryKeyEvent {
+  key: string;
+  metaKey: boolean;
+  altKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * Which caret move a keydown asks for, or null when the composer should keep
+ * its hands off the key.
+ *
+ * Split out from the composer's keydown handler so the mapping can be asserted
+ * on its own — rendering ChatInput takes a dozen contexts, and a test that
+ * heavy would not be written per key combination.
+ *
+ * Only Cmd is claimed. Option+Arrow is Chromium's own word-wise movement and
+ * works under off-screen rendering, so taking it over here would replace a
+ * working behaviour with a reimplementation of it. Ctrl+Arrow belongs to macOS
+ * (Mission Control) and to the IDE elsewhere.
+ */
+export function caretBoundaryMoveFor(e: CaretBoundaryKeyEvent): CaretBoundaryMove | null {
+  if (!e.metaKey || e.altKey || e.ctrlKey) return null;
+
+  switch (e.key) {
+    case 'ArrowLeft':
+      return {
+        direction: CaretDirection.Backward,
+        boundary: CaretBoundary.Line,
+        extend: e.shiftKey,
+      };
+    case 'ArrowRight':
+      return {
+        direction: CaretDirection.Forward,
+        boundary: CaretBoundary.Line,
+        extend: e.shiftKey,
+      };
+    // Up and Down reach the whole text, which is what macOS does with them.
+    //
+    // Cmd+Up does not arrive inside a JetBrains IDE: `meta UP` is ShowNavBar in
+    // the bundled macOS keymap, and the IDE opens the navigation bar — taking
+    // focus off the page — before the keystroke is ours to read. Reaching it
+    // would mean telling CEF to stop treating arrows as IDE shortcuts at all
+    // (WebViewKeyboardHandler), and that switch is not scoped to this input:
+    // it would take the arrows away from every other thing the panel hosts.
+    // Not worth it for one key, so Cmd+Up is knowingly left broken there.
+    //
+    // The mapping stays because the browser build has no such competitor and
+    // Cmd+Up works there; deleting it would break the case that works to match
+    // the one that cannot.
+    case 'ArrowUp':
+      return {
+        direction: CaretDirection.Backward,
+        boundary: CaretBoundary.Document,
+        extend: e.shiftKey,
+      };
+    case 'ArrowDown':
+      return {
+        direction: CaretDirection.Forward,
+        boundary: CaretBoundary.Document,
+        extend: e.shiftKey,
+      };
+    default:
+      return null;
+  }
+}

--- a/webview/src/utils/domSelection.ts
+++ b/webview/src/utils/domSelection.ts
@@ -286,3 +286,68 @@ export function setSelectionRange(
     // Silently ignore if DOM is not attached or in an unexpected state
   }
 }
+
+/** How far one caret move reaches: to the visual line's edge, or the text's. */
+export enum CaretBoundary {
+  /** The edge of the *visual* row, which is where a soft wrap folded it. */
+  Line = 'lineboundary',
+  /** The start or end of the whole text. */
+  Document = 'documentboundary',
+}
+
+/** Which way the caret travels. */
+export enum CaretDirection {
+  Backward = 'backward',
+  Forward = 'forward',
+}
+
+/**
+ * Move (or extend the selection to) the line's or document's edge.
+ *
+ * macOS gives Cmd+Arrow to the composer everywhere else, but under off-screen
+ * rendering Chromium never performs it. Cmd+Arrow is not one of Chromium's own
+ * editing commands; on macOS it arrives as an NSResponder selector
+ * (`moveToBeginningOfLine:` and friends) that the OS sends to the native view.
+ * OSR has no such view, so the keystroke reaches the page — modifiers intact,
+ * nothing calling preventDefault — and then nothing happens. Option+Arrow keeps
+ * working through the same builds because word-wise movement *is* built into
+ * Chromium, which is the asymmetry that gives this away.
+ *
+ * That makes the composer, not the browser, responsible for these four keys
+ * whenever the IDE runs JCEF out of process — the default since 2025.1, and so
+ * what most users are on.
+ *
+ * `Selection.modify` is used rather than scanning the text for "\n". The two
+ * disagree exactly where it matters: a soft-wrapped paragraph is one run of
+ * text with no newline in it, so scanning sends the caret to the paragraph's
+ * edge while the user asked for the edge of the row they are looking at. An
+ * earlier hand-rolled implementation did scan, and was removed for that reason;
+ * reinstating it here would bring the same defect back. `modify` asks the
+ * engine that laid the text out, so it also matches what Up/Down already do.
+ *
+ * Non-standard but implemented by every engine we run on (it predates JCEF's
+ * Chromium by a decade). Absent — as in jsdom — this is a no-op, leaving the
+ * caret where it was rather than moving it somewhere wrong.
+ *
+ * @param extend Keep the selection's anchor and drag its end (Shift is held).
+ */
+export function moveCaretToBoundary(
+  root: HTMLElement,
+  direction: CaretDirection,
+  boundary: CaretBoundary,
+  extend: boolean,
+): void {
+  const selection = window.getSelection();
+  if (!selection?.modify) return;
+
+  try {
+    selection.modify(extend ? 'extend' : 'move', direction, boundary);
+
+    // `modify` moves the caret without scrolling to it, the same gap
+    // setCaretOffset covers for programmatic moves.
+    const range = selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+    if (range) scrollCaretIntoView(root, range);
+  } catch {
+    // Silently ignore if the engine rejects the granularity
+  }
+}

--- a/webview/src/utils/typingTarget.ts
+++ b/webview/src/utils/typingTarget.ts
@@ -1,0 +1,43 @@
+/**
+ * Whether an event landed somewhere characters are meant to go.
+ *
+ * Reads the composed path rather than `event.target`, because an editable can
+ * live inside a shadow root — the review diff's proposed side does — and the
+ * platform retargets `target` to the host element. A digit typed into a
+ * proposed edit then looked like a digit pressed at the approval panel and
+ * picked an option instead of reaching the text (issue #305). The path still
+ * holds the real element.
+ *
+ * `contenteditable` counts for the same reason a textarea does. The attribute
+ * is read as well as the resolved property: jsdom does not implement
+ * `isContentEditable`, and the renderer marks its editable side with the
+ * attribute either way. `contenteditable="false"` is explicitly not editable,
+ * which is why the attribute's value is checked rather than its presence.
+ */
+export function isTypingTarget(event: { composedPath?: () => EventTarget[]; target: EventTarget | null }): boolean {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+  for (const node of path) {
+    if (!(node instanceof HTMLElement)) continue;
+    if (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA') return true;
+    const attr = node.getAttribute('contenteditable');
+    if (attr !== null && attr !== 'false') return true;
+    if (node.isContentEditable) return true;
+  }
+  return false;
+}
+
+/**
+ * The element characters would land in, or null when the event did not land in
+ * one. Same rules as {@link isTypingTarget}, which is written in terms of this.
+ */
+export function typingTargetOf(event: { composedPath?: () => EventTarget[]; target: EventTarget | null }): HTMLElement | null {
+  const path = typeof event.composedPath === 'function' ? event.composedPath() : [event.target];
+  for (const node of path) {
+    if (!(node instanceof HTMLElement)) continue;
+    if (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA') return node;
+    const attr = node.getAttribute('contenteditable');
+    if (attr !== null && attr !== 'false') return node;
+    if (node.isContentEditable) return node;
+  }
+  return null;
+}


### PR DESCRIPTION
Fixes the things that misbehave in v0.29.0: the review diff, and Cmd+Arrow caret movement.

## The review diff

**Fixed**
- Proposed side could not be typed into: the click guard read `e.target`, which the platform retargets to the shadow host
- Hunk picking was ignored once anything was typed: the edited text replaced the reassembly wholesale, so denied hunks were written too
- The notice never reached Claude: the CLI clears its pending-message queue as a turn ends, and answering a permission request is mid-turn
- Select all crashed: block numbers were passed where hunk numbers were expected
- An answered hunk stayed on screen: only the entry type was rewritten, not the lines the renderer paints
- The notice was missing from the message list: it was written to stdin without the broadcast that accompanies a user message
- Reset did nothing, Accept was barely visible over addition rows, the overlay was sized to its content

**Changed**
- The notice is sent for every answer that is not a full accept, not only for edits
- It asks for the acknowledgement in the user's own language and sends the assistant back to compare what it said with what actually landed

The built-in surface still has rough edges under free-form editing; the IDE viewer (the default) is the one to prefer for now.

## Cmd+Arrow caret movement

Cmd+Left/Right moved no caret in any text field in v0.29.0. The composer had
handled these keys itself until v0.28.5 (bfb2997) removed that, on the finding
that JCEF performed them natively — a finding measured in a windowed browser
(the 2024.2 sandbox), and true only there.

On macOS Cmd+Arrow is not a Chromium shortcut. It arrives as an NSResponder
selector that the OS sends to a native view, and off-screen rendering — the
default since IDE 2025.1 — has no such view. The keystroke still reaches the
page with its modifiers intact and nothing prevents it, and then the caret does
not move. Option+Arrow keeps working throughout, being word-wise movement built
into Chromium; that asymmetry is what identified the cause. Reproducing it in a
2025.3 sandbox, on the same Chromium build (137) as the WebStorm it was reported
from, ruled the engine version out.

Handled again through `Selection.modify`, not the `"\n"` scan that went with the
old implementation. A soft-wrapped paragraph holds no newline, so scanning ran on
to the paragraph's edge while the user asked for the edge of the row they were
looking at.

Registered once at the app root rather than in the composer. The first attempt
wired only the chat input and left the session search, the settings fields and
everything else still stuck. Form fields take a separate path, since their
selection is character offsets that `Selection.modify` does not reach into.

**Cmd+Up is knowingly left unfixed inside the IDE.** `meta UP` is ShowNavBar in
the bundled macOS keymap, so the IDE opens the navigation bar and takes focus
before the page sees the key. Reaching it would mean telling CEF to stop treating
arrows as IDE shortcuts at all, and that switch is not scoped to one input — it
would take the arrows away from everything else the panel hosts. The mapping
stays because the browser build has no such competitor and works there.
