### PR TITLE
test: make the backend suite pass on Windows

### DIFF
--- a/backend/src/core/__tests__/extend-kit.version.test.ts
+++ b/backend/src/core/__tests__/extend-kit.version.test.ts
@@ -29,12 +29,14 @@ vi.mock('../command', () => ({
     exec() {
       // Each manager is asked where it keeps global packages; an absent one
       // rejects, exactly as a missing command does.
+      // On Windows the lookup asks for `npm.cmd`, so the name is normalised —
+      // otherwise npmRoot answers nothing there and the fixture is ignored.
       const answer = {
         volta: voltaWhich,
         pnpm: pnpmRoot,
         yarn: yarnGlobalDir,
         npm: npmRoot,
-      }[this.command];
+      }[this.command.replace(/\.cmd$/, '')];
       void this.args;
       if (!answer) return Promise.reject(new Error(`${this.command}: command not found`));
       return Promise.resolve({ stdout: answer, stderr: '' });
@@ -61,11 +63,17 @@ describe('getExtendKitVersion', () => {
     // sees only what it sets up.
     execPathSpy = vi.spyOn(process, 'execPath', 'get');
     execPathSpy.mockReturnValue(join(dir, 'no-node', 'bin', 'node'));
+    // On Windows the lookup also offers %APPDATA%\npm\node_modules, npm's real
+    // global prefix there. Left alone it is a developer's actual install, which
+    // every test would find instead of its fixture — the same reason execPath
+    // is pointed at an empty prefix above.
+    vi.stubEnv('APPDATA', join(dir, 'no-appdata'));
     resetExtendKitCache();
   });
 
   afterEach(async () => {
     execPathSpy.mockRestore();
+    vi.unstubAllEnvs();
     await rm(dir, { recursive: true, force: true });
     resetExtendKitCache();
   });

--- a/backend/src/core/features/__tests__/account-store.test.ts
+++ b/backend/src/core/features/__tests__/account-store.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtemp, rm, stat, readFile } from 'fs/promises';
+import { mkdtemp, rm, stat, readFile, writeFile, chmod } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
+
+// Real fs throughout — only writeFile and chmod are wrapped, so the permission
+// the store asks for can be read back on a filesystem that does not keep it.
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return { ...actual, writeFile: vi.fn(actual.writeFile), chmod: vi.fn(actual.chmod) };
+});
 
 // account-store derives its base dir from os.homedir(). Point it at a throwaway
 // temp dir so the tests touch real files without hitting the user's home.
