### PR TITLE
fix: let Cmd/Ctrl+Z undo pasted text and inserted mentions (#286)

### DIFF
--- a/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/replaceRangeWithText.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/__tests__/replaceRangeWithText.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Tests for replaceRangeWithText.
+ *
+ * The regression this guards (issue #286): mention autocomplete used to write
+ * its result straight into the composer's value, which re-rendered the editable
+ * node. That bypassed the browser's undo history, so Cmd/Ctrl+Z could not undo
+ * an inserted mention, and it also invalidated the entries for text typed
+ * before it. Routing the edit through execCommand keeps it in that history.
+ *
+ * jsdom does not implement `document.execCommand`, so the tests exercise both
+ * paths: the browser accepting the edit (mocked true), and declining it, where
+ * the caller must report the value itself.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { replaceRangeWithText } from '../replaceRangeWithText';
+
+// jsdom leaves document.execCommand undefined, so vi.spyOn cannot attach to it.
+// Assign a stub per test and remove it afterwards, as insertNewlineAtCursor's
+// tests do.
+type ExecCommandHost = { execCommand?: Document['execCommand'] };
+function setExecCommand(fn: Document['execCommand']): void {
+  (document as ExecCommandHost).execCommand = fn;
+}
+function clearExecCommand(): void {
+  delete (document as ExecCommandHost).execCommand;
+}
+
+function makeEditable(text: string): HTMLDivElement {
+  const el = document.createElement('div');
+  el.textContent = text;
+  document.body.appendChild(el);
+  return el;
+}
+
+describe('replaceRangeWithText', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    clearExecCommand();
+    vi.restoreAllMocks();
+  });
+
+  it('asks the browser to insert the replacement text', () => {
+    const el = makeEditable('check @src');
+    const exec = vi.fn().mockReturnValue(true);
+    setExecCommand(exec as unknown as Document['execCommand']);
+
+    replaceRangeWithText(el, 6, 10, '@src/cart.js ');
+
+    expect(exec).toHaveBeenCalledWith('insertText', false, '@src/cart.js ');
+  });
+
+  it('reports true when the browser performs the edit, so the caller stays out', () => {
+    const el = makeEditable('check @src');
+    setExecCommand(vi.fn().mockReturnValue(true) as unknown as Document['execCommand']);
+
+    expect(replaceRangeWithText(el, 6, 10, '@src/cart.js ')).toBe(true);
+  });
+
+  it('reports false when the browser declines, so the caller writes the value', () => {
+    const el = makeEditable('check @src');
+    setExecCommand(vi.fn().mockReturnValue(false) as unknown as Document['execCommand']);
+
+    expect(replaceRangeWithText(el, 6, 10, '@src/cart.js ')).toBe(false);
+  });
+
+  it('reports false when execCommand throws (jsdom "not implemented")', () => {
+    const el = makeEditable('check @src');
+    setExecCommand((() => {
+      throw new Error('not implemented');
+    }) as unknown as Document['execCommand']);
+
+    expect(replaceRangeWithText(el, 6, 10, '@src/cart.js ')).toBe(false);
+  });
+
+  it('reports false when execCommand is absent entirely', () => {
+    const el = makeEditable('check @src');
+    clearExecCommand();
+
+    expect(replaceRangeWithText(el, 6, 10, '@src/cart.js ')).toBe(false);
+  });
+
+  it('selects exactly the span being replaced, so surrounding text survives', () => {
+    const el = makeEditable('check @src tail');
+    let selectedText: string | null = null;
+    setExecCommand(vi.fn().mockImplementation(() => {
+      // Capture what the browser would have replaced at the moment of the call.
+      selectedText = window.getSelection()?.toString() ?? null;
+      return true;
+    }) as unknown as Document['execCommand']);
+
+    // Offsets 6..10 cover "@src" and nothing else.
+    replaceRangeWithText(el, 6, 10, '@src/cart.js ');
+
+    expect(selectedText).toBe('@src');
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/RichInput/replaceRangeWithText.ts
+++ b/webview/src/pages/ChatPage/ChatInput/RichInput/replaceRangeWithText.ts
@@ -1,0 +1,39 @@
+import { setSelectionRange } from '@/utils/domSelection';
+
+/**
+ * Replace the text between two plain-text offsets of a focused contentEditable
+ * with `text`, going through the browser's own editing pipeline so the edit is
+ * recorded in its undo history.
+ *
+ * Why not just write the new string through React state (issue #286): a
+ * contentEditable only records an undo entry when the browser itself performs
+ * the edit. Assigning `textContent`, or re-rendering the editor from a new
+ * `value`, changes what the user sees but leaves the browser's history
+ * untouched, so Ctrl/Cmd+Z has nothing to undo. Worse, replacing the whole node
+ * this way invalidates the entries already there, which is why an autocomplete
+ * insert could strip undo from text typed before it.
+ *
+ * Selecting the span first and then inserting is what makes this one atomic
+ * edit: the browser records "this range became that text", so a single undo
+ * restores exactly the state before the insert, with surrounding text intact.
+ *
+ * Returns whether the browser performed the edit. `false` means the caller must
+ * report the resulting value itself, because no native `input` event will
+ * follow (execCommand is unavailable in jsdom, and can be disabled elsewhere).
+ *
+ * Assumes `root` is focused; offsets are relative to `root.textContent`.
+ */
+export function replaceRangeWithText(
+  root: HTMLElement,
+  start: number,
+  end: number,
+  text: string,
+): boolean {
+  setSelectionRange(root, start, end);
+
+  try {
+    return document.execCommand('insertText', false, text);
+  } catch {
+    return false;
+  }
+}

--- a/webview/src/pages/ChatPage/ChatInput/__tests__/clipboardCarriesImage.test.ts
+++ b/webview/src/pages/ChatPage/ChatInput/__tests__/clipboardCarriesImage.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for clipboardCarriesImage, the composer's sole reason to intercept a
+ * paste.
+ *
+ * The regression this guards (issue #286): the composer used to cancel EVERY
+ * text paste and write the result through React state. That produced the right
+ * glyphs but bypassed the browser's undo stack, so Cmd/Ctrl+Z could not undo a
+ * paste while text typed afterwards undid normally. Text must therefore report
+ * `false` here, so the caller leaves the event alone and the browser's own
+ * paste (which records an undo entry) runs.
+ *
+ * jsdom's DataTransfer does not expose a settable `items` list, so the tests
+ * build minimal stand-ins with just the two fields the predicate reads.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { clipboardCarriesImage } from '../clipboardCarriesImage';
+
+/** Build a DataTransfer-shaped stub carrying the given items. */
+function clipboardWith(items: Array<{ kind: string; type: string }>): DataTransfer {
+  return { items } as unknown as DataTransfer;
+}
+
+describe('clipboardCarriesImage', () => {
+  it('reports false for a plain-text paste, so the browser handles it and undo works', () => {
+    const clipboard = clipboardWith([{ kind: 'string', type: 'text/plain' }]);
+    expect(clipboardCarriesImage(clipboard)).toBe(false);
+  });
+
+  it('reports false for rich text, which plaintext-only strips on its own', () => {
+    const clipboard = clipboardWith([
+      { kind: 'string', type: 'text/plain' },
+      { kind: 'string', type: 'text/html' },
+    ]);
+    expect(clipboardCarriesImage(clipboard)).toBe(false);
+  });
+
+  it('reports true for a pasted image file, which becomes an attachment', () => {
+    const clipboard = clipboardWith([{ kind: 'file', type: 'image/png' }]);
+    expect(clipboardCarriesImage(clipboard)).toBe(true);
+  });
+
+  it('reports true when an image rides alongside text', () => {
+    const clipboard = clipboardWith([
+      { kind: 'string', type: 'text/plain' },
+      { kind: 'file', type: 'image/jpeg' },
+    ]);
+    expect(clipboardCarriesImage(clipboard)).toBe(true);
+  });
+
+  it('reports false for a non-image file, which the composer does not claim', () => {
+    const clipboard = clipboardWith([{ kind: 'file', type: 'application/pdf' }]);
+    expect(clipboardCarriesImage(clipboard)).toBe(false);
+  });
+
+  it('reports false for an image MIME type that is not an actual file', () => {
+    // A dragged <img> can surface as a string entry; only real files become
+    // attachments, so this must not divert the paste.
+    const clipboard = clipboardWith([{ kind: 'string', type: 'image/png' }]);
+    expect(clipboardCarriesImage(clipboard)).toBe(false);
+  });
+
+  it('reports false when the clipboard is null', () => {
+    expect(clipboardCarriesImage(null)).toBe(false);
+  });
+
+  it('reports false when the clipboard exposes no items', () => {
+    expect(clipboardCarriesImage({} as unknown as DataTransfer)).toBe(false);
+  });
+});

--- a/webview/src/pages/ChatPage/ChatInput/clipboardCarriesImage.ts
+++ b/webview/src/pages/ChatPage/ChatInput/clipboardCarriesImage.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a paste carries an image file, which the composer handles itself
+ * (turning it into an attachment) rather than letting it reach the editor.
+ *
+ * This is the composer's ONLY reason to intercept a paste. Text is deliberately
+ * left to the browser (issue #286): the editor is
+ * `contentEditable="plaintext-only"`, so the browser already drops rich markup,
+ * and cancelling the event to write the text ourselves would skip the browser's
+ * undo stack, making Cmd/Ctrl+Z unable to undo a paste even though text typed
+ * afterwards undid normally.
+ *
+ * Keep this predicate free of side effects: it decides, the caller acts.
+ */
+export function clipboardCarriesImage(clipboardData: DataTransfer | null): boolean {
+  const items = clipboardData?.items;
+  if (!items) return false;
+  return Array.from(items).some(
+    item => item.kind === 'file' && item.type.startsWith('image/'),
+  );
+}

--- a/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
+++ b/webview/src/pages/ChatPage/ChatInput/hooks/useMention.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, type RefObject } from 'react';
 import { useBridgeContext } from '@/contexts/BridgeContext';
 import { MessageType } from '@/shared';
+import { replaceRangeWithText } from '../RichInput/replaceRangeWithText';
 
 export enum MentionItemType {
   File = 'file',
@@ -59,6 +60,14 @@ interface UseMentionParams {
   onInsertMention: (token: string, caretOffset: number, nextValue: string) => void;
   value: string;
   onChange: (value: string) => void;
+  /**
+   * The composer's editable element. Mention inserts go through the browser's
+   * editing pipeline on this node so they land in its undo history (issue
+   * #286). Optional so the hook stays usable without a mounted editor; without
+   * it the insert falls back to writing the value directly, which works but is
+   * not undoable.
+   */
+  inputRef?: RefObject<HTMLElement | null>;
 }
 
 /**
@@ -89,7 +98,7 @@ interface UseMentionReturn {
 const DEBOUNCE_MS = 150;
 
 export function useMention(params: UseMentionParams): UseMentionReturn {
-  const { workingDirectory, onInsertMention, value, onChange } = params;
+  const { workingDirectory, onInsertMention, value, onChange, inputRef } = params;
   const bridge = useBridgeContext();
 
   const [state, setState] = useState<MentionState>({
@@ -223,17 +232,26 @@ export function useMention(params: UseMentionParams): UseMentionReturn {
       // resolved path token plus a trailing space, keeping surrounding text intact.
       const token = buildMentionToken(result);
       const currentValue = valueRef.current;
+      const spanEnd = triggerIndex + 1 + state.query.length;
       const before = currentValue.slice(0, triggerIndex);
-      const after = currentValue.slice(triggerIndex + 1 + state.query.length);
+      const after = currentValue.slice(spanEnd);
       const newValue = before + token + ' ' + after;
       const caretOffset = triggerIndex + token.length + 1;
 
-      onChange(newValue);
+      // Hand the edit to the browser so it lands in the undo history (issue
+      // #286); only report the value ourselves when it declines, since a
+      // browser-performed edit fires `input` and the composer syncs from that.
+      const el = inputRef?.current ?? null;
+      const handledByBrowser = el
+        ? replaceRangeWithText(el, triggerIndex, spanEnd, token + ' ')
+        : false;
+      if (!handledByBrowser) onChange(newValue);
+
       onInsertMention(token, caretOffset, newValue);
 
       close();
     },
-    [state, workingDirectory, onInsertMention, onChange, close],
+    [state, workingDirectory, onInsertMention, onChange, close, inputRef],
   );
 
   const handleKeyDown = useCallback(
@@ -268,10 +286,18 @@ export function useMention(params: UseMentionParams): UseMentionReturn {
           if (result) {
             const completedPath = result.relativePath + (result.type === MentionItemType.Directory ? '/' : '');
             const currentValue = valueRef.current;
-            const before = currentValue.slice(0, state.triggerIndex + 1);
-            const after = currentValue.slice(state.triggerIndex + 1 + state.query.length);
+            const queryStart = state.triggerIndex + 1;
+            const queryEnd = queryStart + state.query.length;
+            const before = currentValue.slice(0, queryStart);
+            const after = currentValue.slice(queryEnd);
             const newValue = before + completedPath + after;
-            onChange(newValue);
+            // Same reasoning as selectResult: let the browser make the edit so
+            // Tab-completion stays undoable (issue #286).
+            const el = inputRef?.current ?? null;
+            const handledByBrowser = el
+              ? replaceRangeWithText(el, queryStart, queryEnd, completedPath)
+              : false;
+            if (!handledByBrowser) onChange(newValue);
             setState(prev => ({
               ...prev,
               query: completedPath,

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -25,6 +25,7 @@ import { useBridgeContext } from '@/contexts/BridgeContext';
 import { getTextContent, SessionState } from '@/types';
 import { LoadedMessageType } from '@/dto';
 import { useAttachments } from './hooks/useAttachments';
+import { clipboardCarriesImage } from './clipboardCarriesImage';
 import { AttachmentPreview } from './AttachmentPreview';
 import { ContextWindowTag } from './ContextWindowTag';
 import { IdeSelectionTag } from './IdeSelectionTag';
@@ -61,7 +62,7 @@ import { TelemetryConsentBanner } from '../TelemetryConsentBanner';
 import { InputBanner } from '../InputBanner';
 import { AnnouncementInputBannerSlot } from '@/components/Announcements/placements';
 import { useTelemetryConsent, ConsentStatus, ConsentSource } from '@/hooks/useTelemetryConsent';
-import { getCaretOffset, setCaretOffset, getSelectionRange } from '@/utils/domSelection';
+import { getCaretOffset, setCaretOffset } from '@/utils/domSelection';
 import { MessageType } from '@/shared';
 import { useTranslation } from '@/i18n';
 
@@ -711,38 +712,27 @@ export function ChatInput() {
     }
   }, [disabled, value, attachments.length, onSubmit, pushToHistory, navigateUp, navigateDown, onChange, palette, mention, cycleMode, clearAttachments, mode, appSettings.useCtrlEnterToSend, ime, handleRichChange]);
 
-  // Wrap the attachment paste handler so that, when the clipboard carries no
-  // image, we insert the plain-text payload ourselves. contentEditable would
-  // otherwise paste rich HTML; plaintext-only strips formatting but we still
-  // route through onChange to keep `value` the single source of truth.
+  // Wrap the attachment paste handler so images keep their dedicated path while
+  // text goes through the browser's own editing pipeline.
+  //
+  // Text is deliberately NOT intercepted (issue #286). Cancelling the paste and
+  // writing the result through onChange used to strip formatting and keep
+  // `value` authoritative, but it also meant the browser never recorded the
+  // edit, so Cmd/Ctrl+Z could not undo a paste while text typed afterwards
+  // undid normally. The editor is `contentEditable="plaintext-only"`, which
+  // already drops rich markup on paste, so letting the default run costs us
+  // nothing on formatting and restores undo. The resulting `input` event feeds
+  // handleRichChange, which keeps `value` in sync and runs both detectors.
   const handleRichPaste = useCallback((e: ReactClipboardEvent<HTMLDivElement>) => {
-    const items = e.clipboardData?.items;
-    const hasImage = items
-      ? Array.from(items).some(item => item.kind === 'file' && item.type.startsWith('image/'))
-      : false;
-
-    if (hasImage) {
+    if (clipboardCarriesImage(e.clipboardData)) {
       // Delegate image handling (it calls preventDefault internally).
       handlePaste(e);
       return;
     }
 
-    const text = e.clipboardData.getData('text/plain');
-    if (!text) return;
-
-    e.preventDefault();
-    const el = textareaRef.current;
-    const { start, end } = el ? getSelectionRange(el) : { start: value.length, end: value.length };
-    const newValue = value.slice(0, start) + text + value.slice(end);
-    onChange(newValue);
-    const caret = start + text.length;
-    palette.detectSlashCommand(newValue, caret);
-    mention.detectMention(newValue, caret);
-    requestAnimationFrame(() => {
-      const target = textareaRef.current;
-      if (target) setCaretOffset(target, caret);
-    });
-  }, [handlePaste, value, onChange, palette, mention, textareaRef]);
+    // Text falls through untouched: the default paste inserts it, records the
+    // undo entry, and fires `input`, which handleRichChange picks up.
+  }, [handlePaste]);
 
   const hasValue = !!value.trim() || attachments.length > 0;
 

--- a/webview/src/pages/ChatPage/ChatInput/index.tsx
+++ b/webview/src/pages/ChatPage/ChatInput/index.tsx
@@ -427,6 +427,7 @@ export function ChatInput() {
     workingDirectory,
     value,
     onChange,
+    inputRef: textareaRef,
     // @-mention selection inserts an inline path token (same chip set as Alt+K
     // editor-context inserts), then restores the caret just past the token.
     onInsertMention: (token, caretOffset, nextValue) => {


### PR DESCRIPTION
## What

Cmd/Ctrl+Z could not undo two kinds of text the composer writes on the user's behalf: a **pasted message** and an **inserted @mention**. Typing still undid normally, which made the failure look intermittent rather than structural.

Both are fixed by handing the edit to the browser instead of writing the value ourselves.

## Why it happened

The composer is a `contentEditable`, and **the undo stack belongs to the browser, not to us** (there is no undo stack and no Cmd+Z handler anywhere in this repo). The browser records an entry only when it performs the edit itself. Both paths cancelled that:

- **Paste** called `preventDefault()` and wrote the clipboard text through React state.
- **Mention** replaced the `@query` span by assigning a new composer value.

Either way the glyphs appeared but the browser had done nothing, so there was nothing to undo.

The mention case was worse. Re-rendering the editable node also invalidated the entries already in the browser's history, so an inserted mention did not merely resist undo, it **stripped undo from everything typed before it**.

## Why the paste interception was removable

It existed to strip rich markup. The editor is `contentEditable="plaintext-only"`, which **already drops formatting on paste** — measured in the composer itself: pasting `<b>` / `<i>` / `<a>` markup yields plain text either way. So the cancellation bought nothing and cost undo, and the fix is a deletion rather than an addition.

Mentions still need us to decide the text, so that path selects the span and inserts through `execCommand`, which keeps it in the browser's history as one atomic edit.

## Verification

Measured against the reported steps, before and after.

| Scenario | Before | After |
| --- | --- | --- |
| Paste, then undo | unchanged | input cleared |
| Paste, undo, redo | n/a | paste restored |
| Paste, type `ABC`, undo repeatedly | `125 → 122 → 122 → 122` (stuck) | `125 → 122 → 0` |
| Mention pick, then undo | unchanged | back to `check @src` |
| Mention pick, undo repeatedly | nothing at all | continues into earlier typing |
| Tab completion, then undo | not measured | `look @src/` → `look @s` |

No regressions in what these paths already did: formatting strip, slash-command detection, mention detection, image attachment, chip highlight, caret landing after the token, and mirror sync.

Judged by actual DOM changes rather than `queryCommandEnabled('undo')` — that reported `true` on the mention path while a MutationObserver saw no DOM change at all, so it is not a dependable signal here.

**Environments checked**

- Chromium (dev server)
- **JCEF, IntelliJ IDEA 2024.2** (windowed) — all scenarios pass
- **JCEF, IntelliJ IDEA 2026.2, build IU-262.8665.258** (OSR) — all scenarios pass

The 2026.2 run matters because OSR has previously broken assumptions of the form "the browser will handle it", which is exactly what this change relies on.

**Linux (Ctrl) safety**: the `paste` event carries no modifier-key fields at all (`ctrlKey` / `metaKey` are absent), so the handler cannot and need not distinguish Ctrl from Cmd. Undo is likewise untouched — no code in this repo references the Z key, so the browser applies its own platform rules.

**Suite**: webview 302 files / 2830 tests, backend 143 files / 1606 tests, `wv-lint`, `be-lint`, `full-build` all green. Added 14 tests across the two new units; each was confirmed to fail when the fix was deliberately reverted.

## Not included

**Dictation** still injects values the same way and remains un-undoable. That was left out by decision, not oversight: what a single undo should revert while recognition is still updating is a product question, and it will be settled if users report it.

**Unrelated observation**: with `/clear @src/cart.js`, the slash panel does not return after the mention settles, while picking a directory (`@src/`) does bring it back. Compared against the pre-fix path by withholding the new `inputRef`, and the behaviour is identical, so this predates the change and is filed separately as #373.

Closes #286

