### PR TITLE
fix: read MCP status by its wording, and stop two runs racing to delete one dir

### DIFF
--- a/backend/src/core/features/__tests__/mcp-parser.test.ts
+++ b/backend/src/core/features/__tests__/mcp-parser.test.ts
@@ -64,6 +64,50 @@ workspace-mcp: http://localhost:8000/mcp (HTTP) - ✔ Connected`;
   it('returns empty array when only header present', () => {
     expect(parseMcpList('Checking MCP server health…\n')).toEqual([]);
   });
+
+  // Issue #319: a Windows console on a legacy code page substitutes the CLI's ✔ / ✘ with
+  // characters from its own set. The reporter's screenshot showed U+221A √, which the old
+  // parser could not strip, so a connected server was reported as Failed. The status word
+  // decides the status; whatever icon precedes it must not.
+  describe('status icon substitutions (issue #319)', () => {
+    const CONNECTED_ICONS: Array<[string, string]> = [
+      ['U+2714 ✔ (UTF-8 terminal)', '✔'],
+      ['U+221A √ (Windows code page, reported in #319)', '√'],
+      ['U+2713 ✓', '✓'],
+      ['U+2705 ✅', '✅'],
+      ['no icon at all', ''],
+    ];
+
+    it.each(CONNECTED_ICONS)('reads Connected through %s', (_label, icon) => {
+      const line = `playwright: npx some-pkg - ${icon}${icon ? ' ' : ''}Connected`;
+      expect(parseMcpList(line)[0]?.status).toBe(McpServerStatus.CONNECTED);
+    });
+
+    const FAILED_ICONS: Array<[string, string]> = [
+      ['U+2718 ✘ (UTF-8 terminal)', '✘'],
+      ['U+00D7 × (Windows code page)', '×'],
+      ['U+2717 ✗', '✗'],
+      ['U+274C ❌', '❌'],
+      ['no icon at all', ''],
+    ];
+
+    it.each(FAILED_ICONS)('reads Failed to connect through %s', (_label, icon) => {
+      const line = `jetbrains: http://localhost:64342/sse (SSE) - ${icon}${icon ? ' ' : ''}Failed to connect`;
+      expect(parseMcpList(line)[0]?.status).toBe(McpServerStatus.FAILED);
+    });
+
+    it('does not depend on a space between the icon and the status word', () => {
+      expect(parseMcpList('playwright: npx some-pkg - √Connected')[0]?.status).toBe(
+        McpServerStatus.CONNECTED,
+      );
+    });
+
+    it('still reports FAILED for status wording it does not recognise', () => {
+      expect(parseMcpList('playwright: npx some-pkg - √ Exploded')[0]?.status).toBe(
+        McpServerStatus.FAILED,
+      );
+    });
+  });
 });
 
 // ─── parseMcpGet ─────────────────────────────────────────────────────────────