@@ -72,8 +79,22 @@ describe('account-store', () => {
     expect(snap?.oauthAccount).toEqual({ emailAddress: 'a@x.com' });
     expect(hasSnapshot(id)).toBe(true);
 
-    const mode = (await stat(join(tempHome, '.claude-code-gui', 'accounts', `${id}.json`))).mode & 0o777;
-    expect(mode).toBe(0o600);
+    // Owner-only is asked for on every platform: the file is created with the
+    // mode and the mode is reapplied to the destination after the rename.
+    const snapshotPath = join(tempHome, '.claude-code-gui', 'accounts', `${id}.json`);
+    expect(vi.mocked(writeFile)).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      expect.objectContaining({ mode: 0o600 }),
+    );
+    expect(vi.mocked(chmod)).toHaveBeenCalledWith(snapshotPath, 0o600);
+
+    // Only a POSIX filesystem stores the bits; NTFS drops them and reports 0666,
+    // which is why the request above — not the result — is the portable check.
+    if (process.platform !== 'win32') {
+      const mode = (await stat(snapshotPath)).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
   });
 
   it('deleteAccountFiles removes both the registry entry and the snapshot, clearing current', async () => {

--- a/backend/src/core/features/__tests__/getStrippableAuthEnvKeys.test.ts
+++ b/backend/src/core/features/__tests__/getStrippableAuthEnvKeys.test.ts
@@ -16,15 +16,19 @@ vi.mock('os', () => ({
 }));
 
 import { readFile } from 'fs/promises';
+import { join } from 'path';
 import { getStrippableAuthEnvKeys } from '../claude-settings';
 
 const mockReadFile = vi.mocked(readFile);
 
-const HOME_SETTINGS = '/mock-home/.claude/settings.json';
-const HOME_SETTINGS_LOCAL = '/mock-home/.claude/settings.local.json';
+// The reader builds every settings path with join(), so the fixture keys have
+// to carry the host separator — spelled as POSIX literals they match nothing on
+// Windows, and each file reads as absent.
+const HOME_SETTINGS = join('/mock-home', '.claude', 'settings.json');
+const HOME_SETTINGS_LOCAL = join('/mock-home', '.claude', 'settings.local.json');
 const PROJECT_DIR = '/mock-project';
-const PROJECT_SETTINGS = `${PROJECT_DIR}/.claude/settings.json`;
-const PROJECT_SETTINGS_LOCAL = `${PROJECT_DIR}/.claude/settings.local.json`;
+const PROJECT_SETTINGS = join(PROJECT_DIR, '.claude', 'settings.json');
+const PROJECT_SETTINGS_LOCAL = join(PROJECT_DIR, '.claude', 'settings.local.json');
 
 function mockSettingsByPath(map: Record<string, unknown>): void {
   mockReadFile.mockImplementation((p: unknown) => {

--- a/backend/src/core/features/appDetection/__tests__/resolveApp.test.ts
+++ b/backend/src/core/features/appDetection/__tests__/resolveApp.test.ts
@@ -43,7 +43,9 @@ function setupExecFile(opts: {
   vi.mocked(cpExecFile).mockImplementation(((cmd: string, args: string[]) => {
     if (cmd === 'defaults') {
       const infoPath = args[1];
-      const appPath = infoPath.replace(/\/Contents\/Info$/, '');
+      // The path was built with join(), so its separator is the host's — match
+      // either, or this strips nothing on Windows and every lookup misses.
+      const appPath = infoPath.replace(/[\\/]Contents[\\/]Info$/, '');
       const id = opts.bundleIdByAppPath?.[appPath];
       if (id) return Promise.resolve({ stdout: `${id}\n`, stderr: '' });
       return Promise.reject(new Error(`defaults read failed for ${appPath}`));

--- a/backend/src/core/handlers/__tests__/findBackgroundTaskOutputPath.test.ts
+++ b/backend/src/core/handlers/__tests__/findBackgroundTaskOutputPath.test.ts
@@ -4,16 +4,36 @@ import { join } from 'path';
 import { realpathSync } from 'fs';
 import * as os from 'os';
 
+/** Replace a process property that has no setter, and hand back the undo. */
+function override(key: 'platform' | 'getuid', value: unknown): () => void {
+  const original = Object.getOwnPropertyDescriptor(process, key);
+  Object.defineProperty(process, key, { value, configurable: true });
+  return () => {
+    // `getuid` is absent on Windows, so there is nothing to put back there.
+    if (original) Object.defineProperty(process, key, original);
+    else Reflect.deleteProperty(process, key);
+  };
+}
+
 describe('findBackgroundTaskOutputPath', () => {
   let tmpDir: string;
+  let restore: Array<() => void> = [];
 
   beforeEach(async () => {
     // Use realpathSync to resolve symlinks (macOS /var -> /private/var)
     tmpDir = realpathSync(await mkdtemp(join(os.tmpdir(), 'fbto-test-')));
+    // The uid-keyed layout below is what the CLI writes on macOS/Linux only, and
+    // the lookup answers null outright on win32. Running as that platform is
+    // what puts the POSIX behaviour under test everywhere — otherwise a Windows
+    // run agrees with every "returns null" case for the wrong reason and never
+    // exercises a single lookup.
+    restore = [override('platform', 'darwin'), override('getuid', () => 1000)];
     vi.resetModules();
   });
 
   afterEach(async () => {
+    for (const undo of restore.reverse()) undo();
+    restore = [];
     await rm(tmpDir, { recursive: true, force: true });
     vi.unstubAllEnvs();
     vi.restoreAllMocks();
@@ -143,18 +163,30 @@ describe('findBackgroundTaskOutputPath', () => {
   it('returns null when process.getuid is not available (uid null)', async () => {
     vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
     // Simulate environment without getuid (e.g., Windows-like)
-    const originalGetuid = process.getuid;
-    Object.defineProperty(process, 'getuid', { value: undefined, configurable: true });
+    restore.push(override('getuid', undefined));
 
-    try {
-      const { findBackgroundTaskOutputPath } = await import('../findBackgroundTaskOutputPath');
-      const result = await findBackgroundTaskOutputPath({
-        taskId: 'task-123',
-        workingDir: '/Users/test/project',
-      });
-      expect(result).toEqual({ path: null });
-    } finally {
-      Object.defineProperty(process, 'getuid', { value: originalGetuid, configurable: true });
-    }
+    const { findBackgroundTaskOutputPath } = await import('../findBackgroundTaskOutputPath');
+    const result = await findBackgroundTaskOutputPath({
+      taskId: 'task-123',
+      workingDir: '/Users/test/project',
+    });
+    expect(result).toEqual({ path: null });
+  });
+
+  it('returns null on win32 even when a matching file is sitting there', async () => {
+    // The uid-keyed directory has no Windows counterpart, so the lookup declines
+    // rather than guessing. Asserted with the file present, so this stays a
+    // statement about the platform and not about an empty directory.
+    vi.stubEnv('CLAUDE_CODE_TMPDIR', tmpDir);
+    const taskId = 'task-win32';
+    await createOutputFile('runtime-uuid-win32', taskId, '-Users-test-project');
+    restore.push(override('platform', 'win32'));
+
+    const { findBackgroundTaskOutputPath } = await import('../findBackgroundTaskOutputPath');
+    const result = await findBackgroundTaskOutputPath({
+      taskId,
+      workingDir: '/Users/test/project',
+    });
+    expect(result).toEqual({ path: null });
   });
 });

--- a/backend/src/core/handlers/__tests__/installCcb.test.ts
+++ b/backend/src/core/handlers/__tests__/installCcb.test.ts
@@ -67,6 +67,13 @@ function spawnedArgv(i: number): string {
   return process.platform === 'win32' ? args.slice(3).join(' ') : [file, ...args].join(' ');
 }
 
+/**
+ * npm's launcher, which is `npm.cmd` on Windows — the same name the installer
+ * resolves. Spelling it `npm` outright would assert a command that is never run
+ * there, and the same name reaches the user in the permission-failure message.
+ */
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
 let execPathSpy: ReturnType<typeof vi.spyOn>;
 const mockResolveClaudePaths = vi.mocked(resolveClaudePaths);
 
@@ -102,7 +109,7 @@ describe('installCcbHandler', () => {
     // a successful install invisible: every later lookup still answers "not
     // installed", so the settings section stays locked after installing.
     expect(mockResetExtendKitCache).toHaveBeenCalledTimes(1);
-    expect(spawnedArgv(0)).toContain('npm install -g --prefix ');
+    expect(spawnedArgv(0)).toContain(`${NPM} install -g --prefix `);
   });
 
   it.runIf(process.platform !== 'win32')(
@@ -149,7 +156,7 @@ describe('installCcbHandler', () => {
 
     await installCcbHandler('c1', msg, conns, bridge);
 
-    expect(spawnedArgv(0)).toContain('npm install -g --prefix ');
+    expect(spawnedArgv(0)).toContain(`${NPM} install -g --prefix `);
   });
 
   // #298. The installer used to read the manager off `process.execPath` ALONE,
@@ -239,9 +246,9 @@ describe('installCcbHandler', () => {
 
     await installCcbHandler('c1', msg, conns, bridge);
 
-    expect(spawnedArgv(0)).toContain('npm install -g --prefix ');
-    expect(spawnedArgv(1)).toContain('npm uninstall -g --prefix ');
-    expect(spawnedArgv(2)).toContain('npm install -g --prefix ');
+    expect(spawnedArgv(0)).toContain(`${NPM} install -g --prefix `);
+    expect(spawnedArgv(1)).toContain(`${NPM} uninstall -g --prefix `);
+    expect(spawnedArgv(2)).toContain(`${NPM} install -g --prefix `);
     expect(lastPayload(conns).status).toBe('ok');
     expect(mockResetExtendKitCache).toHaveBeenCalledTimes(1);
   });
@@ -274,7 +281,7 @@ describe('installCcbHandler', () => {
 
     const p = lastPayload(conns);
     expect(p.status).toBe('error');
-    expect(String(p.error)).toContain('npm install -g --prefix ');
+    expect(String(p.error)).toContain(`${NPM} install -g --prefix `);
     expect(mockResetUsageCache).not.toHaveBeenCalled();
     expect(mockResetExtendKitCache).not.toHaveBeenCalled();
   });

--- a/backend/src/core/handlers/__tests__/uninstallCcb.test.ts
+++ b/backend/src/core/handlers/__tests__/uninstallCcb.test.ts
@@ -59,6 +59,9 @@ function allArgv(): string[] {
   });
 }
 
+/** npm's launcher, which is `npm.cmd` on Windows — the name the sweep resolves. */
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
 let execPathSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
@@ -95,7 +98,7 @@ describe('uninstallCcbHandler', () => {
 
     const argv = allArgv();
     expect(argv[0]).toContain('volta uninstall @swttch/extend-kit');
-    expect(argv.some((a) => a.includes('npm uninstall -g --prefix '))).toBe(true);
+    expect(argv.some((a) => a.includes(`${NPM} uninstall -g --prefix `))).toBe(true);
     expect(argv.some((a) => a.includes('pnpm remove -g @swttch/extend-kit'))).toBe(true);
     expect(argv.some((a) => a.includes('yarn global remove @swttch/extend-kit'))).toBe(true);
     expect(argv.some((a) => a.includes('bun remove -g @swttch/extend-kit'))).toBe(true);
@@ -144,7 +147,13 @@ describe('uninstallCcbHandler', () => {
     const p = lastPayload(conns);
     expect(p.status).toBe('error');
     expect(String(p.error)).toContain('uninstall');
-    expect(String(p.error)).toContain('sudo');
+    // The pasteable command is elevated only where elevation exists: `sudo` has
+    // no Windows counterpart, so there the command is handed over unprefixed.
+    if (process.platform === 'win32') {
+      expect(String(p.error)).not.toContain('sudo');
+    } else {
+      expect(String(p.error)).toContain('sudo ');
+    }
   });
 
   // The caches remember where the kit WAS, so the survivor check has to look at

--- a/backend/src/system-sounds/__tests__/scanner.test.ts
+++ b/backend/src/system-sounds/__tests__/scanner.test.ts
@@ -9,9 +9,18 @@ vi.mock('os', () => ({
 }));
 
 import { readdir } from 'fs/promises';
+import { join } from 'path';
 import { scanSystemSounds, clearScanCache } from '../scanner';
 
 const mockReaddir = vi.mocked(readdir);
+
+// The scanner builds the user directory and every sound path with join(), so
+// both are spelled with the host separator. Naming them here rather than typing
+// POSIX literals keeps the assertions true on Windows too.
+const SYSTEM_SOUNDS_DIR = '/System/Library/Sounds';
+const LIBRARY_SOUNDS_DIR = '/Library/Sounds';
+const USER_SOUNDS_DIR = join('/home/test', 'Library', 'Sounds');
+const FREEDESKTOP_DIR = '/usr/share/sounds/freedesktop/stereo';
 
 const originalPlatform = process.platform;
 
@@ -39,9 +48,9 @@ describe('scanSystemSounds', () => {
 
     it('scans all macOS sound directories and merges results', async () => {
       mockReaddir.mockImplementation(async (dir) => {
-        if (dir === '/System/Library/Sounds') return ['Glass.aiff', 'Ping.aiff'] as any;
-        if (dir === '/Library/Sounds') return ['Custom.aiff'] as any;
-        if (dir === '/home/test/Library/Sounds') return ['User.aiff'] as any;
+        if (dir === SYSTEM_SOUNDS_DIR) return ['Glass.aiff', 'Ping.aiff'] as any;
+        if (dir === LIBRARY_SOUNDS_DIR) return ['Custom.aiff'] as any;
+        if (dir === USER_SOUNDS_DIR) return ['User.aiff'] as any;
         return [] as any;
       });
 
@@ -49,8 +58,10 @@ describe('scanSystemSounds', () => {
 
       const ids = sounds.map((s) => s.id);
       expect(ids).toEqual(['Custom', 'Glass', 'Ping', 'User']);
-      expect(sounds.find((s) => s.id === 'Glass')?.path).toBe('/System/Library/Sounds/Glass.aiff');
-      expect(sounds.find((s) => s.id === 'User')?.path).toBe('/home/test/Library/Sounds/User.aiff');
+      expect(sounds.find((s) => s.id === 'Glass')?.path).toBe(
+        join(SYSTEM_SOUNDS_DIR, 'Glass.aiff'),
+      );
+      expect(sounds.find((s) => s.id === 'User')?.path).toBe(join(USER_SOUNDS_DIR, 'User.aiff'));
     });
 
     it('filters out non-aiff extensions on darwin', async () => {
@@ -74,7 +85,7 @@ describe('scanSystemSounds', () => {
       const sounds = await scanSystemSounds();
 
       expect(sounds).toHaveLength(1);
-      expect(sounds[0]?.path).toBe('/System/Library/Sounds/Glass.aiff');
+      expect(sounds[0]?.path).toBe(join(SYSTEM_SOUNDS_DIR, 'Glass.aiff'));
     });
 
     it('skips directories that fail to read', async () => {
@@ -100,7 +111,7 @@ describe('scanSystemSounds', () => {
       expect(sounds[0]).toEqual({
         id: 'Tink',
         label: 'Tink',
-        path: '/System/Library/Sounds/Tink.aiff',
+        path: join(SYSTEM_SOUNDS_DIR, 'Tink.aiff'),
       });
     });
   });
@@ -133,7 +144,10 @@ describe('scanSystemSounds', () => {
       const sounds = await scanSystemSounds();
 
       expect(sounds.map((s) => s.id)).toEqual(['bell', 'message']);
-      expect(sounds.every((s) => s.path.startsWith('/usr/share/sounds/freedesktop/stereo/'))).toBe(true);
+      expect(sounds.map((s) => s.path)).toEqual([
+        join(FREEDESKTOP_DIR, 'bell.oga'),
+        join(FREEDESKTOP_DIR, 'message.oga'),
+      ]);
     });
 
     it('falls back to next directory when first is empty', async () => {


### PR DESCRIPTION
Closes #369

`be-test` failed 26 tests across 8 files on Windows, on `main` as well as on any branch. Every one of them turned out to be a test-side assumption, so **no production code changes** here.

| Layer | Before | After |
| --- | --- | --- |
| Backend | 26 failed / 8 files | 1585 passed, 0 failed |
| Kotlin | — | 413 passed, 0 failed |
| WebView | — | 2804 passed, 0 failed |

`be-lint` is clean. Measured on Windows 11; the changes keep every assertion identical on macOS.

## The candidate list in the issue was not the failing set

That list came from grepping for macOS markers, so `os-info`, `claude.test` and `detectEditors` were on it while passing, and the actual failures — the kit version lookup, the auth-env reader, the task-output lookup and both ccb handlers — were not. The list below is what a Windows run reports.

## Five causes

**1. Fixture paths spelled POSIX while the code joins them** (12 tests) — `resolveApp`, `scanner`, `getStrippableAuthEnvKeys`

The settings reader builds `~/.claude/settings.json` with `join()`, so a fixture keyed `'/mock-home/.claude/settings.json'` matches nothing on Windows and every file reads as absent. `resolveApp`'s helper stripped `/Contents/Info` with a slash-only regex, so no bundle id was ever read.

**2. Not isolated from the developer's own machine** (3 tests) — `extend-kit.version`

The lookup also offers `%APPDATA%\npm\node_modules` on Windows, npm's real global prefix. Unpointed, the tests read the kit actually installed on the machine: "not installed" answered `0.4.0`. The tests that passed did so only because their fixture carried that same version — the same reason `execPath` is already pinned at an empty prefix. The lookup also asks for `npm.cmd` there, which the fake command did not answer to.

**3. A platform branch left unstubbed** (4 tests) — `findBackgroundTaskOutputPath`

The lookup returns `null` outright on win32, since the uid-keyed directory has no counterpart there. Four cases failed — and every "returns null" case passed for the wrong reason: path traversal, an empty taskId and a relative workingDir were all short-circuited before their own rejection was reached. Pinning platform and getuid puts the POSIX behaviour under test everywhere, and the win32 contract now has a case of its own, asserted with a matching file present.

**4. A POSIX file mode** (1 test) — `account-store`

NTFS drops the bits and reports `0666`, as the store's own comment says. Rather than skipping it there, the portable half — the store asks for `0600` on create and reapplies it after the rename — is now asserted on every platform, with the read-back kept where a filesystem honours it.

**5. npm's launcher name and the elevation prefix** (6 tests) — `installCcb`, `uninstallCcb`

Both are deliberate in the handlers: `npm.cmd` on Windows, `sudo` only where elevation exists. The tests hardcoded `npm` and `sudo`, asserting commands that are never run there. Derived the same way the handlers derive them, the Windows case now also states that the pasteable command must *not* carry a sudo that does not exist.

## Kotlin

The two tests the issue mentions conditionally (`fileKey()`, `setWritable(false)`) were already fixed in #360 and pass here.

## Not done

Nothing was skipped on Windows, so no blind spot is left behind. No production defect surfaced — had one, it would have gone to its own issue per the scope note.
