### PR TITLE
fix: let a 401 decide the login control beside it, and keep orange labels readable (#366)

### DIFF
--- a/webview/src/contexts/AuthContext.tsx
+++ b/webview/src/contexts/AuthContext.tsx
@@ -6,6 +6,15 @@ import { useAccountQuery } from '@/hooks/queries/useAccountQuery';
 interface AuthContextValue {
   /** null = not yet determined; true/false = known login state. */
   loggedIn: boolean | null;
+  /**
+   * When `loggedIn` was last resolved, as epoch ms (0 while undetermined).
+   *
+   * Lets a consumer tell whether a login state was confirmed BEFORE or AFTER a
+   * given event. A transcript's 401 entry needs exactly that: `loggedIn === true`
+   * confirmed before the 401 is stale (the token was revoked since), while one
+   * confirmed after it means the user has genuinely re-authenticated.
+   */
+  checkedAt: number;
   /** Re-query the CLI auth status (e.g. after a login completes). Awaitable so
    * callers can show a spinner while the re-check is in flight. */
   refetch: () => Promise<void>;
@@ -38,6 +47,10 @@ export function AuthProvider(props: AuthProviderProps) {
   //   failure rejected with no prior success — never flip a known state on it.
   const loggedIn: boolean | null = accountQuery.data ? accountQuery.data.loggedIn : null;
 
+  // react-query already timestamps every resolved fetch, so the "when was this
+  // confirmed" question needs no extra state of our own.
+  const checkedAt = accountQuery.data ? accountQuery.dataUpdatedAt : 0;
+
   const refetch = useCallback(async () => {
     // Invalidate both the single live-account query (login state, header avatar)
     // and the saved-accounts list (active marker, switcher) so a login/switch made
@@ -68,7 +81,7 @@ export function AuthProvider(props: AuthProviderProps) {
   }, [refetch]);
 
   return (
-    <AuthContext.Provider value={{ loggedIn, refetch }}>
+    <AuthContext.Provider value={{ loggedIn, checkedAt, refetch }}>
       {children}
     </AuthContext.Provider>
   );

--- a/webview/src/pages/ChatPage/AuthErrorBanner.tsx
+++ b/webview/src/pages/ChatPage/AuthErrorBanner.tsx
@@ -27,7 +27,7 @@ export function AuthErrorBanner() {
       <button
         type="button"
         onClick={navigateToLogin}
-        className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md text-xs font-medium bg-accent-claude text-text-primary hover:bg-accent-claude-hover transition-colors"
+        className="inline-flex items-center gap-1.5 px-2.5 py-0.5 rounded-md text-xs font-medium bg-accent-claude text-white hover:bg-accent-claude-hover transition-colors"
       >
         <ArrowRightOnRectangleIcon className="w-3.5 h-3.5 rtl:-scale-x-100" />
         {t('authError.login')}

--- a/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/__tests__/LoginCta.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 const { mockNavigateToLogin, mockRefetch, authState } = vi.hoisted(() => ({
   mockNavigateToLogin: vi.fn(),
   mockRefetch: vi.fn(),
-  authState: { loggedIn: null as boolean | null },
+  authState: { loggedIn: null as boolean | null, checkedAt: 0 },
 }));
 
 vi.mock('@/hooks', () => ({
@@ -12,10 +12,16 @@ vi.mock('@/hooks', () => ({
 }));
 
 vi.mock('@/contexts', () => ({
-  useAuthContext: () => ({ loggedIn: authState.loggedIn, refetch: mockRefetch }),
+  useAuthContext: () => ({
+    loggedIn: authState.loggedIn,
+    checkedAt: authState.checkedAt,
+    refetch: mockRefetch,
+  }),
 }));
 
 import { LoginCta } from '../index';
+
+const FAILED_AT = 1_000;
 
 describe('LoginCta', () => {
   beforeEach(() => {
@@ -23,6 +29,7 @@ describe('LoginCta', () => {
     mockRefetch.mockReset();
     mockRefetch.mockResolvedValue(undefined);
     authState.loggedIn = null;
+    authState.checkedAt = 0;
   });
 
   describe('when logged out', () => {
@@ -76,5 +83,58 @@ describe('LoginCta', () => {
       resolveRefetch();
       await waitFor(() => expect(container.querySelector('.animate-spin')).toBeNull());
     });
+  });
+
+  // `claude auth status` reports the STORED credentials, not whether the API still
+  // accepts them, so a revoked token keeps answering loggedIn:true. Beside a 401
+  // entry that made the button show an inactive "Signed" with no route to login.
+  describe('next to an authentication failure', () => {
+    beforeEach(() => { authState.loggedIn = true; });
+
+    it('shows "Re-Sign" when the logged-in state predates the failure', () => {
+      authState.checkedAt = FAILED_AT - 1;
+      const { container } = render(<LoginCta authFailedAt={FAILED_AT} />);
+      expect(screen.getByRole('button', { name: /re-sign/i })).toBeInTheDocument();
+      expect(container.querySelector('.opacity-50')).toBeNull();
+    });
+
+    it('navigates to the login page when clicked in that state', () => {
+      authState.checkedAt = FAILED_AT - 1;
+      render(<LoginCta authFailedAt={FAILED_AT} />);
+      fireEvent.click(screen.getByRole('button', { name: /re-sign/i }));
+      expect(mockNavigateToLogin).toHaveBeenCalled();
+      expect(mockRefetch).not.toHaveBeenCalled();
+    });
+
+    it('treats an auth check made at the very moment of the failure as stale', () => {
+      authState.checkedAt = FAILED_AT;
+      render(<LoginCta authFailedAt={FAILED_AT} />);
+      expect(screen.getByRole('button', { name: /re-sign/i })).toBeInTheDocument();
+    });
+
+    it('shows "Signed" once auth is re-confirmed AFTER the failure', () => {
+      authState.checkedAt = FAILED_AT + 1;
+      const { container } = render(<LoginCta authFailedAt={FAILED_AT} />);
+      expect(screen.getByRole('button', { name: /signed/i })).toBeInTheDocument();
+      expect(container.querySelector('.opacity-50')).not.toBeNull();
+    });
+
+    it('still shows "Re-Sign" when logged out, whenever the check happened', () => {
+      authState.loggedIn = false;
+      authState.checkedAt = FAILED_AT + 1;
+      render(<LoginCta authFailedAt={FAILED_AT} />);
+      expect(screen.getByRole('button', { name: /re-sign/i })).toBeInTheDocument();
+    });
+  });
+
+  it('renders its label on the orange fill in white, not the theme text colour', () => {
+    // The fill is theme-independent, so a theme-derived foreground (text-primary,
+    // which follows the IDE editor colour when theme sync is on) can land unreadable
+    // on it — as it did here.
+    authState.loggedIn = false;
+    const { container } = render(<LoginCta />);
+    const button = container.querySelector('button');
+    expect(button?.className).toContain('text-white');
+    expect(button?.className).not.toContain('text-text-primary');
   });
 });

--- a/webview/src/pages/ChatPage/LoginCta/index.tsx
+++ b/webview/src/pages/ChatPage/LoginCta/index.tsx
@@ -5,6 +5,13 @@ import { useAuthContext } from '@/contexts';
 import { useTranslation } from '@/i18n';
 
 interface Props {
+  /**
+   * When this control sits next to a CLI authentication failure, the epoch ms of
+   * that failure. The button then reports the state that failure describes —
+   * logged out — unless auth was re-confirmed after it. Omit when the control is
+   * not tied to a specific failure.
+   */
+  authFailedAt?: number;
   className?: string;
 }
 
@@ -19,15 +26,23 @@ interface Props {
  * It never disappears, so a stale auth error in the transcript reads correctly:
  * dimmed "Signed" once the user is authenticated again, prominent "Re-Sign"
  * while still logged out.
+ *
+ * `loggedIn` alone cannot decide that, because `claude auth status` reports the
+ * stored credentials rather than whether the API still accepts them: a revoked
+ * token keeps answering "logged in" while every request 401s. Believing it left
+ * the button showing an inactive "Signed" right beside a "401 OAuth access token
+ * has been revoked" line, with no way to reach the login page. So a `loggedIn`
+ * that predates the failure is treated as stale and the failure wins.
  */
 export function LoginCta(props: Props) {
-  const { className = '' } = props;
+  const { authFailedAt, className = '' } = props;
   const { t } = useTranslation('chat');
   const navigateToLogin = useNavigateToLogin();
-  const { loggedIn, refetch } = useAuthContext();
+  const { loggedIn, checkedAt, refetch } = useAuthContext();
   const [isRechecking, setIsRechecking] = useState(false);
 
-  const isSignedIn = loggedIn === true;
+  const staleAfterFailure = authFailedAt !== undefined && checkedAt <= authFailedAt;
+  const isSignedIn = loggedIn === true && !staleAfterFailure;
 
   const handleClick = async () => {
     if (isSignedIn) {
@@ -47,10 +62,10 @@ export function LoginCta(props: Props) {
     <button
       type="button"
       onClick={() => { void handleClick(); }}
-      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-claude text-text-primary transition-opacity ${isSignedIn ? 'opacity-50 hover:opacity-60' : 'opacity-100 hover:bg-accent-claude-hover'} ${className}`}
+      className={`inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-medium bg-accent-claude text-white transition-opacity ${isSignedIn ? 'opacity-50 hover:opacity-60' : 'opacity-100 hover:bg-accent-claude-hover'} ${className}`}
     >
       {isRechecking ? (
-        <span className="w-3.5 h-3.5 border-2 border-border-strong border-t-text-primary rounded-full animate-spin" />
+        <span className="w-3.5 h-3.5 border-2 border-border-strong border-t-white rounded-full animate-spin" />
       ) : (
         <ArrowRightOnRectangleIcon className="w-3.5 h-3.5 rtl:-scale-x-100" />
       )}

--- a/webview/src/pages/ChatPage/message-renderers/AuthErrorRenderer.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/AuthErrorRenderer.tsx
@@ -10,17 +10,28 @@ interface Props {
  * Renders the CLI's authentication-failure entry (401 / authentication_failed)
  * as a single line — a red status dot, the dimmed error text, and an inline
  * login CTA pushed to the right edge.
+ *
+ * Both the dot and the CTA read the state THIS entry describes, not the ambient
+ * `loggedIn` alone: an auth check that predates the failure is stale, since
+ * `claude auth status` keeps reporting a revoked token as logged in. Only a
+ * check made after the failure can turn the line green.
  */
 export function AuthErrorRenderer(props: Props) {
   const { message } = props;
-  const { loggedIn } = useAuthContext();
+  const { loggedIn, checkedAt } = useAuthContext();
+
+  const failedAt = message.timestamp ? Date.parse(message.timestamp) : NaN;
+  // An unparseable/absent timestamp cannot date the failure, so no auth check can
+  // be shown to postdate it — fall back to the failure standing (dot stays red).
+  const authFailedAt = Number.isNaN(failedAt) ? Infinity : failedAt;
+  const resolved = loggedIn === true && checkedAt > authFailedAt;
 
   return (
     <div className="group pt-2 pb-4 px-6">
       <div className="flex items-center gap-3 flex-wrap text-text-primary text-[1rem] leading-relaxed">
-        <span className={`${loggedIn ? 'text-green-500' : 'text-red-500 animate animate-pulse'} mt-[1px] text-[0.6923rem]`}>●</span>
+        <span className={`${resolved ? 'text-green-500' : 'text-red-500 animate animate-pulse'} mt-[1px] text-[0.6923rem]`}>●</span>
         <span className="opacity-75 mr-auto">{getTextContent(message)}</span>
-        <LoginCta />
+        <LoginCta authFailedAt={authFailedAt} />
       </div>
     </div>
   );

--- a/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
+++ b/webview/src/pages/ChatPage/message-renderers/__tests__/AuthErrorRenderer.test.tsx
@@ -1,22 +1,37 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { LoadedMessageDto } from '../../../../types';
 import { LoadedMessageType, toInstance } from '../../../../dto/common';
 
-// AuthErrorRenderer reads loggedIn from the auth context; without a provider
-// it throws. Mock the context (as LoginCta's own test does) so the renderer can
-// be unit-tested in isolation. logged-out → the red status dot is shown.
+// AuthErrorRenderer reads the auth context; without a provider it throws. Mock the
+// context (as LoginCta's own test does) so the renderer can be unit-tested in
+// isolation, with the login state and its check time driven per test.
+const { authState, ctaProps } = vi.hoisted(() => ({
+  authState: { loggedIn: false as boolean | null, checkedAt: 0 },
+  ctaProps: { authFailedAt: undefined as number | undefined },
+}));
+
 vi.mock('@/contexts', () => ({
-  useAuthContext: () => ({ loggedIn: false }),
+  useAuthContext: () => ({
+    loggedIn: authState.loggedIn,
+    checkedAt: authState.checkedAt,
+    refetch: vi.fn(),
+  }),
 }));
 
 vi.mock('../../LoginCta', () => ({
-  LoginCta: () => <button data-testid="login-cta">Re-Sign</button>,
+  LoginCta: (props: { authFailedAt?: number }) => {
+    ctaProps.authFailedAt = props.authFailedAt;
+    return <button data-testid="login-cta">Re-Sign</button>;
+  },
 }));
 
 import { AuthErrorRenderer } from '../AuthErrorRenderer';
 
-function authErrorMessage(): LoadedMessageDto {
+const FAILED_AT_ISO = '2026-08-29T10:00:00.000Z';
+const FAILED_AT = Date.parse(FAILED_AT_ISO);
+
+function authErrorMessage(overrides: Record<string, unknown> = {}): LoadedMessageDto {
   return toInstance(LoadedMessageDto, {
     type: LoadedMessageType.Assistant,
     message: {
@@ -26,10 +41,18 @@ function authErrorMessage(): LoadedMessageDto {
     isApiErrorMessage: true,
     apiErrorStatus: 401,
     error: 'authentication_failed',
+    timestamp: FAILED_AT_ISO,
+    ...overrides,
   });
 }
 
 describe('AuthErrorRenderer', () => {
+  beforeEach(() => {
+    authState.loggedIn = false;
+    authState.checkedAt = 0;
+    ctaProps.authFailedAt = undefined;
+  });
+
   it('renders the error text', () => {
     render(<AuthErrorRenderer message={authErrorMessage()} />);
     expect(screen.getByText(/failed to authenticate/i)).toBeInTheDocument();
@@ -43,5 +66,77 @@ describe('AuthErrorRenderer', () => {
   it('shows the red status dot', () => {
     const { container } = render(<AuthErrorRenderer message={authErrorMessage()} />);
     expect(container.querySelector('.text-red-500')).not.toBeNull();
+  });
+
+  it('passes the failure time to the CTA so it can date the login state', () => {
+    render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(ctaProps.authFailedAt).toBe(FAILED_AT);
+  });
+
+  // The reported bug: `claude auth status` still answered loggedIn:true after the
+  // token was revoked, so the line rendered a green dot next to "401 OAuth access
+  // token has been revoked".
+  it('keeps the dot red when the logged-in state predates the failure', () => {
+    authState.loggedIn = true;
+    authState.checkedAt = FAILED_AT - 1;
+    const { container } = render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(container.querySelector('.text-red-500')).not.toBeNull();
+    expect(container.querySelector('.text-green-500')).toBeNull();
+  });
+
+  it('turns the dot green once auth is re-confirmed after the failure', () => {
+    authState.loggedIn = true;
+    authState.checkedAt = FAILED_AT + 1;
+    const { container } = render(<AuthErrorRenderer message={authErrorMessage()} />);
+    expect(container.querySelector('.text-green-500')).not.toBeNull();
+    expect(container.querySelector('.text-red-500')).toBeNull();
+  });
+
+  it('keeps the failure standing when the entry carries no usable timestamp', () => {
+    authState.loggedIn = true;
+    authState.checkedAt = Number.MAX_SAFE_INTEGER;
+    const { container } = render(<AuthErrorRenderer message={authErrorMessage({ timestamp: undefined })} />);
+    expect(container.querySelector('.text-red-500')).not.toBeNull();
+    expect(ctaProps.authFailedAt).toBe(Infinity);
+  });
+
+  // Verbatim entry the CLI wrote to its JSONL transcript (session 4b4c26d7,
+  // 2026-08-06), trimmed only of the unrelated `usage` block. Guards the fields
+  // this renderer depends on — `timestamp` above all — against drift in the CLI's
+  // own output, which no hand-written fixture would catch.
+  describe('on a real CLI transcript entry', () => {
+    const REAL_ENTRY = {
+      parentUuid: '5e60f390-2ac3-4727-94bb-6eab2dff8165',
+      isSidechain: false,
+      type: LoadedMessageType.Assistant,
+      uuid: '117b962d-2d73-4a1e-b5c4-407dd377adce',
+      timestamp: '2026-08-06T03:22:19.029Z',
+      message: {
+        id: 'ee3f2acd-0960-441c-b237-acefd822d69b',
+        model: '<synthetic>',
+        role: 'assistant',
+        stop_reason: 'stop_sequence',
+        type: 'message',
+        content: [{
+          type: 'text',
+          text: 'Failed to authenticate. API Error: 401 OAuth access token has expired. Re-authenticate to continue.',
+        }],
+      },
+      error: 'authentication_failed',
+      isApiErrorMessage: true,
+      apiErrorStatus: 401,
+    };
+
+    it('dates the failure from the entry\'s own timestamp', () => {
+      render(<AuthErrorRenderer message={toInstance(LoadedMessageDto, REAL_ENTRY)} />);
+      expect(ctaProps.authFailedAt).toBe(Date.parse('2026-08-06T03:22:19.029Z'));
+    });
+
+    it('reports logged out while `auth status` still claims otherwise', () => {
+      authState.loggedIn = true;
+      authState.checkedAt = Date.parse('2026-08-06T03:00:00.000Z');
+      const { container } = render(<AuthErrorRenderer message={toInstance(LoadedMessageDto, REAL_ENTRY)} />);
+      expect(container.querySelector('.text-red-500')).not.toBeNull();
+    });
   });
 });

--- a/webview/src/pages/SettingsPage/Account/index.tsx
+++ b/webview/src/pages/SettingsPage/Account/index.tsx
@@ -14,7 +14,7 @@ export function AccountSettings() {
         <h2 className="text-xl font-semibold text-text-primary">{t('account.heading')}</h2>
         <button
           onClick={() => navigate(Route.SWITCH_ACCOUNT)}
-          className="flex items-center gap-1.5 text-[0.8461rem] text-text-primary bg-accent-claude hover:bg-accent-claude-hover rounded px-3 py-1.5 transition-colors"
+          className="flex items-center gap-1.5 text-[0.8461rem] text-white bg-accent-claude hover:bg-accent-claude-hover rounded px-3 py-1.5 transition-colors"
         >
           <PlusIcon className="w-4 h-4" />
           {t('account.addAccount')}

--- a/webview/src/pages/SwitchAccountPage/LoginCodeInput/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/LoginCodeInput/index.tsx
@@ -41,7 +41,7 @@ export function LoginCodeInput(props: Props) {
       <button
         onClick={submit}
         disabled={disabled || code.trim() === ''}
-        className="w-full mt-3 py-2.5 rounded-lg bg-accent-claude hover:bg-accent-claude-hover disabled:opacity-60 disabled:cursor-not-allowed text-text-primary font-semibold text-sm transition-colors"
+        className="w-full mt-3 py-2.5 rounded-lg bg-accent-claude hover:bg-accent-claude-hover disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors"
       >
         {t('codeInput.submit')}
       </button>

--- a/webview/src/pages/SwitchAccountPage/LoginUrlModal/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/LoginUrlModal/index.tsx
@@ -65,7 +65,7 @@ export function LoginUrlModal(props: Props) {
 
             <button
               onClick={onOpenUrl}
-              className="w-full py-2.5 rounded-lg bg-accent-claude hover:bg-accent-claude-hover text-text-primary font-semibold text-sm transition-colors flex items-center justify-center gap-1.5"
+              className="w-full py-2.5 rounded-lg bg-accent-claude hover:bg-accent-claude-hover text-white font-semibold text-sm transition-colors flex items-center justify-center gap-1.5"
             >
               {t('urlModal.openButton')}
               <ArrowTopRightOnSquareIcon className="w-3.5 h-3.5" />

--- a/webview/src/pages/SwitchAccountPage/index.tsx
+++ b/webview/src/pages/SwitchAccountPage/index.tsx
@@ -156,7 +156,7 @@ export function SwitchAccountPage(props: Props) {
           <button
             onClick={() => { void handleLogin('claude-ai'); }}
             disabled={loadingMethod !== null}
-            className="w-full mt-6 py-3 rounded-lg bg-accent-claude hover:bg-accent-claude-hover disabled:opacity-60 disabled:cursor-not-allowed text-text-primary font-semibold text-sm transition-colors flex items-center justify-center gap-2"
+            className="w-full mt-6 py-3 rounded-lg bg-accent-claude hover:bg-accent-claude-hover disabled:opacity-60 disabled:cursor-not-allowed text-white font-semibold text-sm transition-colors flex items-center justify-center gap-2"
           >
             {loadingMethod === 'claude-ai' && (
               <span className="w-4 h-4 border-2 border-border-strong border-t-text-primary rounded-full animate-spin" />


### PR DESCRIPTION
Closes #366

Two problems appeared on the same line: the login control beside a `401 OAuth access token has been revoked` message rendered a dimmed, inactive **"Signed"** with a green dot, and its label was barely legible on the orange fill.

## The control contradicted the message it sat next to

`LoginCta` and the status dot read only `loggedIn`, which comes from `claude auth status`. That command reports the *stored credentials*, not whether the API still accepts them — so a revoked token keeps answering "logged in" while every request 401s. The failure entry sitting right beside the button was never consulted, so the two were decided from different sources and could disagree.

Clicking made it worse: in the signed-in state the click only re-runs that same check, which keeps returning "logged in". Nothing happened, and the screen offered no route back to the login page.

Now the failure dates the login state. A `loggedIn` confirmed *before* the failure is stale and the failure stands — the control reads **"Re-Sign"**, is active, and navigates to login (carrying the session as `fallback`). A `loggedIn` confirmed *after* it means the user genuinely re-authenticated, so it dims back to "Signed". The failure time comes from the entry's own `timestamp` and the check time from react-query's existing `dataUpdatedAt` (exposed as `AuthContext.checkedAt`), so no new state is introduced. The dot and the control now decide in one place and can no longer disagree.

There is no reliable "auth recovered" event to key off instead: `ACCOUNTS_CHANGED` fires on save/delete/switch but not when the user logs in from a terminal, as `useAccountQuery` already notes.

## Labels on the orange fill

`--accent-claude` is the same fixed value in both palettes, but six of the seven filled-orange buttons coloured their label with `text-text-primary`. Under IDE theme sync that token resolves to the IDE editor foreground, so nothing guaranteed the pair was legible — the reported screenshot showed a dark brown label on orange. They are now pinned to white, matching `ScheduleSendPopover`, which already did this. The **"Claude.ai Subscription"** button on the login screen was one of the six.

## Verification

Reproducing a 401 is up to the server, so both states were staged by copying a real authentication-failure entry out of an existing transcript into an isolated throwaway project, changing only its identifiers and `timestamp` (the temporary sessions were removed afterwards):

| Staged condition | Result |
| --- | --- |
| failure *before* the auth check (recovered) | dimmed "Signed", green dot |
| failure *after* the auth check (unrecovered) | active **"Re-Sign"**, red dot, click navigates to `/switch-account?...&fallback=...` |

The second is the reported condition. Measured in the browser, the label renders `rgb(255,255,255)` on `rgb(217,119,87)`.

New tests cover both cases plus a verbatim CLI transcript entry, so they guard the fields this depends on — `timestamp` above all — against drift in the CLI's own output. Reverting the fix fails 6 of them, checked.

`wv-lint`, `be-lint`, `wv-test` (2816), `be-test` (1596) and `full-build` all pass.

## Known limit

If the user hits a 401, does *not* re-authenticate, and the app re-checks auth afterwards (on window focus, say), that check postdates the failure and reads as recovered. While `auth status` misreports a revoked token, a timestamp alone cannot separate that from a genuine recovery — telling them apart would need a signal that the API actually accepted the token.