### PR TITLE
fix: keep the slash command panel after a mouse-picked mention (#373)

### DIFF
--- a/webview/src/commandPalette/ui/CommandPalettePanel.tsx
+++ b/webview/src/commandPalette/ui/CommandPalettePanel.tsx
@@ -47,15 +47,30 @@ export const CommandPalettePanel: React.FC<CommandPalettePanelProps> = ({
     });
   }, [selectedSectionIndex, selectedItemIndex]);
 
-  // Click outside to close
+  // Click outside to close.
+  //
+  // The listener is attached a tick late on purpose. A mousedown elsewhere can
+  // be what opens this panel in the first place: picking a file from the mention
+  // dropdown settles the mention, which hands the shared slot back to the
+  // command panel (issue #236) and mounts this component while that very
+  // mousedown is still propagating. Attaching synchronously would let the panel
+  // catch the click that created it, see a target outside itself, and close
+  // immediately, so `/command @file ` lost its panel on a mouse pick while a
+  // keyboard pick kept it (issue #373). Deferring puts the listener in place
+  // only after the current event has finished dispatching.
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
       if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
         onClose();
       }
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    const timer = setTimeout(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+    }, 0);
+    return () => {
+      clearTimeout(timer);
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
   }, [onClose]);
 
   if (sections.length === 0) {

--- a/webview/src/commandPalette/ui/__tests__/CommandPalettePanel.clickOutside.test.tsx
+++ b/webview/src/commandPalette/ui/__tests__/CommandPalettePanel.clickOutside.test.tsx
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, act } from '@testing-library/react';
+import { CommandPalettePanel } from '../CommandPalettePanel';
+import { PanelItemType, PanelSectionId } from '@/types/commandPalette';
+import type { PanelSection } from '@/types/commandPalette';
+
+// The panel footer reads plugin/CLI versions over the bridge; the click-outside
+// behaviour under test does not involve them, so a static stub keeps the test
+// focused (and free of a QueryClient/Bridge provider tree).
+vi.mock('@/hooks/useVersionInfo', () => ({
+  useVersionInfo: () => ({
+    pluginVersion: '0.0.0',
+    cliVersion: null,
+    requiresRestart: false,
+    clientInfo: null,
+    osInfo: null,
+    isLoading: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+// jsdom does not implement scrollIntoView; the panel calls it to keep the
+// selected row visible.
+Element.prototype.scrollIntoView = vi.fn();
+
+const sections: PanelSection[] = [
+  {
+    id: PanelSectionId.SlashCommands,
+    title: 'Slash Commands',
+    showDividerAbove: false,
+    items: [
+      {
+        id: 'clear',
+        label: '/clear',
+        type: PanelItemType.Command,
+        name: '/clear',
+        description: 'Clear conversation',
+        action: vi.fn(),
+      },
+    ],
+  },
+];
+
+function renderPanel(onClose: () => void) {
+  return render(
+    <CommandPalettePanel
+      sections={sections}
+      selectedSectionIndex={0}
+      selectedItemIndex={0}
+      filterQuery="clear"
+      onItemClick={vi.fn()}
+      onItemExecute={vi.fn()}
+      onClose={onClose}
+    />,
+  );
+}
+
+describe('CommandPalettePanel click-outside', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not listen for outside clicks until the current event finishes dispatching (issue #373)', () => {
+    // What breaks in the browser: picking a file from the mention dropdown is a
+    // mousedown, and settling that mention hands the shared slot back to this
+    // panel (issue #236), mounting it while that same mousedown is still
+    // propagating to document. A listener attached during mount therefore caught
+    // the very click that created the panel, saw a target outside itself, and
+    // closed it again, so "/command @file " lost its panel on a mouse pick
+    // while a keyboard pick kept it.
+    //
+    // Asserting on a dispatched event cannot express that here: React defers
+    // effects out of the event under test, so the listener would land after the
+    // dispatch either way and the bug would pass. What the fix actually
+    // guarantees is the registration *timing*, so that is what this measures:
+    // nothing is listening when mount returns, and the listener appears only
+    // once the pending timer runs.
+    const onClose = vi.fn();
+    const addSpy = vi.spyOn(document, 'addEventListener');
+
+    renderPanel(onClose);
+
+    const mousedownRegistrations = () =>
+      addSpy.mock.calls.filter(([type]) => type === 'mousedown').length;
+
+    expect(mousedownRegistrations()).toBe(0);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(mousedownRegistrations()).toBe(1);
+
+    addSpy.mockRestore();
+  });
+
+  it('still closes on a mousedown that starts after it is open', () => {
+    const onClose = vi.fn();
+    renderPanel(onClose);
+
+    // The deferred listener is in place once the current task yields.
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    act(() => {
+      outside.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    outside.remove();
+  });
+
+  it('does not close on a mousedown inside the panel', () => {
+    const onClose = vi.fn();
+    const { container } = renderPanel(onClose);
+
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    const panel = container.querySelector('.slash-command-panel');
+    expect(panel).not.toBeNull();
+    act(() => {
+      panel!.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+    });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #373

## The problem

Picking a file mention inside a slash command (`/clear @src/cart.js`) is supposed to
hand the shared slot above the composer back to the command panel once the mention
settles (the behaviour added in #236). Picking with the mouse did not bring it back.

## Cause

`MentionDropdown` selects on `onMouseDown`, so that it runs before the composer's
`blur`. That mousedown settles the mention, the settled mention hands the slot back,
and `CommandPalettePanel` mounts — all while that same mousedown is **still
propagating**.

The panel attaches its click-outside listener as it mounts. The in-flight mousedown
then reaches `document`, the freshly attached listener catches it, and the click
target (the mention dropdown) sits outside the new panel, so it closes immediately.
The panel is closed by the very click that created it.

A keyboard pick never enters this path, because there is no mouse event. That is why
Enter kept the panel and only a click lost it.

## Correcting the axis in the report

The issue described the split as file vs directory. Measuring all four combinations
shows the axis is the pick method instead: with the mouse, a directory loses the
panel too.

| Pick | Entry | Before | After |
| --- | --- | --- | --- |
| Enter | directory `src/` | returns | returns |
| Enter | file `src/cart.js` | returns | returns |
| Click | directory `src/` | does not return | returns |
| Click | file `src/cart.js` | does not return | returns |

## Fix

Attach the click-outside listener a tick late, so it is in place only after the
current event has finished dispatching.

## Swept the same pattern

Checked all 12 places that attach a mouse listener to `document`. This is the only
one affected. It needs two conditions at once: the trigger lives **outside** the
component's own ref, **and** the component mounts during a mousedown.

- Seven menus keep their trigger inside their own ref, so `contains()` reads the
  opening click as inside (`Select`, `SponsorManageMenu`, `AccountSwitcher`,
  `SessionDropdown`, `OverflowMenu`, `WorkingDirDropdown`, the mode panel).
- Three open only from `onClick`, which fires after `mousedown` has finished
  (`ModelSwitchOverlay`, `AttachMenu`, `ScheduleSendPopover`). Command palette items
  go through `onClick` as well, so every palette-driven path is covered.
- `usePanelFocusReporter` is focus reporting, not click-outside dismissal.

`CommandPalettePanel` is the only panel that is opened by a mention settling rather
than by a button, which is why it alone qualifies.

## Tests

Three regression tests. Reverting the fix makes the first one fail
(`expected 1 to be +0`).

Worth recording: a test that dispatches the event and asserts the panel stayed open
**passes even without the fix**, because React defers effects out of the event under
test, so the listener lands after the dispatch either way. The test therefore
measures the registration timing itself — nothing listening when mount returns, one
listener after the pending timer runs.

## Verification

- webview: 303 files / 2833 tests pass; `wv-tsc` and `wv-lint` clean
- backend: 143 files / 1606 tests pass; `be-lint` clean
- `full-build` (backend + webview + plugin, including Kotlin `:test` and
  `:koverVerify`): BUILD SUCCESSFUL
- Reproduced and re-verified in the browser against `/private/tmp/ccg-demo`, walking
  the exact steps in the report