@@ -218,6 +262,63 @@ To remove this server, run: claude mcp remove "my-server" -s user`;
 
     it('parses disabled status', () => {
       expect(parseMcpGet(FIXTURE)?.status).toBe(McpServerStatus.DISABLED);
+    });
+  });
+
+  // Issue #319: the reporter's screenshot showed the error banner reading "√ Connected" —
+  // the CLI's own success sentence, icon included, presented as the failure reason. Both the
+  // status verdict and the error text come from the same Status line, so both are asserted.
+  describe('status icon substitutions (issue #319)', () => {
+    const fixture = (statusLine: string) => `plugin:toolsmith:toolsmith:
+  Scope: User config (available in all your projects)
+  Status: ${statusLine}
+  Type: stdio
+  Command: npx
+  Args: some-pkg
+
+To remove this server, run: claude mcp remove "plugin:toolsmith:toolsmith" -s user`;
+
+    const CONNECTED_ICONS: Array<[string, string]> = [
+      ['U+2714 ✔ (UTF-8 terminal)', '✔ Connected'],
+      ['U+221A √ (Windows code page, reported in #319)', '√ Connected'],
+      ['U+2713 ✓', '✓ Connected'],
+      ['no icon at all', 'Connected'],
+    ];
+
+    it.each(CONNECTED_ICONS)('reads CONNECTED through %s', (_label, statusLine) => {
+      expect(parseMcpGet(fixture(statusLine))?.status).toBe(McpServerStatus.CONNECTED);
+    });
+
+    it.each(CONNECTED_ICONS)('reports no error through %s', (_label, statusLine) => {
+      expect(parseMcpGet(fixture(statusLine))?.error).toBeNull();
+    });
+
+    const FAILED_ICONS: Array<[string, string]> = [
+      ['U+2718 ✘ (UTF-8 terminal)', '✘ Failed to connect'],
+      ['U+00D7 × (Windows code page)', '× Failed to connect'],
+      ['no icon at all', 'Failed to connect'],
+    ];
+
+    it.each(FAILED_ICONS)('reads FAILED through %s', (_label, statusLine) => {
+      expect(parseMcpGet(fixture(statusLine))?.status).toBe(McpServerStatus.FAILED);
+    });
+
+    it.each(FAILED_ICONS)('strips the icon out of the error message for %s', (_label, statusLine) => {
+      expect(parseMcpGet(fixture(statusLine))?.error).toBe('Failed to connect');
+    });
+
+    it('reads NEEDS_AUTH through a substituted icon', () => {
+      const server = parseMcpGet(fixture('√ needs-auth'));
+      expect(server?.status).toBe(McpServerStatus.NEEDS_AUTH);
+      expect(server?.error).toBe('needs-auth');
+    });
+
+    it('reads PENDING through a substituted icon', () => {
+      expect(parseMcpGet(fixture('√ Connecting…'))?.status).toBe(McpServerStatus.PENDING);
+    });
+
+    it('reads DISABLED through a substituted icon', () => {
+      expect(parseMcpGet(fixture('√ disabled'))?.status).toBe(McpServerStatus.DISABLED);
     });
   });
 

--- a/backend/src/core/features/mcp-parser.ts
+++ b/backend/src/core/features/mcp-parser.ts
@@ -75,7 +75,7 @@ export function parseMcpGet(output: string): McpServer | null {
 
   // CLI does not provide a separate error field — use the status text as the error message
   // when the server is in a failed or auth-required state.
-  const statusText = statusRaw.replace(/^[✔✘]\s*/, '').trim();
+  const statusText = stripStatusIcon(statusRaw);
   const error =
     (status === McpServerStatus.FAILED || status === McpServerStatus.NEEDS_AUTH) && statusText
       ? statusText
@@ -93,9 +93,28 @@ export function parseMcpGet(output: string): McpServer | null {
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
+/**
+ * Drop the decorative icon the CLI prints in front of a status word.
+ *
+ * The icon is not a fixed character. `claude mcp list` prints U+2714 ✔ / U+2718 ✘ on a
+ * UTF-8 terminal, but a Windows console running a legacy code page substitutes them with
+ * whatever its own character set offers — U+221A √ and U+00D7 × have both been observed
+ * (issue #319). Matching against a list of known icons therefore breaks again on every new
+ * substitution, so this does the opposite: it keeps nothing but the status wording itself.
+ *
+ * Every status the CLI reports is ASCII wording ("Connected", "Failed to connect",
+ * "needs-auth", …), so everything before the first ASCII letter is decoration and is dropped.
+ * When the text carries no ASCII letter at all it is returned trimmed but otherwise intact,
+ * leaving the caller to treat it as an unknown status rather than silently emptying it.
+ */
+function stripStatusIcon(text: string): string {
+  const firstLetterIdx = text.search(/[A-Za-z]/);
+  if (firstLetterIdx === -1) return text.trim();
+  return text.slice(firstLetterIdx).trim();
+}
+
 function parseStatusText(text: string): McpServerStatus {
-  // Strip leading icon characters (✔, ✘) and normalise.
-  const t = text.replace(/^[✔✘]\s*/, '').toLowerCase();
+  const t = stripStatusIcon(text).toLowerCase();
   if (t.startsWith('connected')) return McpServerStatus.CONNECTED;
   if (t.startsWith('failed')) return McpServerStatus.FAILED;
   if (t.startsWith('needs-auth') || t.startsWith('needs auth')) return McpServerStatus.NEEDS_AUTH;

--- a/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractor.kt
+++ b/src/main/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractor.kt
@@ -6,8 +6,13 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.extensions.PluginId
 import java.io.File
 import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
 import java.nio.file.StandardCopyOption
+import java.nio.file.attribute.BasicFileAttributes
 import java.util.UUID
 
 /** Final on-disk locations the backend serves from. */
@@ -149,7 +154,7 @@ class PluginResourceExtractor(
         val tmp = File(baseDir, "$TMP_PREFIX${UUID.randomUUID()}")
         var moved = false
         try {
-            tmp.deleteRecursively()
+            reapDirTree(tmp)
             val tmpWebview = File(tmp, WEBVIEW_SUBDIR)
             val tmpBackendDir = File(tmp, BACKEND_SUBDIR)
             tmpWebview.mkdirs()
@@ -213,7 +218,7 @@ class PluginResourceExtractor(
             return served
         } finally {
             // If the move/fallback succeeded, tmp was renamed away; otherwise clean the partial.
-            if (!moved) tmp.deleteRecursively()
+            if (!moved) reapDirTree(tmp)
         }
     }
 
@@ -313,11 +318,11 @@ class PluginResourceExtractor(
             // is always safe — unlike `.tmp-*`, which a concurrent extraction may be filling in
             // right now, and `.locked-*`, which someone may be serving from.
             if (dir.name.startsWith(DISCARD_PREFIX)) {
-                if (dir.deleteRecursively()) logger.info("Reaped discarded dir: ${dir.name}")
+                if (reapDirTree(dir)) logger.info("Reaped discarded dir: ${dir.name}")
                 continue
             }
             if (dir.name.startsWith(TMP_PREFIX) || dir.name.startsWith(LOCKED_PREFIX)) continue
-            val ok = dir.deleteRecursively()
+            val ok = reapDirTree(dir)
             if (ok) logger.info("Pruned stale plugin-resource version dir: ${dir.name}")
             else logger.debug("Could not prune ${dir.name} (in use?); leaving for next run")
         }
@@ -333,7 +338,7 @@ class PluginResourceExtractor(
         val siblings = baseDir.listFiles() ?: return
         for (dir in siblings) {
             if (!dir.isDirectory || !dir.name.startsWith(LOCKED_PREFIX)) continue
-            val ok = dir.deleteRecursively()
+            val ok = reapDirTree(dir)
             if (ok) logger.info("Pruned stale locked-fallback dir: ${dir.name}")
             else logger.debug("Could not prune locked-fallback ${dir.name} (in use?); leaving for next run")
         }
@@ -542,14 +547,86 @@ class PluginResourceExtractor(
             val occupied = aside.exists()
             return try {
                 Files.move(versionDir.toPath(), aside.toPath(), StandardCopyOption.ATOMIC_MOVE)
-                aside.deleteRecursively()
+                reapDirTree(aside)
                 true
             } catch (e: java.io.IOException) {
                 // Locked (Windows) or a filesystem that refuses the rename — leave it in place.
-                if (!occupied) aside.deleteRecursively()
+                if (!occupied) reapDirTree(aside)
                 false
             }
         }
+        /**
+         * Delete a directory tree, tolerating another thread or process deleting the same tree
+         * at the same time. Returns true when nothing of [dir] is left on disk afterwards —
+         * including the case where somebody else is the one who removed it.
+         *
+         * Kotlin's `File.deleteRecursively()` cannot be used here. It walks the tree with
+         * `FileTreeWalk`, which asserts a directory is still a directory at the moment it
+         * descends into it, so a racer removing that subdirectory in between crashes the walk
+         * with `AssertionError: rootDir must be verified to be directory beforehand.` Assertions
+         * are off in production and on under Gradle, so the same race showed up as an
+         * intermittently failing test rather than a visible defect.
+         *
+         * Concurrent deletion is not an edge case here but the normal shape of the work:
+         * [clearByRenamingAside] deletes the `.discard-*` dir it just created while every
+         * concurrent [pruneOtherVersions] reaps any `.discard-*` it finds. "Somebody else
+         * already deleted it" is therefore success, not failure — hence `NoSuchFileException`
+         * is swallowed while a real error (a Windows lock, a permission problem) still makes
+         * this return false so the caller leaves the dir for a later run.
+         */
+        internal fun reapDirTree(dir: File): Boolean {
+            if (!dir.exists()) return true
+            var allGone = true
+            try {
+                Files.walkFileTree(
+                    dir.toPath(),
+                    object : SimpleFileVisitor<Path>() {
+                        override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+                            deleteIfRaceAllows(file)
+                            return FileVisitResult.CONTINUE
+                        }
+
+                        /**
+                         * Reached when a path cannot be read — most often because a racer deleted
+                         * it between the directory listing and our visit. That is the expected
+                         * interleaving, so it is not propagated; anything else is remembered and
+                         * surfaces through the return value.
+                         */
+                        override fun visitFileFailed(file: Path, exc: java.io.IOException): FileVisitResult {
+                            if (exc !is NoSuchFileException) allGone = false
+                            return FileVisitResult.CONTINUE
+                        }
+
+                        override fun postVisitDirectory(d: Path, exc: java.io.IOException?): FileVisitResult {
+                            if (exc != null && exc !is NoSuchFileException) allGone = false
+                            deleteIfRaceAllows(d)
+                            return FileVisitResult.CONTINUE
+                        }
+
+                        private fun deleteIfRaceAllows(path: Path) {
+                            try {
+                                Files.deleteIfExists(path)
+                            } catch (e: java.nio.file.DirectoryNotEmptyException) {
+                                // A racer added or restored an entry under us, or one of our own
+                                // deletes failed above. Either way this tree is not fully gone.
+                                allGone = false
+                            } catch (e: NoSuchFileException) {
+                                // Already reaped by the racer — exactly what we wanted.
+                            } catch (e: java.io.IOException) {
+                                allGone = false
+                            }
+                        }
+                    },
+                )
+            } catch (e: NoSuchFileException) {
+                // The whole tree vanished before the walk started. Nothing left to do.
+                return true
+            } catch (e: java.io.IOException) {
+                return false
+            }
+            return allGone && !dir.exists()
+        }
+
         /** Prefix for the sibling temp dir an extraction unpacks into before the atomic rename. */
         private const val TMP_PREFIX = ".tmp-"
 

--- a/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractorLockTest.kt
+++ b/src/test/kotlin/com/github/yhk1038/claudecodegui/bridge/PluginResourceExtractorLockTest.kt
@@ -384,6 +384,61 @@ class PluginResourceExtractorLockTest {
         }
     }
 
+    /**
+     * Two runs reaping the same `.discard-*` tree must not blow up.
+     *
+     * `clearByRenamingAside` moves a superseded version dir to `.discard-<uuid>` and deletes it
+     * itself, while every concurrent `pruneOtherVersions` reaps any `.discard-*` it finds — so
+     * the same tree is routinely deleted twice at once. `deleteRecursively()` cannot take that:
+     * it walks the tree, and `FileTreeWalk` asserts a directory is still a directory at the
+     * moment it descends. When the other deleter removes that subdirectory in between, the walk
+     * dies with `AssertionError: rootDir must be verified to be directory beforehand.`
+     *
+     * This is what made `parallel extractors all end up serving a complete bundle` flaky. The
+     * tree is deliberately wide and deep here, because the failure window is the gap between
+     * "is a directory" and "descend into it" — a shallow tree usually finishes before the racer
+     * can widen it.
+     */
+    @Test
+    fun `reaping the same discard tree from two threads does not throw`(@TempDir base: File) {
+        val pool = Executors.newFixedThreadPool(2)
+        try {
+            repeat(40) { attempt ->
+                val discard = File(base, ".discard-attempt$attempt")
+                // Wide and deep: many chances for one walker to descend into what the other
+                // has just removed.
+                for (a in 1..12) {
+                    for (b in 1..12) {
+                        File(discard, "d$a/d$b").mkdirs()
+                        File(discard, "d$a/d$b/f.txt").writeText("x")
+                    }
+                }
+
+                val bothReady = java.util.concurrent.CountDownLatch(2)
+                val failure = java.util.concurrent.atomic.AtomicReference<Throwable>()
+                val futures = (1..2).map {
+                    pool.submit {
+                        bothReady.countDown()
+                        bothReady.await(10, TimeUnit.SECONDS)
+                        try {
+                            PluginResourceExtractor.reapDirTree(discard)
+                        } catch (t: Throwable) {
+                            failure.compareAndSet(null, t)
+                        }
+                    }
+                }
+                futures.forEach { it.get(60, TimeUnit.SECONDS) }
+
+                failure.get()?.let {
+                    fail<Unit>("concurrent reap of $discard threw ${it::class.java.name}: ${it.message}")
+                }
+                assertFalse(discard.exists(), "the discard tree must be gone: $discard")
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
     /** Takes an exclusive [java.nio.channels.FileChannel] lock and parks, holding it open. */
     object LockHolderMain {
         @JvmStatic


### PR DESCRIPTION
## Problem

A connected MCP server was listed as **Failed**, and the error banner showed the CLI's own success sentence — `√ Connected` — as the reason for the failure. Reported in #319 on Windows 11 / IntelliJ IDEA 2026.2.1, where `claude mcp list` behaved correctly in the terminal but the plugin did not.


## Cause

The icon `claude mcp list` prints in front of a status is **not a fixed character**. A UTF-8 terminal produces U+2714 `✔` and U+2718 `✘`, but a Windows console running a legacy code page substitutes them with whatever its own character set offers. The reporter's console emitted U+221A `√`, the square-root sign.

`parseStatusText` stripped the icon with `text.replace(/^[✔✘]\s*/, '')` — a list of the two icons it knew. `√` was not in that list, so it survived the strip, the string stayed `"√ connected"`, `startsWith('connected')` did not match, and control reached the final fallthrough:

```ts
// Unknown status text — treat as failed so the UI doesn't silently show a connected badge.
return McpServerStatus.FAILED;
```

The identical regex was written a second time, in `parseMcpGet`, to derive the error message from the same Status line. That is why the banner leaked the icon as well: one bug, printed twice.

Confirmed by running the pre-fix logic directly:

```
U+2714 "✔ Connected"        -> after-strip "connected"           -> CONNECTED
U+221A "√ Connected"        -> after-strip "√ connected"         -> FAILED (fallthrough)
U+2713 "✓ Connected"        -> after-strip "✓ connected"         -> FAILED (fallthrough)
U+00D7 "× Failed to connect"-> after-strip "× failed to connect" -> FAILED (right by accident)
```

Note the last line: the failure cases only looked correct because the fallthrough is *also* `FAILED`. They were never actually being parsed.

## Fix

Adding `√` to the character class would fix this console and break on the next one. So the decision is inverted rather than extended: instead of asking *which icons do I strip*, the parser asks *where does the meaning begin*.

Every status the CLI reports is ASCII wording — `Connected`, `Failed to connect`, `needs-auth` — so everything before the first ASCII letter is decoration and is dropped, whatever character it happens to be:

```ts
function stripStatusIcon(text: string): string {
  const firstLetterIdx = text.search(/[A-Za-z]/);
  if (firstLetterIdx === -1) return text.trim();
  return text.slice(firstLetterIdx).trim();
}
```

Text carrying no ASCII letter at all is returned trimmed but intact, so the caller still treats it as an unknown status instead of being handed a silently emptied string.

Both call sites — the status verdict and the error message — now share this one function, so the two copies of the decision cannot drift apart again.

## Tests

Unit tests in `backend/src/core/features/__tests__/mcp-parser.test.ts`, driven by strings alone — no MCP server or Docker needed, which matches the nature of the bug.

Covered across both `parseMcpList` and `parseMcpGet`:

- **Connected** through U+2714 `✔`, U+221A `√` (the reported one), U+2713 `✓`, U+2705 `✅`, and no icon at all
- **Failed** through U+2718 `✘`, U+00D7 `×`, U+2717 `✗`, U+274C `❌`, and no icon at all
- **needs-auth**, **pending**, and **disabled** through a substituted icon
- The error message is the wording only, with the icon stripped out
- A connected server reports `error: null` — the regression behind the screenshot
- No space between icon and word (`√Connected`)
- Unrecognised wording still reports `FAILED`, so the safety default is intact

Each new assertion was verified to be capable of failing: appending `&& false` turned the passing cases red before being reverted.

## Verification

| Layer | Result |
|---|---|
| `be-test` | 143 files, 1635 passed / 8 skipped |
| `wv-test` | 302 files, 2830 passed |
| `be-lint` / `wv-lint` | clean |
| `full-build` | BUILD SUCCESSFUL |

Scope is limited to the parser, as intended. #363 and #364 affect the same screen but have different causes and are handled separately.

Fixes #319

---

## Also in this PR: a real race behind a flaky test

The first full build of this branch failed in `PluginResourceExtractorLockTest` with `AssertionError: rootDir must be verified to be directory beforehand.`, thrown out of `pruneOtherVersions`. It passed on re-run. Rather than write it off as flaky, it turned out to be a genuine race that assertions merely made visible.

**Deleting the same tree twice at once is the normal shape of this code, not an edge case.** `clearByRenamingAside` moves a superseded version dir to `.discard-<uuid>` and deletes it itself, while every concurrent `pruneOtherVersions` reaps any `.discard-*` it finds.

Kotlin's `File.deleteRecursively()` cannot take that. It is implemented as a `walkBottomUp()` fold, and `FileTreeWalk.DirectoryState` asserts a directory is still a directory at the moment it descends:

```kotlin
private abstract class DirectoryState(rootDir: File) : WalkState(rootDir) {
    init {
        if (_Assertions.ENABLED)
            assert(rootDir.isDirectory) { "rootDir must be verified to be directory beforehand." }
    }
}
```

Note the `_Assertions.ENABLED` guard. Gradle's `Test` task enables assertions by default and a production JVM does not, **so in production this never threw — it returned `false`, and the caller logged the directory as "in use" when nothing was holding it.** The defect was always there; the test was the only place it was audible.

### Fix

`reapDirTree()` reaps via `Files.walkFileTree()` and treats `NoSuchFileException` as success, because "somebody else already deleted it" is precisely the outcome being asked for. A real failure — a Windows lock, a permission problem — still returns `false`, so the existing "leave it for the next run" behaviour is preserved.

All seven recursive deletes in the file now route through it, including the `.tmp-<uuid>` ones no racer can currently reach. Leaving two ways to delete a tree in one file invites the next change to pick the unsafe one.

### Test

`reaping the same discard tree from two threads does not throw` reaps a wide, deep `.discard-*` tree from two threads, 40 iterations. Narrowing the test to the contended operation rather than replaying the whole extraction scenario is what made it deterministic: **the original flake needed dozens of runs to appear, while this fails on the previous implementation from the first iteration.** Verified by reverting `reapDirTree` to the old body and watching it go red, then restoring it.

`gradlew test` was run 5 times over with `--rerun-tasks`, passing each time.
